### PR TITLE
DoveVannoINostriSoldi: rebrand, linguaggio semplice e audit

### DIFF
--- a/.github/workflows/mef-participations-refresh.yml
+++ b/.github/workflows/mef-participations-refresh.yml
@@ -65,7 +65,7 @@ jobs:
             echo "No MEF participation release change to commit."
             exit 0
           fi
-          git config user.name "trasparenza-italia-bot"
+          git config user.name "dove-vanno-i-nostri-soldi-bot"
           git config user.email "actions@users.noreply.github.com"
           git add src/data/generated/mef-participations-overview.json
           git commit -m "chore(data): refresh MEF participations snapshot"

--- a/.github/workflows/opencoesione-refresh.yml
+++ b/.github/workflows/opencoesione-refresh.yml
@@ -83,7 +83,7 @@ jobs:
             exit 0
           fi
 
-          git config user.name "trasparenza-italia-bot"
+          git config user.name "dove-vanno-i-nostri-soldi-bot"
           git config user.email "actions@users.noreply.github.com"
           git add src/data/generated/opencoesione-overview.json
           git commit -m "chore(data): refresh OpenCoesione snapshot"

--- a/.github/workflows/siope-refresh.yml
+++ b/.github/workflows/siope-refresh.yml
@@ -99,7 +99,7 @@ jobs:
             exit 0
           fi
 
-          git config user.name "trasparenza-italia-bot"
+          git config user.name "dove-vanno-i-nostri-soldi-bot"
           git config user.email "actions@users.noreply.github.com"
           git add src/data/generated/siope-municipal.json
           git commit -m "chore(data): refresh SIOPE municipal snapshot"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,12 +1,12 @@
-# Trasparenza Italia — Design System
+# DoveVannoINostriSoldi — Design System
 
 ## 01 Overview
 
-**Creative North Star: “The Civic Ledger.”**
+**Direzione: “Il conto pubblico.”**
 
-Trasparenza Italia è un prodotto operativo di consultazione e verifica. Deve sembrare un'infrastruttura civica contemporanea: autorevole, leggibile e densa quanto serve, senza sembrare né un portale ministeriale legacy né una dashboard cyber.
+DoveVannoINostriSoldi è un prodotto operativo di consultazione e verifica. Deve sembrare un'infrastruttura civica contemporanea: autorevole, leggibile e densa quanto serve, senza sembrare né un portale ministeriale legacy né una dashboard cyber.
 
-La direzione è **data-first, provenance-first, flat by default**.
+La direzione è **dati subito, fonte vicina, superfici semplici**.
 
 La schermata deve far capire rapidamente:
 
@@ -36,6 +36,7 @@ La palette è blu-notte istituzionale con accenti freddi desaturati. Evitare ner
 - `--blue: #55b8ef` — azione e informazione primaria;
 - `--green: #6ee7a8` — fonte verificata / stato positivo;
 - `--amber: #f0c56c` — attenzione / integrazione incompleta;
+- `--violet: #a78bda` — scenario o scelta di policy;
 - `--red: #ff7a7a` — errore o variazione negativa, non “colpevolezza”.
 
 ### Data visualization tokens
@@ -43,7 +44,12 @@ La palette è blu-notte istituzionale con accenti freddi desaturati. Evitare ner
 - `--chart-primary: #72aeca`;
 - `--chart-secondary: #78ad8d`;
 - `--chart-tertiary: #c3a66c`;
+- `--chart-policy: #a78bda`;
 - `--chart-negative: #ca7d7d`.
+
+Nelle pagine di audit i colori hanno un significato stabile: blu per dati osservati,
+ambra per aree da approfondire, viola per scenari di policy e rosso attenuato per stock
+o passività. Testo e spiegazione accompagnano sempre il colore.
 
 Le serie devono avere luminosità comparabile e il colore deve significare qualcosa. Non usare automaticamente rosso/verde per giudicare enti o persone. Il colore non può essere l'unico mezzo per comunicare uno stato.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,4 +1,4 @@
-# Trasparenza Italia — Product Context
+# DoveVannoINostriSoldi — Product Context
 
 ## Platform
 
@@ -19,15 +19,15 @@ La situazione d'uso tipica è esplorativa e investigativa: una persona parte da 
 
 ## Product purpose
 
-Trasparenza Italia aggrega e normalizza fonti pubbliche ufficiali italiane per rendere la gestione delle risorse pubbliche leggibile, ricercabile, confrontabile e verificabile da un unico punto di accesso.
+DoveVannoINostriSoldi aggrega e normalizza fonti pubbliche ufficiali italiane per rendere la gestione delle risorse pubbliche leggibile, ricercabile, confrontabile e verificabile da un unico punto di accesso.
 
 Il prodotto non sostituisce le fonti ufficiali. Le collega, conserva la provenienza e riduce il costo cognitivo necessario per capire dati oggi dispersi tra portali, API, dataset e documenti.
 
 ## Positioning
 
-**Un unico grafo verificabile della spesa pubblica italiana, dal bilancio nazionale al singolo ente, contratto, progetto e pagamento quando la fonte lo consente.**
+**Un unico posto per capire la spesa pubblica italiana e controllare i numeri alla fonte.**
 
-Un normale portale open data può pubblicare dataset. Trasparenza Italia deve poter mostrare come record provenienti da sistemi diversi sono collegati tra loro e permettere all'utente di tornare sempre all'originale.
+Un normale portale open data pubblica file. DoveVannoINostriSoldi li trasforma in percorsi comprensibili: dal quadro nazionale al territorio, all'ente e infine al dato originale.
 
 ## Operating context
 
@@ -59,7 +59,7 @@ La UI deve rendere visibile la freschezza effettiva del dato.
 - consulenze e incarichi pubblici;
 - Camera, Senato e altre istituzioni;
 - viste per territorio, settore, ente, fornitore e progetto;
-- API pubblica con provenance;
+- API pubblica con fonte e date;
 - indicatori di anomalia e confronti tra enti omogenei.
 
 ### Vincoli permanenti
@@ -93,11 +93,11 @@ OpenBDAP espone un catalogo CKAN interrogabile via API. ANAC e altri sistemi pub
 
 ## Design principles
 
-- Operate first: la dashboard è uno strumento di lavoro e consultazione, non una landing page promozionale.
-- Overview → drill-down → source: ogni percorso deve partire da un quadro leggibile, permettere l'approfondimento e terminare su un'origine verificabile.
-- Comparison over spectacle: grafici e mappe esistono per rendere confronti più rapidi, non per decorare.
-- Progressive disclosure: la prima vista mostra ciò che serve a orientarsi; metodologia, metadati e dettagli tecnici restano sempre raggiungibili.
-- Honest empty states: se una fonte manca o è in ritardo, la UI lo dice esplicitamente.
+- Dashboard subito: la home mostra i dati, non una presentazione promozionale.
+- Dal quadro alla fonte: ogni percorso parte semplice, permette di approfondire e arriva all'originale.
+- Confronti, non spettacolo: grafici e mappe servono a capire più in fretta.
+- Dettagli quando servono: la prima vista orienta; metodo e dati tecnici restano raggiungibili.
+- Vuoti onesti: se una fonte manca o è in ritardo, lo diciamo chiaramente.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Trasparenza Italia
+# DoveVannoINostriSoldi
 
 > **Dove vanno i soldi pubblici, fonte per fonte.**
 
-Trasparenza Italia è un progetto civico open source per aggregare, normalizzare e rendere comprensibili i dati pubblici sulla spesa e sulla gestione delle risorse della Pubblica Amministrazione italiana.
+DoveVannoINostriSoldi è un progetto civico open source per capire come vengono usati i soldi pubblici italiani.
 
-L'obiettivo non è creare una classifica dello scandalo. È costruire una **infrastruttura di verifica**: un cittadino dovrebbe poter partire da un grafico, un ente, un contratto o un progetto, arrivare al record originale, capire quando il dato è stato aggiornato e ricostruire come è stato trasformato.
+Riunisce dati ufficiali oggi dispersi tra portali diversi. Da un grafico, un ente o un progetto si può arrivare alla fonte originale, vedere la data del dato e capire i suoi limiti. Non crea classifiche dello scandalo e non trasforma un segnale in un'accusa.
 
 ## Principio fondamentale
 
-**Nessun numero senza fonte, data e percorso di verifica.**
+**Nessun numero senza fonte, data e spiegazione.**
 
-“Live” non significa inventare un tempo reale che non esiste. Trasparenza Italia controlla le sorgenti più spesso della loro cadenza di pubblicazione quando è utile, rileva rapidamente i nuovi rilasci ufficiali e mostra separatamente:
+“Aggiornato” significa aggiornato quanto la fonte. DoveVannoINostriSoldi controlla quando arrivano nuovi dati ufficiali e mostra separatamente:
 
-- timestamp del dato sorgente;
-- momento di acquisizione;
-- disponibilità dell'upstream;
-- freshness rispetto alla cadenza dichiarata;
-- trasformazioni applicate.
+- la data a cui si riferisce il dato;
+- quando la piattaforma lo ha acquisito;
+- se la fonte risponde;
+- quanto spesso la fonte pubblica nuovi dati;
+- i calcoli applicati.
 
 ## Cosa vogliamo unire
 
@@ -40,7 +40,8 @@ La route `/` è direttamente il prodotto: non contiene una landing promozionale 
 
 - ricerca reale degli enti sul datastore IPA;
 - quadro SIOPE dei pagamenti di cassa dei Comuni e flusso mensile ufficiale;
-- coropleta delle 20 regioni alimentata dai valori SIOPE pro capite e dai confini ISTAT 2026;
+- mappa delle 20 regioni alimentata dai valori SIOPE pro capite e dai confini ISTAT 2026;
+- pagina `/controlli` con i numeri del dossier 2026, colori semantici e limiti di lettura espliciti;
 - riepilogo OpenCoesione con rapporto finanziario distinto dall'avanzamento fisico;
 - data di riferimento, pubblicazione della fonte, acquisizione e frequenza di controllo visibili;
 - percorsi diretti verso dashboard di dettaglio, metodologia e fonti originali.
@@ -131,7 +132,7 @@ API e aggiornamento:
 
 `/fonti/stato` separa tre concetti che spesso vengono confusi:
 
-1. **integrazione**: esiste un adapter di Trasparenza Italia?
+1. **integrazione**: esiste un adapter di DoveVannoINostriSoldi?
 2. **reachability**: l'upstream risponde?
 3. **freshness**: quanto è vecchio il dato secondo un timestamp ufficiale e una soglia coerente con la fonte?
 
@@ -271,7 +272,7 @@ Leggi [`docs/LEGAL_AND_ETHICS.md`](docs/LEGAL_AND_ETHICS.md).
 
 ## Indipendenza
 
-Trasparenza Italia è un progetto civico indipendente. Non è un sito ufficiale dello Stato italiano, di ANAC, RGS, Banca d'Italia, AgID, Camera o Senato.
+DoveVannoINostriSoldi è un progetto civico indipendente. Non è un sito ufficiale dello Stato italiano, di ANAC, RGS, Banca d'Italia, AgID, Camera o Senato.
 
 I dati restano attribuiti alle rispettive fonti e vengono riutilizzati nel rispetto delle licenze, delle condizioni applicabili e della normativa sulla protezione dei dati personali.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,6 @@ The MIT license in `LICENSE` applies to the project code. Embedded or linked dat
 - **Publisher:** Istituto Nazionale di Statistica (ISTAT);
 - **Source:** https://www.istat.it/storage/cartografia/confini_amministrativi/generalizzati/2026/Limiti01012026_g.zip;
 - **License:** Creative Commons Attribution 4.0 International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/;
-- **Changes:** regional geometries were simplified and projected to static SVG paths by Trasparenza Italia; names and ISTAT region codes were preserved.
+- **Changes:** regional geometries were simplified and projected to static SVG paths by DoveVannoINostriSoldi; names and ISTAT region codes were preserved.
 
-Attribution: `© Istituto Nazionale di Statistica (ISTAT), 2026 — CC BY 4.0. Adapted by Trasparenza Italia.`
+Attribution: `© Istituto Nazionale di Statistica (ISTAT), 2026 — CC BY 4.0. Adapted by DoveVannoINostriSoldi.`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Obiettivo
 
-Trasparenza Italia deve poter rispondere a una domanda semplice — “dove sono andati questi soldi?” — senza perdere la complessità contabile necessaria a dare una risposta corretta.
+DoveVannoINostriSoldi deve poter rispondere a una domanda semplice — “dove sono andati questi soldi?” — senza perdere la complessità contabile necessaria a dare una risposta corretta.
 
 Per questo l'architettura è pensata in livelli separati.
 

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -68,7 +68,7 @@ Strategia:
 8. non fare OCR di PDF se esiste un formato strutturato;
 9. pubblicare un indice di copertura separato dalla spesa.
 
-ANAC TrasparenzAI dimostra che il monitoraggio automatico della struttura di Amministrazione Trasparente è tecnicamente applicabile su scala IPA. Trasparenza Italia non deve duplicare il giudizio di conformità ANAC: deve usare la stessa idea di discovery per aggregare i dati effettivamente pubblicati.
+ANAC TrasparenzAI dimostra che il monitoraggio automatico della struttura di Amministrazione Trasparente è tecnicamente applicabile su scala IPA. DoveVannoINostriSoldi non deve duplicare il giudizio di conformità ANAC: deve usare la stessa idea di discovery per aggregare i dati effettivamente pubblicati.
 
 ## Tier 3 — investimenti
 

--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -1,6 +1,6 @@
 # Freshness, refresh e observability delle fonti
 
-Trasparenza Italia non usa la parola **live** come sinonimo di polling continuo. Il dato può essere aggiornato soltanto quando la fonte ufficiale pubblica nuova informazione.
+DoveVannoINostriSoldi non usa la parola **live** come sinonimo di polling continuo. Il dato può essere aggiornato soltanto quando la fonte ufficiale pubblica nuova informazione.
 
 L'obiettivo operativo è diverso: **rilevare ogni nuovo rilascio ufficiale il prima possibile, conservarne la provenienza e non servire dati inventati quando l'upstream ha problemi**.
 
@@ -90,7 +90,7 @@ La cadenza dichiarata dalla fonte resta bimestrale prevista. `/api/fonti/stato` 
 
 ## Policy iniziali
 
-| Fonte | Cadenza sorgente | Discovery Trasparenza Italia | Dati |
+| Fonte | Cadenza sorgente | Discovery DoveVannoINostriSoldi | Dati |
 | --- | --- | ---: | ---: |
 | IPA Enti | giornaliera | 1 h | 1 h |
 | OpenBDAP · Pagamenti Stato | mensile per mese contabile | 2 h | 6 h |

--- a/docs/ISTAT_REGIONAL_MAP.md
+++ b/docs/ISTAT_REGIONAL_MAP.md
@@ -28,4 +28,4 @@ Il colore rappresenta i **pagamenti di cassa dei Comuni per abitante della popol
 
 Attribuzione mostrata nell'interfaccia:
 
-> Confini amministrativi a fini statistici: ISTAT, 1 gennaio 2026, CC BY 4.0; geometria semplificata da Trasparenza Italia.
+> Confini amministrativi a fini statistici: ISTAT, 1 gennaio 2026, CC BY 4.0; geometria semplificata da DoveVannoINostriSoldi.

--- a/docs/LEGAL_AND_ETHICS.md
+++ b/docs/LEGAL_AND_ETHICS.md
@@ -1,6 +1,6 @@
 # Principi legali ed etici
 
-Trasparenza Italia nasce per aumentare l'accessibilità di dati già pubblici, non per trasformare un database in un tribunale automatico.
+DoveVannoINostriSoldi nasce per aumentare l'accessibilità di dati già pubblici, non per trasformare un database in un tribunale automatico.
 
 ## Dati pubblici non significa “qualsiasi riuso senza contesto”
 
@@ -62,4 +62,4 @@ Il primo è una misura verificabile; il secondo attribuisce un comportamento che
 
 ## Enforcement
 
-Revoche, sanzioni, responsabilità disciplinari, erariali o penali competono alle autorità e ai procedimenti previsti dalla legge. Trasparenza Italia può rendere più semplice trovare e verificare i fatti pubblici, non sostituire il due process.
+Revoche, sanzioni, responsabilità disciplinari, erariali o penali competono alle autorità e ai procedimenti previsti dalla legge. DoveVannoINostriSoldi può rendere più semplice trovare e verificare i fatti pubblici, non sostituire il due process.

--- a/docs/SIOPE_MUNICIPAL.md
+++ b/docs/SIOPE_MUNICIPAL.md
@@ -1,6 +1,6 @@
 # SIOPE · pagamenti di cassa dei Comuni
 
-Trasparenza Italia usa la fonte primaria `siope.it` per il primo dataset territoriale operativo. OpenBDAP resta una fonte RGS importante per altri domini, ma non è il trasporto usato da questa pipeline.
+DoveVannoINostriSoldi usa la fonte primaria `siope.it` per il primo dataset territoriale operativo. OpenBDAP resta una fonte RGS importante per altri domini, ma non è il trasporto usato da questa pipeline.
 
 ## Perimetro del primo adapter
 
@@ -24,7 +24,7 @@ La pipeline usa tre file ufficiali:
 2. `SIOPE_ANAGRAFICHE.zip` — anagrafiche degli enti SIOPE;
 3. `amministrazioni.txt` di Indice PA — join del codice fiscale dell'ente alla regione della sede amministrativa.
 
-Il file annuale SIOPE contiene movimenti mensili puri. Non è una successione di snapshot cumulativi: per questo il grafico mensile non calcola differenze tra rilasci. Il cumulato visualizzato da Trasparenza Italia è semplicemente la somma progressiva dei flussi mensili.
+Il file annuale SIOPE contiene movimenti mensili puri. Non è una successione di snapshot cumulativi: per questo il grafico mensile non calcola differenze tra rilasci. Il cumulato visualizzato da DoveVannoINostriSoldi è semplicemente la somma progressiva dei flussi mensili.
 
 Gli importi SIOPE sono elaborati come interi in centesimi e convertiti in euro soltanto nello snapshot finale. In questo modo l'ETL evita errori di somma dovuti a floating point durante le aggregazioni.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "trasparenzaitalia",
+  "name": "dove-vanno-i-nostri-soldi",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "trasparenzaitalia",
+      "name": "dove-vanno-i-nostri-soldi",
       "version": "0.2.0",
       "dependencies": {
         "@hugeicons/core-free-icons": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "trasparenzaitalia",
+  "name": "dove-vanno-i-nostri-soldi",
   "version": "0.2.0",
   "private": true,
   "type": "module",
-  "description": "Dashboard civica open source sui dati della spesa pubblica italiana.",
+  "description": "Dati pubblici italiani spiegati in modo semplice, verificabile e open source.",
   "engines": {
     "node": ">=22.13.0"
   },

--- a/scripts/etl/mef_participations_snapshot.py
+++ b/scripts/etl/mef_participations_snapshot.py
@@ -56,7 +56,7 @@ def tax_code(value: str | None) -> str:
 def fetch_bytes(url: str) -> bytes:
     request = urllib.request.Request(
         url,
-        headers={"User-Agent": "TrasparenzaItalia/0.6 (+https://github.com/metaforismo/trasparenzaitalia)"},
+        headers={"User-Agent": "DoveVannoINostriSoldi/0.6 (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)"},
     )
     with urllib.request.urlopen(request, timeout=60) as response:
         return response.read()

--- a/scripts/etl/opencoesione_snapshot.py
+++ b/scripts/etl/opencoesione_snapshot.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse
 ENDPOINT = "https://opencoesione.gov.it/it/api/aggregati/"
 DEFAULT_OUTPUT = Path("src/data/generated/opencoesione-overview.json")
 OFFICIAL_HOSTS = {"opencoesione.gov.it", "www.opencoesione.gov.it"}
-USER_AGENT = "TrasparenzaItalia-ETL/1.0 (+https://github.com/metaforismo/trasparenzaitalia)"
+USER_AGENT = "DoveVannoINostriSoldi-ETL/1.0 (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)"
 TRANSIENT_HTTP = {403, 408, 425, 429, 500, 502, 503, 504}
 MONEY_TOLERANCE_CENTS = 200
 MAX_SAFE_INTEGER = 9_007_199_254_740_991

--- a/scripts/etl/siope_municipal_snapshot.py
+++ b/scripts/etl/siope_municipal_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build the small SIOPE snapshot consumed by Trasparenza Italia.
+"""Build the small SIOPE snapshot consumed by DoveVannoINostriSoldi.
 
 The public SIOPE source publishes one national ZIP per year with *pure monthly*
 cash movements. Downloading and parsing that file during a web request would be
@@ -39,7 +39,7 @@ IPA_ADMINISTRATIONS_URL = (
     "resource/3ed63523-ff9c-41f6-a6fe-980f3d9e501f/download/amministrazioni.txt"
 )
 DEFAULT_OUTPUT = Path("src/data/generated/siope-municipal.json")
-USER_AGENT = "TrasparenzaItalia-ETL/1.0 (+https://github.com/metaforismo/trasparenzaitalia)"
+USER_AGENT = "DoveVannoINostriSoldi-ETL/1.0 (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)"
 CHUNK_SIZE = 1 << 20
 MAX_ATTEMPTS = 3
 

--- a/src/app/api/fonti/bdap/route.ts
+++ b/src/app/api/fonti/bdap/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
     const response = await fetch(BDAP_PACKAGE_LIST, {
       headers: {
         Accept: "application/json",
-        "User-Agent": "TrasparenzaItalia/0.1 (+https://github.com/metaforismo/trasparenzaitalia)",
+        "User-Agent": "DoveVannoINostriSoldi/0.1 (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)",
       },
       next: { revalidate: 3600 },
       signal: AbortSignal.timeout(8000),

--- a/src/app/api/spese/stato/route.ts
+++ b/src/app/api/spese/stato/route.ts
@@ -14,7 +14,7 @@ export async function GET() {
           owner: "Ragioneria Generale dello Stato",
           platform: "OpenBDAP",
           cadence: "rilasci periodici per mese contabile",
-          normalization: "Trasparenza Italia",
+          normalization: "DoveVannoINostriSoldi",
         },
         ...snapshot,
       },

--- a/src/app/controlli/controlli.module.css
+++ b/src/app/controlli/controlli.module.css
@@ -1,0 +1,102 @@
+.page {
+  width: min(1280px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 44px 0 80px;
+}
+
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(260px, .6fr);
+  gap: 64px;
+  align-items: end;
+  padding-bottom: 36px;
+  border-bottom: 1px solid var(--line);
+}
+.intro h1 { max-width: 780px; margin: 0; font-size: clamp(42px, 6vw, 72px); line-height: .98; letter-spacing: -.04em; font-weight: 620; }
+.intro p { max-width: 68ch; margin: 22px 0 0; color: var(--muted); font-size: 17px; line-height: 1.65; }
+.intro aside { padding: 18px 0; border-top: 1px solid var(--line-strong); border-bottom: 1px solid var(--line); }
+.intro aside strong, .intro aside span { display: block; }
+.intro aside strong { font-size: 13px; }
+.intro aside span { margin-top: 7px; color: var(--muted); font-size: 12px; line-height: 1.5; }
+
+.readingRule { display: grid; grid-template-columns: .55fr 1.15fr 1fr; gap: 28px; align-items: center; padding: 20px 0; border-bottom: 1px solid var(--line); }
+.readingRule strong { font-size: 13px; }
+.readingRule p { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.55; }
+.readingRule > div { display: flex; flex-wrap: wrap; gap: 8px 14px; justify-content: flex-end; }
+.readingRule span { display: inline-flex; align-items: center; gap: 7px; color: #bdcbd2; font-size: 11px; }
+.readingRule span::before { content: ""; width: 8px; height: 8px; border-radius: 2px; background: var(--tone); }
+
+.page [data-tone="observed"] { --tone: #64b5db; --tone-soft: rgba(100,181,219,.1); }
+.page [data-tone="attention"] { --tone: #e5ae5d; --tone-soft: rgba(229,174,93,.1); }
+.page [data-tone="policy"] { --tone: #a78bda; --tone-soft: rgba(167,139,218,.1); }
+.page [data-tone="stock"] { --tone: #d77f7f; --tone-soft: rgba(215,127,127,.1); }
+
+.procurement, .scenarios { margin-top: 24px; padding: 30px; border-radius: 14px; background: #091d2e; }
+.procurement > header, .scenarios > header { display: flex; justify-content: space-between; gap: 32px; align-items: flex-start; }
+.procurement h2, .signals h2, .scenarios h2, .close h2 { margin: 0; font-size: clamp(25px, 3vw, 34px); letter-spacing: -.03em; font-weight: 610; }
+.procurement header p, .signals header p, .scenarios header p { max-width: 70ch; margin: 9px 0 0; color: var(--muted); font-size: 13px; line-height: 1.6; }
+.procurement a, .scenarios a, .close a { color: #8bc9e5; font-size: 12px; white-space: nowrap; }
+.comparisonRows { display: grid; grid-template-columns: 1fr 1fr; gap: 34px; margin-top: 34px; }
+.comparisonRows span { display: flex; align-items: baseline; gap: 8px; color: #b6c6ce; font-size: 13px; }
+.comparisonRows span strong { color: #f7fafb; font-size: 28px; font-variant-numeric: tabular-nums; }
+.comparisonRows > div > div { height: 14px; margin-top: 12px; overflow: hidden; border-radius: 3px; background: rgba(255,255,255,.07); }
+.comparisonRows i { display: block; height: 100%; background: #e5ae5d; }
+.comparisonRows > div:last-child i { background: #64b5db; }
+.comparisonRows p { margin: 8px 0 0; color: var(--muted); font-size: 12px; }
+.procurement footer { margin-top: 26px; padding-top: 18px; border-top: 1px solid var(--line); color: #d6bd92; font-size: 12px; line-height: 1.55; }
+
+.signals { margin-top: 64px; }
+.signals > header { display: flex; justify-content: space-between; align-items: end; gap: 24px; padding-bottom: 18px; border-bottom: 1px solid var(--line); }
+.signals > div { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.signals article { min-width: 0; padding: 28px 28px 26px 0; border-bottom: 1px solid var(--line); }
+.signals article:nth-child(3n + 2), .signals article:nth-child(3n + 3) { padding-left: 28px; border-left: 1px solid var(--line); }
+.signals article > div { display: flex; justify-content: space-between; gap: 12px; color: var(--tone); font-size: 11px; font-weight: 700; }
+.signals article small { color: var(--muted); font-weight: 500; }
+.signals article > strong { display: block; margin-top: 22px; color: var(--tone); font-size: clamp(34px, 4vw, 48px); letter-spacing: -.035em; font-variant-numeric: tabular-nums; }
+.signals h3 { margin: 12px 0 0; font-size: 15px; }
+.signals article > p { min-height: 60px; margin: 10px 0 0; color: var(--muted); font-size: 12px; line-height: 1.55; }
+.signals article aside { margin-top: 16px; padding: 12px; border-radius: 8px; color: #ccd7dc; background: var(--tone-soft); font-size: 11px; line-height: 1.5; }
+.signals article a { display: inline-flex; gap: 8px; margin-top: 16px; color: #b9ced8; font-size: 11px; text-decoration: underline; text-underline-offset: 3px; }
+
+.scenarios { margin-top: 64px; background: #101a2e; }
+.scenarioBars { margin-top: 32px; }
+.scenarioBars > div { display: grid; grid-template-columns: 90px minmax(120px, 1fr) 140px; gap: 18px; align-items: center; padding: 12px 0; border-top: 1px solid rgba(255,255,255,.08); }
+.scenarioBars span { font-size: 12px; }
+.scenarioBars > div > div { height: 18px; overflow: hidden; border-radius: 3px; background: rgba(255,255,255,.07); }
+.scenarioBars i { display: block; height: 100%; background: #a78bda; }
+.scenarioBars strong { text-align: right; font-size: 13px; font-variant-numeric: tabular-nums; }
+.centralBreakdown { display: grid; grid-template-columns: 1.2fr repeat(2, 1fr); margin-top: 28px; border-top: 1px solid rgba(255,255,255,.1); }
+.centralBreakdown h3 { grid-row: span 2; margin: 0; padding: 22px 26px 22px 0; font-size: 16px; line-height: 1.45; }
+.centralBreakdown > div { display: flex; justify-content: space-between; gap: 20px; padding: 18px; border-left: 1px solid rgba(255,255,255,.08); border-bottom: 1px solid rgba(255,255,255,.08); }
+.centralBreakdown span { color: #bac7cf; font-size: 11px; line-height: 1.4; }
+.centralBreakdown strong { color: var(--tone); font-size: 12px; white-space: nowrap; }
+
+.close { max-width: 820px; margin: 84px 0 0 auto; padding-top: 26px; border-top: 1px solid var(--line-strong); }
+.close p { max-width: 68ch; margin: 14px 0 20px; color: var(--muted); line-height: 1.65; }
+
+@media (max-width: 900px) {
+  .intro { grid-template-columns: 1fr; gap: 28px; }
+  .readingRule { grid-template-columns: 1fr; gap: 10px; }
+  .readingRule > div { justify-content: flex-start; }
+  .signals > div { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .signals article:nth-child(3n + 2), .signals article:nth-child(3n + 3) { padding-left: 0; border-left: 0; }
+  .signals article:nth-child(even) { padding-left: 24px; border-left: 1px solid var(--line); }
+  .centralBreakdown { grid-template-columns: 1fr 1fr; }
+  .centralBreakdown h3 { grid-column: 1 / -1; grid-row: auto; padding-right: 0; }
+}
+
+@media (max-width: 620px) {
+  .page { width: min(100% - 28px, 1280px); padding-top: 30px; }
+  .intro h1 { font-size: 42px; }
+  .procurement, .scenarios { padding: 22px 18px; }
+  .procurement > header, .scenarios > header { display: block; }
+  .procurement a, .scenarios a { display: inline-flex; margin-top: 14px; }
+  .comparisonRows { grid-template-columns: 1fr; gap: 24px; }
+  .signals > div { display: block; }
+  .signals article, .signals article:nth-child(even) { padding: 24px 0; border-left: 0; }
+  .signals article > p { min-height: 0; }
+  .scenarioBars > div { grid-template-columns: 74px 1fr; }
+  .scenarioBars strong { grid-column: 2; text-align: left; }
+  .centralBreakdown { display: block; }
+  .centralBreakdown > div { padding-right: 0; padding-left: 0; border-left: 0; }
+}

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  auditReviewedAt,
+  auditScenarios,
+  auditSignals,
+  centralScenarioBreakdown,
+  procurementComparison,
+  type AuditSignal,
+} from "@/lib/audit-data";
+import styles from "./controlli.module.css";
+
+export const metadata: Metadata = {
+  title: "Cosa controllare",
+  description: "Numeri e aree della spesa pubblica che meritano verifiche più approfondite, senza trasformare segnali in accuse.",
+};
+
+const number = new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 });
+
+function formatSignal(signal: AuditSignal) {
+  if (signal.unit === "percent") return `${number.format(signal.value)}%`;
+  if (signal.unit === "billion-euro") return `${number.format(signal.value)} mld €`;
+  if (signal.unit === "million-euro") return `${number.format(signal.value)} mln €`;
+  return number.format(signal.value);
+}
+
+function date(value: string) {
+  return new Intl.DateTimeFormat("it-IT", { day: "numeric", month: "long", year: "numeric" })
+    .format(new Date(`${value}T00:00:00Z`));
+}
+
+export default function ControlsPage() {
+  const maxScenario = Math.max(...auditScenarios.map((scenario) => scenario.annualBillion));
+  const centralTotal = centralScenarioBreakdown.reduce((sum, item) => sum + item.value, 0);
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.intro}>
+        <div>
+          <h1>Dove vale la pena guardare meglio</h1>
+          <p>
+            Questi numeri aiutano a scegliere dove fare controlli più approfonditi.
+            Non sono una classifica degli sprechi e non dimostrano illeciti.
+          </p>
+        </div>
+        <aside>
+          <strong>Dossier verificato il {date(auditReviewedAt)}</strong>
+          <span>Dati con date diverse: ogni riquadro mostra il proprio periodo.</span>
+        </aside>
+      </header>
+
+      <section className={styles.readingRule} aria-label="Come leggere questa pagina">
+        <strong>La regola più importante</strong>
+        <p>Flussi, stock, costi di una misura e scenari non si sommano. Colori e parole li tengono separati.</p>
+        <div>
+          <span data-tone="observed">Dato osservato</span>
+          <span data-tone="attention">Da controllare</span>
+          <span data-tone="policy">Scelta di policy</span>
+          <span data-tone="stock">Stock accumulato</span>
+        </div>
+      </section>
+
+      <section className={styles.procurement} aria-labelledby="procurement-title">
+        <header>
+          <div>
+            <h2 id="procurement-title">Appalti: tanti affidamenti, una quota di valore più piccola</h2>
+            <p>Sopra 40.000 euro, affidamenti diretti e negoziate senza bando pesano in modo molto diverso per numero e per valore.</p>
+          </div>
+          <a href="https://www.anticorruzione.it/" target="_blank" rel="noreferrer">Fonte ANAC ↗</a>
+        </header>
+        <div className={styles.comparisonRows}>
+          <div>
+            <span><strong>{number.format(procurementComparison.byNumber)}%</strong> delle procedure</span>
+            <div aria-hidden="true"><i style={{ width: `${procurementComparison.byNumber}%` }} /></div>
+            <p>Misura quante procedure usano queste modalità.</p>
+          </div>
+          <div>
+            <span><strong>{number.format(procurementComparison.byValue)}%</strong> del valore</span>
+            <div aria-hidden="true"><i style={{ width: `${procurementComparison.byValue}%` }} /></div>
+            <p>Circa {number.format(procurementComparison.exposedValueBillion)} miliardi su {number.format(procurementComparison.totalValueBillion)}.</p>
+          </div>
+        </div>
+        <footer>Minore confronto competitivo significa più bisogno di confrontare prezzi, motivazioni e rotazione. Non significa automaticamente corruzione.</footer>
+      </section>
+
+      <section className={styles.signals} aria-labelledby="signals-title">
+        <header>
+          <h2 id="signals-title">Sei numeri, sei significati diversi</h2>
+          <p>Apri la fonte per controllare il perimetro originale.</p>
+        </header>
+        <div>
+          {auditSignals.map((signal) => (
+            <article key={signal.id} data-tone={signal.tone}>
+              <div><span>{signal.area}</span><small>{signal.referenceDate}</small></div>
+              <strong>{formatSignal(signal)}</strong>
+              <h3>{signal.label}</h3>
+              <p>{signal.plainMeaning}</p>
+              <aside>{signal.caveat}</aside>
+              <a href={signal.source.url} target="_blank" rel="noreferrer">
+                {signal.source.institution}: apri la fonte <span>↗</span>
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.scenarios} aria-labelledby="scenarios-title">
+        <header>
+          <div>
+            <h2 id="scenarios-title">Tre ipotesi di miglioramento annuale</h2>
+            <p>Sono esercizi di policy basati su percentuali dichiarate. Non sono soldi già recuperati né previsioni.</p>
+          </div>
+          <Link href="/metodologia">Come leggiamo gli scenari <span>→</span></Link>
+        </header>
+        <div className={styles.scenarioBars}>
+          {auditScenarios.map((scenario) => (
+            <div key={scenario.id}>
+              <span>{scenario.label}</span>
+              <div aria-hidden="true"><i style={{ width: `${(scenario.annualBillion / maxScenario) * 100}%` }} /></div>
+              <strong>{number.format(scenario.annualBillion)} mld €/anno</strong>
+            </div>
+          ))}
+        </div>
+        <div className={styles.centralBreakdown}>
+          <h3>Da cosa nasce lo scenario centrale di {number.format(centralTotal)} miliardi</h3>
+          {centralScenarioBreakdown.map((item) => (
+            <div key={item.label} data-tone={item.tone}>
+              <span>{item.label}</span><strong>{number.format(item.value)} mld €</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.close}>
+        <h2>Un segnale serve ad aprire una verifica, non a chiuderla.</h2>
+        <p>Prima di giudicare un ente bisogna conoscere quantità, servizio, periodo, regole applicabili e fonte originale.</p>
+        <Link href="/fonti">Vai alle fonti ufficiali <span>→</span></Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/enti/[codice]/page.tsx
+++ b/src/app/enti/[codice]/page.tsx
@@ -41,14 +41,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   try {
     const entity = await getIpaEntityByCode(decodeURIComponent(codice));
-    if (!entity) return { title: "Ente non trovato · Trasparenza Italia" };
+    if (!entity) return { title: "Ente non trovato" };
 
     return {
-      title: `${entity.denominazione} · Trasparenza Italia`,
+      title: entity.denominazione,
       description: `Scheda pubblica dell'ente ${entity.denominazione}, Codice IPA ${entity.codiceIpa}.`,
     };
   } catch {
-    return { title: "Ente · Trasparenza Italia" };
+    return { title: "Ente" };
   }
 }
 
@@ -320,7 +320,7 @@ export default async function EntityPage({ params }: PageProps) {
 
           <section className={styles.section}>
             <div className={styles.sectionHeading}>
-              <h2>API Trasparenza Italia</h2>
+              <h2>API DoveVannoINostriSoldi</h2>
               <span>json</span>
             </div>
             <div className={styles.provenanceRow}>

--- a/src/app/enti/page.tsx
+++ b/src/app/enti/page.tsx
@@ -164,7 +164,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
       </nav>
 
       <section className={styles.searchSection} aria-labelledby="ricerca-enti">
-        <span className={styles.kicker}>CERCA NEL DATASTORE UFFICIALE</span>
+          <span className={styles.kicker}>CERCA NEL REGISTRO UFFICIALE</span>
         <form className={styles.searchForm} action="/enti" method="get">
           <label className={styles.visuallyHidden} htmlFor="q">Cerca un ente</label>
           <input
@@ -179,21 +179,21 @@ export default async function EntiPage({ searchParams }: PageProps) {
           <button className={styles.searchButton} type="submit">Cerca ente</button>
         </form>
         <p className={styles.searchHelp} id="ricerca-enti">
-          Ricerca full-text direttamente sul datastore IPA. I risultati non sono una copia dimostrativa:
-          vengono letti dalla Data API AgID e normalizzati dal server.
+          La ricerca legge direttamente il registro IPA di AgID. Non usiamo nomi dimostrativi
+          o un elenco scritto a mano.
         </p>
       </section>
 
       <section className={styles.registrySnapshot} aria-labelledby="snapshot-registro">
         <div className={styles.snapshotSummary}>
-          <span className={styles.kicker}>SNAPSHOT DEL REGISTRO</span>
+            <span className={styles.kicker}>REGISTRO IN NUMERI</span>
           <div className={styles.snapshotNumber}>
             <strong>{stats ? numberFormatter.format(stats.total) : "—"}</strong>
             <span>record presenti nel dataset Enti</span>
           </div>
           <p>
-            È il perimetro anagrafico da cui partiremo per collegare le fonti economiche. Il numero
-            descrive i record IPA, non il numero di sole amministrazioni centrali né la spesa pubblica.
+            Questo è il numero di record presenti nel registro IPA. Non indica il numero dei soli
+            ministeri e non misura la spesa pubblica.
           </p>
           <dl className={styles.snapshotMeta}>
             <div>
@@ -201,7 +201,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
               <dd>{formatObservedAt(stats?.observedAt ?? distributionObservedAt)}</dd>
             </div>
             <div>
-              <dt>Dati economici simulati</dt>
+              <dt>Valori dimostrativi</dt>
               <dd>nessuno</dd>
             </div>
           </dl>

--- a/src/app/fonti/page.tsx
+++ b/src/app/fonti/page.tsx
@@ -4,38 +4,37 @@ import { publicSources, sourceCounts } from "@/lib/sources";
 
 export const metadata: Metadata = {
   title: "Fonti",
-  description: "Registro delle fonti ufficiali mappate da Trasparenza Italia.",
+  description: "Da dove arrivano i dati, quanto spesso cambiano e quali fonti sono già collegate.",
 };
 
 const statusLabel = {
-  attiva: "Connettore attivo",
-  integrazione: "In integrazione",
-  mappata: "Mappata",
+  attiva: "Collegata",
+  integrazione: "Ci stiamo lavorando",
+  mappata: "Individuata",
 };
 
 export default function SourcesPage() {
   return (
     <main className="subpage">
       <header className="page-intro">
-        <h1>Registro delle fonti</h1>
+        <h1>Da dove arrivano i dati</h1>
         <p>
-          Questa pagina è il contratto di Trasparenza Italia con chi consulta i dati:
-          per ogni sorgente dichiariamo proprietario, copertura, formato, frequenza e stato
-          dell&apos;integrazione.
+          Qui trovi chi pubblica ogni dato, che cosa contiene, quanto spesso cambia
+          e se è già collegato alla dashboard.
         </p>
         <div className="hero-actions" style={{ justifyContent: "flex-start" }}>
           <Link href="/fonti/stato" className="button button-primary">
-            Stato live delle fonti
+            Le fonti funzionano?
           </Link>
           <Link href="/metodologia" className="button button-secondary">
-            Metodologia
+            Come leggiamo i dati
           </Link>
         </div>
         <dl className="source-counts" aria-label="Copertura del registro">
           <div><dt>Totale</dt><dd>{sourceCounts.total}</dd></div>
-          <div><dt>Connettori attivi</dt><dd>{sourceCounts.active}</dd></div>
-          <div><dt>In integrazione</dt><dd>{sourceCounts.integrating}</dd></div>
-          <div><dt>Censite</dt><dd>{sourceCounts.mapped}</dd></div>
+          <div><dt>Fonti collegate</dt><dd>{sourceCounts.active}</dd></div>
+          <div><dt>In lavorazione</dt><dd>{sourceCounts.integrating}</dd></div>
+          <div><dt>Da collegare</dt><dd>{sourceCounts.mapped}</dd></div>
         </dl>
       </header>
 
@@ -61,11 +60,11 @@ export default function SourcesPage() {
       </section>
 
       <section className="notice">
-        <strong>“Live” significa aggiornato alla fonte.</strong>
+        <strong>“Aggiornato” significa: aggiornato quanto la fonte.</strong>
         <p>
-          Se una fonte ufficiale pubblica dati mensilmente, la dashboard non li presenterà
-          come dati del minuto. Mostrerà invece l&apos;ultima osservazione disponibile, quando è
-          stata acquisita e quando ci si aspetta il prossimo aggiornamento.
+          Se una fonte pubblica nuovi dati una volta al mese, non li chiamiamo dati in tempo reale.
+          Mostriamo l&apos;ultimo periodo disponibile, quando lo abbiamo controllato e quando è atteso
+          il prossimo aggiornamento.
         </p>
       </section>
     </main>

--- a/src/app/fonti/stato/page.tsx
+++ b/src/app/fonti/stato/page.tsx
@@ -8,7 +8,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Stato delle fonti",
   description:
-    "Stato operativo, freschezza e policy di aggiornamento delle fonti ufficiali integrate in Trasparenza Italia.",
+    "Disponibilità e aggiornamento delle fonti ufficiali collegate a DoveVannoINostriSoldi.",
 };
 
 const numberFormatter = new Intl.NumberFormat("it-IT");
@@ -41,7 +41,7 @@ function sourceDate(value: string | null): string {
 function reachabilityLabel(source: SourceHealth): string {
   if (source.reachability === "up") return "Raggiungibile";
   if (source.reachability === "down") return "Non raggiungibile";
-  return "Non ancora sondato";
+  return "Non ancora controllato";
 }
 
 function reachabilityClass(source: SourceHealth): string {
@@ -51,9 +51,9 @@ function reachabilityClass(source: SourceHealth): string {
 }
 
 function freshnessLabel(source: SourceHealth): string {
-  if (source.freshness.state === "fresh") return "Dato fresco";
-  if (source.freshness.state === "stale") return "Dato oltre soglia";
-  return "Freschezza non classificata";
+  if (source.freshness.state === "fresh") return "Nei tempi attesi";
+  if (source.freshness.state === "stale") return "Aggiornamento atteso";
+  return "Data non valutabile";
 }
 
 function freshnessClass(source: SourceHealth): string {
@@ -80,50 +80,50 @@ export default async function SourceStatusPage() {
 
       <header className={styles.header}>
         <div>
-          <span className={styles.kicker}>OSSERVABILITÀ DELLE SORGENTI</span>
-          <h1 className={styles.title}>Quanto sono vivi i dati che stai guardando.</h1>
+          <span className={styles.kicker}>STATO DELLE FONTI</span>
+          <h1 className={styles.title}>Quando sono stati aggiornati i dati.</h1>
           <p className={styles.lead}>
-            Separiamo lo stato del nostro adapter dalla disponibilità dell&apos;upstream e dalla
-            freschezza del dato pubblicato. Una fonte raggiungibile non è necessariamente fresca;
-            una fonte temporaneamente offline non rende falso l&apos;ultimo dato già acquisito.
+            Mostriamo tre cose diverse: se abbiamo collegato la fonte, se risponde in questo
+            momento e a quando risale il dato. Un sito temporaneamente irraggiungibile non rende
+            falso l&apos;ultimo dato già acquisito.
           </p>
         </div>
 
         <div className={styles.summary} aria-label="Riepilogo stato fonti">
           <div>
             <strong>{sources.length}</strong>
-            <span>fonti con policy</span>
+            <span>fonti controllate</span>
           </div>
           <div>
             <strong>{active.length}</strong>
-            <span>adapter attivi</span>
+            <span>fonti collegate</span>
           </div>
           <div>
             <strong>{reachable.length}</strong>
-            <span>upstream raggiungibili ora</span>
+            <span>fonti raggiungibili ora</span>
           </div>
           <div>
             <strong>{unreachable.length}</strong>
-            <span>probe falliti</span>
+            <span>controlli non riusciti</span>
           </div>
         </div>
       </header>
 
       <section className={styles.explainer}>
         <div>
-          <h2>Controlliamo più spesso di quanto la fonte pubblichi.</h2>
+          <h2>Controllare spesso non rende il dato in tempo reale.</h2>
           <p>
             Se IPA aggiorna ogni giorno, possiamo ricontrollarlo ogni ora. Se un dataset è mensile,
-            ricontrollarlo più volte al giorno ci permette di rilevare rapidamente il nuovo rilascio,
-            senza chiamare “tempo reale” un dato che resta mensile.
+            controllarlo più volte al giorno ci aiuta a trovare presto il nuovo rilascio,
+            ma il dato resta mensile.
           </p>
         </div>
         <div>
-          <h2>Reachability e freshness sono due misure diverse.</h2>
+          <h2>Disponibilità e aggiornamento sono cose diverse.</h2>
           <p>
-            Il primo stato misura se l&apos;adapter riesce a interrogare la fonte. Il secondo usa,
-            quando disponibile, un timestamp pubblicato dalla fonte e lo confronta con una soglia
-            coerente con la sua cadenza. Se non abbiamo abbastanza informazioni, mostriamo “unknown”.
+            Una fonte può rispondere ma avere dati vecchi, oppure essere momentaneamente offline
+            mentre l&apos;ultimo dato acquisito è ancora valido. Se non abbiamo abbastanza informazioni,
+            lo diciamo senza inventare un semaforo.
           </p>
         </div>
       </section>
@@ -131,9 +131,9 @@ export default async function SourceStatusPage() {
       <section className={styles.table} aria-label="Stato delle fonti ufficiali">
         <div className={styles.tableHeader}>
           <span>Fonte</span>
-          <span>Integrazione</span>
-          <span>Stato upstream</span>
-          <span>Freschezza</span>
+          <span>Collegamento</span>
+          <span>Risponde ora?</span>
+          <span>Data del dato</span>
         </div>
 
         {sources.map((source) => (
@@ -147,9 +147,9 @@ export default async function SourceStatusPage() {
             </div>
 
             <div className={styles.meta}>
-              <strong>{source.integration === "active" ? "Adapter attivo" : "Mappata"}</strong>
+              <strong>{source.integration === "active" ? "Collegata" : "Individuata"}</strong>
               <span>Cadenza: {source.policy.cadence}</span>
-              <span>Discovery: {duration(source.policy.discoveryRevalidateSeconds)}</span>
+              <span>Cerchiamo nuovi dati ogni {duration(source.policy.discoveryRevalidateSeconds)}</span>
             </div>
 
             <div className={styles.health}>
@@ -161,7 +161,7 @@ export default async function SourceStatusPage() {
               </strong>
               <span>{source.detail ?? "Nessun dettaglio disponibile"}</span>
               {source.recordCount !== null && (
-                <span>{numberFormatter.format(source.recordCount)} elementi rilevati dal probe</span>
+                <span>{numberFormatter.format(source.recordCount)} elementi rilevati dal controllo</span>
               )}
             </div>
 
@@ -179,10 +179,9 @@ export default async function SourceStatusPage() {
       </section>
 
       <p className={styles.footerNote}>
-        “Non ancora sondato” non significa che il sito ufficiale sia offline. “Freschezza non classificata”
-        non significa che il dato sia vecchio. In entrambi i casi significa che Trasparenza Italia non ha
-        ancora evidenza sufficiente per attribuire automaticamente quello stato. Preferiamo un&apos;assenza di
-        misura a un semaforo inventato.
+        “Non ancora controllato” non significa che il sito ufficiale sia offline. “Data non valutabile”
+        non significa che il dato sia vecchio. Significa che non abbiamo abbastanza informazioni.
+        Preferiamo lasciare un dubbio visibile invece di inventare una certezza.
       </p>
     </main>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,7 @@
   --blue-2: #168bc7;
   --green: #6ee7a8;
   --amber: #f0c56c;
+  --violet: #a78bda;
   --red: #ff7a7a;
   --max: 1420px;
   --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", ui-sans-serif, sans-serif;
@@ -52,8 +53,8 @@ button, input { font: inherit; caret-color: var(--blue); }
 }
 .brand { display: inline-flex; align-items: center; gap: 12px; justify-self: start; }
 .brand > span:last-child { display: grid; gap: 3px; }
-.brand strong { font-size: 13px; letter-spacing: .16em; }
-.brand small { color: var(--muted); font-size: 10px; letter-spacing: .05em; }
+.brand strong { font-size: 14px; letter-spacing: -.01em; }
+.brand small { color: var(--muted); font-size: 10px; letter-spacing: .01em; }
 .brand-mark {
   width: 33px;
   height: 38px;
@@ -319,7 +320,8 @@ main { width: min(var(--max), calc(100% - 40px)); margin: 0 auto; }
   color: #668294;
 }
 .site-footer strong { color: #a7bdca; font-size: 11px; }
-.site-footer p, .footer-rule { font-size: 9px; max-width: 470px; line-height: 1.5; }
+.site-footer p, .footer-rule { font-size: 10px; max-width: 520px; line-height: 1.5; }
+.footer-rule a { color: #86bed8; text-decoration: underline; text-underline-offset: 3px; }
 .site-footer p { margin: 5px 0 0; }
 
 .subpage { padding-bottom: 100px; }
@@ -403,6 +405,7 @@ main { width: min(var(--max), calc(100% - 40px)); margin: 0 auto; }
   }
   .header-search { grid-column: 1 / -1; grid-row: 2; }
   .brand small { display: none; }
+  .brand strong { font-size: 12px; }
   .nav-row { overflow-x: auto; justify-content: flex-start; scrollbar-width: none; }
   .nav-row::-webkit-scrollbar { display: none; }
   .primary-nav { flex: 0 0 auto; }

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -81,6 +81,83 @@
   line-height: 1.4;
 }
 
+.auditCallout {
+  margin-top: 16px;
+  padding: 24px 26px;
+  border: 1px solid rgba(137, 171, 190, 0.17);
+  border-radius: 12px;
+  background: #071927;
+}
+
+.auditCallout > header h2 {
+  margin: 7px 0 0;
+  color: #eaf2f5;
+  font-size: 21px;
+  font-weight: 580;
+  letter-spacing: -0.02em;
+}
+
+.auditCallout > header p {
+  margin: 7px 0 0;
+  color: #829aa7;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.auditCallout > div {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 22px;
+  border-top: 1px solid rgba(137, 171, 190, 0.14);
+  border-bottom: 1px solid rgba(137, 171, 190, 0.14);
+}
+
+.auditCallout article {
+  min-width: 0;
+  padding: 20px 22px 20px 16px;
+  border-right: 1px solid rgba(137, 171, 190, 0.14);
+  box-shadow: inset 3px 0 0 var(--audit-tone);
+}
+
+.auditCallout article:first-child { padding-left: 16px; }
+.auditCallout article:last-child { border-right: 0; }
+.auditCallout article[data-tone="attention"] { --audit-tone: #d8a84c; }
+.auditCallout article[data-tone="observed"] { --audit-tone: #55a9d4; }
+.auditCallout article[data-tone="policy"] { --audit-tone: #9a7bd4; }
+
+.auditCallout article > strong {
+  color: var(--audit-tone);
+  font-size: clamp(27px, 3vw, 38px);
+  font-weight: 610;
+  letter-spacing: -0.035em;
+  font-variant-numeric: tabular-nums;
+}
+
+.auditCallout article h3 {
+  margin: 9px 0 0;
+  color: #e2ebef;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.auditCallout article p {
+  margin: 6px 0 0;
+  color: #8299a5;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.auditCallout > a {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 10px;
+  margin-top: 9px;
+  color: #83c4e3;
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .siopeGrid {
   width: 100%;
   max-width: 100%;
@@ -358,6 +435,9 @@
   .pulse { grid-template-columns: repeat(3, 1fr); }
   .pulse div:nth-child(3) { border-right: 0; }
   .pulse div:nth-child(n + 4) { border-top: 1px solid rgba(137, 171, 190, 0.14); }
+  .auditCallout > div { grid-template-columns: 1fr; }
+  .auditCallout article { border-right: 0; border-bottom: 1px solid rgba(137, 171, 190, 0.14); }
+  .auditCallout article:last-child { border-bottom: 0; }
 }
 
 @media (max-width: 760px) {
@@ -388,9 +468,10 @@
 }
 
 @media (max-width: 420px) {
-  .pulse { grid-template-columns: 1fr; }
-  .pulse div { border-right: 0; border-top: 1px solid rgba(137, 171, 190, 0.14); }
-  .pulse div:first-child { border-top: 0; }
+  .pulse { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .pulse div:nth-child(2n) { border-right: 0; }
+  .pulse div:nth-child(n + 3) { border-top: 1px solid rgba(137, 171, 190, 0.14); }
+  .pulse div:last-child { grid-column: 1 / -1; }
   .primaryMetric > strong { font-size: 39px; }
   .ratioBlock > div:first-child { align-items: flex-start; flex-direction: column; gap: 8px; }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,16 @@
 import type { Metadata, Viewport } from "next";
+import Link from "next/link";
 import { Navigation } from "@/components/navigation";
 import "./globals.css";
 import "./design-system.css";
 
 export const metadata: Metadata = {
   title: {
-    default: "Trasparenza Italia",
-    template: "%s · Trasparenza Italia",
+    default: "DoveVannoINostriSoldi",
+    template: "%s · DoveVannoINostriSoldi",
   },
   description:
-    "Dashboard civica open source che aggrega fonti ufficiali sulla spesa e sulla gestione delle risorse pubbliche italiane.",
+    "Dati pubblici italiani spiegati in modo semplice, con la fonte sempre a portata di mano.",
 };
 
 export const viewport: Viewport = {
@@ -31,11 +32,11 @@ export default function RootLayout({
         {children}
         <footer className="site-footer">
           <div>
-            <strong>Trasparenza Italia</strong>
-            <p>Progetto civico indipendente e open source. Non è un sito della Pubblica Amministrazione.</p>
+            <strong>DoveVannoINostriSoldi</strong>
+            <p>Progetto indipendente e open source. Non è un sito della Pubblica Amministrazione.</p>
           </div>
           <div className="footer-rule">
-            Ogni numero deve avere una fonte, una data e un percorso di verifica.
+            <Link href="/metodologia">Come leggiamo i dati</Link> · Ogni numero ha una fonte, una data e un limite dichiarato.
           </div>
         </footer>
       </body>

--- a/src/app/metodologia/page.tsx
+++ b/src/app/metodologia/page.tsx
@@ -1,28 +1,28 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Metodologia",
-  description: "Principi di provenienza, confronto e indicatori di Trasparenza Italia.",
+  title: "Come leggiamo i dati",
+  description: "Sei regole semplici per capire i numeri di DoveVannoINostriSoldi.",
 };
 
 const rules = [
-  ["01", "Nessun numero senza provenienza", "Ogni record conserva fonte ufficiale, URL, identificativo originario, timestamp di pubblicazione e di ingestione."],
-  ["02", "Contabilità comparabile", "Competenza, cassa, impegni, pagamenti e stanziamenti non vengono sommati o confrontati come se fossero la stessa grandezza."],
-  ["03", "Freschezza esplicita", "Il dato è “live” solo quanto lo è la fonte. La dashboard mostra ritardo e frequenza di aggiornamento."],
-  ["04", "Alert non significa colpa", "Gli indicatori di anomalia servono a prioritizzare verifiche. Non sono giudizi su persone, enti o fornitori."],
-  ["05", "Confronti tra pari", "Prezzi e spese vengono confrontati tra enti, territori e servizi realmente omogenei, con normalizzazioni dichiarate."],
-  ["06", "Correzioni tracciabili", "Una rettifica non cancella la storia: la pipeline conserva versione, hash e trasformazioni applicate al dato."],
+  ["01", "Mostriamo sempre la fonte", "Ogni numero porta al documento o al dataset ufficiale da cui arriva."],
+  ["02", "Non sommiamo cose diverse", "Pagamenti, costi previsti, debiti e scenari hanno significati diversi e restano separati."],
+  ["03", "Diciamo quanto è recente", "Mostriamo la data del dato, quando lo abbiamo controllato e quanto spesso cambia la fonte."],
+  ["04", "Un segnale non è una colpa", "Un valore insolito indica dove guardare meglio. Da solo non prova errori, sprechi o illeciti."],
+  ["05", "Confrontiamo casi simili", "Mettiamo a confronto enti e servizi solo quando le grandezze sono davvero confrontabili."],
+  ["06", "Le correzioni restano visibili", "Se un dato cambia, conserviamo la versione precedente e spieghiamo che cosa è stato corretto."],
 ];
 
 export default function MethodPage() {
   return (
     <main className="subpage">
       <header className="page-intro">
-        <span className="eyebrow"><span /> METODOLOGIA</span>
-        <h1>Trasparenza senza<br /><em>scorciatoie.</em></h1>
+        <span className="eyebrow"><span /> COME LEGGIAMO I DATI</span>
+        <h1>Prima capire.<br /><em>Poi confrontare.</em></h1>
         <p>
-          Rendere pubblici più dati è utile solo se si evita di produrre classifiche fuorvianti.
-          La piattaforma separa fatti, trasformazioni, indicatori e interpretazioni.
+          Un numero senza contesto può confondere. Per questo mostriamo sempre la fonte,
+          la data, il significato e ciò che quel numero non può dimostrare.
         </p>
       </header>
 
@@ -37,11 +37,11 @@ export default function MethodPage() {
       </section>
 
       <section className="notice warning-notice">
-        <strong>Persone e responsabilità.</strong>
+        <strong>Un controllo non è una condanna.</strong>
         <p>
-          Trasparenza Italia può mostrare dati già pubblici e indicatori documentabili, ma
-          non sostituisce autorità giudiziarie, ANAC, Corte dei conti o procedimenti disciplinari.
-          Nessun algoritmo attribuirà automaticamente illeciti o responsabilità personali.
+          DoveVannoINostriSoldi aiuta a trovare dati e segnali da approfondire. Non sostituisce
+          ANAC, Corte dei conti, magistratura o verifiche dell&apos;amministrazione. Nessun algoritmo
+          attribuisce automaticamente illeciti o responsabilità personali.
         </p>
       </section>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/opencoesione-snapshot";
 import { siopeMunicipalSnapshot as siope } from "@/lib/siope-snapshot";
 import { publicSources, sourceCounts } from "@/lib/sources";
+import { auditScenarios, procurementComparison } from "@/lib/audit-data";
 import styles from "./home.module.css";
 
 const integer = new Intl.NumberFormat("it-IT", { maximumFractionDigits: 0 });
@@ -72,12 +73,12 @@ const sourceRows = ["siope", "openbdap", "ipa", "opencoesione", "partecipazioni-
   .filter((source): source is NonNullable<typeof source> => Boolean(source));
 
 const analysisPaths = [
-  { href: "/spese", area: "Spesa dello Stato", detail: "Pagamenti, missioni e serie mensile", source: "RGS · OpenBDAP", status: "Dashboard attiva" },
-  { href: "/territori", area: "Territori", detail: "Pagamenti di cassa di Comuni e regioni", source: "SIOPE · IPA", status: "Dashboard attiva" },
-  { href: "/coesione", area: "Politiche di coesione", detail: "Costo, pagamenti e progetti monitorati", source: "OpenCoesione", status: "Dashboard attiva" },
-  { href: "/enti", area: "Enti pubblici", detail: "Ricerca nel registro nazionale", source: "IPA · AgID", status: "Ricerca attiva" },
-  { href: "/partecipazioni", area: "Partecipazioni pubbliche", detail: "Relazioni amministrazioni–partecipate", source: "MEF · rilevazione 2023", status: "Snapshot attivo" },
-  { href: "/fonti", area: "Contratti pubblici", detail: "CIG, procedure e aggiudicazioni", source: "ANAC · BDNCP", status: "In integrazione" },
+  { href: "/spese", area: "Stato", detail: "Quanto paga e per quali funzioni", source: "RGS · OpenBDAP", status: "Disponibile" },
+  { href: "/territori", area: "Comuni e regioni", detail: "Pagamenti e confronti tra territori", source: "SIOPE · IPA", status: "Disponibile" },
+  { href: "/coesione", area: "Fondi e progetti", detail: "Costo, pagamenti e progetti seguiti", source: "OpenCoesione", status: "Disponibile" },
+  { href: "/enti", area: "Enti pubblici", detail: "Cerca un ente nel registro nazionale", source: "IPA · AgID", status: "Disponibile" },
+  { href: "/partecipazioni", area: "Società partecipate", detail: "Chi partecipa in quali società", source: "MEF · dati 2023", status: "Disponibile" },
+  { href: "/fonti", area: "Contratti pubblici", detail: "Gare, affidamenti e aggiudicazioni", source: "ANAC · BDNCP", status: "In lavorazione" },
 ];
 
 export default function HomePage() {
@@ -85,31 +86,57 @@ export default function HomePage() {
     <main className={styles.dashboard}>
       <header className={styles.overviewHeader}>
         <div>
-          <h1>Quadro nazionale</h1>
-          <p>Dati ufficiali disponibili oggi su spesa, enti e progetti pubblici.</p>
+          <h1>Dove vanno i nostri soldi?</h1>
+          <p>Una dashboard per capire i dati pubblici italiani e risalire sempre alla fonte.</p>
         </div>
-        <Link href="/fonti/stato">Stato e frequenza delle fonti <span>→</span></Link>
+        <Link href="/fonti/stato">Quando sono aggiornati i dati <span>→</span></Link>
       </header>
 
       <section className={styles.pulse} aria-label="Copertura attuale della piattaforma">
-        <div><strong>{sourceCounts.active}</strong><span>fonti con adapter attivo</span></div>
-        <div><strong>{integer.format(siope.coverage.includedMovementRows)}</strong><span>movimenti SIOPE inclusi</span></div>
-        <div><strong>{integer.format(siope.coverage.withMovements)}</strong><span>Comuni con movimenti</span></div>
-        <div><strong>{siope.regions.length}</strong><span>regioni aggregate</span></div>
-        <div><strong>{integer.format(cohesion.totals.projects)}</strong><span>progetti OpenCoesione</span></div>
+        <div><strong>{sourceCounts.active}</strong><span>fonti collegate</span></div>
+        <div><strong>{integer.format(siope.coverage.includedMovementRows)}</strong><span>pagamenti comunali letti</span></div>
+        <div><strong>{integer.format(siope.coverage.withMovements)}</strong><span>Comuni presenti</span></div>
+        <div><strong>{siope.regions.length}</strong><span>regioni confrontabili</span></div>
+        <div><strong>{integer.format(cohesion.totals.projects)}</strong><span>progetti seguiti</span></div>
+      </section>
+
+      <section className={styles.auditCallout} aria-labelledby="audit-title">
+        <header>
+          <span className={styles.sectionLabelText}>LEGGERE BENE I NUMERI</span>
+          <h2 id="audit-title">Tre dati che raccontano cose diverse</h2>
+          <p>Una cifra grande non è automaticamente uno spreco. Il contesto cambia il significato.</p>
+        </header>
+        <div>
+          <article data-tone="attention">
+            <strong>{procurementComparison.byNumber.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%</strong>
+            <h3>Procedure con meno confronto</h3>
+            <p>Quota per numero di procedure sopra 40.000 €, non stima di corruzione.</p>
+          </article>
+          <article data-tone="observed">
+            <strong>{procurementComparison.byValue.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%</strong>
+            <h3>Quota sul valore dei contratti</h3>
+            <p>Lo stesso fenomeno pesa molto meno se misurato in euro.</p>
+          </article>
+          <article data-tone="policy">
+            <strong>{auditScenarios[1].annualBillion.toLocaleString("it-IT", { maximumFractionDigits: 1 })} mld €</strong>
+            <h3>Scenario centrale</h3>
+            <p>È un esercizio di policy con ipotesi dichiarate, non denaro già disponibile.</p>
+          </article>
+        </div>
+        <Link href="/controlli">Capire i numeri dell&apos;audit <span>→</span></Link>
       </section>
 
       <section className={styles.siopeGrid} aria-labelledby="siope-title">
         <article className={styles.primaryMetric}>
           <div className={styles.sectionLabel}>
-            <span>SIOPE · COMUNI</span>
+              <span>PAGAMENTI DEI COMUNI · SIOPE</span>
             <InfoTooltip id="cash-payments-tip" label="Che cosa sono i pagamenti di cassa?">
               Uscite effettivamente registrate in SIOPE dai Comuni. Non rappresentano tutta la spesa pubblica italiana.
             </InfoTooltip>
           </div>
-          <h2 id="siope-title">Pagamenti di cassa</h2>
+          <h2 id="siope-title">Quanto hanno pagato i Comuni</h2>
           <strong>{compactEuro(siope.totalPaid)}</strong>
-          <p>Cumulato {period}</p>
+          <p>Totale da {period}</p>
           <dl>
             <div><dt>Comuni inclusi</dt><dd>{integer.format(siope.coverage.withMovements)}</dd></div>
             <div>
@@ -121,7 +148,7 @@ export default function HomePage() {
               </dt>
               <dd>{coverageRatio.toLocaleString("it-IT", { maximumFractionDigits: 2 })}%</dd>
             </div>
-            <div><dt>File SIOPE · ultima modifica</dt><dd>{date(siope.source.siopeMovementsLastModified)}</dd></div>
+            <div><dt>Fonte aggiornata il</dt><dd>{date(siope.source.siopeMovementsLastModified)}</dd></div>
           </dl>
           <Link href="/territori">Apri il dettaglio territoriale <span>→</span></Link>
         </article>
@@ -129,22 +156,22 @@ export default function HomePage() {
         <figure className={styles.monthlyPanel}>
           <header>
             <div>
-              <span className={styles.sectionLabelText}>FLUSSO MENSILE · EURO</span>
-              <h2>Quando vengono registrati i pagamenti</h2>
+              <span className={styles.sectionLabelText}>MESE PER MESE · EURO</span>
+              <h2>Come cambia la spesa durante l&apos;anno</h2>
             </div>
             <b>SIOPE diretto</b>
           </header>
           <HomeMonthlyChart data={siope.monthly} />
-          <figcaption>Movimenti mensili, non differenze stimate. Fonte SIOPE · {period} · valore esatto nel tooltip.</figcaption>
+          <figcaption>Pagamenti registrati ogni mese. Fonte SIOPE · {period}. Passa sul grafico per il valore esatto.</figcaption>
         </figure>
       </section>
 
       <section className={styles.mapPanel} aria-labelledby="map-title">
         <header className={styles.panelHeader}>
           <div>
-            <span className={styles.sectionLabelText}>CONFRONTO TERRITORIALE · SIOPE</span>
-            <h2 id="map-title">Pagamenti comunali per regione</h2>
-            <p>Euro per abitante della popolazione coperta; seleziona una regione per il dettaglio.</p>
+            <span className={styles.sectionLabelText}>TERRITORI · SIOPE</span>
+            <h2 id="map-title">Quanto spendono i Comuni in ogni regione</h2>
+            <p>Euro per abitante. Seleziona una regione per vedere il dettaglio.</p>
           </div>
           <Link href="/territori">Tabelle e classificazioni <span>→</span></Link>
         </header>
@@ -161,22 +188,22 @@ export default function HomePage() {
         <article className={styles.cohesionPanel}>
           <header className={styles.panelHeader}>
             <div>
-              <span className={styles.sectionLabelText}>OPENCOESIONE · AGGREGATO NAZIONALE</span>
-              <h2>Investimenti e politiche di coesione</h2>
+              <span className={styles.sectionLabelText}>FONDI E PROGETTI · OPENCOESIONE</span>
+              <h2>Quanto costano e quanto è stato pagato</h2>
             </div>
             <span className={cohesionFreshnessClass}>{cohesionFreshnessLabel}</span>
           </header>
 
           <div className={styles.cohesionStats}>
-            <div><span>Costo pubblico</span><strong>{compactEuro(cohesion.totals.publicCostCents / 100)}</strong></div>
-            <div><span>Pagamenti registrati</span><strong>{compactEuro(cohesion.totals.paymentsCents / 100)}</strong></div>
-            <div><span>Progetti monitorati</span><strong>{integer.format(cohesion.totals.projects)}</strong></div>
+            <div><span>Costo previsto</span><strong>{compactEuro(cohesion.totals.publicCostCents / 100)}</strong></div>
+            <div><span>Già pagato</span><strong>{compactEuro(cohesion.totals.paymentsCents / 100)}</strong></div>
+            <div><span>Progetti seguiti</span><strong>{integer.format(cohesion.totals.projects)}</strong></div>
           </div>
 
           <div className={styles.ratioBlock}>
             <div>
               <span className={styles.inlineTerm}>
-                Pagamenti / costo pubblico
+                Pagato sul costo previsto
                 <InfoTooltip id="cohesion-ratio-tip" label="Che cosa significa questo rapporto?">
                   Rapporto finanziario aggregato. Non indica avanzamento fisico, qualità o completamento dei progetti.
                 </InfoTooltip>
@@ -184,7 +211,7 @@ export default function HomePage() {
               <strong>{cohesionRatioPercent.toLocaleString("it-IT", { maximumFractionDigits: 2 })}%</strong>
             </div>
             <div className={styles.ratioTrack} aria-hidden="true"><i style={{ width: `${Math.min(cohesionRatioPercent, 100)}%` }} /></div>
-            <p>Indicatore finanziario aggregato, non avanzamento fisico dei progetti.</p>
+            <p>Confronta euro pagati e costo previsto. Non dice quante opere sono finite.</p>
           </div>
 
           <footer>
@@ -195,9 +222,9 @@ export default function HomePage() {
 
         <aside className={styles.freshnessPanel}>
           <header>
-            <span className={styles.sectionLabelText}>FRESCHEZZA</span>
-            <h2>Quando cambia il dato</h2>
-            <p>Pubblicazione della fonte e controllo della piattaforma restano distinti.</p>
+            <span className={styles.sectionLabelText}>AGGIORNAMENTI</span>
+            <h2>Quanto sono recenti i dati</h2>
+            <p>Mostriamo sia la data della fonte sia quando l&apos;abbiamo controllata.</p>
           </header>
           <div className={styles.freshnessRows}>
             <article>
@@ -226,17 +253,17 @@ export default function HomePage() {
       <section className={styles.pathsPanel} aria-labelledby="paths-title">
         <header className={styles.panelHeader}>
           <div>
-            <span className={styles.sectionLabelText}>PERCORSI DI ANALISI</span>
-            <h2 id="paths-title">Dal quadro generale alla fonte</h2>
+              <span className={styles.sectionLabelText}>ESPLORA</span>
+              <h2 id="paths-title">Scegli da dove iniziare</h2>
           </div>
-          <Link href="/metodologia">Come normalizziamo i dati <span>→</span></Link>
+          <Link href="/metodologia">Come leggiamo i dati <span>→</span></Link>
         </header>
         <div className={styles.pathTable}>
           <div className={styles.pathHead} aria-hidden="true"><span>Area</span><span>Contenuto</span><span>Fonte</span><span>Stato</span><span /></div>
           {analysisPaths.map((item) => (
             <Link href={item.href} className={styles.pathRow} key={item.area}>
               <strong>{item.area}</strong><span>{item.detail}</span><span>{item.source}</span>
-              <b className={item.status === "In integrazione" ? styles.integrating : ""}>{item.status}</b>
+              <b className={item.status === "In lavorazione" ? styles.integrating : ""}>{item.status}</b>
               <i aria-hidden="true">→</i>
             </Link>
           ))}
@@ -245,8 +272,8 @@ export default function HomePage() {
 
       <section className={styles.sourceRegister} aria-labelledby="sources-title">
         <div>
-          <h2 id="sources-title">Fonti ufficiali, collegate all&apos;originale.</h2>
-          <p>Ogni vista espone perimetro, data e collegamento all&apos;originale.</p>
+          <h2 id="sources-title">Da dove arrivano questi numeri</h2>
+          <p>Ogni dato mostra la fonte ufficiale, la data e ciò che non può spiegare.</p>
         </div>
         <div className={styles.sourceLinks}>
           {sourceRows.map((source) => (

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -18,7 +18,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Spese dello Stato",
   description:
-    "Pagamenti del Bilancio dello Stato aggregati da fonti ufficiali RGS/OpenBDAP, con andamento nel tempo, missioni, amministrazioni, classificazione economica e provenienza.",
+    "Pagamenti del Bilancio dello Stato da RGS/OpenBDAP, spiegati con grafici, date e fonti.",
 };
 
 const exactEuro = new Intl.NumberFormat("it-IT", {
@@ -100,8 +100,8 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           <span className={styles.kicker}>RGS / OPENBDAP · PAGAMENTI DEL BILANCIO DELLO STATO</span>
           <h1 className={styles.title}>Dove va la spesa dello Stato.</h1>
           <p className={styles.lead}>
-            Uniamo i dataset ufficiali della Ragioneria Generale dello Stato per leggere lo stesso
-            dato per andamento nel tempo, missione, amministrazione e natura economica. Nessuna stima e nessun dato dimostrativo.
+            Leggiamo i dati ufficiali della Ragioneria Generale dello Stato per mostrare come cambia
+            la spesa, chi la gestisce e per quale funzione. Non usiamo stime o valori dimostrativi.
           </p>
         </div>
 
@@ -191,7 +191,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             height={500}
           />
           <p className={styles.chartCaption}>
-            Valori cumulati in euro. Ordinamento calcolato da Trasparenza Italia sul campo “Totale Pagato” del dataset RGS per Missione.
+            Valori cumulati in euro. Ordinamento calcolato da DoveVannoINostriSoldi sul campo “Totale Pagato” del dataset RGS per Missione.
           </p>
         </div>
       </section>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -8,7 +8,7 @@ import {
 import styles from "./territori.module.css";
 
 export const metadata = {
-  title: "Territori · Trasparenza Italia",
+  title: "Territori",
   description:
     "Pagamenti di cassa SIOPE dei Comuni italiani: flussi mensili, regioni, categorie e principali amministrazioni.",
 };
@@ -77,9 +77,8 @@ export default function TerritoriesPage() {
           </div>
           <h1>Dove spendono i Comuni italiani.</h1>
           <p>
-            Movimenti di cassa pubblicati dalla fonte primaria SIOPE, aggregati senza
-            trasformare il significato del dato. La vista regionale raggruppa i Comuni
-            per sede dell&apos;ente; non attribuisce la spesa al luogo fisico in cui è avvenuta.
+            Pagamenti pubblicati da SIOPE e riuniti per territorio. La vista regionale raggruppa
+            i Comuni in base alla sede dell&apos;ente: non dice necessariamente dove è avvenuta la spesa.
           </p>
         </div>
 
@@ -120,8 +119,8 @@ export default function TerritoriesPage() {
             <h2>Il ritmo dei pagamenti durante l&apos;anno</h2>
           </div>
           <p>
-            A differenza degli snapshot cumulativi del Bilancio dello Stato, questi sono
-            flussi mensili SIOPE diretti. Il cumulato è soltanto la loro somma progressiva.
+            Qui ogni barra mostra i pagamenti registrati nel singolo mese. Il totale da gennaio
+            è la somma dei mesi già disponibili.
           </p>
         </div>
         <MunicipalSpendingTrendChart data={data.monthly} />
@@ -134,8 +133,8 @@ export default function TerritoriesPage() {
             <h2>Confrontare volume e intensità</h2>
           </div>
           <p>
-            Il totale premia inevitabilmente le regioni con più abitanti e più Comuni; la
-            seconda vista normalizza sui residenti coperti per rendere il confronto più leggibile.
+            Le regioni più grandi tendono ad avere totali maggiori. Per questo mostriamo anche
+            gli euro per abitante della popolazione coperta.
           </p>
         </div>
 

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -15,13 +15,13 @@ import {
 } from "@hugeicons/core-free-icons";
 
 const primary = [
-  { href: "/", label: "Quadro", icon: Home04Icon },
-  { href: "/spese", label: "Spese", icon: ChartLineIcon },
-  { href: "/coesione", label: "Coesione", icon: Globe02Icon },
-  { href: "/enti", label: "Organizzazioni", icon: BankIcon, aliases: ["/partecipazioni"] },
+  { href: "/", label: "Home", icon: Home04Icon },
+  { href: "/spese", label: "Soldi", icon: ChartLineIcon },
   { href: "/territori", label: "Territori", icon: MapsIcon },
+  { href: "/coesione", label: "Fondi e progetti", icon: Globe02Icon },
+  { href: "/enti", label: "Enti", icon: BankIcon, aliases: ["/partecipazioni"] },
+  { href: "/controlli", label: "Cosa controllare", icon: LegalDocument01Icon },
   { href: "/fonti", label: "Fonti", icon: Database02Icon },
-  { href: "/metodologia", label: "Metodo", icon: LegalDocument01Icon },
 ];
 
 export function Navigation() {
@@ -30,15 +30,15 @@ export function Navigation() {
   return (
     <header className="site-header">
       <div className="header-inner">
-        <Link href="/" className="brand" aria-label="Trasparenza Italia, home">
+        <Link href="/" className="brand" aria-label="DoveVannoINostriSoldi, home">
           <span className="brand-mark" aria-hidden="true">
             <i />
             <i />
             <i />
           </span>
           <span>
-            <strong>TRASPARENZA ITALIA</strong>
-            <small>I dati pubblici, finalmente insieme</small>
+            <strong>DoveVannoINostriSoldi</strong>
+            <small>Dati pubblici, spiegati semplice</small>
           </span>
         </Link>
 
@@ -71,7 +71,7 @@ export function Navigation() {
             );
           })}
         </nav>
-        <span>Solo fonti ufficiali · ogni dato verificabile</span>
+        <span>Fonti, date e limiti sempre visibili</span>
       </div>
     </header>
   );

--- a/src/lib/audit-data.ts
+++ b/src/lib/audit-data.ts
@@ -1,0 +1,137 @@
+export type AuditSignal = {
+  id: string;
+  area: string;
+  value: number;
+  unit: "percent" | "billion-euro" | "million-euro" | "count";
+  label: string;
+  plainMeaning: string;
+  caveat: string;
+  referenceDate: string;
+  tone: "observed" | "attention" | "policy" | "stock";
+  source: {
+    institution: string;
+    title: string;
+    url: string;
+  };
+};
+
+export const auditReviewedAt = "2026-06-24";
+
+export const auditSignals: AuditSignal[] = [
+  {
+    id: "procurement-low-competition-value",
+    area: "Appalti",
+    value: 59.7721,
+    unit: "billion-euro",
+    label: "Contratti con confronto competitivo ridotto",
+    plainMeaning: "Nel 2025 affidamenti diretti e negoziate senza bando valgono il 19,3% dei contratti sopra 40.000 euro.",
+    caveat: "È spesa da controllare meglio, non una perdita già accertata.",
+    referenceDate: "2025",
+    tone: "attention",
+    source: {
+      institution: "ANAC",
+      title: "Relazione annuale 2026 sull'attività svolta nel 2025",
+      url: "https://www.anticorruzione.it/documents/91439/393633199/Anac%2B-%2BRelazione%2Bannuale%2B2026%2Bsu%2Battivit%C3%A0%2B2025.pdf/c2ff7d91-d715-800d-7689-15899ef650c9?t=1776760815657",
+    },
+  },
+  {
+    id: "pnrr-spending",
+    area: "PNRR",
+    value: 113.5,
+    unit: "billion-euro",
+    label: "Spesa PNRR registrata",
+    plainMeaning: "A febbraio 2026 risultava speso oltre il 58% delle risorse del Piano.",
+    caveat: "Spendere non significa automaticamente avere completato opere e servizi.",
+    referenceDate: "2026-02",
+    tone: "observed",
+    source: {
+      institution: "Corte dei conti · copia del referto",
+      title: "Relazione sullo stato di attuazione del PNRR - maggio 2026",
+      url: "https://www.corteconti.it/HOME/StampaMedia/ComunicatiStampa/DettaglioComunicati?Id=0a3d0038-093b-4197-918f-d98b87cd9158",
+    },
+  },
+  {
+    id: "pnrr-beyond-2026",
+    area: "PNRR",
+    value: 24.2,
+    unit: "billion-euro",
+    label: "Risorse previste oltre il 2026",
+    plainMeaning: "Una parte del Piano ha una coda di spesa successiva alla scadenza originaria.",
+    caveat: "È un rischio di ritardo, non denaro perso.",
+    referenceDate: "2026-02",
+    tone: "attention",
+    source: {
+      institution: "Corte dei conti",
+      title: "Relazione sullo stato di attuazione del PNRR - maggio 2026",
+      url: "https://www.corteconti.it/HOME/StampaMedia/ComunicatiStampa/DettaglioComunicati?Id=0a3d0038-093b-4197-918f-d98b87cd9158",
+    },
+  },
+  {
+    id: "tax-expenditures",
+    area: "Agevolazioni fiscali",
+    value: 108.6,
+    unit: "billion-euro",
+    label: "Effetto stimato delle agevolazioni fiscali",
+    plainMeaning: "Il rapporto MEF censisce 575 misure e stima il loro effetto finanziario per il 2025.",
+    caveat: "Sono scelte di politica fiscale: non sono tutte sprechi e non sono tutte eliminabili.",
+    referenceDate: "2025",
+    tone: "policy",
+    source: {
+      institution: "Ministero dell'Economia e delle Finanze",
+      title: "Rapporto annuale sulle spese fiscali 2024",
+      url: "https://www.mef.gov.it/export/sites/MEF/documenti-allegati/2024/RSF-2024.pdf",
+    },
+  },
+  {
+    id: "off-budget-debt",
+    area: "Comuni",
+    value: 945.749,
+    unit: "million-euro",
+    label: "Debiti fuori bilancio rilevati",
+    plainMeaning: "L'indagine riguarda 7.106 Comuni e fotografa posizioni contabili diverse nel 2023.",
+    caveat: "Circa 250,5 milioni derivano da acquisti senza un impegno contabile preventivo.",
+    referenceDate: "2023",
+    tone: "attention",
+    source: {
+      institution: "Corte dei conti",
+      title: "Gestione finanziaria degli enti locali - Del. 14/SEZAUT/2025/FRG",
+      url: "https://mirapa.it/wp-content/uploads/2025/07/delibera_14_2025_sezaut.pdf",
+    },
+  },
+  {
+    id: "collection-stock",
+    area: "Riscossione",
+    value: 1272.9,
+    unit: "billion-euro",
+    label: "Carichi affidati alla riscossione",
+    plainMeaning: "È il valore nominale accumulato dei carichi ancora presenti al 31 gennaio 2025.",
+    caveat: "Gran parte non è realisticamente recuperabile: non è un tesoretto disponibile.",
+    referenceDate: "2025-01-31",
+    tone: "stock",
+    source: {
+      institution: "Agenzia delle entrate-Riscossione",
+      title: "Audizione del Direttore - 27 marzo 2025",
+      url: "https://www.agenziaentrateriscossione.gov.it/export/.files/it/Audizione-VI-COMM.-SENATO_27-marzo-2025.pdf",
+    },
+  },
+];
+
+export const procurementComparison = {
+  byNumber: 76.2,
+  byValue: 19.3,
+  totalValueBillion: 309.7,
+  exposedValueBillion: 59.7721,
+};
+
+export const auditScenarios = [
+  { id: "prudent", label: "Prudente", annualBillion: 1.4383151 },
+  { id: "central", label: "Centrale", annualBillion: 4.11206045 },
+  { id: "ambitious", label: "Ambizioso", annualBillion: 7.0846663 },
+] as const;
+
+export const centralScenarioBreakdown = [
+  { label: "Revisione mirata delle agevolazioni fiscali", value: 3.258, tone: "policy" },
+  { label: "Più concorrenza e controlli negli appalti", value: 0.74715125, tone: "attention" },
+  { label: "Minore ricorso strutturale ai gettonisti", value: 0.0568, tone: "observed" },
+  { label: "Prevenzione di nuovi debiti fuori bilancio", value: 0.0501092, tone: "stock" },
+] as const;

--- a/src/lib/data/source-fetch.ts
+++ b/src/lib/data/source-fetch.ts
@@ -50,7 +50,7 @@ const ALLOWED_HOSTS: Readonly<Record<SourceId, readonly string[]>> = {
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const RETRY_DELAY_MS = 300;
 const USER_AGENT =
-  "TrasparenzaItalia/0.5 (+https://github.com/metaforismo/trasparenzaitalia)";
+  "DoveVannoINostriSoldi/0.5 (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)";
 
 export class SourceFetchError extends Error {
   constructor(

--- a/src/lib/data/source-policy.ts
+++ b/src/lib/data/source-policy.ts
@@ -45,7 +45,7 @@ const HOUR = 60 * 60;
 const DAY = 24 * HOUR;
 
 /**
- * Operational freshness policies for Trasparenza Italia.
+ * Operational freshness policies for DoveVannoINostriSoldi.
  *
  * `cadence` describes the publication cadence declared by the source when it
  * is known. Revalidation is intentionally more frequent than publication: it

--- a/tests/audit-data.test.mjs
+++ b/tests/audit-data.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  auditScenarios,
+  auditSignals,
+  centralScenarioBreakdown,
+  procurementComparison,
+} from "../src/lib/audit-data.ts";
+
+test("audit signals preserve source, date and interpretation limits", () => {
+  assert.ok(auditSignals.length >= 6);
+  for (const signal of auditSignals) {
+    assert.match(signal.source.url, /^https:\/\//);
+    assert.ok(signal.referenceDate.length >= 4);
+    assert.ok(signal.caveat.length > 20);
+  }
+});
+
+test("procurement comparison reconciles exposed value", () => {
+  const expected = procurementComparison.totalValueBillion * procurementComparison.byValue / 100;
+  assert.ok(Math.abs(expected - procurementComparison.exposedValueBillion) < 0.001);
+  assert.ok(procurementComparison.byNumber > procurementComparison.byValue);
+});
+
+test("central scenario equals its visible components and scenarios stay ordered", () => {
+  const central = auditScenarios.find((scenario) => scenario.id === "central");
+  assert.ok(central);
+  const components = centralScenarioBreakdown.reduce((sum, item) => sum + item.value, 0);
+  assert.ok(Math.abs(components - central.annualBillion) < 0.000001);
+  assert.deepEqual(
+    auditScenarios.map((scenario) => scenario.annualBillion),
+    [...auditScenarios].map((scenario) => scenario.annualBillion).sort((a, b) => a - b),
+  );
+});

--- a/tests/mef-participations.test.mjs
+++ b/tests/mef-participations.test.mjs
@@ -19,7 +19,7 @@ const requiredHeaders = [
 ];
 
 function runFixture(values, headers = requiredHeaders) {
-  const directory = mkdtempSync(join(tmpdir(), "trasparenzaitalia-mef-"));
+  const directory = mkdtempSync(join(tmpdir(), "dovevanno-mef-"));
   const input = join(directory, "input.csv");
   const output = join(directory, "output.json");
   writeFileSync(input, `${headers.join(";")}\n${headers.map((header) => values[header] ?? "").join(";")}\n`);


### PR DESCRIPTION
## Cosa cambia
- rinomina completa del prodotto e dei riferimenti tecnici in DoveVannoINostriSoldi
- home dashboard-first con linguaggio più semplice e gerarchia più chiara
- nuova pagina /controlli basata sul dossier 2026, con fonti, date, caveat e colori semantici
- navigazione, fonti, metodologia, spese, territori ed enti riscritti per cittadini
- README, documentazione, workflow e user-agent allineati alla nuova repository

## Regole di lettura
- nessuna cifra del dossier è presentata come live
- appalti a minore concorrenza non sono presentati come corruzione o perdita
- flussi, stock, costi di policy e scenari restano separati
- il referto enti locali collegato dal dossier è dichiarato come copia del documento della Corte dei conti

## Verifiche
- 20 test Node passati
- TypeScript pass
- ESLint zero warning
- build Next.js production pass
- Impeccable detector: nessun rilievo
- OpenCoesione e MEF offline check pass
- QA Browser 1440px e 390px: nessun overflow di pagina o nuovo errore console