### PR TITLE
fix: tolerate temporary parliament source outages

### DIFF
--- a/.github/workflows/parliament-sources.yml
+++ b/.github/workflows/parliament-sources.yml
@@ -48,4 +48,32 @@ jobs:
         run: python scripts/etl/parliament_sources.py --check
       - name: Check official document registers
         if: github.event_name != 'pull_request'
-        run: python scripts/etl/parliament_sources.py
+        shell: bash
+        run: |
+          status=2
+          for attempt in 1 2 3; do
+            set +e
+            output=$(python scripts/etl/parliament_sources.py 2>&1)
+            status=$?
+            set -e
+            printf '%s\n' "$output"
+
+            case "$status" in
+              0) exit 0 ;;
+              1) exit 1 ;;
+              2)
+                if [ "$attempt" -lt 3 ]; then
+                  echo "::notice::Fonte parlamentare non raggiungibile. Nuovo tentativo $((attempt + 1)) di 3."
+                  sleep $((attempt * 10))
+                fi
+                ;;
+              *) exit "$status" ;;
+            esac
+          done
+
+          echo "::warning title=Fonte parlamentare non raggiungibile::Lo snapshot verificato resta valido. Il controllo live verrà ripetuto alla prossima esecuzione."
+          {
+            echo "### Fonte parlamentare temporaneamente non raggiungibile"
+            echo "Lo snapshot verificato non è stato modificato e questo tentativo non conta come controllo riuscito."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0

--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -106,6 +106,12 @@ La ricerca delle opere pubbliche non dipende da alias OData scritti a mano. Il c
 
 Il refresh orario invalida il tag OpenBDAP e la route `/api/opere`. Al primo accesso successivo vengono ricontrollati metadati e schema; i dati di una singola ricerca CUP hanno cache di 6 ore e possono essere serviti per altre 24 ore mentre avviene la riconvalida. La risposta espone separatamente data della fonte e momento del controllo della piattaforma.
 
+### Parlamento
+
+Il monitor controlla ogni 6 ore i registri ufficiali di Camera e Senato. La validazione offline dello snapshot e del manifesto resta sempre obbligatoria. Un nuovo documento, un formato cambiato o un errore HTTP permanente interrompono il workflow e richiedono una revisione.
+
+Timeout, errori di rete, risposte `408`, `425`, `429` e alcuni errori `5xx` vengono ritentati. I siti parlamentari possono inoltre rispondere con `403` ai runner automatici: in quel caso il controllo viene segnato come non riuscito e genera un avviso, ma non invalida l'ultimo snapshot verificato. Il timestamp pubblico non viene aggiornato durante questi fallimenti.
+
 ## Policy iniziali
 
 | Fonte | Cadenza sorgente | Discovery DoveVannoINostriSoldi | Dati |

--- a/scripts/etl/parliament_sources.py
+++ b/scripts/etl/parliament_sources.py
@@ -33,6 +33,7 @@ MAX_HTML_BYTES = 2_000_000
 MAX_CSV_BYTES = 8_000_000
 CAMERA_HOSTS = {"trasparenza.camera.it", "documenti.camera.it", "www.camera.it", "camera.it"}
 SENATE_HOSTS = {"dati.senato.it", "www.senato.it", "senato.it"}
+SOURCE_UNAVAILABLE_HTTP_CODES = {403, 408, 425, 429, 500, 502, 503, 504}
 SENATE_DOCUMENT_TYPE = "Rendiconto delle entrate e delle spese e progetto di bilancio interno del Senato"
 
 
@@ -464,7 +465,13 @@ def main() -> int:
     except StructuralError as error:
         print(f"errore strutturale: {error}", file=sys.stderr)
         return 1
-    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, socket.timeout) as error:
+    except urllib.error.HTTPError as error:
+        if error.code not in SOURCE_UNAVAILABLE_HTTP_CODES:
+            print(f"errore permanente dalla fonte ufficiale: HTTP {error.code}", file=sys.stderr)
+            return 1
+        print(f"fonte ufficiale temporaneamente non raggiungibile: {error}", file=sys.stderr)
+        return 2
+    except (urllib.error.URLError, TimeoutError, socket.timeout) as error:
         print(f"fonte ufficiale temporaneamente non raggiungibile: {error}", file=sys.stderr)
         return 2
     print(

--- a/tests/etl/test_parliament_sources.py
+++ b/tests/etl/test_parliament_sources.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import sys
 import unittest
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts/etl/parliament_sources.py"
@@ -17,6 +21,15 @@ FIXTURES = ROOT / "tests/fixtures/parliament"
 
 
 class ParliamentSourceParserTests(unittest.TestCase):
+    def run_main_with_online_error(self, error: Exception) -> int:
+        with (
+            patch.object(sys, "argv", ["parliament_sources.py"]),
+            patch.object(MODULE, "online_check", side_effect=error),
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            return MODULE.main()
+
     def test_camera_discovers_only_primary_documents(self) -> None:
         documents = MODULE.parse_camera_documents(
             (FIXTURES / "camera.html").read_text(encoding="utf-8")
@@ -41,6 +54,49 @@ class ParliamentSourceParserTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(MODULE.StructuralError, "titolo.*non riconosciuto"):
             MODULE.parse_senate_documents(payload)
+
+    def test_main_marks_http_503_as_temporarily_unavailable(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://example.invalid", 503, "unavailable", {}, io.BytesIO()
+        )
+        self.addCleanup(error.close)
+        self.assertEqual(self.run_main_with_online_error(error), 2)
+
+    def test_main_keeps_the_snapshot_when_a_runner_is_blocked(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://example.invalid", 403, "forbidden", {}, io.BytesIO()
+        )
+        self.addCleanup(error.close)
+        self.assertEqual(self.run_main_with_online_error(error), 2)
+
+    def test_main_marks_network_errors_as_temporarily_unavailable(self) -> None:
+        self.assertEqual(
+            self.run_main_with_online_error(urllib.error.URLError("timeout")),
+            2,
+        )
+
+    def test_main_fails_on_http_404(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://example.invalid", 404, "not found", {}, io.BytesIO()
+        )
+        self.addCleanup(error.close)
+        self.assertEqual(self.run_main_with_online_error(error), 1)
+
+    def test_main_fails_on_structural_drift(self) -> None:
+        self.assertEqual(
+            self.run_main_with_online_error(MODULE.StructuralError("nuovo documento")),
+            1,
+        )
+
+    def test_check_mode_never_calls_the_network(self) -> None:
+        with (
+            patch.object(sys, "argv", ["parliament_sources.py", "--check"]),
+            patch.object(MODULE, "online_check") as online_check,
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(MODULE.main(), 0)
+        online_check.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problema

Il controllo live del Parlamento su main ha ricevuto HTTP 503 dal sito ufficiale. Lo snapshot verificato era ancora valido, ma il workflow ha segnato come fallito l'intero branch.

## Correzione

- ritenta tre volte i problemi temporanei
- tratta 403, 408, 425, 429 e gli errori server selezionati come fonte non raggiungibile
- conserva lo snapshot e scrive un avviso senza aggiornare il timestamp del controllo
- mantiene come errori bloccanti 401, 404, drift di schema e nuovi documenti da revisionare
- documenta la distinzione tra disponibilità della fonte e validità dello snapshot

## Verifiche

- 15 test Python ETL superati
- 48 test Node superati
- actionlint superato
- lint e typecheck superati
- controllo live locale Camera e Senato superato
