### PR TITLE
Limite totale per il caricamento OpenBDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,208 +1,57 @@
 # DoveVannoINostriSoldi
 
-> **Dove vanno i soldi pubblici, fonte per fonte.**
-
 DoveVannoINostriSoldi è un progetto civico open source per capire come vengono usati i soldi pubblici italiani.
 
-Riunisce dati ufficiali oggi dispersi tra portali diversi. Da un grafico, un ente o un progetto si può arrivare alla fonte originale, vedere la data del dato e capire i suoi limiti. Non crea classifiche dello scandalo e non trasforma un segnale in un'accusa.
+Riunisce dati ufficiali che oggi si trovano in portali diversi. Ogni numero mostra la fonte, il periodo a cui si riferisce e i limiti da conoscere. Un valore insolito può indicare dove controllare meglio, ma non dimostra da solo uno spreco o un illecito.
 
-## Principio fondamentale
+## Cosa puoi consultare
 
-**Nessun numero senza fonte, data e spiegazione.**
+| Sezione | Che cosa mostra | Fonte |
+| --- | --- | --- |
+| Home | Pagamenti dei Comuni, mappa regionale, andamento mensile e dati OpenCoesione | SIOPE, IPA, OpenCoesione |
+| Spese dello Stato | Pagamenti per funzione, amministrazione e tipo di spesa | RGS, OpenBDAP |
+| Territori | Confronti tra regioni e Comuni per il 2024, 2025 e 2026 | SIOPE, IPA |
+| Enti | Ministeri, Presidenza del Consiglio, enti pubblici, uffici e contatti | IPA, AgID |
+| Partecipazioni | Società e organizzazioni partecipate dichiarate dalle amministrazioni | MEF |
+| Controlli | Dati che meritano verifiche più approfondite, con spiegazioni e fonti | ANAC, MEF, Corte dei conti e altre fonti ufficiali |
+| Fonti | Stato dei collegamenti e date di aggiornamento | Registro interno delle fonti |
 
-“Aggiornato” significa aggiornato quanto la fonte. DoveVannoINostriSoldi controlla quando arrivano nuovi dati ufficiali e mostra separatamente:
+Gli appalti ANAC, il PNRR ReGiS e altre fonti già censite non sono ancora presentati come dati correnti. Il sito lo indica chiaramente e non usa numeri dimostrativi per riempire gli spazi mancanti.
 
-- la data a cui si riferisce il dato;
-- quando la piattaforma lo ha acquisito;
-- se la fonte risponde;
-- quanto spesso la fonte pubblica nuovi dati;
-- i calcoli applicati.
+## Scegliere l'anno
 
-## Cosa vogliamo unire
-
-- pagamenti e incassi della PA tramite SIOPE / SIOPE+ e OpenBDAP;
-- bilancio e pagamenti dello Stato pubblicati dalla Ragioneria Generale dello Stato;
-- contratti pubblici, CIG, stazioni appaltanti e aggiudicazioni ANAC / BDNCP;
-- dati sui pagamenti pubblicati dalle singole amministrazioni ai sensi dell'art. 4-bis del D.Lgs. 33/2013;
-- anagrafe degli enti tramite IPA;
-- opere pubbliche, CUP, PNRR e politiche di coesione;
-- consulenze e incarichi pubblici;
-- bilanci, gare e dati economici pubblicati da Camera e Senato;
-- in seguito: sovvenzioni, partecipate, patrimonio, personale e indicatori di pagamento.
-
-Il registro pubblico è in [`src/lib/sources.ts`](src/lib/sources.ts); le policy operative di freshness sono in [`src/lib/data/source-policy.ts`](src/lib/data/source-policy.ts).
-
-## Cosa c'è già
-
-### Home dashboard-first
-
-La route `/` è direttamente il prodotto: non contiene una landing promozionale e non usa valori dimostrativi.
-
-- ricerca reale degli enti sul datastore IPA;
-- quadro SIOPE dei pagamenti di cassa dei Comuni e flusso mensile ufficiale;
-- mappa delle 20 regioni alimentata dai valori SIOPE pro capite e dai confini ISTAT 2026;
-- pagina `/controlli` con i numeri del dossier 2026, colori semantici e limiti di lettura espliciti;
-- riepilogo OpenCoesione con rapporto finanziario distinto dall'avanzamento fisico;
-- data di riferimento, pubblicazione della fonte, acquisizione e frequenza di controllo visibili;
-- percorsi diretti verso dashboard di dettaglio, metodologia e fonti originali.
-
-I tooltip sono riservati ai termini che richiedono una spiegazione contabile; freschezza e provenienza non vengono nascoste al loro interno.
-
-### Spese dello Stato
-
-`/spese` usa esclusivamente dataset ufficiali RGS/OpenBDAP e scopre automaticamente il periodo più recente disponibile.
-
-La dashboard contiene:
-
-- Totale Pagato del Bilancio dello Stato;
-- pagamenti per Missione;
-- pagamenti per Amministrazione;
-- classificazione economica;
-- canali di pagamento;
-- riconciliazione automatica dei totali tra dataset indipendenti;
-- serie cumulativa 2026;
-- flusso mensile derivato come differenza tra due snapshot cumulativi consecutivi;
-- link diretti ai CSV e package ufficiali RGS.
-
-API:
-
-- `/api/spese/stato`
-- `/api/spese/stato/storico`
-
-### Registro nazionale degli enti
-
-L'Indice PA è la prima anagrafe canonica del progetto.
-
-- ricerca full-text in `/enti`;
-- pagina canonica `/enti/[codice]` per Codice IPA;
-- API normalizzata `/api/enti` e `/api/enti/[codice]`;
-- aggregazioni reali via Data API SQL;
-- grafico della distribuzione per tipologia;
-- provenienza e licenza esposte insieme al record.
-
-Le schede ente leggono inoltre i dataset IPA **Unità Organizzative** e **Aree Organizzative Omogenee**:
-
-- relazioni UO padre-figlio solo quando dichiarate da IPA;
-- collegamenti UO → AOO tramite gli identificativi ufficiali;
-- conteggi e prime 24 unità nella scheda, fino a 500 record nell'API;
-- endpoint `/api/enti/[codice]/struttura`;
-- nessuna deduzione automatica “UO = dipartimento”.
-
-La pagina `/enti` espone anche l'indice strutturale IPA C1 di ministeri, Presidenza del Consiglio e Avvocatura.
-
-### Partecipazioni pubbliche
-
-`/partecipazioni` usa il CSV ufficiale del censimento MEF riferito al 31 dicembre 2023 e pubblicato il 10 marzo 2026.
-
-- 53.656 relazioni amministrazione–partecipata;
-- 8.360 amministrazioni dichiaranti;
-- 7.979 organizzazioni partecipate;
-- distinzione tra partecipazioni dirette e indirette;
-- segnali dichiarati di controllo analogo e affidamento diretto presentati come evidence datata, non come status legale corrente;
-- provenienza completa con URL, SHA-256, codifica rilevata e licenza;
-- endpoint `/api/partecipazioni`;
-- refresh automatico giornaliero senza commit se il rilascio ufficiale è invariato.
-
-```bash
-python3 scripts/etl/mef_participations_snapshot.py
-python3 scripts/etl/mef_participations_snapshot.py --check
-```
-
-### Politiche di coesione
-
-`/coesione` usa l’aggregato nazionale dell’API ufficiale OpenCoesione e pubblica uno snapshot verificato, senza numeri dimostrativi.
-
-La dashboard contiene:
-
-- costo pubblico, pagamenti e numero di progetti;
-- rapporto finanziario pagamenti/costo, esplicitamente distinto dall’avanzamento fisico;
-- letture interattive per tema, natura e stato con tabella accessibile equivalente;
-- serie annuale cumulativa di impegni e pagamenti;
-- data del rilascio sorgente, acquisizione, cadenza dichiarata e frequenza di controllo separate;
-- riconciliazioni ricalcolate dei totali generali e della componente coesione, con avvertenza sui progetti multilocalizzati.
-
-API e aggiornamento:
-
-- `/api/coesione`
-- `python3 scripts/etl/opencoesione_snapshot.py` per verificare e aggiornare lo snapshot;
-- `python3 scripts/etl/opencoesione_snapshot.py --check` per la validazione offline;
-- workflow schedulato ogni 6 ore, con retry limitati e commit soltanto quando cambia il payload normalizzato, esclusi i timestamp di osservazione.
-
-### Stato delle fonti
-
-`/fonti/stato` separa tre concetti che spesso vengono confusi:
-
-1. **integrazione**: esiste un adapter di DoveVannoINostriSoldi?
-2. **reachability**: l'upstream risponde?
-3. **freshness**: quanto è vecchio il dato secondo un timestamp ufficiale e una soglia coerente con la fonte?
-
-L'API corrispondente è `/api/fonti/stato`.
-
-Per una fonte ancora soltanto mappata non mostriamo un falso semaforo online/offline.
-
-## Architettura delle sorgenti
-
-Ogni nuovo adapter deve usare progressivamente il layer condiviso in `src/lib/data/`:
+La home e la pagina Territori permettono di scegliere il 2024, 2025 o 2026. La scelta resta nell'indirizzo della pagina, per esempio:
 
 ```text
-source-policy.ts   cadenza, timeout, retry, cache tag, stale threshold
-source-fetch.ts    HTTPS + host allowlist + GET/HEAD + timeout + retry transitori
-freshness.ts       classificazione fresh / stale / unknown
-source-health.ts   reachability e timestamp ufficiali
-Delimited parser   parsing riutilizzabile per CSV pubblici
+/?anno=2025
+/territori?anno=2025
 ```
 
-Il fetch layer non accetta host arbitrari, non consente write verso gli upstream e non permette agli adapter di sovrascrivere direttamente la cache policy.
+I dati SIOPE e la serie annuale OpenCoesione cambiano con l'anno scelto. Se un indicatore non esiste per quel periodo, viene mostrato come non disponibile. Non riutilizziamo un dato di un altro anno.
 
-Leggi [`docs/FRESHNESS_AND_REFRESH.md`](docs/FRESHNESS_AND_REFRESH.md).
+## Regole del progetto
 
-## Aggiornamento automatico
+- Nessun numero senza fonte e data.
+- Nessun dato inventato o dimostrativo nelle pagine pubbliche.
+- Pagamenti, costi previsti, debiti e ipotesi restano separati.
+- Un segnale non viene presentato come una colpa.
+- I confronti usano solo casi e misure compatibili.
+- Se una fonte non risponde, il problema resta visibile.
 
-La cache applicativa è segmentata per source tag. L'endpoint interno:
-
-```text
-POST /api/internal/refresh-sources
-```
-
-è disabilitato se `SOURCE_REFRESH_SECRET` non è configurato e accetta soltanto identificativi di fonti conosciute.
-
-Dopo il deployment:
-
-1. genera un secret lungo e casuale;
-2. configura `SOURCE_REFRESH_SECRET` nell'ambiente del deployment;
-3. configura lo stesso valore come repository secret GitHub `SOURCE_REFRESH_SECRET`;
-4. configura il repository secret `REFRESH_URL` con l'origin del deployment, per esempio `https://example.org`.
-
-I workflow separati fanno poi:
-
-- **Source refresh**: invalidazione source-scoped ogni ora;
-- **Source health**: probe ogni 6 ore degli adapter inclusi nel monitor applicativo; OpenCoesione è controllata dal workflow snapshot dedicato.
-- **OpenCoesione snapshot**: controllo dell’API ogni 6 ore e aggiornamento del file versionato soltanto quando cambia il payload normalizzato.
-- **MEF partecipazioni**: discovery giornaliera del CSV annuale e commit soltanto quando cambia hash, schema o trasformazione.
-
-Un outage RGS/AgID può rendere rosso il monitor delle fonti, ma **non** la CI del codice.
-
-## Stack
-
-- Next.js 16.3
-- React 19.2
-- TypeScript strict
-- Recharts per le visualizzazioni dashboard
-- CSS nativo con design tokens
-- Impeccable come design quality gate
-- Node.js 22.23.2 nel progetto/CI
-- npm lockfile committato e installazioni CI riproducibili con `npm ci`
-
-La persistenza verrà introdotta quando i volumi e le query cross-fonte la rendono necessaria. Il progetto evita di costruire un database attorno a ipotesi di join non ancora validate.
+Le regole complete sono in [docs/LEGAL_AND_ETHICS.md](docs/LEGAL_AND_ETHICS.md) e [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Avvio locale
+
+Richiede Node.js 22 o successivo.
 
 ```bash
 npm ci
 npm run dev
 ```
 
-Controlli completi:
+Apri [http://localhost:3000](http://localhost:3000).
+
+## Controlli prima di una modifica
 
 ```bash
 npm run lint
@@ -212,85 +61,54 @@ npm run design:check
 npm run build
 ```
 
-La CI richiede **zero warning ESLint**, test verdi, TypeScript verde, detector Impeccable verde e production build verde.
+La verifica automatica deve terminare senza avvisi ESLint, errori TypeScript o test falliti.
 
-Per lavorare sul design con un harness supportato da Impeccable:
+## Aggiornamento dei dati
+
+Gli script in `scripts/etl/` scaricano le fonti ufficiali, controllano il formato e producono file piccoli usati dal sito.
 
 ```bash
-npx impeccable install
+python3 scripts/etl/siope_municipal_snapshot.py --year 2025 \
+  --output src/data/generated/siope-municipal-2025.json
+python3 scripts/etl/opencoesione_snapshot.py --check
+python3 scripts/etl/mef_participations_snapshot.py --check
 ```
 
-Il contesto persistente del prodotto è in [`PRODUCT.md`](PRODUCT.md); il sistema visuale è in [`DESIGN.md`](DESIGN.md).
+Le attività automatiche controllano periodicamente la presenza di nuovi dati. Un'interruzione di una fonte esterna non viene confusa con un errore del codice.
 
-## Architettura dati
+Dettagli: [docs/FRESHNESS_AND_REFRESH.md](docs/FRESHNESS_AND_REFRESH.md).
 
-Ogni record normalizzato dovrà conservare almeno:
+## Struttura essenziale
 
 ```text
-source_id
-source_record_id
-source_url
-source_published_at
-observed_at
-ingested_at
-entity_identifiers
-raw_hash
-schema_version
-transform_version
+src/app/                 pagine e servizi web
+src/components/          grafici, mappa e controlli dell'interfaccia
+src/lib/                 lettura, controllo e collegamento dei dati
+src/data/generated/      copie ridotte e verificate usate dal sito
+scripts/etl/             aggiornamento delle fonti
+tests/                   controlli automatici
+docs/                    metodo, architettura e note legali
 ```
 
-Gli identificativi di dominio, come Codice IPA, codice fiscale dell'ente, CIG, CUP e codici territoriali, rimangono separati. Nessun join probabilistico viene promosso a fatto senza una regola documentata.
-
-Leggi [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
-
-## Regole per grafici e mappe
-
-Una visualizzazione entra in produzione soltanto quando esiste un dato verificabile.
-
-- fonte e data devono essere visibili o immediatamente raggiungibili;
-- assi e unità devono dichiarare che cosa viene misurato;
-- valori cumulati non vengono presentati come valori periodali senza trasformazione documentata;
-- mappe e marker devono rappresentare una misura reale o uno stato di copertura;
-- se il dato manca, mostriamo uno stato vuoto, non una serie dimostrativa;
-- le animazioni non devono alterare o spettacolarizzare la percezione di un dato finanziario.
-
-La geometria regionale della home è generata in modo riproducibile dal pacchetto ufficiale ISTAT. Fonte, checksum, licenza e procedura sono documentati in [`docs/ISTAT_REGIONAL_MAP.md`](docs/ISTAT_REGIONAL_MAP.md).
-
-## Alert e anomalie
-
-Una procedura poco concorrenziale, un prezzo elevato o un fornitore ricorrente possono meritare un controllo, ma **non provano un illecito**.
-
-Gli indicatori futuri dovranno essere:
-
-1. riproducibili;
-2. spiegabili;
-3. confrontati tra casi omogenei;
-4. collegati ai record originali;
-5. presentati come segnali di verifica, non come sentenze.
-
-Leggi [`docs/LEGAL_AND_ETHICS.md`](docs/LEGAL_AND_ETHICS.md).
-
-## Indipendenza
-
-DoveVannoINostriSoldi è un progetto civico indipendente. Non è un sito ufficiale dello Stato italiano, di ANAC, RGS, Banca d'Italia, AgID, Camera o Senato.
-
-I dati restano attribuiti alle rispettive fonti e vengono riutilizzati nel rispetto delle licenze, delle condizioni applicabili e della normativa sulla protezione dei dati personali.
+Il registro delle fonti è in [src/lib/sources.ts](src/lib/sources.ts). Le regole operative sono in [src/lib/data/source-policy.ts](src/lib/data/source-policy.ts).
 
 ## Contribuire
 
-Le contribution più utili sono:
+Sono utili segnalazioni di fonti mancanti, correzioni alle spiegazioni, controlli sulla qualità dei dati e miglioramenti di accessibilità.
 
-- nuovi adapter verso fonti ufficiali;
-- test di qualità e riconciliazione dei dati;
-- documentazione delle classificazioni contabili;
-- miglioramenti di accessibilità e data visualization;
-- metodologie robuste per benchmark e anomaly detection;
-- segnalazioni di fonti pubbliche mancanti.
+Per proporre una nuova fonte, apri una issue con:
 
-Per una nuova fonte, aprire una issue indicando almeno proprietario, URL ufficiale, licenza, formato, frequenza, identificativi e chiavi utili al join.
+- ente che pubblica il dato;
+- collegamento ufficiale;
+- licenza;
+- formato e frequenza di aggiornamento;
+- identificativi utili, come Codice IPA, codice fiscale, CIG o CUP.
+
+## Contributori
+
+- [@fragiannicola](https://x.com/fragiannicola)
+- [@dom_gag_96](https://x.com/dom_gag_96)
 
 ## Licenza
 
-Codice rilasciato con licenza MIT. I dataset incorporati o collegati mantengono le licenze e le condizioni delle rispettive fonti.
-
-Le attribuzioni degli asset e dei dati incorporati sono raccolte in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+Il codice è distribuito con licenza MIT. I dati e gli elementi di terze parti mantengono le licenze indicate dalle rispettive fonti. Le attribuzioni sono raccolte in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/src/app/coesione/page.tsx
+++ b/src/app/coesione/page.tsx
@@ -73,17 +73,17 @@ export default function CohesionPage() {
           <h1>Dove si concentrano gli investimenti per la coesione.</h1>
           <p>
             Un quadro nazionale dei progetti monitorati da OpenCoesione: costo pubblico, pagamenti,
-            temi, natura e stato. I valori arrivano dall’API ufficiale e restano disponibili come
-            ultimo snapshot verificato anche durante un disservizio della fonte.
+            temi, natura e stato. I valori arrivano dal servizio ufficiale e conserviamo l&apos;ultimo
+            dato controllato anche se la fonte è temporaneamente irraggiungibile.
           </p>
         </div>
         <aside className={styles.freshness} aria-label="Freschezza e provenienza del dato">
           <div><span>Fonte</span><strong>OpenCoesione</strong></div>
           <div><span>Dato aggiornato dalla fonte</span><strong>{formatDate(snapshot.referenceDate)}</strong></div>
-          <div><span>Acquisito dalla piattaforma</span><strong>{formatDateTime(snapshot.generatedAt)}</strong></div>
-          <div><span>Cadenza dichiarata</span><strong>{snapshot.source.declaredCadence}</strong></div>
+          <div><span>Scaricato da noi</span><strong>{formatDateTime(snapshot.generatedAt)}</strong></div>
+          <div><span>Quanto spesso cambia</span><strong>{snapshot.source.declaredCadence}</strong></div>
           <div><span>Controllo automatico</span><strong>{snapshot.source.platformCheckCadence}</strong></div>
-          <div><span>Consegna</span><strong>API ufficiale · snapshot verificato</strong></div>
+          <div><span>Come lo leggiamo</span><strong>Servizio ufficiale e copia controllata</strong></div>
           <div><span>Licenza</span><strong>{snapshot.source.license}</strong></div>
           <a href={snapshot.source.endpoint} target="_blank" rel="noreferrer">Apri l’aggregato originale ↗</a>
         </aside>
@@ -109,8 +109,8 @@ export default function CohesionPage() {
         <div>
           <h2 id="ratio-title">Quanto è stato pagato rispetto al costo monitorato</h2>
           <p>
-            Il rapporto è finanziario: confronta i pagamenti pubblicati con il costo pubblico
-            aggregato. Non misura l’avanzamento fisico, la qualità o il completamento dei progetti.
+            Il rapporto confronta i pagamenti pubblicati con il costo pubblico totale. Non dice
+            quante opere sono finite né se sono state realizzate bene.
           </p>
         </div>
         <div className={styles.ratioVisual}>
@@ -139,8 +139,8 @@ export default function CohesionPage() {
       <section className={styles.section} aria-labelledby="history-title">
         <div className={styles.sectionHeader}>
           <div>
-            <h2 id="history-title">Come si è formato il cumulato</h2>
-            <p>Impegni e pagamenti attribuiti dalla fonte all’anno di riferimento, mostrati come serie cumulativa.</p>
+            <h2 id="history-title">Come sono cresciuti i totali nel tempo</h2>
+            <p>Ogni punto mostra il totale registrato dalla fonte fino all&apos;anno indicato.</p>
           </div>
           {latestAnnual && <span>Serie fino al {latestAnnual.year}</span>}
         </div>
@@ -151,9 +151,9 @@ export default function CohesionPage() {
         <div>
           <h2 id="method-title">Come leggere e verificare questi numeri</h2>
           <p>
-            Lo snapshot conserva i centesimi come interi, valida schema e dominio della fonte e
-            riconcilia ogni classificazione con il totale nazionale. La fonte arrotonda alcuni
-            aggregati all’euro: accettiamo al massimo due euro di scarto e nessuno scarto nei progetti.
+            Conserviamo gli importi al centesimo e confrontiamo ogni gruppo con il totale nazionale.
+            La fonte arrotonda alcuni valori all&apos;euro: accettiamo al massimo due euro di differenza
+            e nessuna differenza nel numero dei progetti.
           </p>
         </div>
         <dl>
@@ -167,7 +167,7 @@ export default function CohesionPage() {
         </div>
         <div className={styles.actions}>
           <a href={snapshot.source.endpoint} target="_blank" rel="noreferrer">API OpenCoesione ↗</a>
-          <Link href="/api/coesione">API normalizzata</Link>
+          <Link href="/api/coesione">Dati pronti per altre applicazioni</Link>
           <Link href="/fonti">Registro delle fonti</Link>
           <Link href="/metodologia">Metodologia</Link>
         </div>

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -51,12 +51,12 @@ export default function ControlsPage() {
 
       <section className={styles.readingRule} aria-label="Come leggere questa pagina">
         <strong>La regola più importante</strong>
-        <p>Flussi, stock, costi di una misura e scenari non si sommano. Colori e parole li tengono separati.</p>
+        <p>Pagamenti, debiti, costi e ipotesi sono numeri diversi. Non vanno sommati.</p>
         <div>
           <span data-tone="observed">Dato osservato</span>
           <span data-tone="attention">Da controllare</span>
-          <span data-tone="policy">Scelta di policy</span>
-          <span data-tone="stock">Stock accumulato</span>
+          <span data-tone="policy">Scelta pubblica</span>
+          <span data-tone="stock">Totale accumulato</span>
         </div>
       </section>
 
@@ -85,8 +85,8 @@ export default function ControlsPage() {
 
       <section className={styles.signals} aria-labelledby="signals-title">
         <header>
-          <h2 id="signals-title">Sei numeri, sei significati diversi</h2>
-          <p>Apri la fonte per controllare il perimetro originale.</p>
+          <h2 id="signals-title">Numeri da leggere con attenzione</h2>
+          <p>Ogni dato ha una data, una spiegazione e un collegamento alla fonte.</p>
         </header>
         <div>
           {auditSignals.map((signal) => (
@@ -108,7 +108,7 @@ export default function ControlsPage() {
         <header>
           <div>
             <h2 id="scenarios-title">Tre ipotesi di miglioramento annuale</h2>
-            <p>Sono esercizi di policy basati su percentuali dichiarate. Non sono soldi già recuperati né previsioni.</p>
+            <p>Sono ipotesi basate su percentuali dichiarate. Non sono soldi già recuperati e non sono previsioni.</p>
           </div>
           <Link href="/metodologia">Come leggiamo gli scenari <span>→</span></Link>
         </header>

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -2,10 +2,10 @@
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
 
-  --chart-primary: #72aeca;
-  --chart-secondary: #78ad8d;
-  --chart-tertiary: #c3a66c;
-  --chart-negative: #ca7d7d;
+  --chart-primary: #43b69a;
+  --chart-secondary: #e3b65a;
+  --chart-tertiary: #9c83d3;
+  --chart-negative: #d97979;
 
   --focus-ring: rgba(117, 178, 210, .68);
 }

--- a/src/app/enti/[codice]/page.tsx
+++ b/src/app/enti/[codice]/page.tsx
@@ -33,7 +33,7 @@ function responsibleLabel(
   cognome: string | null,
 ): string {
   const identity = [nome, cognome].filter(Boolean).join(" ");
-  return [titolo, identity].filter(Boolean).join(" · ") || "Non indicato nel record IPA";
+  return [titolo, identity].filter(Boolean).join(", ") || "Non indicato da IPA";
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -94,8 +94,8 @@ export default async function EntityPage({ params }: PageProps) {
           <h1 className={styles.detailTitle}>{entity.denominazione}</h1>
           <p className={styles.detailSubtitle}>
             Codice IPA <strong>{entity.codiceIpa}</strong>
-            {entity.acronimo ? ` · ${entity.acronimo}` : ""}
-            {entity.dataAggiornamento ? ` · record aggiornato ${entity.dataAggiornamento}` : ""}
+            {entity.acronimo ? `, ${entity.acronimo}` : ""}
+            {entity.dataAggiornamento ? `, aggiornato ${entity.dataAggiornamento}` : ""}
           </p>
           <div className={styles.badges}>
             {entity.tipologia && <i className={styles.badge}>{entity.tipologia}</i>}
@@ -278,8 +278,8 @@ export default async function EntityPage({ params }: PageProps) {
               </div>
             </div>
             <p className={styles.disclaimer}>
-              Non mostriamo grafici economici finché il relativo record non è collegato a una fonte
-              ufficiale verificabile. La pagina è già il punto canonico su cui verranno innestati i dataset finanziari.
+              Mostreremo un grafico economico solo quando riusciremo a collegare questo ente a una
+              fonte ufficiale. Non usiamo valori stimati o abbinamenti basati solo sul nome.
             </p>
           </section>
         </div>
@@ -287,12 +287,12 @@ export default async function EntityPage({ params }: PageProps) {
         <aside className={styles.detailSide}>
           <section className={styles.section}>
             <div className={styles.sectionHeading}>
-              <h2>Provenienza</h2>
-              <span>record sorgente</span>
+              <h2>Da dove arrivano i dati</h2>
+              <span>fonte originale</span>
             </div>
             <div className={styles.provenance}>
               <div className={styles.provenanceRow}>
-                <span>Dataset</span>
+                <span>Fonte</span>
                 <a href={IPA_ENTI_DATASET_URL} target="_blank" rel="noreferrer">Indice PA · Enti ↗</a>
               </div>
               <div className={styles.provenanceRow}>
@@ -300,7 +300,7 @@ export default async function EntityPage({ params }: PageProps) {
                 <b>Agenzia per l&apos;Italia Digitale</b>
               </div>
               <div className={styles.provenanceRow}>
-                <span>Resource ID</span>
+                <span>Identificativo del file</span>
                 <b>{IPA_ENTI_RESOURCE_ID}</b>
               </div>
               <div className={styles.provenanceRow}>
@@ -312,7 +312,7 @@ export default async function EntityPage({ params }: PageProps) {
                 <b>giornaliera</b>
               </div>
               <div className={styles.provenanceRow}>
-                <span>Data record</span>
+                <span>Data del dato</span>
                 <b>{show(entity.dataAggiornamento)}</b>
               </div>
             </div>
@@ -320,17 +320,17 @@ export default async function EntityPage({ params }: PageProps) {
 
           <section className={styles.section}>
             <div className={styles.sectionHeading}>
-              <h2>API DoveVannoINostriSoldi</h2>
-              <span>json</span>
+              <h2>Usa questi dati</h2>
+              <span>formato JSON</span>
             </div>
             <div className={styles.provenanceRow}>
-              <span>Endpoint normalizzato</span>
+              <span>Indirizzo per altre applicazioni</span>
               <Link href={`/api/enti/${encodeURIComponent(entity.codiceIpa)}`}>
                 /api/enti/{entity.codiceIpa} →
               </Link>
             </div>
             <p className={styles.disclaimer}>
-              L&apos;endpoint aggiunge metadati di provenienza e normalizza i campi, ma non modifica il significato del record IPA.
+              Il servizio rende i campi più facili da usare, ma non cambia ciò che IPA ha pubblicato.
             </p>
           </section>
         </aside>

--- a/src/app/enti/page.tsx
+++ b/src/app/enti/page.tsx
@@ -127,15 +127,15 @@ export default async function EntiPage({ searchParams }: PageProps) {
             </div>
             <div>
               <b>Accesso</b>
-              <span>CKAN Data API + SQL</span>
+              <span>Servizio dati AgID</span>
             </div>
             <div>
-              <b>Resource ID</b>
+              <b>Identificativo del file</b>
               <span>{IPA_ENTI_RESOURCE_ID}</span>
             </div>
           </div>
           <a className={styles.sourceLink} href={IPA_ENTI_DATASET_URL} target="_blank" rel="noreferrer">
-            Verifica sul dataset AgID <span>↗</span>
+            Apri i dati AgID <span>↗</span>
           </a>
         </aside>
       </section>
@@ -188,16 +188,16 @@ export default async function EntiPage({ searchParams }: PageProps) {
         <div className={styles.snapshotSummary}>
             <span className={styles.kicker}>REGISTRO IN NUMERI</span>
           <div className={styles.snapshotNumber}>
-            <strong>{stats ? numberFormatter.format(stats.total) : "—"}</strong>
-            <span>record presenti nel dataset Enti</span>
+            <strong>{stats ? numberFormatter.format(stats.total) : "Non disponibile"}</strong>
+            <span>enti presenti nel registro</span>
           </div>
           <p>
-            Questo è il numero di record presenti nel registro IPA. Non indica il numero dei soli
+            Questo è il numero di enti presenti nel registro IPA. Non indica il numero dei soli
             ministeri e non misura la spesa pubblica.
           </p>
           <dl className={styles.snapshotMeta}>
             <div>
-              <dt>Interrogazione</dt>
+              <dt>Controllato</dt>
               <dd>{formatObservedAt(stats?.observedAt ?? distributionObservedAt)}</dd>
             </div>
             <div>
@@ -213,7 +213,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
               <span className={styles.kicker}>COMPOSIZIONE</span>
               <h2 id="snapshot-registro">Tipologie più presenti</h2>
             </div>
-            <span className={styles.chartSource}>query SQL · IPA</span>
+            <span className={styles.chartSource}>dati IPA</span>
           </div>
           <RegistryTypeChart data={distribution} />
         </div>
@@ -224,7 +224,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
           <div className={styles.resultsHeader}>
             <div>
               <h2 id="amministrazioni-centrali">Ministeri, Presidenza e Avvocatura</h2>
-              <p>Perimetro strutturale IPA: Codice Categoria C1. La natura dell&apos;ente distingue i ministeri dalla PCM.</p>
+              <p>IPA raccoglie questi enti nella categoria C1 e distingue i ministeri dalla Presidenza del Consiglio.</p>
             </div>
             <span>{numberFormatter.format(centralAdministrations.total)} enti · aggiornamento giornaliero</span>
           </div>
@@ -252,7 +252,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
 
       {!query && !centralAdministrations && (
         <div className={styles.empty}>
-          <strong>Il perimetro delle amministrazioni centrali non è disponibile ora.</strong>
+          <strong>L&apos;elenco delle amministrazioni centrali non è disponibile ora.</strong>
           <p>La ricerca IPA resta utilizzabile; non sostituiamo l&apos;elenco ufficiale con una lista statica.</p>
         </div>
       )}
@@ -260,7 +260,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
       {query && !canSearch && (
         <div className={styles.empty}>
           <strong>Scrivi almeno due caratteri.</strong>
-          <p>La ricerca parte dopo due caratteri per evitare interrogazioni troppo ampie sul datastore pubblico.</p>
+          <p>La ricerca parte dopo due caratteri per non sovraccaricare il servizio pubblico.</p>
         </div>
       )}
 
@@ -268,7 +268,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
         <div className={styles.error}>
           <strong>La fonte IPA non risponde in questo momento.</strong>
           <p>
-            Non sostituiamo il dato ufficiale con valori di fallback. Riprova più tardi oppure apri direttamente il dataset AgID.
+            Non sostituiamo il dato ufficiale con un elenco inventato. Riprova più tardi oppure apri i dati AgID.
           </p>
         </div>
       )}
@@ -318,7 +318,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
           ) : (
             <div className={styles.empty}>
               <strong>Nessun ente trovato.</strong>
-              <p>La query non ha prodotto corrispondenze nel dataset IPA corrente.</p>
+              <p>La ricerca non ha trovato corrispondenze nel registro IPA.</p>
             </div>
           )}
         </>

--- a/src/app/fonti/page.tsx
+++ b/src/app/fonti/page.tsx
@@ -20,7 +20,7 @@ export default function SourcesPage() {
         <h1>Da dove arrivano i dati</h1>
         <p>
           Qui trovi chi pubblica ogni dato, che cosa contiene, quanto spesso cambia
-          e se è già collegato alla dashboard.
+          e se è già collegato al sito.
         </p>
         <div className="hero-actions" style={{ justifyContent: "flex-start" }}>
           <Link href="/fonti/stato" className="button button-primary">
@@ -51,7 +51,7 @@ export default function SourcesPage() {
             </div>
             <div>
               <strong>{source.coverage}</strong><small>{source.format}</small>
-              {source.joinKeys && <small>Chiavi: {source.joinKeys.join(" · ")}</small>}
+              {source.joinKeys && <small>Campi usati per collegare i dati: {source.joinKeys.join(", ")}</small>}
             </div>
             <div><strong>{source.cadence}</strong></div>
             <div><span className={`status status-${source.status}`}>{statusLabel[source.status]}</span></div>

--- a/src/app/fonti/stato/page.tsx
+++ b/src/app/fonti/stato/page.tsx
@@ -113,7 +113,7 @@ export default async function SourceStatusPage() {
         <div>
           <h2>Controllare spesso non rende il dato in tempo reale.</h2>
           <p>
-            Se IPA aggiorna ogni giorno, possiamo ricontrollarlo ogni ora. Se un dataset è mensile,
+            Se IPA aggiorna ogni giorno, possiamo ricontrollarlo ogni ora. Se una fonte è mensile,
             controllarlo più volte al giorno ci aiuta a trovare presto il nuovo rilascio,
             ma il dato resta mensile.
           </p>
@@ -157,7 +157,7 @@ export default async function SourceStatusPage() {
                 {reachabilityLabel(source)}
               </span>
               <strong>
-                {source.latencyMs !== null ? `${numberFormatter.format(source.latencyMs)} ms` : "—"}
+                {source.latencyMs !== null ? `${numberFormatter.format(source.latencyMs)} ms` : "Non disponibile"}
               </strong>
               <span>{source.detail ?? "Nessun dettaglio disponibile"}</span>
               {source.recordCount !== null && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -320,8 +320,10 @@ main { width: min(var(--max), calc(100% - 40px)); margin: 0 auto; }
   color: #668294;
 }
 .site-footer strong { color: #a7bdca; font-size: 11px; }
-.site-footer p, .footer-rule { font-size: 10px; max-width: 520px; line-height: 1.5; }
-.footer-rule a { color: #86bed8; text-decoration: underline; text-underline-offset: 3px; }
+.site-footer p, .footer-rule, .footer-contributors { font-size: 10px; max-width: 520px; line-height: 1.5; }
+.footer-rule, .footer-contributors { display: flex; flex-wrap: wrap; gap: 5px 12px; align-items: center; }
+.footer-rule a, .footer-contributors a { color: #86bed8; text-decoration: underline; text-underline-offset: 3px; }
+.footer-contributors > span { color: #8ea4b1; }
 .site-footer p { margin: 5px 0 0; }
 
 .subpage { padding-bottom: 100px; }

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -31,7 +31,7 @@
   overflow-wrap: anywhere;
 }
 
-.overviewHeader > a,
+.headerActions > a,
 .panelHeader > a,
 .primaryMetric > a,
 .freshnessPanel > a,
@@ -47,11 +47,17 @@
   transition: color 140ms ease;
 }
 
-.overviewHeader > a:hover,
+.headerActions > a:hover,
 .panelHeader > a:hover,
 .primaryMetric > a:hover,
 .freshnessPanel > a:hover,
 .cohesionPanel footer a:hover { color: #c7e8f5; }
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
 
 .pulse {
   display: grid;
@@ -157,6 +163,23 @@
   font-size: 12px;
   font-weight: 600;
 }
+
+.yearNotice {
+  display: grid;
+  grid-template-columns: minmax(170px, .55fr) minmax(260px, 1.2fr) auto;
+  gap: 24px;
+  align-items: center;
+  margin-top: 16px;
+  padding: 20px 22px;
+  border: 1px solid rgba(240, 197, 108, .2);
+  border-radius: 12px;
+  background: rgba(64, 48, 21, .12);
+}
+
+.yearNotice strong { color: #ebd5a1; font-size: 14px; }
+.yearNotice p { margin: 0; color: #9caab2; font-size: 12px; line-height: 1.55; }
+.yearNotice a { color: #e1bd6e; font-size: 12px; font-weight: 650; white-space: nowrap; }
+.yearNotice a:active { transform: scale(.97); }
 
 .siopeGrid {
   width: 100%;
@@ -438,11 +461,12 @@
   .auditCallout > div { grid-template-columns: 1fr; }
   .auditCallout article { border-right: 0; border-bottom: 1px solid rgba(137, 171, 190, 0.14); }
   .auditCallout article:last-child { border-bottom: 0; }
+  .yearNotice { grid-template-columns: 1fr; gap: 9px; }
 }
 
 @media (max-width: 760px) {
   .dashboard { width: min(100% - 24px, 1440px); padding-top: 18px; }
-  .overviewHeader, .panelHeader, .monthlyPanel > header, .cohesionPanel > header, .cohesionPanel footer {
+  .overviewHeader, .headerActions, .panelHeader, .monthlyPanel > header, .cohesionPanel > header, .cohesionPanel footer {
     align-items: flex-start;
     flex-direction: column;
     gap: 10px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,8 +35,14 @@ export default function RootLayout({
             <strong>DoveVannoINostriSoldi</strong>
             <p>Progetto indipendente e open source. Non è un sito della Pubblica Amministrazione.</p>
           </div>
+          <div className="footer-contributors">
+            <span>Contributori</span>
+            <a href="https://x.com/fragiannicola" target="_blank" rel="noreferrer">@fragiannicola</a>
+            <a href="https://x.com/dom_gag_96" target="_blank" rel="noreferrer">@dom_gag_96</a>
+          </div>
           <div className="footer-rule">
-            <Link href="/metodologia">Come leggiamo i dati</Link> · Ogni numero ha una fonte, una data e un limite dichiarato.
+            <Link href="/metodologia">Come leggiamo i dati</Link>
+            <span>Ogni numero ha una fonte e una data.</span>
           </div>
         </footer>
       </body>

--- a/src/app/metodologia/page.tsx
+++ b/src/app/metodologia/page.tsx
@@ -6,20 +6,19 @@ export const metadata: Metadata = {
 };
 
 const rules = [
-  ["01", "Mostriamo sempre la fonte", "Ogni numero porta al documento o al dataset ufficiale da cui arriva."],
-  ["02", "Non sommiamo cose diverse", "Pagamenti, costi previsti, debiti e scenari hanno significati diversi e restano separati."],
-  ["03", "Diciamo quanto è recente", "Mostriamo la data del dato, quando lo abbiamo controllato e quanto spesso cambia la fonte."],
-  ["04", "Un segnale non è una colpa", "Un valore insolito indica dove guardare meglio. Da solo non prova errori, sprechi o illeciti."],
-  ["05", "Confrontiamo casi simili", "Mettiamo a confronto enti e servizi solo quando le grandezze sono davvero confrontabili."],
-  ["06", "Le correzioni restano visibili", "Se un dato cambia, conserviamo la versione precedente e spieghiamo che cosa è stato corretto."],
+  ["Mostriamo sempre la fonte", "Ogni numero porta al documento o ai dati ufficiali da cui arriva."],
+  ["Non sommiamo cose diverse", "Pagamenti, costi previsti, debiti e ipotesi hanno significati diversi e restano separati."],
+  ["Diciamo quanto è recente", "Mostriamo la data del dato, quando lo abbiamo controllato e quanto spesso cambia la fonte."],
+  ["Un segnale non è una colpa", "Un valore insolito indica dove guardare meglio. Da solo non prova errori, sprechi o illeciti."],
+  ["Confrontiamo casi simili", "Mettiamo a confronto enti e servizi solo quando i numeri misurano la stessa cosa."],
+  ["Le correzioni restano visibili", "Se un dato cambia, conserviamo la versione precedente e spieghiamo che cosa è stato corretto."],
 ];
 
 export default function MethodPage() {
   return (
     <main className="subpage">
       <header className="page-intro">
-        <span className="eyebrow"><span /> COME LEGGIAMO I DATI</span>
-        <h1>Prima capire.<br /><em>Poi confrontare.</em></h1>
+        <h1>Come leggere i dati</h1>
         <p>
           Un numero senza contesto può confondere. Per questo mostriamo sempre la fonte,
           la data, il significato e ciò che quel numero non può dimostrare.
@@ -27,9 +26,8 @@ export default function MethodPage() {
       </header>
 
       <section className="method-grid">
-        {rules.map(([index, title, text]) => (
-          <article key={index}>
-            <span>{index}</span>
+        {rules.map(([title, text]) => (
+          <article key={title}>
             <h2>{title}</h2>
             <p>{text}</p>
           </article>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,16 @@ import Link from "next/link";
 import { HomeMonthlyChart } from "@/components/charts/home-monthly-chart";
 import { InfoTooltip } from "@/components/info-tooltip";
 import { ItalyRegionsMap } from "@/components/italy-regions-map";
+import { PeriodSelector } from "@/components/period-selector";
 import { classifyFreshness } from "@/lib/data/freshness";
 import { SOURCE_POLICIES } from "@/lib/data/source-policy";
 import {
-  openCoesionePaymentCostRatio,
   openCoesioneSnapshot as cohesion,
 } from "@/lib/opencoesione-snapshot";
-import { siopeMunicipalSnapshot as siope } from "@/lib/siope-snapshot";
+import {
+  availableSiopeYears,
+  getSiopeMunicipalSnapshot,
+} from "@/lib/siope-snapshot";
 import { publicSources, sourceCounts } from "@/lib/sources";
 import { auditScenarios, procurementComparison } from "@/lib/audit-data";
 import styles from "./home.module.css";
@@ -43,12 +46,6 @@ function date(value: string | null): string {
   }).format(parsed);
 }
 
-const period = `gennaio–${siope.latestMonthLabel.toLocaleLowerCase("it-IT")} ${siope.year}`;
-const coverageRatio =
-  siope.coverage.activeSiopeMunicipalities > 0
-    ? (siope.coverage.withMovements / siope.coverage.activeSiopeMunicipalities) * 100
-    : 0;
-const cohesionRatioPercent = openCoesionePaymentCostRatio * 100;
 const cohesionFreshness = classifyFreshness(
   SOURCE_POLICIES.opencoesione.staleAfterSeconds,
   cohesion.referenceDate,
@@ -81,15 +78,38 @@ const analysisPaths = [
   { href: "/fonti", area: "Contratti pubblici", detail: "Gare, affidamenti e aggiudicazioni", source: "ANAC · BDNCP", status: "In lavorazione" },
 ];
 
-export default function HomePage() {
+function selectedYear(value: string | string[] | undefined): number {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] ?? "" : value ?? "", 10);
+  return availableSiopeYears.includes(parsed) ? parsed : availableSiopeYears[0];
+}
+
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ anno?: string | string[] }>;
+}) {
+  const year = selectedYear((await searchParams).anno);
+  const siope = getSiopeMunicipalSnapshot(year);
+  const period = `gennaio a ${siope.latestMonthLabel.toLocaleLowerCase("it-IT")} ${siope.year}`;
+  const coverageRatio = siope.coverage.activeSiopeMunicipalities > 0
+    ? (siope.coverage.withMovements / siope.coverage.activeSiopeMunicipalities) * 100
+    : 0;
+  const cohesionPoint = cohesion.annualSeries.find((point) => point.year === year) ?? null;
+  const cohesionRatioPercent = cohesionPoint && cohesionPoint.commitmentsCents > 0
+    ? (cohesionPoint.paymentsCents / cohesionPoint.commitmentsCents) * 100
+    : null;
+
   return (
     <main className={styles.dashboard}>
       <header className={styles.overviewHeader}>
         <div>
           <h1>Dove vanno i nostri soldi?</h1>
-          <p>Una dashboard per capire i dati pubblici italiani e risalire sempre alla fonte.</p>
+          <p>Scopri quanto spendono Stato e Comuni, da quali fonti arrivano i dati e a quale periodo si riferiscono.</p>
         </div>
-        <Link href="/fonti/stato">Quando sono aggiornati i dati <span>→</span></Link>
+        <div className={styles.headerActions}>
+          <PeriodSelector activeYear={year} years={availableSiopeYears} pathname="/" />
+          <Link href="/fonti/stato">Quando sono aggiornati i dati <span>→</span></Link>
+        </div>
       </header>
 
       <section className={styles.pulse} aria-label="Copertura attuale della piattaforma">
@@ -97,10 +117,10 @@ export default function HomePage() {
         <div><strong>{integer.format(siope.coverage.includedMovementRows)}</strong><span>pagamenti comunali letti</span></div>
         <div><strong>{integer.format(siope.coverage.withMovements)}</strong><span>Comuni presenti</span></div>
         <div><strong>{siope.regions.length}</strong><span>regioni confrontabili</span></div>
-        <div><strong>{integer.format(cohesion.totals.projects)}</strong><span>progetti seguiti</span></div>
+        <div><strong>{integer.format(siope.populationCovered)}</strong><span>abitanti coperti</span></div>
       </section>
 
-      <section className={styles.auditCallout} aria-labelledby="audit-title">
+      {year === 2025 ? <section className={styles.auditCallout} aria-labelledby="audit-title">
         <header>
           <span className={styles.sectionLabelText}>LEGGERE BENE I NUMERI</span>
           <h2 id="audit-title">Tre dati che raccontano cose diverse</h2>
@@ -119,12 +139,21 @@ export default function HomePage() {
           </article>
           <article data-tone="policy">
             <strong>{auditScenarios[1].annualBillion.toLocaleString("it-IT", { maximumFractionDigits: 1 })} mld €</strong>
-            <h3>Scenario centrale</h3>
-            <p>È un esercizio di policy con ipotesi dichiarate, non denaro già disponibile.</p>
+            <h3>Ipotesi centrale</h3>
+            <p>È una stima costruita su ipotesi dichiarate. Non è denaro già disponibile.</p>
           </article>
         </div>
-        <Link href="/controlli">Capire i numeri dell&apos;audit <span>→</span></Link>
-      </section>
+        <Link href="/controlli">Capire i numeri da controllare <span>→</span></Link>
+      </section> : (
+        <section className={styles.yearNotice} aria-label={`Controlli disponibili per il ${year}`}>
+          <strong>Controlli approfonditi per il {year}</strong>
+          <p>
+            Non abbiamo ancora un insieme completo di indicatori confrontabili per questo anno.
+            I dati SIOPE e OpenCoesione qui sotto cambiano davvero con il periodo scelto.
+          </p>
+          <Link href="/controlli">Vedi tutti i controlli con la loro data <span>→</span></Link>
+        </section>
+      )}
 
       <section className={styles.siopeGrid} aria-labelledby="siope-title">
         <article className={styles.primaryMetric}>
@@ -150,7 +179,7 @@ export default function HomePage() {
             </div>
             <div><dt>Fonte aggiornata il</dt><dd>{date(siope.source.siopeMovementsLastModified)}</dd></div>
           </dl>
-          <Link href="/territori">Apri il dettaglio territoriale <span>→</span></Link>
+          <Link href={`/territori?anno=${year}`}>Apri il dettaglio territoriale <span>→</span></Link>
         </article>
 
         <figure className={styles.monthlyPanel}>
@@ -173,14 +202,14 @@ export default function HomePage() {
             <h2 id="map-title">Quanto spendono i Comuni in ogni regione</h2>
             <p>Euro per abitante. Seleziona una regione per vedere il dettaglio.</p>
           </div>
-          <Link href="/territori">Tabelle e classificazioni <span>→</span></Link>
+          <Link href={`/territori?anno=${year}`}>Tabelle e classificazioni <span>→</span></Link>
         </header>
         <ItalyRegionsMap regions={siope.regions} period={period} />
         <footer className={styles.mapAttribution}>
           Confini amministrativi a fini statistici: {" "}
           <a href="https://www.istat.it/storage/cartografia/confini_amministrativi/generalizzati/2026/Limiti01012026_g.zip" target="_blank" rel="noreferrer">ISTAT, 1 gennaio 2026</a>
-          {" · "}<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">CC BY 4.0</a>
-          {" · "}geometria semplificata.
+          {", "}<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">CC BY 4.0</a>
+          {", "}geometria semplificata.
         </footer>
       </section>
 
@@ -189,33 +218,33 @@ export default function HomePage() {
           <header className={styles.panelHeader}>
             <div>
               <span className={styles.sectionLabelText}>FONDI E PROGETTI · OPENCOESIONE</span>
-              <h2>Quanto costano e quanto è stato pagato</h2>
+              <h2>Impegni e pagamenti fino al {year}</h2>
             </div>
             <span className={cohesionFreshnessClass}>{cohesionFreshnessLabel}</span>
           </header>
 
           <div className={styles.cohesionStats}>
-            <div><span>Costo previsto</span><strong>{compactEuro(cohesion.totals.publicCostCents / 100)}</strong></div>
-            <div><span>Già pagato</span><strong>{compactEuro(cohesion.totals.paymentsCents / 100)}</strong></div>
-            <div><span>Progetti seguiti</span><strong>{integer.format(cohesion.totals.projects)}</strong></div>
+            <div><span>Impegni fino al {year}</span><strong>{cohesionPoint ? compactEuro(cohesionPoint.commitmentsCents / 100) : "Non disponibile"}</strong></div>
+            <div><span>Pagamenti fino al {year}</span><strong>{cohesionPoint ? compactEuro(cohesionPoint.paymentsCents / 100) : "Non disponibile"}</strong></div>
+            <div><span>Pagato sugli impegni</span><strong>{cohesionRatioPercent === null ? "Non disponibile" : `${cohesionRatioPercent.toLocaleString("it-IT", { maximumFractionDigits: 2 })}%`}</strong></div>
           </div>
 
           <div className={styles.ratioBlock}>
             <div>
               <span className={styles.inlineTerm}>
-                Pagato sul costo previsto
+                Pagato sugli impegni
                 <InfoTooltip id="cohesion-ratio-tip" label="Che cosa significa questo rapporto?">
-                  Rapporto finanziario aggregato. Non indica avanzamento fisico, qualità o completamento dei progetti.
+                  Confronta i pagamenti e gli impegni registrati fino all&apos;anno scelto. Non dice quante opere sono finite.
                 </InfoTooltip>
               </span>
-              <strong>{cohesionRatioPercent.toLocaleString("it-IT", { maximumFractionDigits: 2 })}%</strong>
+              <strong>{cohesionRatioPercent === null ? "Non disponibile" : `${cohesionRatioPercent.toLocaleString("it-IT", { maximumFractionDigits: 2 })}%`}</strong>
             </div>
-            <div className={styles.ratioTrack} aria-hidden="true"><i style={{ width: `${Math.min(cohesionRatioPercent, 100)}%` }} /></div>
-            <p>Confronta euro pagati e costo previsto. Non dice quante opere sono finite.</p>
+            <div className={styles.ratioTrack} aria-hidden="true"><i style={{ width: `${Math.min(cohesionRatioPercent ?? 0, 100)}%` }} /></div>
+            <p>La serie è pubblicata da OpenCoesione e cresce nel tempo. Non è la spesa del solo {year}.</p>
           </div>
 
           <footer>
-            <span>Dati riferiti al {date(cohesion.referenceDate)} · fonte controllata il {date(cohesion.source.observedAt)}</span>
+            <span>Serie annuale fino al {year}. Fonte controllata il {date(cohesion.source.observedAt)}.</span>
             <Link href="/coesione">Apri OpenCoesione <span>→</span></Link>
           </footer>
         </article>
@@ -231,8 +260,8 @@ export default function HomePage() {
               <div><strong>SIOPE</strong><span>Pagamenti dei Comuni</span></div>
               <dl>
                 <div><dt>Dati fino a</dt><dd>{siope.latestMonthLabel} {siope.year}</dd></div>
-                <div><dt>File · ultima modifica</dt><dd>{date(siope.source.siopeMovementsLastModified)}</dd></div>
-                <div><dt>Acquisizione</dt><dd>{date(siope.generatedAt)}</dd></div>
+                <div><dt>File aggiornato</dt><dd>{date(siope.source.siopeMovementsLastModified)}</dd></div>
+                <div><dt>Scaricato da noi</dt><dd>{date(siope.generatedAt)}</dd></div>
                 <div><dt>Controllo</dt><dd>ogni ora</dd></div>
               </dl>
             </article>

--- a/src/app/partecipazioni/page.tsx
+++ b/src/app/partecipazioni/page.tsx
@@ -39,7 +39,7 @@ export default function ParticipationsPage() {
           <h1>Partecipazioni pubbliche</h1>
           <p>
             Relazioni dichiarate dalle amministrazioni nel censimento MEF, riferite al 31 dicembre {snapshot.referenceYear}.
-            Una relazione di partecipazione non equivale automaticamente a controllo pubblico né a status in-house corrente.
+            Una partecipazione non significa automaticamente che la società sia oggi controllata dalla PA o operi per essa.
           </p>
         </div>
         <a href={snapshot.source.landingUrl} target="_blank" rel="noreferrer">
@@ -49,9 +49,9 @@ export default function ParticipationsPage() {
 
       <section className={styles.metrics} aria-label="Dimensione del censimento MEF">
         <article className={styles.primaryMetric}>
-          <span><HugeiconsIcon icon={HierarchyIcon} size={19} strokeWidth={1.5} aria-hidden="true" /> Relazioni censite</span>
+          <span><HugeiconsIcon icon={HierarchyIcon} size={19} strokeWidth={1.5} aria-hidden="true" /> Partecipazioni dichiarate</span>
           <strong>{number.format(snapshot.totals.participationRecords)}</strong>
-          <p>Ogni riga collega un&apos;amministrazione dichiarante a un&apos;organizzazione partecipata per l&apos;anno di riferimento.</p>
+          <p>Ogni riga collega un&apos;amministrazione a una società o organizzazione partecipata per l&apos;anno indicato.</p>
         </article>
         <dl>
           <div><dt>Amministrazioni dichiaranti</dt><dd>{number.format(snapshot.totals.declaringAdministrations)}</dd></div>
@@ -77,7 +77,7 @@ export default function ParticipationsPage() {
         <aside className={styles.evidence}>
           <HugeiconsIcon icon={LegalDocument01Icon} size={24} strokeWidth={1.5} aria-hidden="true" />
           <div>
-            <h2>Evidence, non verdetti</h2>
+            <h2>Indicazioni dichiarate, non sentenze</h2>
             <p>{snapshot.declaredEvidence.legalMeaning}</p>
             <dl>
               <div><dt>Controllo analogo dichiarato</dt><dd>{number.format(snapshot.declaredEvidence.analogControlRecords)}</dd></div>
@@ -110,12 +110,12 @@ export default function ParticipationsPage() {
       <section className={styles.provenance}>
         <HugeiconsIcon icon={Database02Icon} size={23} strokeWidth={1.5} aria-hidden="true" />
         <div>
-          <h2>Provenienza dello snapshot</h2>
+          <h2>Da dove arrivano i dati</h2>
           <dl>
             <div><dt>Data del dato</dt><dd>{formatDate(snapshot.referenceDate)}</dd></div>
             <div><dt>Pubblicato dal MEF</dt><dd>{formatDate(snapshot.publishedAt)}</dd></div>
-            <div><dt>Acquisito</dt><dd>{formatDate(snapshot.generatedAt)}</dd></div>
-            <div><dt>Codifica rilevata</dt><dd>{snapshot.source.detectedEncoding}</dd></div>
+            <div><dt>Scaricato da noi</dt><dd>{formatDate(snapshot.generatedAt)}</dd></div>
+            <div><dt>Formato del testo</dt><dd>{snapshot.source.detectedEncoding}</dd></div>
             <div><dt>Licenza</dt><dd>{snapshot.source.license}</dd></div>
             <div><dt>SHA-256 originale</dt><dd><code>{snapshot.source.rawSha256}</code></dd></div>
           </dl>

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -15,6 +15,8 @@ import styles from "./spese.module.css";
 
 export const dynamic = "force-dynamic";
 
+const PAGE_DATA_BUDGET_MS = 8_000;
+
 export const metadata: Metadata = {
   title: "Spese dello Stato",
   description:
@@ -325,7 +327,9 @@ export default async function StateSpendingPage() {
   let errorMessage: string | null = null;
 
   try {
-    snapshot = await getStateSpendingSnapshot();
+    snapshot = await getStateSpendingSnapshot({
+      signal: AbortSignal.timeout(PAGE_DATA_BUDGET_MS),
+    });
   } catch (error) {
     errorMessage = error instanceof Error ? error.message : "Errore sconosciuto";
   }

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -66,8 +66,8 @@ function differenceLabel(value: number | null): string {
 
 function datasetLabel(dataset: BdapDataset): string {
   if (dataset.dimension === "mission") return "Missione";
-  if (dataset.dimension === "missionAdministration") return "Missione × amministrazione";
-  return "Amministrazione × classificazione economica II livello";
+  if (dataset.dimension === "missionAdministration") return "Missione e amministrazione";
+  return "Amministrazione e tipo di spesa";
 }
 
 function SourceRow({ dataset }: { dataset: BdapDataset }) {
@@ -79,7 +79,7 @@ function SourceRow({ dataset }: { dataset: BdapDataset }) {
       </div>
       <div>
         <span>{dataset.title}</span>
-        <small>package · {dataset.packageId}</small>
+        <small>Identificativo {dataset.packageId}</small>
       </div>
       <div className={styles.provenanceActions}>
         <a href={dataset.csvUrl} target="_blank" rel="noreferrer">CSV RGS ↗</a>
@@ -123,7 +123,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             <strong>{formatDateTime(snapshot.observedAt)}</strong>
           </div>
           <div className={styles.sourceSummaryRow}>
-            <span>Dataset raw</span>
+            <span>File originale</span>
             <a href={snapshot.sources.mission.csvUrl} target="_blank" rel="noreferrer">apri CSV ufficiale ↗</a>
           </div>
         </aside>
@@ -133,13 +133,13 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
         <div className={styles.primaryMetric}>
           <div className={styles.metricLabel}>
             <i aria-hidden="true" />
-            Pagamenti cumulati da inizio anno
+            Pagamenti da inizio anno
           </div>
           <strong>{compactEuro(snapshot.totalPaid)}</strong>
           <span>Somma del campo ufficiale “Totale Pagato” per tutte le missioni.</span>
           <p>
             RGS descrive il rilascio come pagamenti effettuati <b>dal 1° gennaio fino al mese contabile di riferimento</b>.
-            Il valore è quindi cumulativo; nella serie temporale il singolo mese viene derivato sottraendo due snapshot consecutivi.
+            Il valore è il totale da gennaio. Nel grafico mensile sottraiamo il totale del mese precedente.
           </p>
         </div>
 
@@ -150,11 +150,11 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           </div>
           <div className={styles.fact}>
             <span>Amministrazioni centrali</span>
-            <strong>{snapshot.counts.administrations > 0 ? snapshot.counts.administrations.toLocaleString("it-IT") : "—"}</strong>
+            <strong>{snapshot.counts.administrations > 0 ? snapshot.counts.administrations.toLocaleString("it-IT") : "Non disponibile"}</strong>
           </div>
           <div className={styles.fact}>
             <span>Categorie economiche</span>
-            <strong>{snapshot.counts.economicCategories > 0 ? snapshot.counts.economicCategories.toLocaleString("it-IT") : "—"}</strong>
+            <strong>{snapshot.counts.economicCategories > 0 ? snapshot.counts.economicCategories.toLocaleString("it-IT") : "Non disponibile"}</strong>
           </div>
           <div className={styles.fact}>
             <span>Frequenza di controllo</span>
@@ -175,13 +175,13 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           </div>
           <p>
             Le missioni rappresentano le principali funzioni e finalità perseguite attraverso la spesa pubblica.
-            Qui mostriamo le prime dodici nel cumulato disponibile.
+            Qui mostriamo le dodici con il totale più alto nel periodo disponibile.
           </p>
         </div>
 
         <div className={styles.chartBlock}>
           <div className={styles.chartTitle}>
-            <h3>Top missioni · {snapshot.period.label}</h3>
+            <h3>Missioni principali, {snapshot.period.label}</h3>
             <a href={snapshot.sources.mission.csvUrl} target="_blank" rel="noreferrer">fonte CSV ↗</a>
           </div>
           <SpendingBarChart
@@ -191,7 +191,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             height={500}
           />
           <p className={styles.chartCaption}>
-            Valori cumulati in euro. Ordinamento calcolato da DoveVannoINostriSoldi sul campo “Totale Pagato” del dataset RGS per Missione.
+            Totali in euro da gennaio. L&apos;ordine usa il campo “Totale Pagato” del file RGS per Missione.
           </p>
         </div>
       </section>
@@ -203,8 +203,8 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             <h2>Amministrazioni e natura economica</h2>
           </div>
           <p>
-            Due letture indipendenti dello stesso cumulato: amministrazioni centrali e categorie economiche.
-            Se una fonte secondaria del periodo non è disponibile, la relativa visualizzazione resta vuota.
+            Lo stesso totale viene diviso prima per amministrazione e poi per tipo di spesa.
+            Se manca uno dei file ufficiali, il relativo grafico resta vuoto.
           </p>
         </div>
 
@@ -249,7 +249,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           </div>
           <p>
             Composizione delle modalità incluse da RGS nel “Totale Pagato”. La barra più lunga corrisponde
-            al canale con valore maggiore nel cumulato, non a una soglia normativa.
+            al canale con il totale maggiore. Non indica una soglia prevista dalla legge.
           </p>
         </div>
 
@@ -276,8 +276,8 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             <h2>Tre viste, un totale da verificare</h2>
           </div>
           <p>
-            Confrontiamo automaticamente i totali ottenuti da dataset RGS distinti. Una differenza non viene
-            corretta o nascosta: rimane visibile come segnale di qualità del dato o del perimetro.
+            Confrontiamo i totali ottenuti da file RGS diversi. Se non coincidono, mostriamo la
+            differenza senza correggerla o nasconderla.
           </p>
         </div>
 
@@ -303,12 +303,10 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
       <section className={styles.section}>
         <div className={styles.sectionHeader}>
           <div>
-            <span className={styles.kicker}>PROVENIENZA</span>
-            <h2>Arriva sempre al dato originale</h2>
+            <h2>Apri sempre il dato originale</h2>
           </div>
           <p>
-            Il package UUID è conservato separatamente dagli eventuali resource UUID OData. I link sotto
-            puntano direttamente ai file e alle API ufficiali RGS usati per questa pagina.
+            I link portano ai file e ai servizi ufficiali RGS usati per costruire questa pagina.
           </p>
         </div>
 
@@ -349,15 +347,15 @@ export default async function StateSpendingPage() {
               <span className={styles.kicker}>RGS / OPENBDAP</span>
               <h1 className={styles.title}>Spese dello Stato.</h1>
               <p className={styles.lead}>
-                Questa pagina usa esclusivamente i dataset ufficiali OpenBDAP. Se la fonte non risponde,
-                non sostituiamo i valori con cache inventate o numeri dimostrativi.
+                Questa pagina usa solo dati ufficiali OpenBDAP. Se la fonte non risponde, non
+                sostituiamo i valori con numeri inventati.
               </p>
             </div>
           </header>
           <div className={styles.errorState}>
             <strong>Dati temporaneamente non disponibili.</strong>
             <p>
-              Il server non è riuscito a completare l&apos;acquisizione da OpenBDAP. Dettaglio tecnico: {errorMessage ?? "non disponibile"}.
+              Non siamo riusciti a leggere OpenBDAP. Puoi riprovare più tardi. Dettaglio: {errorMessage ?? "non disponibile"}.
             </p>
           </div>
         </>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 import { MunicipalSpendingTrendChart } from "@/components/charts/municipal-spending-trend-chart";
+import { PeriodSelector } from "@/components/period-selector";
 import { SpendingBarChart } from "@/components/charts/spending-bar-chart";
 import {
+  availableSiopeYears,
+  getSiopeMunicipalSnapshot,
   regionsByPerCapita,
-  siopeMunicipalSnapshot as data,
 } from "@/lib/siope-snapshot";
 import styles from "./territori.module.css";
 
@@ -45,29 +47,37 @@ function dateTime(value: string | null): string {
   }).format(date);
 }
 
-const regionTotalData = data.regions.map((region) => ({
-  label: region.region,
-  value: region.value,
-  code: `${integer.format(region.municipalities)} Comuni`,
-}));
+function selectedYear(value: string | string[] | undefined): number {
+  const parsed = Number.parseInt(Array.isArray(value) ? value[0] ?? "" : value ?? "", 10);
+  return availableSiopeYears.includes(parsed) ? parsed : availableSiopeYears[0];
+}
 
-const regionPerCapitaData = regionsByPerCapita(data).map((region) => ({
-  label: region.region,
-  value: region.perCapita ?? 0,
-  code: `${integer.format(region.municipalities)} Comuni`,
-}));
+export default async function TerritoriesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ anno?: string | string[] }>;
+}) {
+  const year = selectedYear((await searchParams).anno);
+  const data = getSiopeMunicipalSnapshot(year);
+  const regionTotalData = data.regions.map((region) => ({
+    label: region.region,
+    value: region.value,
+    code: `${integer.format(region.municipalities)} Comuni`,
+  }));
+  const regionPerCapitaData = regionsByPerCapita(data).map((region) => ({
+    label: region.region,
+    value: region.perCapita ?? 0,
+    code: `${integer.format(region.municipalities)} Comuni`,
+  }));
+  const titleData = data.titles.map((title) => ({
+    label: title.label,
+    value: title.value,
+    code: `Titolo ${title.code}`,
+  }));
+  const coverageRatio = data.coverage.activeSiopeMunicipalities > 0
+    ? (data.coverage.withMovements / data.coverage.activeSiopeMunicipalities) * 100
+    : 0;
 
-const titleData = data.titles.map((title) => ({
-  label: title.label,
-  value: title.value,
-  code: `Titolo ${title.code}`,
-}));
-
-const coverageRatio = data.coverage.activeSiopeMunicipalities > 0
-  ? (data.coverage.withMovements / data.coverage.activeSiopeMunicipalities) * 100
-  : 0;
-
-export default function TerritoriesPage() {
   return (
     <main className={styles.page}>
       <section className={styles.hero}>
@@ -83,9 +93,10 @@ export default function TerritoriesPage() {
         </div>
 
         <div className={styles.heroMeta}>
-          <span>ULTIMO MESE DISPONIBILE</span>
+          <PeriodSelector activeYear={year} years={availableSiopeYears} pathname="/territori" />
+          <span>Ultimo mese disponibile</span>
           <strong>{data.latestMonthLabel} {data.year}</strong>
-          <small>Snapshot generato {dateTime(data.generatedAt)}</small>
+          <small>Dati preparati il {dateTime(data.generatedAt)}</small>
         </div>
       </section>
 
@@ -97,7 +108,7 @@ export default function TerritoriesPage() {
         </article>
         <article>
           <span>PER ABITANTE COPERTO</span>
-          <strong>{data.nationalPerCapita === null ? "—" : euro.format(data.nationalPerCapita)}</strong>
+          <strong>{data.nationalPerCapita === null ? "Non disponibile" : euro.format(data.nationalPerCapita)}</strong>
           <small>rapporto descrittivo, non costo individuale</small>
         </article>
         <article>
@@ -115,7 +126,6 @@ export default function TerritoriesPage() {
       <section className={styles.section}>
         <div className={styles.sectionHeading}>
           <div>
-            <span className={styles.sectionIndex}>01 · ANDAMENTO</span>
             <h2>Il ritmo dei pagamenti durante l&apos;anno</h2>
           </div>
           <p>
@@ -129,7 +139,6 @@ export default function TerritoriesPage() {
       <section className={styles.section}>
         <div className={styles.sectionHeading}>
           <div>
-            <span className={styles.sectionIndex}>02 · REGIONI</span>
             <h2>Confrontare volume e intensità</h2>
           </div>
           <p>
@@ -153,13 +162,13 @@ export default function TerritoriesPage() {
               maxItems={10}
               height={430}
             />
-            <p className={styles.chartNote}>Prime 10 per volume cumulato da gennaio.</p>
+            <p className={styles.chartNote}>Prime 10 per totale da gennaio.</p>
           </article>
 
           <article className={styles.chartPanel}>
             <header>
               <div>
-                <span>NORMALIZZATO</span>
+              <span>CONFRONTO PER ABITANTE</span>
                 <h3>Euro per abitante coperto</h3>
               </div>
               <b>€/abitante</b>
@@ -181,7 +190,6 @@ export default function TerritoriesPage() {
         <div className={styles.categoryPanel}>
           <div className={styles.panelHeading}>
             <div>
-              <span className={styles.sectionIndex}>03 · NATURA ECONOMICA</span>
               <h2>Che tipo di uscita è</h2>
             </div>
           </div>
@@ -192,7 +200,7 @@ export default function TerritoriesPage() {
             height={365}
           />
           <p className={styles.chartNote}>
-            Raggruppamento per titolo ricavato dalla codifica gestionale SIOPE; il dettaglio delle singole voci arriverà nel drill-down dell&apos;ente.
+            Raggruppamento secondo i titoli usati da SIOPE. Il dettaglio delle singole voci sarà aggiunto alle pagine degli enti.
           </p>
         </div>
 
@@ -225,7 +233,7 @@ export default function TerritoriesPage() {
             </div>
           </dl>
           <p>
-            Gli enti non abbinati restano fuori dalle aggregazioni regionali: preferiamo una lacuna dichiarata a un join geografico indovinato.
+            Gli enti non abbinati restano fuori dai totali regionali. Non assegniamo una regione senza una corrispondenza ufficiale.
           </p>
         </aside>
       </section>
@@ -233,7 +241,6 @@ export default function TerritoriesPage() {
       <section className={styles.section}>
         <div className={styles.sectionHeading}>
           <div>
-            <span className={styles.sectionIndex}>04 · AMMINISTRAZIONI</span>
             <h2>I maggiori volumi comunali</h2>
           </div>
           <p>
@@ -249,7 +256,7 @@ export default function TerritoriesPage() {
                 <th scope="col">#</th>
                 <th scope="col">Comune</th>
                 <th scope="col">Regione</th>
-                <th scope="col">Pagamenti YTD</th>
+                <th scope="col">Pagamenti da gennaio</th>
                 <th scope="col">€/abitante</th>
               </tr>
             </thead>
@@ -263,7 +270,7 @@ export default function TerritoriesPage() {
                   </th>
                   <td>{municipality.region}</td>
                   <td>{euro.format(municipality.value)}</td>
-                  <td>{municipality.perCapita === null ? "—" : euro.format(municipality.perCapita)}</td>
+                  <td>{municipality.perCapita === null ? "Non disponibile" : euro.format(municipality.perCapita)}</td>
                 </tr>
               ))}
             </tbody>
@@ -273,11 +280,10 @@ export default function TerritoriesPage() {
 
       <section className={styles.provenance}>
         <div className={styles.provenanceIntro}>
-          <span className={styles.sectionIndex}>05 · PROVENIENZA</span>
-          <h2>Il grafico non è la fonte.</h2>
+          <h2>Controlla i dati originali</h2>
           <p>
-            Lo snapshot conserva gli URL upstream e i loro validator. Il controllo gira
-            frequentemente, ma il dato cambia soltanto quando cambia la pubblicazione ufficiale.
+            Conserviamo i collegamenti ai file usati. Il controllo gira spesso, ma i numeri
+            cambiano solo quando SIOPE pubblica un aggiornamento.
           </p>
           <Link href="/fonti/stato" className={styles.inlineLink}>
             Stato di tutte le fonti <span aria-hidden="true">→</span>
@@ -289,7 +295,7 @@ export default function TerritoriesPage() {
             <span>01</span>
             <div>
               <strong>SIOPE · movimenti di uscita {data.year}</strong>
-              <small>Fonte primaria · modificata {dateTime(data.source.siopeMovementsLastModified)}</small>
+              <small>Fonte principale. Aggiornata {dateTime(data.source.siopeMovementsLastModified)}</small>
             </div>
             <i aria-hidden="true">↗</i>
           </a>
@@ -297,7 +303,7 @@ export default function TerritoriesPage() {
             <span>02</span>
             <div>
               <strong>SIOPE · anagrafiche</strong>
-              <small>Ente, codice fiscale e popolazione · modificata {dateTime(data.source.siopeRegistryLastModified)}</small>
+              <small>Ente, codice fiscale e popolazione. Aggiornata {dateTime(data.source.siopeRegistryLastModified)}</small>
             </div>
             <i aria-hidden="true">↗</i>
           </a>
@@ -305,7 +311,7 @@ export default function TerritoriesPage() {
             <span>03</span>
             <div>
               <strong>Indice PA · amministrazioni</strong>
-              <small>Join codice fiscale → regione · modificata {dateTime(data.source.ipaLastModified)}</small>
+              <small>Il codice fiscale collega ogni ente alla regione. Aggiornata {dateTime(data.source.ipaLastModified)}</small>
             </div>
             <i aria-hidden="true">↗</i>
           </a>

--- a/src/components/charts/cohesion-explorer-chart.tsx
+++ b/src/components/charts/cohesion-explorer-chart.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   Bar,
   BarChart,
+  Cell,
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
@@ -11,6 +12,7 @@ import {
   YAxis,
 } from "recharts";
 import type { OpenCoesioneDimension } from "@/lib/data/opencoesione-contract";
+import { chartColor } from "@/lib/chart-colors";
 import styles from "./cohesion-explorer-chart.module.css";
 
 type View = "themes" | "natures" | "statuses";
@@ -129,10 +131,13 @@ export function CohesionExplorerChart({
             />
             <Bar
               dataKey="publicCostEuro"
-              fill="var(--chart-primary)"
               radius={[0, 3, 3, 0]}
               isAnimationActive={false}
-            />
+            >
+              {data.map((point, index) => (
+                <Cell key={point.slug} fill={chartColor(index)} />
+              ))}
+            </Bar>
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/components/charts/cohesion-history-chart.tsx
+++ b/src/components/charts/cohesion-history-chart.tsx
@@ -68,8 +68,8 @@ export function CohesionHistoryChart({ data }: { data: OpenCoesioneAnnualPoint[]
                 return (
                   <div className={styles.tooltip}>
                     <strong>{point.year}</strong>
-                    <span>Impegni cumulati <b>{exactEuro.format(point.commitmentsEuro)}</b></span>
-                    <span>Pagamenti cumulati <b>{exactEuro.format(point.paymentsEuro)}</b></span>
+                    <span>Impegni fino all&apos;anno <b>{exactEuro.format(point.commitmentsEuro)}</b></span>
+                    <span>Pagamenti fino all&apos;anno <b>{exactEuro.format(point.paymentsEuro)}</b></span>
                   </div>
                 );
               }}
@@ -98,20 +98,20 @@ export function CohesionHistoryChart({ data }: { data: OpenCoesioneAnnualPoint[]
         </ResponsiveContainer>
       </div>
       <div className={styles.legend} aria-hidden="true">
-        <span><i className={styles.commitments} /> Impegni cumulati</span>
-        <span><i className={styles.payments} /> Pagamenti cumulati</span>
+        <span><i className={styles.commitments} /> Impegni fino all&apos;anno</span>
+        <span><i className={styles.payments} /> Pagamenti fino all&apos;anno</span>
       </div>
       <figcaption>
-        Serie cumulativa per anno pubblicata dall’API aggregata; non rappresenta il flusso del solo anno indicato.
+        Ogni punto contiene il totale registrato fino a quell&apos;anno, non il valore del solo anno indicato.
       </figcaption>
       <div className={styles.tableWrap}>
         <table>
-          <caption>Valori annuali della serie cumulativa OpenCoesione</caption>
+          <caption>Totali annuali pubblicati da OpenCoesione</caption>
           <thead>
             <tr>
               <th scope="col">Anno</th>
-              <th scope="col">Impegni cumulati</th>
-              <th scope="col">Pagamenti cumulati</th>
+              <th scope="col">Impegni fino all&apos;anno</th>
+              <th scope="col">Pagamenti fino all&apos;anno</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/charts/home-monthly-chart.tsx
+++ b/src/components/charts/home-monthly-chart.tsx
@@ -3,6 +3,7 @@
 import {
   Bar,
   BarChart,
+  Cell,
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
@@ -10,6 +11,7 @@ import {
   YAxis,
 } from "recharts";
 import type { SiopeMunicipalMonthlyPoint } from "@/lib/siope-snapshot";
+import { chartColor } from "@/lib/chart-colors";
 import styles from "./home-monthly-chart.module.css";
 
 const exactEuro = new Intl.NumberFormat("it-IT", {
@@ -79,10 +81,13 @@ export function HomeMonthlyChart({ data }: { data: SiopeMunicipalMonthlyPoint[] 
             />
             <Bar
               dataKey="flow"
-              fill="var(--chart-secondary)"
               radius={[3, 3, 0, 0]}
               isAnimationActive={false}
-            />
+            >
+              {data.map((point, index) => (
+                <Cell key={point.month} fill={chartColor(index)} />
+              ))}
+            </Bar>
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/components/charts/municipal-spending-trend-chart.tsx
+++ b/src/components/charts/municipal-spending-trend-chart.tsx
@@ -5,6 +5,7 @@ import {
   AreaChart,
   Bar,
   BarChart,
+  Cell,
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
@@ -12,6 +13,7 @@ import {
   YAxis,
 } from "recharts";
 import type { SiopeMunicipalMonthlyPoint } from "@/lib/siope-snapshot";
+import { chartColor } from "@/lib/chart-colors";
 import styles from "./municipal-spending-trend-chart.module.css";
 
 const exactEuro = new Intl.NumberFormat("it-IT", {
@@ -41,7 +43,7 @@ function TooltipCard({
   return (
     <div className={styles.tooltip}>
       <span>{point.label}</span>
-      <strong>{mode === "flow" ? "Pagamenti del mese" : "Cumulato da gennaio"}</strong>
+      <strong>{mode === "flow" ? "Pagamenti del mese" : "Totale da gennaio"}</strong>
       <b>{exactEuro.format(mode === "flow" ? point.flow : point.cumulative)}</b>
     </div>
   );
@@ -102,15 +104,18 @@ export function MunicipalSpendingTrendChart({
               />
               <Bar
                 dataKey="flow"
-                fill="var(--chart-secondary)"
                 radius={[3, 3, 0, 0]}
                 isAnimationActive={false}
-              />
+              >
+                {data.map((point, index) => (
+                  <Cell key={point.month} fill={chartColor(index)} />
+                ))}
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>
         <figcaption>
-          SIOPE pubblica movimenti mensili puri: qui non ricaviamo il mese per differenza tra snapshot.
+          SIOPE pubblica direttamente i movimenti di ogni mese. Non dobbiamo stimarli.
         </figcaption>
       </figure>
 
@@ -118,7 +123,7 @@ export function MunicipalSpendingTrendChart({
         <div className={styles.figureHeader}>
           <div>
             <span>PROGRESSIONE ANNUALE</span>
-            <h3>Pagamenti cumulati da gennaio</h3>
+            <h3>Totale dei pagamenti da gennaio</h3>
           </div>
           <b>somma dei flussi</b>
         </div>
@@ -175,7 +180,7 @@ export function MunicipalSpendingTrendChart({
           </ResponsiveContainer>
         </div>
         <figcaption>
-          Il cumulato è una trasformazione trasparente: somma progressiva dei movimenti mensili ufficiali.
+          Il totale cresce sommando, mese dopo mese, i movimenti ufficiali.
         </figcaption>
       </figure>
     </div>

--- a/src/components/charts/spending-bar-chart.tsx
+++ b/src/components/charts/spending-bar-chart.tsx
@@ -3,6 +3,7 @@
 import {
   Bar,
   BarChart,
+  Cell,
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
@@ -10,6 +11,7 @@ import {
   YAxis,
 } from "recharts";
 import styles from "./spending-bar-chart.module.css";
+import { chartColor } from "@/lib/chart-colors";
 
 export type SpendingChartPoint = {
   label: string;
@@ -106,10 +108,13 @@ export function SpendingBarChart({
             />
             <Bar
               dataKey="value"
-              fill="var(--chart-primary)"
               radius={[0, 3, 3, 0]}
               isAnimationActive={false}
-            />
+            >
+              {chartData.map((point, index) => (
+                <Cell key={`${point.code ?? point.label}-${index}`} fill={chartColor(index)} />
+              ))}
+            </Bar>
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/components/charts/spending-history-chart.tsx
+++ b/src/components/charts/spending-history-chart.tsx
@@ -43,8 +43,8 @@ function TooltipCard({
   return (
     <div className={styles.tooltip}>
       <span>{point.monthName} {point.year}</span>
-      <strong>{mode === "cumulative" ? "Cumulato da gennaio" : "Pagamento del mese derivato"}</strong>
-      <b>{exactEuro.format(value)}</b>
+      <strong>{mode === "cumulative" ? "Totale da gennaio" : "Pagamento del mese calcolato"}</strong>
+      <b>{value === null ? "Non calcolabile" : exactEuro.format(value)}</b>
     </div>
   );
 }
@@ -63,10 +63,10 @@ export function SpendingHistoryChart({
       <figure className={styles.figure}>
         <div className={styles.figureHeader}>
           <div>
-            <span>ANDAMENTO CUMULATIVO</span>
+            <span>TOTALE DA GENNAIO</span>
             <h3>Pagamenti da inizio anno</h3>
           </div>
-          <b>{data.length} snapshot</b>
+          <b>{data.length} mesi disponibili</b>
         </div>
         <div className={styles.chart} role="img" aria-label="Pagamenti cumulati del Bilancio dello Stato da gennaio">
           <ResponsiveContainer width="100%" height="100%">
@@ -108,17 +108,17 @@ export function SpendingHistoryChart({
           </ResponsiveContainer>
         </div>
         <figcaption>
-          Ogni punto è il totale ufficiale cumulato dal 1° gennaio fino alla fine del mese contabile indicato.
+          Ogni punto è il totale ufficiale dal 1° gennaio fino alla fine del mese indicato.
         </figcaption>
       </figure>
 
       <figure className={styles.figure}>
         <div className={styles.figureHeader}>
           <div>
-            <span>FLUSSO DERIVATO</span>
-            <h3>Pagamenti attribuiti al singolo mese</h3>
+            <span>MESE PER MESE</span>
+            <h3>Pagamenti calcolati per ogni mese</h3>
           </div>
-          <b>Δ snapshot</b>
+          <b>Differenza tra due mesi</b>
         </div>
         <div className={styles.chart} role="img" aria-label="Pagamenti mensili derivati dalla differenza tra snapshot cumulativi RGS">
           <ResponsiveContainer width="100%" height="100%">
@@ -156,7 +156,7 @@ export function SpendingHistoryChart({
           </ResponsiveContainer>
         </div>
         <figcaption>
-          Gennaio coincide con il primo snapshot; da febbraio il valore è calcolato come differenza tra due cumulati consecutivi.
+          Da febbraio sottraiamo il totale del mese precedente. Se manca uno dei due mesi, non calcoliamo il valore.
         </figcaption>
       </figure>
     </div>

--- a/src/components/italy-regions-map.module.css
+++ b/src/components/italy-regions-map.module.css
@@ -31,11 +31,11 @@
   outline: none;
 }
 
-.level0 { fill: #18384b; background: #18384b; }
-.level1 { fill: #26516a; background: #26516a; }
-.level2 { fill: #386d88; background: #386d88; }
-.level3 { fill: #528aa4; background: #528aa4; }
-.level4 { fill: #76a8bd; background: #76a8bd; }
+.level0 { fill: #56468f; background: #56468f; }
+.level1 { fill: #346ea1; background: #346ea1; }
+.level2 { fill: #2d8d8a; background: #2d8d8a; }
+.level3 { fill: #65a66f; background: #65a66f; }
+.level4 { fill: #d2a84f; background: #d2a84f; }
 .noData { fill: #29343b; }
 
 .legend {

--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -125,20 +125,20 @@ export function ItalyRegionsMap({
                 ? `fino a ${integer.format(thresholds[0])} €`
                 : index === 4
                   ? `oltre ${integer.format(thresholds[3])} €`
-                  : `${integer.format(thresholds[index - 1])}–${integer.format(thresholds[index])} €`}
+                  : `da ${integer.format(thresholds[index - 1])} a ${integer.format(thresholds[index])} €`}
             </span>
           ))}
         </div>
       </div>
 
       <aside className={styles.detail} aria-live="polite">
-        <span>REGIONE SELEZIONATA</span>
+        <span>Regione selezionata</span>
         <h3>{selected?.region ?? "Dato non disponibile"}</h3>
-        <strong>{selected?.perCapita === null || !selected ? "—" : euro.format(selected.perCapita)}</strong>
+        <strong>{selected?.perCapita === null || !selected ? "Non disponibile" : euro.format(selected.perCapita)}</strong>
         <small>per abitante della popolazione coperta</small>
         <dl>
-          <div><dt>Totale pagato</dt><dd>{selected ? compactEuro(selected.value) : "—"}</dd></div>
-          <div><dt>Comuni inclusi</dt><dd>{selected ? integer.format(selected.municipalities) : "—"}</dd></div>
+          <div><dt>Totale pagato</dt><dd>{selected ? compactEuro(selected.value) : "Non disponibile"}</dd></div>
+          <div><dt>Comuni inclusi</dt><dd>{selected ? integer.format(selected.municipalities) : "Non disponibile"}</dd></div>
           <div><dt>Periodo</dt><dd>{period}</dd></div>
         </dl>
         <p>

--- a/src/components/period-selector.module.css
+++ b/src/components/period-selector.module.css
@@ -1,0 +1,62 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.wrapper > span {
+  color: #8199a6;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.wrapper > div {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid rgba(137, 171, 190, .2);
+  border-radius: 9px;
+  background: rgba(3, 13, 22, .62);
+}
+
+.wrapper a {
+  display: grid;
+  min-width: 58px;
+  min-height: 34px;
+  place-items: center;
+  border-radius: 6px;
+  color: #8299a6;
+  font-size: 12px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  transition: color 160ms cubic-bezier(.23, 1, .32, 1), background-color 160ms cubic-bezier(.23, 1, .32, 1), transform 120ms cubic-bezier(.23, 1, .32, 1);
+}
+
+.wrapper a[aria-current="page"] {
+  color: #07151f;
+  background: #edf6f8;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, .16);
+}
+
+.wrapper a:active {
+  transform: scale(.97);
+}
+
+@media (max-width: 560px) {
+  .wrapper {
+    width: 100%;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  .wrapper > div,
+  .wrapper a {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wrapper a {
+    transition-duration: 0ms;
+  }
+}

--- a/src/components/period-selector.tsx
+++ b/src/components/period-selector.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import styles from "./period-selector.module.css";
+
+export function PeriodSelector({
+  activeYear,
+  years,
+  pathname,
+}: {
+  activeYear: number;
+  years: number[];
+  pathname: string;
+}) {
+  return (
+    <nav className={styles.wrapper} aria-label="Anno dei dati SIOPE">
+      <span>Anno</span>
+      <div>
+        {years.map((year) => (
+          <Link
+            key={year}
+            href={`${pathname}?anno=${year}`}
+            aria-current={year === activeYear ? "page" : undefined}
+          >
+            {year}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/state-spending-history-section.module.css
+++ b/src/components/state-spending-history-section.module.css
@@ -94,6 +94,16 @@
   border-top: 1px solid var(--line);
 }
 
+.coverageNote {
+  margin: 14px 0 0;
+  padding: 12px 14px;
+  border-left: 2px solid var(--amber);
+  color: #aebfca;
+  background: rgba(240, 197, 108, .05);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
 .methodology div {
   min-width: 0;
 }

--- a/src/components/state-spending-history-section.tsx
+++ b/src/components/state-spending-history-section.tsx
@@ -34,9 +34,10 @@ function HistoryUnavailable() {
   return (
     <section className={styles.section}>
       <div className={styles.error}>
-        <strong>Serie temporale momentaneamente non disponibile.</strong>
+        <strong>Lo storico non è disponibile in questo momento.</strong>
         <p>
-          La dashboard principale resta valida. Lo storico richiede più rilasci OpenBDAP e viene omesso se uno degli snapshot necessari non è raggiungibile.
+          OpenBDAP non ha restituito dati mensili utilizzabili. Gli altri numeri della pagina
+          provengono comunque dai file ufficiali indicati sopra.
         </p>
       </div>
     </section>
@@ -48,8 +49,8 @@ export function StateSpendingHistoryFallback() {
     <section className={styles.section} aria-busy="true">
       <div className={styles.header}>
         <div>
-          <span>SERIE 2026</span>
-          <h2>Caricamento degli snapshot mensili RGS…</h2>
+          <span>SPESA MESE PER MESE</span>
+          <h2>Caricamento dei dati mensili RGS...</h2>
         </div>
       </div>
       <div className={styles.loadingGrid} aria-hidden="true">
@@ -65,57 +66,69 @@ export async function StateSpendingHistorySection() {
   if (!history || history.points.length === 0) return <HistoryUnavailable />;
 
   const latest = history.points.at(-1);
-  const maxMonth = history.points.reduce((maximum, point) =>
-    point.monthlyPaid > maximum.monthlyPaid ? point : maximum,
+  const monthlyPoints = history.points.filter(
+    (point): point is typeof point & { monthlyPaid: number } => point.monthlyPaid !== null,
   );
-  const averageMonthly = latest ? latest.cumulativePaid / history.points.length : 0;
+  const maxMonth = monthlyPoints.reduce(
+    (maximum, point) => point.monthlyPaid > maximum.monthlyPaid ? point : maximum,
+    monthlyPoints[0],
+  );
+  const averageMonthly = latest ? latest.cumulativePaid / latest.month : 0;
+  const hasMissingMonths = history.coverage.missingMonths.length > 0;
 
   return (
     <section className={styles.section}>
       <div className={styles.header}>
         <div>
-          <span>SERIE TEMPORALE · RGS / OPENBDAP</span>
-          <h2>Dal cumulato al flusso mensile.</h2>
+          <span>SPESA MESE PER MESE · RGS / OPENBDAP</span>
+          <h2>Come cambiano i pagamenti durante l&apos;anno</h2>
         </div>
         <p>
-          RGS pubblica i pagamenti “a tutto” il mese indicato, quindi cumulati dal 1° gennaio.
-          Il secondo grafico sottrae due snapshot consecutivi per isolare il pagamento attribuito al mese.
+          RGS pubblica il totale dal 1° gennaio al mese indicato. Per ottenere il valore del
+          singolo mese sottraiamo due totali consecutivi.
         </p>
       </div>
 
       <div className={styles.metrics}>
         <div>
           <span>Ultimo mese disponibile</span>
-          <strong>{latest ? compactEuro(latest.monthlyPaid) : "—"}</strong>
-          <small>{latest ? `${latest.monthName} ${latest.year}` : "dato non disponibile"}</small>
+          <strong>{latest?.monthlyPaid === null || !latest ? "Non calcolabile" : compactEuro(latest.monthlyPaid)}</strong>
+          <small>{latest ? `${latest.monthName} ${latest.year}` : "Dato non disponibile"}</small>
         </div>
         <div>
-          <span>Media mensile YTD</span>
+          <span>Media mensile da gennaio</span>
           <strong>{compactEuro(averageMonthly)}</strong>
-          <small>cumulato diviso {history.points.length} mesi disponibili</small>
+          <small>Totale da gennaio diviso {latest?.month ?? history.points.length} mesi</small>
         </div>
         <div>
-          <span>Mese con flusso maggiore</span>
-          <strong>{compactEuro(maxMonth.monthlyPaid)}</strong>
-          <small>{maxMonth.monthName}</small>
+          <span>Mese con più pagamenti</span>
+          <strong>{maxMonth ? compactEuro(maxMonth.monthlyPaid) : "Non calcolabile"}</strong>
+          <small>{maxMonth?.monthName ?? "Servono due mesi consecutivi"}</small>
         </div>
       </div>
 
       <SpendingHistoryChart data={history.points} />
 
+      {hasMissingMonths && (
+        <p className={styles.coverageNote}>
+          Storico parziale: OpenBDAP non ha restituito {history.coverage.missingMonths.join(", ").toLocaleLowerCase("it-IT")}.
+          I mesi mancanti non sono stati stimati.
+        </p>
+      )}
+
       <div className={styles.methodology}>
         <div>
           <span>Metodo</span>
-          <strong>Δ cumulato mese t − cumulato mese t−1</strong>
+          <strong>Totale del mese meno totale del mese precedente</strong>
         </div>
         <div>
           <span>Semantica ufficiale</span>
           <a href={history.methodology.officialSemanticsUrl} target="_blank" rel="noreferrer">
-            RGS · pagamenti dal 1° gennaio al mese di riferimento ↗
+            RGS: pagamenti dal 1° gennaio al mese indicato ↗
           </a>
         </div>
         <div>
-          <span>Acquisito</span>
+          <span>Controllato</span>
           <strong>{observedAtFormatter.format(new Date(history.observedAt))}</strong>
         </div>
       </div>

--- a/src/data/generated/siope-municipal-2024.json
+++ b/src/data/generated/siope-municipal-2024.json
@@ -1,0 +1,1091 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-20T11:18:14+00:00",
+  "scope": "municipalities",
+  "year": 2024,
+  "latestMonth": 12,
+  "latestMonthLabel": "Dicembre",
+  "totalPaid": 109432987088.37,
+  "populationCovered": 58939649,
+  "nationalPerCapita": 1856.7,
+  "coverage": {
+    "activeSiopeMunicipalities": 7903,
+    "matchedToIpaRegion": 7893,
+    "withMovements": 7892,
+    "unmatchedToIpaRegion": 10,
+    "movementRows": 8507733,
+    "includedMovementRows": 7013990,
+    "malformedRows": 0
+  },
+  "monthly": [
+    {
+      "month": 1,
+      "label": "Gennaio",
+      "flow": 7049715060.5,
+      "cumulative": 7049715060.5
+    },
+    {
+      "month": 2,
+      "label": "Febbraio",
+      "flow": 8174196301.01,
+      "cumulative": 15223911361.51
+    },
+    {
+      "month": 3,
+      "label": "Marzo",
+      "flow": 8460478148.43,
+      "cumulative": 23684389509.94
+    },
+    {
+      "month": 4,
+      "label": "Aprile",
+      "flow": 8014415440.07,
+      "cumulative": 31698804950.01
+    },
+    {
+      "month": 5,
+      "label": "Maggio",
+      "flow": 9677610293.13,
+      "cumulative": 41376415243.14
+    },
+    {
+      "month": 6,
+      "label": "Giugno",
+      "flow": 9017565691.11,
+      "cumulative": 50393980934.25
+    },
+    {
+      "month": 7,
+      "label": "Luglio",
+      "flow": 10286818250.6,
+      "cumulative": 60680799184.85
+    },
+    {
+      "month": 8,
+      "label": "Agosto",
+      "flow": 7908608142.79,
+      "cumulative": 68589407327.64
+    },
+    {
+      "month": 9,
+      "label": "Settembre",
+      "flow": 7537625545.13,
+      "cumulative": 76127032872.77
+    },
+    {
+      "month": 10,
+      "label": "Ottobre",
+      "flow": 8828068669.58,
+      "cumulative": 84955101542.35
+    },
+    {
+      "month": 11,
+      "label": "Novembre",
+      "flow": 8581593439.69,
+      "cumulative": 93536694982.04
+    },
+    {
+      "month": 12,
+      "label": "Dicembre",
+      "flow": 15896292106.33,
+      "cumulative": 109432987088.37
+    }
+  ],
+  "regions": [
+    {
+      "region": "Lombardia",
+      "value": 16523205886.89,
+      "population": 10011929,
+      "perCapita": 1650.35,
+      "municipalities": 1501
+    },
+    {
+      "region": "Lazio",
+      "value": 11985585854.89,
+      "population": 5714745,
+      "perCapita": 2097.31,
+      "municipalities": 378
+    },
+    {
+      "region": "Sicilia",
+      "value": 9479728706.1,
+      "population": 4797359,
+      "perCapita": 1976.03,
+      "municipalities": 391
+    },
+    {
+      "region": "Campania",
+      "value": 9344711021.11,
+      "population": 5576133,
+      "perCapita": 1675.84,
+      "municipalities": 549
+    },
+    {
+      "region": "Emilia-Romagna",
+      "value": 7538732214.59,
+      "population": 4451938,
+      "perCapita": 1693.36,
+      "municipalities": 330
+    },
+    {
+      "region": "Piemonte",
+      "value": 7142718696.07,
+      "population": 4251355,
+      "perCapita": 1680.1,
+      "municipalities": 1180
+    },
+    {
+      "region": "Veneto",
+      "value": 7121358354.25,
+      "population": 4846305,
+      "perCapita": 1469.44,
+      "municipalities": 558
+    },
+    {
+      "region": "Toscana",
+      "value": 6842434908.74,
+      "population": 3660530,
+      "perCapita": 1869.25,
+      "municipalities": 273
+    },
+    {
+      "region": "Puglia",
+      "value": 5739037020.37,
+      "population": 3890661,
+      "perCapita": 1475.08,
+      "municipalities": 257
+    },
+    {
+      "region": "Calabria",
+      "value": 4257404807.12,
+      "population": 1838568,
+      "perCapita": 2315.61,
+      "municipalities": 404
+    },
+    {
+      "region": "Liguria",
+      "value": 4111065636.32,
+      "population": 1509140,
+      "perCapita": 2724.11,
+      "municipalities": 234
+    },
+    {
+      "region": "Sardegna",
+      "value": 3670689675.89,
+      "population": 1568211,
+      "perCapita": 2340.69,
+      "municipalities": 377
+    },
+    {
+      "region": "Trentino-Alto Adige/Südtirol",
+      "value": 3304388897.91,
+      "population": 1077440,
+      "perCapita": 3066.89,
+      "municipalities": 282
+    },
+    {
+      "region": "Marche",
+      "value": 3108107365.05,
+      "population": 1482746,
+      "perCapita": 2096.18,
+      "municipalities": 225
+    },
+    {
+      "region": "Abruzzo",
+      "value": 2968287712.76,
+      "population": 1269571,
+      "perCapita": 2338.02,
+      "municipalities": 305
+    },
+    {
+      "region": "Friuli-Venezia Giulia",
+      "value": 2643497854.58,
+      "population": 1194616,
+      "perCapita": 2212.84,
+      "municipalities": 215
+    },
+    {
+      "region": "Umbria",
+      "value": 1569565135.58,
+      "population": 853068,
+      "perCapita": 1839.91,
+      "municipalities": 92
+    },
+    {
+      "region": "Basilicata",
+      "value": 1020756749.63,
+      "population": 533233,
+      "perCapita": 1914.28,
+      "municipalities": 131
+    },
+    {
+      "region": "Molise",
+      "value": 631585073.38,
+      "population": 289224,
+      "perCapita": 2183.72,
+      "municipalities": 136
+    },
+    {
+      "region": "Valle d'Aosta/Vallée d'Aoste",
+      "value": 430125517.14,
+      "population": 122877,
+      "perCapita": 3500.46,
+      "municipalities": 74
+    }
+  ],
+  "titles": [
+    {
+      "code": "1",
+      "label": "Spese correnti",
+      "value": 62322026936.11
+    },
+    {
+      "code": "2",
+      "label": "Spese in conto capitale",
+      "value": 21682598267.14
+    },
+    {
+      "code": "7",
+      "label": "Uscite per conto terzi e partite di giro",
+      "value": 19000781064.89
+    },
+    {
+      "code": "4",
+      "label": "Rimborso prestiti",
+      "value": 2659185196.32
+    },
+    {
+      "code": "5",
+      "label": "Chiusura anticipazioni da tesoriere/cassiere",
+      "value": 2614870924.7
+    },
+    {
+      "code": "3",
+      "label": "Spese per incremento di attività finanziarie",
+      "value": 1139248876.35
+    },
+    {
+      "code": "0",
+      "label": "Pagamenti da regolarizzare",
+      "value": 14275822.86
+    }
+  ],
+  "topMunicipalities": [
+    {
+      "name": "ROMA CAPITALE",
+      "region": "Lazio",
+      "codiceFiscale": "02438750586",
+      "population": 2751747,
+      "value": 7041805276.75,
+      "perCapita": 2559.03
+    },
+    {
+      "name": "COMUNE DI MILANO",
+      "region": "Lombardia",
+      "codiceFiscale": "01199250158",
+      "population": 1371499,
+      "value": 4376669061.5,
+      "perCapita": 3191.16
+    },
+    {
+      "name": "COMUNE DI NAPOLI",
+      "region": "Campania",
+      "codiceFiscale": "80014890638",
+      "population": 913704,
+      "value": 2017015632.67,
+      "perCapita": 2207.52
+    },
+    {
+      "name": "COMUNE DI GENOVA",
+      "region": "Liguria",
+      "codiceFiscale": "00856930102",
+      "population": 562422,
+      "value": 1956907719.48,
+      "perCapita": 3479.43
+    },
+    {
+      "name": "COMUNE DI TORINO",
+      "region": "Piemonte",
+      "codiceFiscale": "00514490010",
+      "population": 851199,
+      "value": 1885858031.24,
+      "perCapita": 2215.53
+    },
+    {
+      "name": "COMUNE DI CATANIA",
+      "region": "Sicilia",
+      "codiceFiscale": "00137020871",
+      "population": 298680,
+      "value": 1298480774.87,
+      "perCapita": 4347.4
+    },
+    {
+      "name": "COMUNE DI VENEZIA",
+      "region": "Veneto",
+      "codiceFiscale": "00339370272",
+      "population": 250290,
+      "value": 1158689223.62,
+      "perCapita": 4629.39
+    },
+    {
+      "name": "COMUNE DI FIRENZE",
+      "region": "Toscana",
+      "codiceFiscale": "01307110484",
+      "population": 362613,
+      "value": 1065127671.63,
+      "perCapita": 2937.37
+    },
+    {
+      "name": "COMUNE DI BOLOGNA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "01232710374",
+      "population": 390098,
+      "value": 948531655.18,
+      "perCapita": 2431.52
+    },
+    {
+      "name": "COMUNE DI PALERMO",
+      "region": "Sicilia",
+      "codiceFiscale": "80016350821",
+      "population": 630427,
+      "value": 892290906.24,
+      "perCapita": 1415.38
+    },
+    {
+      "name": "COMUNE DI MESSINA",
+      "region": "Sicilia",
+      "codiceFiscale": "00080270838",
+      "population": 217959,
+      "value": 785435489.51,
+      "perCapita": 3603.59
+    },
+    {
+      "name": "COMUNE DI BARI",
+      "region": "Puglia",
+      "codiceFiscale": "80015010723",
+      "population": 316226,
+      "value": 551093161.12,
+      "perCapita": 1742.72
+    },
+    {
+      "name": "COMUNE DI TRIESTE",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "00210240321",
+      "population": 198843,
+      "value": 498984708.17,
+      "perCapita": 2509.44
+    },
+    {
+      "name": "COMUNE DI VERONA",
+      "region": "Veneto",
+      "codiceFiscale": "00215150236",
+      "population": 255298,
+      "value": 474459542.25,
+      "perCapita": 1858.45
+    },
+    {
+      "name": "COMUNE DI PADOVA",
+      "region": "Veneto",
+      "codiceFiscale": "00644060287",
+      "population": 207502,
+      "value": 472834846.77,
+      "perCapita": 2278.7
+    },
+    {
+      "name": "COMUNE DI BRESCIA",
+      "region": "Lombardia",
+      "codiceFiscale": "00761890177",
+      "population": 198259,
+      "value": 422830996.56,
+      "perCapita": 2132.72
+    },
+    {
+      "name": "COMUNE DI MODENA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00221940364",
+      "population": 184597,
+      "value": 403708249.57,
+      "perCapita": 2186.97
+    },
+    {
+      "name": "COMUNE DI L'AQUILA",
+      "region": "Abruzzo",
+      "codiceFiscale": "80002270660",
+      "population": 69717,
+      "value": 393192216.15,
+      "perCapita": 5639.83
+    },
+    {
+      "name": "COMUNE DI SALERNO",
+      "region": "Campania",
+      "codiceFiscale": "80000330656",
+      "population": 126715,
+      "value": 388688018.27,
+      "perCapita": 3067.42
+    },
+    {
+      "name": "COMUNE DI CAGLIARI",
+      "region": "Sardegna",
+      "codiceFiscale": "00147990923",
+      "population": 147411,
+      "value": 370299520.65,
+      "perCapita": 2512.02
+    },
+    {
+      "name": "COMUNE DI TARANTO",
+      "region": "Puglia",
+      "codiceFiscale": "80008750731",
+      "population": 187025,
+      "value": 369161940.74,
+      "perCapita": 1973.86
+    },
+    {
+      "name": "COMUNE DI PARMA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00162210348",
+      "population": 198121,
+      "value": 331582256.76,
+      "perCapita": 1673.64
+    },
+    {
+      "name": "COMUNE DI BOLZANO",
+      "region": "Trentino-Alto Adige/Südtirol",
+      "codiceFiscale": "00389240219",
+      "population": 106357,
+      "value": 311394956.8,
+      "perCapita": 2927.83
+    },
+    {
+      "name": "COMUNE DI BERGAMO",
+      "region": "Lombardia",
+      "codiceFiscale": "80034840167",
+      "population": 120157,
+      "value": 303275058.95,
+      "perCapita": 2523.99
+    },
+    {
+      "name": "COMUNE DI RIMINI",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00304260409",
+      "population": 150046,
+      "value": 302211711.77,
+      "perCapita": 2014.13
+    },
+    {
+      "name": "COMUNE DI RAVENNA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00354730392",
+      "population": 156304,
+      "value": 297412632.52,
+      "perCapita": 1902.78
+    },
+    {
+      "name": "COMUNE DI TRENTO",
+      "region": "Trentino-Alto Adige/Südtirol",
+      "codiceFiscale": "00355870221",
+      "population": 118504,
+      "value": 285653402.9,
+      "perCapita": 2410.5
+    },
+    {
+      "name": "COMUNE DI LIVORNO",
+      "region": "Toscana",
+      "codiceFiscale": "00104330493",
+      "population": 153418,
+      "value": 275149312.88,
+      "perCapita": 1793.46
+    },
+    {
+      "name": "COMUNE DI PERUGIA",
+      "region": "Umbria",
+      "codiceFiscale": "00163570542",
+      "population": 162099,
+      "value": 273055359.93,
+      "perCapita": 1684.5
+    },
+    {
+      "name": "COMUNE DI REGGIO DI CALABRIA",
+      "region": "Calabria",
+      "codiceFiscale": "00136380805",
+      "population": 169679,
+      "value": 266531138.94,
+      "perCapita": 1570.8
+    },
+    {
+      "name": "COMUNE DI PRATO",
+      "region": "Toscana",
+      "codiceFiscale": "84006890481",
+      "population": 197088,
+      "value": 262410478.09,
+      "perCapita": 1331.44
+    },
+    {
+      "name": "COMUNE DI REGGIO NELL'EMILIA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00145920351",
+      "population": 171207,
+      "value": 252137986.48,
+      "perCapita": 1472.71
+    },
+    {
+      "name": "COMUNE DI ALESSANDRIA",
+      "region": "Piemonte",
+      "codiceFiscale": "00429440068",
+      "population": 91854,
+      "value": 248382575.81,
+      "perCapita": 2704.1
+    },
+    {
+      "name": "COMUNE DI COSENZA",
+      "region": "Calabria",
+      "codiceFiscale": "00347720781",
+      "population": 63701,
+      "value": 233000594.53,
+      "perCapita": 3657.72
+    },
+    {
+      "name": "COMUNE DI FERRARA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00297110389",
+      "population": 129391,
+      "value": 228087005.13,
+      "perCapita": 1762.77
+    },
+    {
+      "name": "COMUNE DI CATANZARO",
+      "region": "Calabria",
+      "codiceFiscale": "00129520797",
+      "population": 84109,
+      "value": 222858829.32,
+      "perCapita": 2649.64
+    },
+    {
+      "name": "COMUNE DI LECCE",
+      "region": "Puglia",
+      "codiceFiscale": "80008510754",
+      "population": 94250,
+      "value": 213465321.1,
+      "perCapita": 2264.88
+    },
+    {
+      "name": "COMUNE DI FORLI'",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00606620409",
+      "population": 117050,
+      "value": 211977118.97,
+      "perCapita": 1811.0
+    },
+    {
+      "name": "COMUNE DI ANCONA",
+      "region": "Marche",
+      "codiceFiscale": "00351040423",
+      "population": 99377,
+      "value": 209134728.3,
+      "perCapita": 2104.46
+    },
+    {
+      "name": "COMUNE DI SASSARI",
+      "region": "Sardegna",
+      "codiceFiscale": "00239740905",
+      "population": 121085,
+      "value": 206497959.47,
+      "perCapita": 1705.4
+    },
+    {
+      "name": "COMUNE DI UDINE",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "00168650307",
+      "population": 98304,
+      "value": 206180204.25,
+      "perCapita": 2097.37
+    },
+    {
+      "name": "COMUNE DI PISA",
+      "region": "Toscana",
+      "codiceFiscale": "00341620508",
+      "population": 89117,
+      "value": 199891476.23,
+      "perCapita": 2243.02
+    },
+    {
+      "name": "COMUNE DI MONZA",
+      "region": "Lombardia",
+      "codiceFiscale": "02030880153",
+      "population": 122883,
+      "value": 192257628.06,
+      "perCapita": 1564.56
+    },
+    {
+      "name": "COMUNE DI VICENZA",
+      "region": "Veneto",
+      "codiceFiscale": "00516890241",
+      "population": 110299,
+      "value": 191545803.05,
+      "perCapita": 1736.61
+    },
+    {
+      "name": "COMUNE DI RICCIONE",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00324360403",
+      "population": 34465,
+      "value": 190652812.9,
+      "perCapita": 5531.78
+    },
+    {
+      "name": "COMUNE DI FOGGIA",
+      "region": "Puglia",
+      "codiceFiscale": "00363460718",
+      "population": 145652,
+      "value": 188686593.9,
+      "perCapita": 1295.46
+    },
+    {
+      "name": "COMUNE DI PESCARA",
+      "region": "Abruzzo",
+      "codiceFiscale": "00124600685",
+      "population": 118461,
+      "value": 184876210.58,
+      "perCapita": 1560.65
+    },
+    {
+      "name": "COMUNE DI PIACENZA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00229080338",
+      "population": 102887,
+      "value": 183408317.36,
+      "perCapita": 1782.62
+    },
+    {
+      "name": "COMUNE DI POMEZIA",
+      "region": "Lazio",
+      "codiceFiscale": "02298490588",
+      "population": 64451,
+      "value": 181199817.35,
+      "perCapita": 2811.44
+    },
+    {
+      "name": "COMUNE DI TIVOLI",
+      "region": "Lazio",
+      "codiceFiscale": "02696630587",
+      "population": 55061,
+      "value": 178363927.46,
+      "perCapita": 3239.39
+    },
+    {
+      "name": "COMUNE DI PESARO",
+      "region": "Marche",
+      "codiceFiscale": "00272430414",
+      "population": 95392,
+      "value": 171726599.18,
+      "perCapita": 1800.22
+    },
+    {
+      "name": "COMUNE DI SIRACUSA",
+      "region": "Sicilia",
+      "codiceFiscale": "80001010893",
+      "population": 116247,
+      "value": 170003100.53,
+      "perCapita": 1462.43
+    },
+    {
+      "name": "COMUNE DI NOVARA",
+      "region": "Piemonte",
+      "codiceFiscale": "00125680033",
+      "population": 102187,
+      "value": 169159489.32,
+      "perCapita": 1655.39
+    },
+    {
+      "name": "COMUNE DI TERNI",
+      "region": "Umbria",
+      "codiceFiscale": "00175660554",
+      "population": 106436,
+      "value": 167964312.34,
+      "perCapita": 1578.08
+    },
+    {
+      "name": "COMUNE DI APRILIA",
+      "region": "Lazio",
+      "codiceFiscale": "80003450592",
+      "population": 74470,
+      "value": 165993577.15,
+      "perCapita": 2229.0
+    },
+    {
+      "name": "COMUNE DI FIUMICINO",
+      "region": "Lazio",
+      "codiceFiscale": "97086740582",
+      "population": 82481,
+      "value": 164526379.86,
+      "perCapita": 1994.72
+    },
+    {
+      "name": "COMUNE DI CORIGLIANO-ROSSANO",
+      "region": "Calabria",
+      "codiceFiscale": "03557570789",
+      "population": 74268,
+      "value": 163284461.95,
+      "perCapita": 2198.58
+    },
+    {
+      "name": "COMUNE DI MACERATA",
+      "region": "Marche",
+      "codiceFiscale": "80001650433",
+      "population": 40538,
+      "value": 161584540.54,
+      "perCapita": 3986.0
+    },
+    {
+      "name": "COMUNE DI POZZUOLI",
+      "region": "Campania",
+      "codiceFiscale": "00508900636",
+      "population": 76255,
+      "value": 157666522.48,
+      "perCapita": 2067.62
+    },
+    {
+      "name": "COMUNE DI CIVITAVECCHIA",
+      "region": "Lazio",
+      "codiceFiscale": "02700960582",
+      "population": 51697,
+      "value": 157508744.74,
+      "perCapita": 3046.77
+    },
+    {
+      "name": "COMUNE DI IMPERIA",
+      "region": "Liguria",
+      "codiceFiscale": "00089700082",
+      "population": 42490,
+      "value": 155629264.13,
+      "perCapita": 3662.73
+    },
+    {
+      "name": "COMUNE DI LATINA",
+      "region": "Lazio",
+      "codiceFiscale": "00097020598",
+      "population": 127859,
+      "value": 153020388.89,
+      "perCapita": 1196.79
+    },
+    {
+      "name": "COMUNE DI LA SPEZIA",
+      "region": "Liguria",
+      "codiceFiscale": "00211160114",
+      "population": 92696,
+      "value": 143254016.05,
+      "perCapita": 1545.42
+    },
+    {
+      "name": "COMUNE DI ASCOLI PICENO",
+      "region": "Marche",
+      "codiceFiscale": "00229010442",
+      "population": 45448,
+      "value": 142764144.11,
+      "perCapita": 3141.26
+    },
+    {
+      "name": "COMUNE DI COMO",
+      "region": "Lombardia",
+      "codiceFiscale": "80005370137",
+      "population": 83586,
+      "value": 140861735.75,
+      "perCapita": 1685.23
+    },
+    {
+      "name": "COMUNE DI LUCCA",
+      "region": "Toscana",
+      "codiceFiscale": "00378210462",
+      "population": 89234,
+      "value": 139863461.06,
+      "perCapita": 1567.38
+    },
+    {
+      "name": "COMUNE DI PORDENONE",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "80002150938",
+      "population": 52147,
+      "value": 139032640.72,
+      "perCapita": 2666.17
+    },
+    {
+      "name": "COMUNE DI BENEVENTO",
+      "region": "Campania",
+      "codiceFiscale": "00074270620",
+      "population": 56048,
+      "value": 138628618.99,
+      "perCapita": 2473.39
+    },
+    {
+      "name": "COMUNE DI NUORO",
+      "region": "Sardegna",
+      "codiceFiscale": "00053070918",
+      "population": 33622,
+      "value": 138489368.65,
+      "perCapita": 4119.01
+    },
+    {
+      "name": "COMUNE DI PISTOIA",
+      "region": "Toscana",
+      "codiceFiscale": "00108690470",
+      "population": 89054,
+      "value": 137969598.72,
+      "perCapita": 1549.28
+    },
+    {
+      "name": "COMUNE DI BAGHERIA",
+      "region": "Sicilia",
+      "codiceFiscale": "81000170829",
+      "population": 53010,
+      "value": 137801993.91,
+      "perCapita": 2599.55
+    },
+    {
+      "name": "COMUNE DI CESENA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00143280402",
+      "population": 96066,
+      "value": 136889157.03,
+      "perCapita": 1424.95
+    },
+    {
+      "name": "COMUNE DI SANREMO",
+      "region": "Liguria",
+      "codiceFiscale": "00253750087",
+      "population": 52992,
+      "value": 131977904.09,
+      "perCapita": 2490.53
+    },
+    {
+      "name": "COMUNE DI AREZZO",
+      "region": "Toscana",
+      "codiceFiscale": "00176820512",
+      "population": 96330,
+      "value": 130829595.93,
+      "perCapita": 1358.14
+    },
+    {
+      "name": "COMUNE DI VARESE",
+      "region": "Lombardia",
+      "codiceFiscale": "00441340122",
+      "population": 78818,
+      "value": 130647829.49,
+      "perCapita": 1657.59
+    },
+    {
+      "name": "COMUNE DI VIAREGGIO",
+      "region": "Toscana",
+      "codiceFiscale": "00274950468",
+      "population": 60755,
+      "value": 129943670.37,
+      "perCapita": 2138.81
+    },
+    {
+      "name": "COMUNE DI SIENA",
+      "region": "Toscana",
+      "codiceFiscale": "00050800523",
+      "population": 52833,
+      "value": 128878196.5,
+      "perCapita": 2439.35
+    },
+    {
+      "name": "COMUNE DI OLBIA",
+      "region": "Sardegna",
+      "codiceFiscale": "91008330903",
+      "population": 61481,
+      "value": 128232847.39,
+      "perCapita": 2085.73
+    },
+    {
+      "name": "COMUNE DI MODICA",
+      "region": "Sicilia",
+      "codiceFiscale": "00175500883",
+      "population": 53485,
+      "value": 124987274.33,
+      "perCapita": 2336.87
+    },
+    {
+      "name": "COMUNE DI CREMONA",
+      "region": "Lombardia",
+      "codiceFiscale": "00297960197",
+      "population": 70675,
+      "value": 124864218.25,
+      "perCapita": 1766.74
+    },
+    {
+      "name": "COMUNE DI TREVISO",
+      "region": "Veneto",
+      "codiceFiscale": "80007310263",
+      "population": 85322,
+      "value": 120694684.47,
+      "perCapita": 1414.58
+    },
+    {
+      "name": "COMUNE DI MANTOVA",
+      "region": "Lombardia",
+      "codiceFiscale": "00189800204",
+      "population": 49044,
+      "value": 120055724.78,
+      "perCapita": 2447.92
+    },
+    {
+      "name": "COMUNE DI GROSSETO",
+      "region": "Toscana",
+      "codiceFiscale": "00082520537",
+      "population": 81482,
+      "value": 118757142.48,
+      "perCapita": 1457.46
+    },
+    {
+      "name": "COMUNE DI BUSTO ARSIZIO",
+      "region": "Lombardia",
+      "codiceFiscale": "00224000125",
+      "population": 83372,
+      "value": 118278046.39,
+      "perCapita": 1418.68
+    },
+    {
+      "name": "COMUNE DI RAGUSA",
+      "region": "Sicilia",
+      "codiceFiscale": "00180270886",
+      "population": 73736,
+      "value": 117493725.18,
+      "perCapita": 1593.44
+    },
+    {
+      "name": "COMUNE DI PAVIA",
+      "region": "Lombardia",
+      "codiceFiscale": "00296180185",
+      "population": 71297,
+      "value": 113143154.09,
+      "perCapita": 1586.93
+    },
+    {
+      "name": "COMUNE DI BRINDISI",
+      "region": "Puglia",
+      "codiceFiscale": "80000250748",
+      "population": 82298,
+      "value": 112589545.46,
+      "perCapita": 1368.07
+    },
+    {
+      "name": "COMUNE DI MAZARA DEL VALLO",
+      "region": "Sicilia",
+      "codiceFiscale": "82001410818",
+      "population": 50029,
+      "value": 110141725.96,
+      "perCapita": 2201.56
+    },
+    {
+      "name": "COMUNE DI SESTO SAN GIOVANNI",
+      "region": "Lombardia",
+      "codiceFiscale": "02253930156",
+      "population": 78495,
+      "value": 109665610.01,
+      "perCapita": 1397.1
+    },
+    {
+      "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
+      "region": "Campania",
+      "codiceFiscale": "80049220637",
+      "population": 124209,
+      "value": 108316682.62,
+      "perCapita": 872.05
+    },
+    {
+      "name": "COMUNE DI VITERBO",
+      "region": "Lazio",
+      "codiceFiscale": "80008850564",
+      "population": 66188,
+      "value": 107979687.11,
+      "perCapita": 1631.41
+    },
+    {
+      "name": "COMUNE DI ALBANO LAZIALE",
+      "region": "Lazio",
+      "codiceFiscale": "82011210588",
+      "population": 39773,
+      "value": 106521288.66,
+      "perCapita": 2678.23
+    },
+    {
+      "name": "COMUNE DI GORIZIA",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "00122500317",
+      "population": 33608,
+      "value": 105432507.1,
+      "perCapita": 3137.13
+    },
+    {
+      "name": "COMUNE DI MASSA",
+      "region": "Toscana",
+      "codiceFiscale": "00181760455",
+      "population": 65992,
+      "value": 105113593.39,
+      "perCapita": 1592.82
+    },
+    {
+      "name": "COMUNE DI ASTI",
+      "region": "Piemonte",
+      "codiceFiscale": "00072360050",
+      "population": 73401,
+      "value": 103567026.81,
+      "perCapita": 1410.98
+    },
+    {
+      "name": "COMUNE DI ROVERETO",
+      "region": "Trentino-Alto Adige/Südtirol",
+      "codiceFiscale": "00125390229",
+      "population": 40077,
+      "value": 103186965.61,
+      "perCapita": 2574.72
+    },
+    {
+      "name": "COMUNE DI CARRARA",
+      "region": "Toscana",
+      "codiceFiscale": "00079450458",
+      "population": 59757,
+      "value": 103008403.78,
+      "perCapita": 1723.79
+    },
+    {
+      "name": "COMUNE DI ALTAMURA",
+      "region": "Puglia",
+      "codiceFiscale": "82002590725",
+      "population": 70093,
+      "value": 102591941.46,
+      "perCapita": 1463.65
+    },
+    {
+      "name": "COMUNE DI MATERA",
+      "region": "Basilicata",
+      "codiceFiscale": "80002870774",
+      "population": 59652,
+      "value": 101872743.54,
+      "perCapita": 1707.78
+    },
+    {
+      "name": "COMUNE DI FANO",
+      "region": "Marche",
+      "codiceFiscale": "00127440410",
+      "population": 59992,
+      "value": 100646882.51,
+      "perCapita": 1677.67
+    }
+  ],
+  "source": {
+    "siopeOwner": "Ragioneria Generale dello Stato · banca dati gestita da Banca d'Italia",
+    "siopeMovementsUrl": "https://www.siope.it/documenti/siope2/open/last/SIOPE_USCITE.2024.zip",
+    "siopeRegistryUrl": "https://www.siope.it/documenti/siope2/open/last/SIOPE_ANAGRAFICHE.zip",
+    "ipaUrl": "https://indicepa.gov.it/ipa-dati/dataset/502ff370-1b2c-4310-94c7-f39ceb7500e3/resource/3ed63523-ff9c-41f6-a6fe-980f3d9e501f/download/amministrazioni.txt",
+    "siopeMovementsLastModified": "Thu, 13 Aug 2026 18:45:07 GMT",
+    "siopeRegistryLastModified": "Thu, 13 Aug 2026 18:45:07 GMT",
+    "ipaLastModified": "Thu, 20 Aug 2026 03:13:24 GMT",
+    "observedAt": "2026-08-20T11:18:14+00:00"
+  },
+  "methodology": {
+    "measure": "pagamenti di cassa SIOPE dei Comuni",
+    "periodicity": "movimenti mensili puri, sommati da gennaio all'ultimo mese disponibile",
+    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA",
+    "warning": "Il totale regionale rappresenta i pagamenti dei Comuni con sede nella regione; non misura tutta la spesa pubblica effettuata fisicamente nel territorio."
+  }
+}

--- a/src/data/generated/siope-municipal-2025.json
+++ b/src/data/generated/siope-municipal-2025.json
@@ -1,0 +1,1091 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-20T11:19:24+00:00",
+  "scope": "municipalities",
+  "year": 2025,
+  "latestMonth": 12,
+  "latestMonthLabel": "Dicembre",
+  "totalPaid": 114139622029.85,
+  "populationCovered": 58939649,
+  "nationalPerCapita": 1936.55,
+  "coverage": {
+    "activeSiopeMunicipalities": 7903,
+    "matchedToIpaRegion": 7893,
+    "withMovements": 7892,
+    "unmatchedToIpaRegion": 10,
+    "movementRows": 8714207,
+    "includedMovementRows": 7065991,
+    "malformedRows": 0
+  },
+  "monthly": [
+    {
+      "month": 1,
+      "label": "Gennaio",
+      "flow": 7220546316.97,
+      "cumulative": 7220546316.97
+    },
+    {
+      "month": 2,
+      "label": "Febbraio",
+      "flow": 8477315481.6,
+      "cumulative": 15697861798.57
+    },
+    {
+      "month": 3,
+      "label": "Marzo",
+      "flow": 8753365864.7,
+      "cumulative": 24451227663.27
+    },
+    {
+      "month": 4,
+      "label": "Aprile",
+      "flow": 8646270937.06,
+      "cumulative": 33097498600.33
+    },
+    {
+      "month": 5,
+      "label": "Maggio",
+      "flow": 8934173093.2,
+      "cumulative": 42031671693.53
+    },
+    {
+      "month": 6,
+      "label": "Giugno",
+      "flow": 10676875195.46,
+      "cumulative": 52708546888.99
+    },
+    {
+      "month": 7,
+      "label": "Luglio",
+      "flow": 10183249689.93,
+      "cumulative": 62891796578.92
+    },
+    {
+      "month": 8,
+      "label": "Agosto",
+      "flow": 7868656973.41,
+      "cumulative": 70760453552.33
+    },
+    {
+      "month": 9,
+      "label": "Settembre",
+      "flow": 8132756466.26,
+      "cumulative": 78893210018.59
+    },
+    {
+      "month": 10,
+      "label": "Ottobre",
+      "flow": 9219755069.85,
+      "cumulative": 88112965088.44
+    },
+    {
+      "month": 11,
+      "label": "Novembre",
+      "flow": 9192386097.27,
+      "cumulative": 97305351185.71
+    },
+    {
+      "month": 12,
+      "label": "Dicembre",
+      "flow": 16834270844.14,
+      "cumulative": 114139622029.85
+    }
+  ],
+  "regions": [
+    {
+      "region": "Lombardia",
+      "value": 16846624712.21,
+      "population": 10011929,
+      "perCapita": 1682.66,
+      "municipalities": 1501
+    },
+    {
+      "region": "Lazio",
+      "value": 12944282525.75,
+      "population": 5714745,
+      "perCapita": 2265.07,
+      "municipalities": 378
+    },
+    {
+      "region": "Sicilia",
+      "value": 9790764994.59,
+      "population": 4797359,
+      "perCapita": 2040.87,
+      "municipalities": 391
+    },
+    {
+      "region": "Campania",
+      "value": 9712319783.45,
+      "population": 5576133,
+      "perCapita": 1741.77,
+      "municipalities": 549
+    },
+    {
+      "region": "Emilia-Romagna",
+      "value": 7858999242.16,
+      "population": 4451938,
+      "perCapita": 1765.3,
+      "municipalities": 330
+    },
+    {
+      "region": "Veneto",
+      "value": 7303260229.85,
+      "population": 4846305,
+      "perCapita": 1506.97,
+      "municipalities": 558
+    },
+    {
+      "region": "Toscana",
+      "value": 7165247168.21,
+      "population": 3660530,
+      "perCapita": 1957.43,
+      "municipalities": 273
+    },
+    {
+      "region": "Piemonte",
+      "value": 7114858065.62,
+      "population": 4251355,
+      "perCapita": 1673.55,
+      "municipalities": 1180
+    },
+    {
+      "region": "Puglia",
+      "value": 6161680088.44,
+      "population": 3890661,
+      "perCapita": 1583.71,
+      "municipalities": 257
+    },
+    {
+      "region": "Calabria",
+      "value": 4651243753.62,
+      "population": 1838568,
+      "perCapita": 2529.82,
+      "municipalities": 404
+    },
+    {
+      "region": "Sardegna",
+      "value": 3907960848.21,
+      "population": 1568211,
+      "perCapita": 2491.99,
+      "municipalities": 377
+    },
+    {
+      "region": "Liguria",
+      "value": 3779821868.7,
+      "population": 1509140,
+      "perCapita": 2504.62,
+      "municipalities": 234
+    },
+    {
+      "region": "Trentino-Alto Adige/Südtirol",
+      "value": 3576489306.42,
+      "population": 1077440,
+      "perCapita": 3319.43,
+      "municipalities": 282
+    },
+    {
+      "region": "Marche",
+      "value": 3287252715.33,
+      "population": 1482746,
+      "perCapita": 2217.0,
+      "municipalities": 225
+    },
+    {
+      "region": "Abruzzo",
+      "value": 3145243155.58,
+      "population": 1269571,
+      "perCapita": 2477.41,
+      "municipalities": 305
+    },
+    {
+      "region": "Friuli-Venezia Giulia",
+      "value": 2985589543.26,
+      "population": 1194616,
+      "perCapita": 2499.2,
+      "municipalities": 215
+    },
+    {
+      "region": "Umbria",
+      "value": 1634136369.26,
+      "population": 853068,
+      "perCapita": 1915.6,
+      "municipalities": 92
+    },
+    {
+      "region": "Basilicata",
+      "value": 1111948186.45,
+      "population": 533233,
+      "perCapita": 2085.3,
+      "municipalities": 131
+    },
+    {
+      "region": "Molise",
+      "value": 680258204.22,
+      "population": 289224,
+      "perCapita": 2352.01,
+      "municipalities": 136
+    },
+    {
+      "region": "Valle d'Aosta/Vallée d'Aoste",
+      "value": 481641268.52,
+      "population": 122877,
+      "perCapita": 3919.7,
+      "municipalities": 74
+    }
+  ],
+  "titles": [
+    {
+      "code": "1",
+      "label": "Spese correnti",
+      "value": 64261791067.83
+    },
+    {
+      "code": "2",
+      "label": "Spese in conto capitale",
+      "value": 25006593335.78
+    },
+    {
+      "code": "7",
+      "label": "Uscite per conto terzi e partite di giro",
+      "value": 17978323730.11
+    },
+    {
+      "code": "4",
+      "label": "Rimborso prestiti",
+      "value": 2841315673.42
+    },
+    {
+      "code": "5",
+      "label": "Chiusura anticipazioni da tesoriere/cassiere",
+      "value": 2834841232.56
+    },
+    {
+      "code": "3",
+      "label": "Spese per incremento di attività finanziarie",
+      "value": 1200719207.58
+    },
+    {
+      "code": "0",
+      "label": "Pagamenti da regolarizzare",
+      "value": 16037782.57
+    }
+  ],
+  "topMunicipalities": [
+    {
+      "name": "ROMA CAPITALE",
+      "region": "Lazio",
+      "codiceFiscale": "02438750586",
+      "population": 2751747,
+      "value": 7912216920.96,
+      "perCapita": 2875.34
+    },
+    {
+      "name": "COMUNE DI MILANO",
+      "region": "Lombardia",
+      "codiceFiscale": "01199250158",
+      "population": 1371499,
+      "value": 4484047568.47,
+      "perCapita": 3269.45
+    },
+    {
+      "name": "COMUNE DI NAPOLI",
+      "region": "Campania",
+      "codiceFiscale": "80014890638",
+      "population": 913704,
+      "value": 1974890842.15,
+      "perCapita": 2161.41
+    },
+    {
+      "name": "COMUNE DI TORINO",
+      "region": "Piemonte",
+      "codiceFiscale": "00514490010",
+      "population": 851199,
+      "value": 1825035843.95,
+      "perCapita": 2144.08
+    },
+    {
+      "name": "COMUNE DI GENOVA",
+      "region": "Liguria",
+      "codiceFiscale": "00856930102",
+      "population": 562422,
+      "value": 1632103818.64,
+      "perCapita": 2901.92
+    },
+    {
+      "name": "COMUNE DI CATANIA",
+      "region": "Sicilia",
+      "codiceFiscale": "00137020871",
+      "population": 298680,
+      "value": 1243422297.36,
+      "perCapita": 4163.06
+    },
+    {
+      "name": "COMUNE DI FIRENZE",
+      "region": "Toscana",
+      "codiceFiscale": "01307110484",
+      "population": 362613,
+      "value": 1195937594.82,
+      "perCapita": 3298.11
+    },
+    {
+      "name": "COMUNE DI BOLOGNA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "01232710374",
+      "population": 390098,
+      "value": 1190197904.47,
+      "perCapita": 3051.02
+    },
+    {
+      "name": "COMUNE DI VENEZIA",
+      "region": "Veneto",
+      "codiceFiscale": "00339370272",
+      "population": 250290,
+      "value": 1093939112.17,
+      "perCapita": 4370.69
+    },
+    {
+      "name": "COMUNE DI PALERMO",
+      "region": "Sicilia",
+      "codiceFiscale": "80016350821",
+      "population": 630427,
+      "value": 912885322.32,
+      "perCapita": 1448.04
+    },
+    {
+      "name": "COMUNE DI MESSINA",
+      "region": "Sicilia",
+      "codiceFiscale": "00080270838",
+      "population": 217959,
+      "value": 843819759.22,
+      "perCapita": 3871.46
+    },
+    {
+      "name": "COMUNE DI BARI",
+      "region": "Puglia",
+      "codiceFiscale": "80015010723",
+      "population": 316226,
+      "value": 596028400.75,
+      "perCapita": 1884.82
+    },
+    {
+      "name": "COMUNE DI TRIESTE",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "00210240321",
+      "population": 198843,
+      "value": 579467755.98,
+      "perCapita": 2914.2
+    },
+    {
+      "name": "COMUNE DI PADOVA",
+      "region": "Veneto",
+      "codiceFiscale": "00644060287",
+      "population": 207502,
+      "value": 484306736.74,
+      "perCapita": 2333.99
+    },
+    {
+      "name": "COMUNE DI BRESCIA",
+      "region": "Lombardia",
+      "codiceFiscale": "00761890177",
+      "population": 198259,
+      "value": 482810041.45,
+      "perCapita": 2435.25
+    },
+    {
+      "name": "COMUNE DI VERONA",
+      "region": "Veneto",
+      "codiceFiscale": "00215150236",
+      "population": 255298,
+      "value": 459109122.18,
+      "perCapita": 1798.33
+    },
+    {
+      "name": "COMUNE DI CAGLIARI",
+      "region": "Sardegna",
+      "codiceFiscale": "00147990923",
+      "population": 147411,
+      "value": 433593529.13,
+      "perCapita": 2941.39
+    },
+    {
+      "name": "COMUNE DI L'AQUILA",
+      "region": "Abruzzo",
+      "codiceFiscale": "80002270660",
+      "population": 69717,
+      "value": 427629896.75,
+      "perCapita": 6133.8
+    },
+    {
+      "name": "COMUNE DI BERGAMO",
+      "region": "Lombardia",
+      "codiceFiscale": "80034840167",
+      "population": 120157,
+      "value": 377739458.69,
+      "perCapita": 3143.72
+    },
+    {
+      "name": "COMUNE DI BOLZANO",
+      "region": "Trentino-Alto Adige/Südtirol",
+      "codiceFiscale": "00389240219",
+      "population": 106357,
+      "value": 373659470.28,
+      "perCapita": 3513.26
+    },
+    {
+      "name": "COMUNE DI MODENA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00221940364",
+      "population": 184597,
+      "value": 367333886.87,
+      "perCapita": 1989.92
+    },
+    {
+      "name": "COMUNE DI TARANTO",
+      "region": "Puglia",
+      "codiceFiscale": "80008750731",
+      "population": 187025,
+      "value": 356539395.36,
+      "perCapita": 1906.37
+    },
+    {
+      "name": "COMUNE DI PARMA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00162210348",
+      "population": 198121,
+      "value": 330210968.38,
+      "perCapita": 1666.71
+    },
+    {
+      "name": "COMUNE DI RIMINI",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00304260409",
+      "population": 150046,
+      "value": 313677657.68,
+      "perCapita": 2090.54
+    },
+    {
+      "name": "COMUNE DI REGGIO DI CALABRIA",
+      "region": "Calabria",
+      "codiceFiscale": "00136380805",
+      "population": 169679,
+      "value": 312890600.94,
+      "perCapita": 1844.01
+    },
+    {
+      "name": "COMUNE DI COSENZA",
+      "region": "Calabria",
+      "codiceFiscale": "00347720781",
+      "population": 63701,
+      "value": 293661381.27,
+      "perCapita": 4610.0
+    },
+    {
+      "name": "COMUNE DI PERUGIA",
+      "region": "Umbria",
+      "codiceFiscale": "00163570542",
+      "population": 162099,
+      "value": 285343206.12,
+      "perCapita": 1760.3
+    },
+    {
+      "name": "COMUNE DI TRENTO",
+      "region": "Trentino-Alto Adige/Südtirol",
+      "codiceFiscale": "00355870221",
+      "population": 118504,
+      "value": 283605629.69,
+      "perCapita": 2393.22
+    },
+    {
+      "name": "COMUNE DI SALERNO",
+      "region": "Campania",
+      "codiceFiscale": "80000330656",
+      "population": 126715,
+      "value": 275527092.79,
+      "perCapita": 2174.38
+    },
+    {
+      "name": "COMUNE DI LIVORNO",
+      "region": "Toscana",
+      "codiceFiscale": "00104330493",
+      "population": 153418,
+      "value": 274344274.46,
+      "perCapita": 1788.21
+    },
+    {
+      "name": "COMUNE DI PRATO",
+      "region": "Toscana",
+      "codiceFiscale": "84006890481",
+      "population": 197088,
+      "value": 273844964.43,
+      "perCapita": 1389.46
+    },
+    {
+      "name": "COMUNE DI RAVENNA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00354730392",
+      "population": 156304,
+      "value": 265078438.68,
+      "perCapita": 1695.92
+    },
+    {
+      "name": "COMUNE DI REGGIO NELL'EMILIA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00145920351",
+      "population": 171207,
+      "value": 264386706.13,
+      "perCapita": 1544.25
+    },
+    {
+      "name": "COMUNE DI UDINE",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "00168650307",
+      "population": 98304,
+      "value": 261669105.12,
+      "perCapita": 2661.84
+    },
+    {
+      "name": "COMUNE DI ALESSANDRIA",
+      "region": "Piemonte",
+      "codiceFiscale": "00429440068",
+      "population": 91854,
+      "value": 242846833.6,
+      "perCapita": 2643.84
+    },
+    {
+      "name": "COMUNE DI CATANZARO",
+      "region": "Calabria",
+      "codiceFiscale": "00129520797",
+      "population": 84109,
+      "value": 235458694.0,
+      "perCapita": 2799.45
+    },
+    {
+      "name": "COMUNE DI SASSARI",
+      "region": "Sardegna",
+      "codiceFiscale": "00239740905",
+      "population": 121085,
+      "value": 225771036.93,
+      "perCapita": 1864.57
+    },
+    {
+      "name": "COMUNE DI FERRARA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00297110389",
+      "population": 129391,
+      "value": 220758160.54,
+      "perCapita": 1706.13
+    },
+    {
+      "name": "COMUNE DI PESCARA",
+      "region": "Abruzzo",
+      "codiceFiscale": "00124600685",
+      "population": 118461,
+      "value": 211536799.45,
+      "perCapita": 1785.71
+    },
+    {
+      "name": "COMUNE DI PISA",
+      "region": "Toscana",
+      "codiceFiscale": "00341620508",
+      "population": 89117,
+      "value": 210943233.65,
+      "perCapita": 2367.04
+    },
+    {
+      "name": "COMUNE DI ANCONA",
+      "region": "Marche",
+      "codiceFiscale": "00351040423",
+      "population": 99377,
+      "value": 210729258.34,
+      "perCapita": 2120.5
+    },
+    {
+      "name": "COMUNE DI RICCIONE",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00324360403",
+      "population": 34465,
+      "value": 209745868.27,
+      "perCapita": 6085.76
+    },
+    {
+      "name": "COMUNE DI MONZA",
+      "region": "Lombardia",
+      "codiceFiscale": "02030880153",
+      "population": 122883,
+      "value": 206929880.4,
+      "perCapita": 1683.96
+    },
+    {
+      "name": "COMUNE DI FOGGIA",
+      "region": "Puglia",
+      "codiceFiscale": "00363460718",
+      "population": 145652,
+      "value": 205350480.5,
+      "perCapita": 1409.87
+    },
+    {
+      "name": "COMUNE DI ASCOLI PICENO",
+      "region": "Marche",
+      "codiceFiscale": "00229010442",
+      "population": 45448,
+      "value": 201683299.03,
+      "perCapita": 4437.67
+    },
+    {
+      "name": "COMUNE DI PIACENZA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00229080338",
+      "population": 102887,
+      "value": 201174652.0,
+      "perCapita": 1955.3
+    },
+    {
+      "name": "COMUNE DI VICENZA",
+      "region": "Veneto",
+      "codiceFiscale": "00516890241",
+      "population": 110299,
+      "value": 195400443.31,
+      "perCapita": 1771.55
+    },
+    {
+      "name": "COMUNE DI CORIGLIANO-ROSSANO",
+      "region": "Calabria",
+      "codiceFiscale": "03557570789",
+      "population": 74268,
+      "value": 191756773.48,
+      "perCapita": 2581.96
+    },
+    {
+      "name": "COMUNE DI PORDENONE",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "80002150938",
+      "population": 52147,
+      "value": 187615039.75,
+      "perCapita": 3597.81
+    },
+    {
+      "name": "COMUNE DI PESARO",
+      "region": "Marche",
+      "codiceFiscale": "00272430414",
+      "population": 95392,
+      "value": 186563407.9,
+      "perCapita": 1955.76
+    },
+    {
+      "name": "COMUNE DI FORLI'",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00606620409",
+      "population": 117050,
+      "value": 184862872.74,
+      "perCapita": 1579.35
+    },
+    {
+      "name": "COMUNE DI NOVARA",
+      "region": "Piemonte",
+      "codiceFiscale": "00125680033",
+      "population": 102187,
+      "value": 180626575.96,
+      "perCapita": 1767.61
+    },
+    {
+      "name": "COMUNE DI LECCE",
+      "region": "Puglia",
+      "codiceFiscale": "80008510754",
+      "population": 94250,
+      "value": 177890585.5,
+      "perCapita": 1887.43
+    },
+    {
+      "name": "COMUNE DI FIUMICINO",
+      "region": "Lazio",
+      "codiceFiscale": "97086740582",
+      "population": 82481,
+      "value": 174928977.17,
+      "perCapita": 2120.84
+    },
+    {
+      "name": "COMUNE DI MACERATA",
+      "region": "Marche",
+      "codiceFiscale": "80001650433",
+      "population": 40538,
+      "value": 174812406.71,
+      "perCapita": 4312.31
+    },
+    {
+      "name": "COMUNE DI POMEZIA",
+      "region": "Lazio",
+      "codiceFiscale": "02298490588",
+      "population": 64451,
+      "value": 174123818.85,
+      "perCapita": 2701.65
+    },
+    {
+      "name": "COMUNE DI SIRACUSA",
+      "region": "Sicilia",
+      "codiceFiscale": "80001010893",
+      "population": 116247,
+      "value": 165898005.57,
+      "perCapita": 1427.12
+    },
+    {
+      "name": "COMUNE DI POZZUOLI",
+      "region": "Campania",
+      "codiceFiscale": "00508900636",
+      "population": 76255,
+      "value": 157636529.76,
+      "perCapita": 2067.23
+    },
+    {
+      "name": "COMUNE DI PISTOIA",
+      "region": "Toscana",
+      "codiceFiscale": "00108690470",
+      "population": 89054,
+      "value": 155926492.17,
+      "perCapita": 1750.92
+    },
+    {
+      "name": "COMUNE DI TERNI",
+      "region": "Umbria",
+      "codiceFiscale": "00175660554",
+      "population": 106436,
+      "value": 150995208.1,
+      "perCapita": 1418.65
+    },
+    {
+      "name": "COMUNE DI TREVISO",
+      "region": "Veneto",
+      "codiceFiscale": "80007310263",
+      "population": 85322,
+      "value": 147896940.13,
+      "perCapita": 1733.4
+    },
+    {
+      "name": "COMUNE DI LUCCA",
+      "region": "Toscana",
+      "codiceFiscale": "00378210462",
+      "population": 89234,
+      "value": 146224816.1,
+      "perCapita": 1638.67
+    },
+    {
+      "name": "COMUNE DI LATINA",
+      "region": "Lazio",
+      "codiceFiscale": "00097020598",
+      "population": 127859,
+      "value": 145494142.62,
+      "perCapita": 1137.93
+    },
+    {
+      "name": "COMUNE DI OLBIA",
+      "region": "Sardegna",
+      "codiceFiscale": "91008330903",
+      "population": 61481,
+      "value": 143461636.81,
+      "perCapita": 2333.43
+    },
+    {
+      "name": "COMUNE DI CESENA",
+      "region": "Emilia-Romagna",
+      "codiceFiscale": "00143280402",
+      "population": 96066,
+      "value": 143447581.28,
+      "perCapita": 1493.22
+    },
+    {
+      "name": "COMUNE DI LA SPEZIA",
+      "region": "Liguria",
+      "codiceFiscale": "00211160114",
+      "population": 92696,
+      "value": 141877787.82,
+      "perCapita": 1530.57
+    },
+    {
+      "name": "COMUNE DI RAGUSA",
+      "region": "Sicilia",
+      "codiceFiscale": "00180270886",
+      "population": 73736,
+      "value": 141638458.34,
+      "perCapita": 1920.89
+    },
+    {
+      "name": "COMUNE DI MODICA",
+      "region": "Sicilia",
+      "codiceFiscale": "00175500883",
+      "population": 53485,
+      "value": 140311045.59,
+      "perCapita": 2623.37
+    },
+    {
+      "name": "COMUNE DI VARESE",
+      "region": "Lombardia",
+      "codiceFiscale": "00441340122",
+      "population": 78818,
+      "value": 137597795.2,
+      "perCapita": 1745.77
+    },
+    {
+      "name": "COMUNE DI VIAREGGIO",
+      "region": "Toscana",
+      "codiceFiscale": "00274950468",
+      "population": 60755,
+      "value": 137146316.9,
+      "perCapita": 2257.37
+    },
+    {
+      "name": "COMUNE DI BRINDISI",
+      "region": "Puglia",
+      "codiceFiscale": "80000250748",
+      "population": 82298,
+      "value": 136947607.67,
+      "perCapita": 1664.05
+    },
+    {
+      "name": "COMUNE DI AREZZO",
+      "region": "Toscana",
+      "codiceFiscale": "00176820512",
+      "population": 96330,
+      "value": 136228379.15,
+      "perCapita": 1414.18
+    },
+    {
+      "name": "COMUNE DI SANREMO",
+      "region": "Liguria",
+      "codiceFiscale": "00253750087",
+      "population": 52992,
+      "value": 135869806.14,
+      "perCapita": 2563.97
+    },
+    {
+      "name": "COMUNE DI COMO",
+      "region": "Lombardia",
+      "codiceFiscale": "80005370137",
+      "population": 83586,
+      "value": 134515872.78,
+      "perCapita": 1609.31
+    },
+    {
+      "name": "COMUNE DI APRILIA",
+      "region": "Lazio",
+      "codiceFiscale": "80003450592",
+      "population": 74470,
+      "value": 134345446.07,
+      "perCapita": 1804.02
+    },
+    {
+      "name": "COMUNE DI SIENA",
+      "region": "Toscana",
+      "codiceFiscale": "00050800523",
+      "population": 52833,
+      "value": 133217421.66,
+      "perCapita": 2521.48
+    },
+    {
+      "name": "COMUNE DI TIVOLI",
+      "region": "Lazio",
+      "codiceFiscale": "02696630587",
+      "population": 55061,
+      "value": 131872859.15,
+      "perCapita": 2395.03
+    },
+    {
+      "name": "COMUNE DI BUSTO ARSIZIO",
+      "region": "Lombardia",
+      "codiceFiscale": "00224000125",
+      "population": 83372,
+      "value": 130836796.72,
+      "perCapita": 1569.31
+    },
+    {
+      "name": "COMUNE DI CREMONA",
+      "region": "Lombardia",
+      "codiceFiscale": "00297960197",
+      "population": 70675,
+      "value": 128946572.69,
+      "perCapita": 1824.5
+    },
+    {
+      "name": "COMUNE DI CARRARA",
+      "region": "Toscana",
+      "codiceFiscale": "00079450458",
+      "population": 59757,
+      "value": 127966606.76,
+      "perCapita": 2141.45
+    },
+    {
+      "name": "COMUNE DI CUNEO",
+      "region": "Piemonte",
+      "codiceFiscale": "00480530047",
+      "population": 55914,
+      "value": 124960724.39,
+      "perCapita": 2234.87
+    },
+    {
+      "name": "COMUNE DI BAGHERIA",
+      "region": "Sicilia",
+      "codiceFiscale": "81000170829",
+      "population": 53010,
+      "value": 124542421.54,
+      "perCapita": 2349.41
+    },
+    {
+      "name": "COMUNE DI ANDRIA",
+      "region": "Puglia",
+      "codiceFiscale": "81001210723",
+      "population": 96941,
+      "value": 124156230.37,
+      "perCapita": 1280.74
+    },
+    {
+      "name": "COMUNE DI SPOLETO",
+      "region": "Umbria",
+      "codiceFiscale": "00316820547",
+      "population": 36149,
+      "value": 123023612.61,
+      "perCapita": 3403.24
+    },
+    {
+      "name": "COMUNE DI BENEVENTO",
+      "region": "Campania",
+      "codiceFiscale": "00074270620",
+      "population": 56048,
+      "value": 122770867.34,
+      "perCapita": 2190.46
+    },
+    {
+      "name": "COMUNE DI PAVIA",
+      "region": "Lombardia",
+      "codiceFiscale": "00296180185",
+      "population": 71297,
+      "value": 120046169.26,
+      "perCapita": 1683.75
+    },
+    {
+      "name": "COMUNE DI MANTOVA",
+      "region": "Lombardia",
+      "codiceFiscale": "00189800204",
+      "population": 49044,
+      "value": 117357883.52,
+      "perCapita": 2392.91
+    },
+    {
+      "name": "COMUNE DI MASSAFRA",
+      "region": "Puglia",
+      "codiceFiscale": "80009410731",
+      "population": 31966,
+      "value": 115986112.5,
+      "perCapita": 3628.42
+    },
+    {
+      "name": "COMUNE DI MASSA",
+      "region": "Toscana",
+      "codiceFiscale": "00181760455",
+      "population": 65992,
+      "value": 115110070.37,
+      "perCapita": 1744.3
+    },
+    {
+      "name": "COMUNE DI MERANO",
+      "region": "Trentino-Alto Adige/Südtirol",
+      "codiceFiscale": "00394920219",
+      "population": 41404,
+      "value": 114661657.13,
+      "perCapita": 2769.34
+    },
+    {
+      "name": "COMUNE DI GORIZIA",
+      "region": "Friuli-Venezia Giulia",
+      "codiceFiscale": "00122500317",
+      "population": 33608,
+      "value": 114354822.45,
+      "perCapita": 3402.61
+    },
+    {
+      "name": "COMUNE DI FANO",
+      "region": "Marche",
+      "codiceFiscale": "00127440410",
+      "population": 59992,
+      "value": 114283842.34,
+      "perCapita": 1904.98
+    },
+    {
+      "name": "COMUNE DI VITERBO",
+      "region": "Lazio",
+      "codiceFiscale": "80008850564",
+      "population": 66188,
+      "value": 114141611.77,
+      "perCapita": 1724.51
+    },
+    {
+      "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
+      "region": "Campania",
+      "codiceFiscale": "80049220637",
+      "population": 124209,
+      "value": 113483688.85,
+      "perCapita": 913.65
+    },
+    {
+      "name": "COMUNE DI SESTO SAN GIOVANNI",
+      "region": "Lombardia",
+      "codiceFiscale": "02253930156",
+      "population": 78495,
+      "value": 112979080.51,
+      "perCapita": 1439.32
+    },
+    {
+      "name": "COMUNE DI QUARTU SANT'ELENA",
+      "region": "Sardegna",
+      "codiceFiscale": "00288630924",
+      "population": 68509,
+      "value": 111259633.22,
+      "perCapita": 1624.01
+    },
+    {
+      "name": "COMUNE DI GROSSETO",
+      "region": "Toscana",
+      "codiceFiscale": "00082520537",
+      "population": 81482,
+      "value": 111106481.52,
+      "perCapita": 1363.57
+    },
+    {
+      "name": "COMUNE DI SANTA MARIA CAPUA VETERE",
+      "region": "Campania",
+      "codiceFiscale": "00136270618",
+      "population": 32122,
+      "value": 109712053.38,
+      "perCapita": 3415.48
+    },
+    {
+      "name": "COMUNE DI AVELLINO",
+      "region": "Campania",
+      "codiceFiscale": "00184530640",
+      "population": 52121,
+      "value": 109123082.71,
+      "perCapita": 2093.65
+    },
+    {
+      "name": "COMUNE DI NUORO",
+      "region": "Sardegna",
+      "codiceFiscale": "00053070918",
+      "population": 33622,
+      "value": 108268777.9,
+      "perCapita": 3220.18
+    }
+  ],
+  "source": {
+    "siopeOwner": "Ragioneria Generale dello Stato · banca dati gestita da Banca d'Italia",
+    "siopeMovementsUrl": "https://www.siope.it/documenti/siope2/open/last/SIOPE_USCITE.2025.zip",
+    "siopeRegistryUrl": "https://www.siope.it/documenti/siope2/open/last/SIOPE_ANAGRAFICHE.zip",
+    "ipaUrl": "https://indicepa.gov.it/ipa-dati/dataset/502ff370-1b2c-4310-94c7-f39ceb7500e3/resource/3ed63523-ff9c-41f6-a6fe-980f3d9e501f/download/amministrazioni.txt",
+    "siopeMovementsLastModified": "Thu, 13 Aug 2026 18:45:07 GMT",
+    "siopeRegistryLastModified": "Thu, 13 Aug 2026 18:45:07 GMT",
+    "ipaLastModified": "Thu, 20 Aug 2026 03:13:24 GMT",
+    "observedAt": "2026-08-20T11:19:24+00:00"
+  },
+  "methodology": {
+    "measure": "pagamenti di cassa SIOPE dei Comuni",
+    "periodicity": "movimenti mensili puri, sommati da gennaio all'ultimo mese disponibile",
+    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA",
+    "warning": "Il totale regionale rappresenta i pagamenti dei Comuni con sede nella regione; non misura tutta la spesa pubblica effettuata fisicamente nel territorio."
+  }
+}

--- a/src/lib/bdap-history.ts
+++ b/src/lib/bdap-history.ts
@@ -4,6 +4,7 @@ import {
   getStatePaymentDatasetTotal,
   type BdapDataset,
 } from "@/lib/bdap-payments";
+import { deriveStateSpendingHistoryPoints } from "@/lib/data/bdap-history-points";
 
 const MONTH_NAMES = [
   "GENNAIO",
@@ -26,7 +27,7 @@ export type StateSpendingHistoryPoint = {
   monthName: string;
   label: string;
   cumulativePaid: number;
-  monthlyPaid: number;
+  monthlyPaid: number | null;
   source: {
     productCode: string;
     packageId: string;
@@ -41,6 +42,12 @@ export type StateSpendingHistory = {
   latestMonthName: string;
   points: StateSpendingHistoryPoint[];
   observedAt: string;
+  coverage: {
+    requestedMonths: number;
+    availableMonths: number;
+    monthlyValues: number;
+    missingMonths: string[];
+  };
   methodology: {
     cumulative: true;
     monthlyDerivation: "difference-between-consecutive-cumulative-snapshots";
@@ -48,53 +55,43 @@ export type StateSpendingHistory = {
   };
 };
 
-async function requireMissionDataset(year: number, month: number): Promise<BdapDataset> {
-  const dataset = await getStatePaymentDatasetForPeriod("mission", year, month);
-  if (!dataset) {
-    throw new Error(
-      `Dataset Missione ${year}/${String(month).padStart(2, "0")} non trovato`,
-    );
-  }
-  return dataset;
-}
+type DatasetWithTotal = { dataset: BdapDataset; cumulativePaid: number };
 
 export async function getStateSpendingHistory(): Promise<StateSpendingHistory> {
   const latest = await discoverLatestStatePaymentDataset("mission");
   const year = latest.referenceYear;
   const latestMonth = latest.referenceMonth;
 
-  const datasets = await Promise.all(
+  const datasetResults = await Promise.allSettled(
     Array.from({ length: latestMonth }, (_, index) => {
       const month = index + 1;
-      return month === latestMonth ? Promise.resolve(latest) : requireMissionDataset(year, month);
+      return month === latestMonth
+        ? Promise.resolve(latest)
+        : getStatePaymentDatasetForPeriod("mission", year, month);
     }),
   );
 
-  const cumulativeTotals = await Promise.all(
-    datasets.map((dataset) => getStatePaymentDatasetTotal(dataset)),
+  const datasets = datasetResults
+    .map((result) => (result.status === "fulfilled" ? result.value : null))
+    .filter((dataset): dataset is BdapDataset => dataset !== null);
+
+  const totalResults = await Promise.allSettled(
+    datasets.map(async (dataset) => ({
+      dataset,
+      cumulativePaid: await getStatePaymentDatasetTotal(dataset),
+    })),
   );
 
-  const points = datasets.map((dataset, index): StateSpendingHistoryPoint => {
-    const cumulativePaid = cumulativeTotals[index] ?? 0;
-    const previous = index === 0 ? 0 : cumulativeTotals[index - 1] ?? 0;
-    const monthName =
-      MONTH_NAMES[dataset.referenceMonth - 1] ?? `MESE ${dataset.referenceMonth}`;
-
-    return {
-      year,
-      month: dataset.referenceMonth,
-      monthName,
-      label: monthName.slice(0, 3),
-      cumulativePaid,
-      monthlyPaid: cumulativePaid - previous,
-      source: {
-        productCode: dataset.productCode,
-        packageId: dataset.packageId,
-        csvUrl: dataset.csvUrl,
-        metadataModified: dataset.metadataModified,
-      },
-    };
-  });
+  const values = totalResults
+    .filter((result): result is PromiseFulfilledResult<DatasetWithTotal> =>
+      result.status === "fulfilled",
+    )
+    .map((result) => result.value);
+  const points = deriveStateSpendingHistoryPoints(year, values);
+  const available = new Set(points.map((point) => point.month));
+  const missingMonths = Array.from({ length: latestMonth }, (_, index) => index + 1)
+    .filter((month) => !available.has(month))
+    .map((month) => MONTH_NAMES[month - 1] ?? `MESE ${month}`);
 
   return {
     year,
@@ -102,6 +99,12 @@ export async function getStateSpendingHistory(): Promise<StateSpendingHistory> {
     latestMonthName: MONTH_NAMES[latestMonth - 1] ?? `MESE ${latestMonth}`,
     points,
     observedAt: new Date().toISOString(),
+    coverage: {
+      requestedMonths: latestMonth,
+      availableMonths: points.length,
+      monthlyValues: points.filter((point) => point.monthlyPaid !== null).length,
+      missingMonths,
+    },
     methodology: {
       cumulative: true,
       monthlyDerivation: "difference-between-consecutive-cumulative-snapshots",

--- a/src/lib/bdap-payments.ts
+++ b/src/lib/bdap-payments.ts
@@ -204,6 +204,7 @@ function normalizePackage(
 async function searchProduct(
   code: string,
   dimension: StatePaymentDimension,
+  signal?: AbortSignal,
 ): Promise<BdapDataset[]> {
   const url = `${BDAP_ACTION}/package_search?${new URLSearchParams({
     q: code,
@@ -211,6 +212,7 @@ async function searchProduct(
   }).toString()}`;
   const response = await fetchOfficialSource("openbdap", url, {
     kind: "discovery",
+    signal,
     headers: { Accept: "application/json" },
     tags: [`product:${code}`, `dimension:${dimension}`],
   });
@@ -236,7 +238,7 @@ function periodAtOffset(now: Date, offset: number): { year: number; month: numbe
 
 export async function discoverLatestStatePaymentDataset(
   dimension: StatePaymentDimension,
-  options: { now?: Date; maxMonthsBack?: number } = {},
+  options: { now?: Date; maxMonthsBack?: number; signal?: AbortSignal } = {},
 ): Promise<BdapDataset> {
   const now = options.now ?? new Date();
   const maxMonthsBack = Math.min(Math.max(options.maxMonthsBack ?? 16, 1), 36);
@@ -247,6 +249,7 @@ export async function discoverLatestStatePaymentDataset(
       dimension,
       target.year,
       target.month,
+      { signal: options.signal },
     );
     if (dataset) return dataset;
   }
@@ -258,6 +261,7 @@ export async function getStatePaymentDatasetForPeriod(
   dimension: StatePaymentDimension,
   year: number,
   month: number,
+  options: { signal?: AbortSignal } = {},
 ): Promise<BdapDataset | null> {
   if (!Number.isInteger(year) || year < 2000 || year > 2200) {
     throw new Error(`Anno OpenBDAP non valido: ${year}`);
@@ -267,7 +271,7 @@ export async function getStatePaymentDatasetForPeriod(
   }
 
   const code = productCode(month, dimension);
-  const datasets = await searchProduct(code, dimension);
+  const datasets = await searchProduct(code, dimension, options.signal);
   return (
     datasets.find(
       (dataset) => dataset.referenceYear === year && dataset.referenceMonth === month,
@@ -275,9 +279,13 @@ export async function getStatePaymentDatasetForPeriod(
   );
 }
 
-async function fetchDatasetRows(dataset: BdapDataset): Promise<DelimitedRecord[]> {
+async function fetchDatasetRows(
+  dataset: BdapDataset,
+  signal?: AbortSignal,
+): Promise<DelimitedRecord[]> {
   const response = await fetchOfficialSource("openbdap", dataset.csvUrl, {
     kind: "data",
+    signal,
     headers: { Accept: "text/csv" },
     tags: [`dataset:${dataset.packageId}`, `dimension:${dataset.dimension}`],
   });
@@ -296,8 +304,11 @@ async function fetchDatasetRows(dataset: BdapDataset): Promise<DelimitedRecord[]
   return rows;
 }
 
-export async function getStatePaymentDatasetTotal(dataset: BdapDataset): Promise<number> {
-  const rows = await fetchDatasetRows(dataset);
+export async function getStatePaymentDatasetTotal(
+  dataset: BdapDataset,
+  options: { signal?: AbortSignal } = {},
+): Promise<number> {
+  const rows = await fetchDatasetRows(dataset, options.signal);
   return rows.reduce(
     (total, record) => total + parsePublicNumber(record["Totale Pagato"]),
     0,
@@ -411,13 +422,17 @@ function monthName(month: number): string {
   return MONTH_NAMES[month - 1] ?? `MESE ${month}`;
 }
 
-export async function getStateSpendingSnapshot(): Promise<StateSpendingSnapshot> {
-  const missionDataset = await discoverLatestStatePaymentDataset("mission");
+export async function getStateSpendingSnapshot(
+  options: { signal?: AbortSignal } = {},
+): Promise<StateSpendingSnapshot> {
+  const missionDataset = await discoverLatestStatePaymentDataset("mission", {
+    signal: options.signal,
+  });
   const { referenceYear: year, referenceMonth: month } = missionDataset;
 
   const [administrationDatasetResult, economicDatasetResult] = await Promise.allSettled([
-    getStatePaymentDatasetForPeriod("missionAdministration", year, month),
-    getStatePaymentDatasetForPeriod("administrationEconomic", year, month),
+    getStatePaymentDatasetForPeriod("missionAdministration", year, month, options),
+    getStatePaymentDatasetForPeriod("administrationEconomic", year, month, options),
   ]);
 
   const administrationDataset =
@@ -428,9 +443,11 @@ export async function getStateSpendingSnapshot(): Promise<StateSpendingSnapshot>
     economicDatasetResult.status === "fulfilled" ? economicDatasetResult.value : null;
 
   const [missionRowsResult, administrationRowsResult, economicRowsResult] = await Promise.allSettled([
-    fetchDatasetRows(missionDataset),
-    administrationDataset ? fetchDatasetRows(administrationDataset) : Promise.resolve([]),
-    economicDataset ? fetchDatasetRows(economicDataset) : Promise.resolve([]),
+    fetchDatasetRows(missionDataset, options.signal),
+    administrationDataset
+      ? fetchDatasetRows(administrationDataset, options.signal)
+      : Promise.resolve([]),
+    economicDataset ? fetchDatasetRows(economicDataset, options.signal) : Promise.resolve([]),
   ]);
 
   if (missionRowsResult.status !== "fulfilled") {

--- a/src/lib/chart-colors.ts
+++ b/src/lib/chart-colors.ts
@@ -1,0 +1,12 @@
+export const CHART_COLORS = [
+  "#4fa3d1",
+  "#43b69a",
+  "#e3b65a",
+  "#d97979",
+  "#9c83d3",
+  "#7fb36e",
+] as const;
+
+export function chartColor(index: number): string {
+  return CHART_COLORS[index % CHART_COLORS.length];
+}

--- a/src/lib/data/bdap-history-points.ts
+++ b/src/lib/data/bdap-history-points.ts
@@ -1,0 +1,53 @@
+const MONTH_NAMES = [
+  "GENNAIO", "FEBBRAIO", "MARZO", "APRILE", "MAGGIO", "GIUGNO",
+  "LUGLIO", "AGOSTO", "SETTEMBRE", "OTTOBRE", "NOVEMBRE", "DICEMBRE",
+] as const;
+
+export type HistoryDatasetWithTotal = {
+  dataset: {
+    referenceMonth: number;
+    productCode: string;
+    packageId: string;
+    csvUrl: string;
+    metadataModified: string | null;
+  };
+  cumulativePaid: number;
+};
+
+export function deriveStateSpendingHistoryPoints(
+  year: number,
+  values: HistoryDatasetWithTotal[],
+) {
+  const ordered = [...values].sort(
+    (left, right) => left.dataset.referenceMonth - right.dataset.referenceMonth,
+  );
+
+  return ordered.map(({ dataset, cumulativePaid }, index) => {
+    const previous = ordered[index - 1];
+    const isJanuary = dataset.referenceMonth === 1;
+    const followsPreviousMonth =
+      previous?.dataset.referenceMonth === dataset.referenceMonth - 1;
+    const monthlyPaid = isJanuary
+      ? cumulativePaid
+      : followsPreviousMonth
+        ? cumulativePaid - previous.cumulativePaid
+        : null;
+    const monthName =
+      MONTH_NAMES[dataset.referenceMonth - 1] ?? `MESE ${dataset.referenceMonth}`;
+
+    return {
+      year,
+      month: dataset.referenceMonth,
+      monthName,
+      label: monthName.slice(0, 3),
+      cumulativePaid,
+      monthlyPaid,
+      source: {
+        productCode: dataset.productCode,
+        packageId: dataset.packageId,
+        csvUrl: dataset.csvUrl,
+        metadataModified: dataset.metadataModified,
+      },
+    };
+  });
+}

--- a/src/lib/siope-snapshot.ts
+++ b/src/lib/siope-snapshot.ts
@@ -1,4 +1,6 @@
-import snapshot from "@/data/generated/siope-municipal.json";
+import snapshot2024 from "@/data/generated/siope-municipal-2024.json";
+import snapshot2025 from "@/data/generated/siope-municipal-2025.json";
+import snapshot2026 from "@/data/generated/siope-municipal.json";
 
 export type SiopeMunicipalMonthlyPoint = {
   month: number;
@@ -76,7 +78,24 @@ export type SiopeMunicipalSnapshot = {
  * committed. Keeping it as a versioned build input makes web requests cheap,
  * deterministic and independent from a 50+ MB upstream download.
  */
-export const siopeMunicipalSnapshot = snapshot as SiopeMunicipalSnapshot;
+const snapshots = {
+  2024: snapshot2024,
+  2025: snapshot2025,
+  2026: snapshot2026,
+} as const;
+
+export const availableSiopeYears = Object.keys(snapshots)
+  .map(Number)
+  .sort((left, right) => right - left);
+
+export function getSiopeMunicipalSnapshot(year?: number): SiopeMunicipalSnapshot {
+  if (year && year in snapshots) {
+    return snapshots[year as keyof typeof snapshots] as SiopeMunicipalSnapshot;
+  }
+  return snapshot2026 as SiopeMunicipalSnapshot;
+}
+
+export const siopeMunicipalSnapshot = getSiopeMunicipalSnapshot();
 
 export function regionsByPerCapita(
   data: SiopeMunicipalSnapshot = siopeMunicipalSnapshot,

--- a/tests/bdap-history.test.mjs
+++ b/tests/bdap-history.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveStateSpendingHistoryPoints } from "../src/lib/data/bdap-history-points.ts";
+
+function row(month, cumulativePaid) {
+  return {
+    dataset: {
+      referenceMonth: month,
+      productCode: `M${month}`,
+      packageId: `package-${month}`,
+      csvUrl: `https://example.test/${month}.csv`,
+      metadataModified: null,
+    },
+    cumulativePaid,
+  };
+}
+
+test("OpenBDAP history keeps available months and never bridges a missing month", () => {
+  const points = deriveStateSpendingHistoryPoints(2026, [
+    row(4, 45),
+    row(1, 10),
+    row(2, 25),
+  ]);
+
+  assert.deepEqual(points.map((point) => point.month), [1, 2, 4]);
+  assert.deepEqual(points.map((point) => point.monthlyPaid), [10, 15, null]);
+  assert.equal(points[2].cumulativePaid, 45);
+});

--- a/tests/copy-quality.test.mjs
+++ b/tests/copy-quality.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import test from "node:test";
+
+const root = new URL("..", import.meta.url);
+const uiRoots = ["src/app", "src/components"];
+
+async function filesBelow(relativePath) {
+  const absolutePath = new URL(`${relativePath}/`, root);
+  const entries = await readdir(absolutePath, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const child = join(relativePath, entry.name);
+    if (entry.isDirectory()) files.push(...await filesBelow(child));
+    if (entry.isFile() && extname(entry.name) === ".tsx") files.push(child);
+  }
+  return files;
+}
+
+test("public copy avoids old branding, dash separators and known filler phrases", async () => {
+  const files = ["README.md", ...(await Promise.all(uiRoots.map(filesBelow))).flat()];
+  const forbidden = [
+    /Trasparenza ?Italia/i,
+    /trasparenzaitalia/i,
+    /—|–/,
+    /Sei numeri, sei significati diversi/i,
+    /La dashboard principale resta valida/i,
+  ];
+
+  for (const file of files) {
+    const content = await readFile(new URL(file, root), "utf8");
+    for (const pattern of forbidden) {
+      assert.doesNotMatch(content, pattern, `${file} contiene ${pattern}`);
+    }
+  }
+});

--- a/tests/siope-snapshot.test.mjs
+++ b/tests/siope-snapshot.test.mjs
@@ -3,6 +3,11 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const snapshotUrl = new URL("../src/data/generated/siope-municipal.json", import.meta.url);
+const historicalSnapshotUrls = [
+  new URL("../src/data/generated/siope-municipal-2024.json", import.meta.url),
+  new URL("../src/data/generated/siope-municipal-2025.json", import.meta.url),
+  snapshotUrl,
+];
 
 async function loadSnapshot() {
   return JSON.parse(await readFile(snapshotUrl, "utf8"));
@@ -63,5 +68,20 @@ test("regional and municipal rankings are sorted and numerically sane", async ()
     assert.ok(region.value >= 0);
     assert.ok(region.municipalities > 0);
     if (region.perCapita !== null) assert.ok(region.perCapita >= 0);
+  }
+});
+
+test("the period selector is backed by three reconciled SIOPE years", async () => {
+  const snapshots = await Promise.all(
+    historicalSnapshotUrls.map(async (url) => JSON.parse(await readFile(url, "utf8"))),
+  );
+
+  assert.deepEqual(snapshots.map((data) => data.year), [2024, 2025, 2026]);
+  for (const data of snapshots) {
+    assert.equal(data.regions.length, 20);
+    assert.ok(data.monthly.length > 0);
+    assert.equal(data.latestMonth, data.monthly.at(-1).month);
+    assertMoneyClose(sum(data.monthly.map((point) => point.flow)), data.totalPaid);
+    assertMoneyClose(sum(data.regions.map((region) => region.value)), data.totalPaid);
   }
 });


### PR DESCRIPTION
## Cosa cambia

- propaga un unico segnale di annullamento a discovery e download OpenBDAP
- limita a otto secondi il caricamento dati della pagina Spese dello Stato
- mantiene il comportamento fail-closed: nessun dato simulato quando la fonte non risponde

## Verifiche

- npm test: 23 test superati
- npm run lint: superato
- npm run typecheck: superato
- npm run build: superato
- browser locale /spese: pagina completa con dati reali, 193 ms con cache calda