### PR TITLE
fix: handle incomplete Senate registry responses

### DIFF
--- a/.github/workflows/parliament-sources.yml
+++ b/.github/workflows/parliament-sources.yml
@@ -63,7 +63,7 @@ jobs:
               1) exit 1 ;;
               2)
                 if [ "$attempt" -lt 3 ]; then
-                  echo "::notice::Fonte parlamentare non raggiungibile. Nuovo tentativo $((attempt + 1)) di 3."
+                  echo "::notice::Fonte parlamentare non verificabile. Nuovo tentativo $((attempt + 1)) di 3."
                   sleep $((attempt * 10))
                 fi
                 ;;
@@ -71,9 +71,9 @@ jobs:
             esac
           done
 
-          echo "::warning title=Fonte parlamentare non raggiungibile::Lo snapshot verificato resta valido. Il controllo live verrà ripetuto alla prossima esecuzione."
+          echo "::warning title=Fonte parlamentare non verificabile::Lo snapshot verificato resta valido. Il controllo live verrà ripetuto alla prossima esecuzione."
           {
-            echo "### Fonte parlamentare temporaneamente non raggiungibile"
+            echo "### Fonte parlamentare temporaneamente non verificabile"
             echo "Lo snapshot verificato non è stato modificato e questo tentativo non conta come controllo riuscito."
           } >> "$GITHUB_STEP_SUMMARY"
           exit 0

--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -110,7 +110,7 @@ Il refresh orario invalida il tag OpenBDAP e la route `/api/opere`. Al primo acc
 
 Il monitor controlla ogni 6 ore i registri ufficiali di Camera e Senato. La validazione offline dello snapshot e del manifesto resta sempre obbligatoria. Un nuovo documento, un formato cambiato o un errore HTTP permanente interrompono il workflow e richiedono una revisione.
 
-Timeout, errori di rete, risposte `408`, `425`, `429` e alcuni errori `5xx` vengono ritentati. I siti parlamentari possono inoltre rispondere con `403` ai runner automatici: in quel caso il controllo viene segnato come non riuscito e genera un avviso, ma non invalida l'ultimo snapshot verificato. Il timestamp pubblico non viene aggiornato durante questi fallimenti.
+Timeout, errori di rete, risposte `408`, `425`, `429` e alcuni errori `5xx` vengono ritentati. I siti parlamentari possono inoltre rispondere con `403` ai runner automatici o restituire temporaneamente un CSV con campi indispensabili vuoti: in questi casi il controllo viene segnato come non riuscito e genera un avviso, ma non invalida l'ultimo snapshot verificato. Il monitor non completa i campi usando il manifesto e non registra un falso successo. Un valore presente ma malformato, un documento rimosso o un cambio di struttura restano invece errori bloccanti. Il timestamp pubblico non viene aggiornato durante questi fallimenti.
 
 ## Policy iniziali
 

--- a/scripts/etl/parliament_sources.py
+++ b/scripts/etl/parliament_sources.py
@@ -41,6 +41,10 @@ class StructuralError(RuntimeError):
     """The official source or committed data no longer matches its contract."""
 
 
+class TemporarySourceError(RuntimeError):
+    """The official source returned an incomplete response that can be retried."""
+
+
 @dataclass(frozen=True, order=True)
 class Document:
     kind: str
@@ -294,6 +298,18 @@ def parse_senate_documents(payload: str, series: str = "VIII") -> list[Document]
     for row in reader:
         if row["numeroRomano"].strip() != series or row["tipoDoc"].strip() != SENATE_DOCUMENT_TYPE:
             continue
+        indispensable = ("documento", "numeroDoc", "titolo", "dataPresentazione", "URLTesto")
+        missing = [
+            field
+            for field in indispensable
+            if not isinstance(row.get(field), str) or not row[field].strip()
+        ]
+        if missing:
+            record = row.get("documento") or "record senza URL"
+            raise TemporarySourceError(
+                "Senato CSV: risposta temporaneamente incompleta "
+                f"per {record!r}; campi mancanti: {', '.join(missing)}"
+            )
         title = " ".join(row["titolo"].split())
         account = re.fullmatch(
             r"Rendiconto delle entrate e delle spese del Senato per l'anno finanziario (\d{4})",
@@ -307,10 +323,14 @@ def parse_senate_documents(payload: str, series: str = "VIII") -> list[Document]
         )
         if not account and not budget:
             raise StructuralError(f"Senato CSV: titolo del Doc. {series} non riconosciuto: {title}")
+        raw_number = row["numeroDoc"].strip()
         try:
-            number = int(row["numeroDoc"])
+            number = int(raw_number)
         except ValueError as error:
-            raise StructuralError("Senato CSV: numero documento non valido") from error
+            raise StructuralError(
+                "Senato CSV: numero documento non valido "
+                f"per {row['documento']!r}: {raw_number!r}"
+            ) from error
         kind = "account" if account else "budget"
         year = int((account or budget).group(1))
         record_url = normalize_official_url(row["documento"], "Senato.recordUrl", SENATE_HOSTS)
@@ -442,7 +462,8 @@ def online_check(manifest: dict[str, Any], expected_camera: list[Document], expe
     if latest_number > known_max:
         new_documents = [item.identity() for item in actual_senate if (item.document_number or 0) > known_max]
         raise StructuralError(f"Senato: nuovi documenti ufficiali da verificare: {new_documents}")
-    actual_latest = [item for item in actual_senate if item.document_number in {item.document_number for item in expected_senate}]
+    expected_numbers = {item.document_number for item in expected_senate}
+    actual_latest = [item for item in actual_senate if item.document_number in expected_numbers]
     compare_documents("Senato", expected_senate, actual_latest)
 
 
@@ -462,6 +483,9 @@ def main() -> int:
         camera_docs, senate_docs, known_max = validate_manifest(manifest, snapshot)
         if not args.check:
             online_check(manifest, camera_docs, senate_docs, known_max, args.timeout)
+    except TemporarySourceError as error:
+        print(f"fonte ufficiale temporaneamente incompleta: {error}", file=sys.stderr)
+        return 2
     except StructuralError as error:
         print(f"errore strutturale: {error}", file=sys.stderr)
         return 1

--- a/tests/etl/test_parliament_sources.py
+++ b/tests/etl/test_parliament_sources.py
@@ -55,6 +55,38 @@ class ParliamentSourceParserTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.StructuralError, "titolo.*non riconosciuto"):
             MODULE.parse_senate_documents(payload)
 
+    def test_senate_marks_a_blank_document_number_as_temporarily_incomplete(self) -> None:
+        payload = (FIXTURES / "senato.csv").read_text(encoding="utf-8")
+        payload = payload.replace(",6,,VIII,", ",,,VIII,")
+        with self.assertRaisesRegex(MODULE.TemporarySourceError, "temporaneamente incompleta"):
+            MODULE.parse_senate_documents(payload)
+
+    def test_senate_marks_a_blank_document_url_as_temporarily_incomplete(self) -> None:
+        payload = (FIXTURES / "senato.csv").read_text(encoding="utf-8")
+        payload = payload.replace(
+            "http://www.senato.it/service/PDF/PDFServer/BGT/1487095.pdf",
+            "",
+        )
+        with self.assertRaisesRegex(MODULE.TemporarySourceError, "URLTesto"):
+            MODULE.parse_senate_documents(payload)
+
+    def test_senate_keeps_a_non_numeric_document_number_structural(self) -> None:
+        payload = (FIXTURES / "senato.csv").read_text(encoding="utf-8")
+        payload = payload.replace(",6,,VIII,", ",sei,,VIII,")
+        with self.assertRaisesRegex(MODULE.StructuralError, "numero documento non valido"):
+            MODULE.parse_senate_documents(payload)
+
+    def test_online_check_keeps_an_omitted_known_document_structural(self) -> None:
+        snapshot = MODULE.load_json(MODULE.SNAPSHOT_PATH)
+        manifest = MODULE.load_json(MODULE.MANIFEST_PATH)
+        camera, senate, known_max = MODULE.validate_manifest(manifest, snapshot)
+        with (
+            patch.object(MODULE, "download_camera", return_value=camera),
+            patch.object(MODULE, "download_senate", return_value=senate[1:]),
+            self.assertRaisesRegex(MODULE.StructuralError, "mancanti_o_modificati"),
+        ):
+            MODULE.online_check(manifest, camera, senate, known_max, 1)
+
     def test_main_marks_http_503_as_temporarily_unavailable(self) -> None:
         error = urllib.error.HTTPError(
             "https://example.invalid", 503, "unavailable", {}, io.BytesIO()
@@ -72,6 +104,12 @@ class ParliamentSourceParserTests(unittest.TestCase):
     def test_main_marks_network_errors_as_temporarily_unavailable(self) -> None:
         self.assertEqual(
             self.run_main_with_online_error(urllib.error.URLError("timeout")),
+            2,
+        )
+
+    def test_main_marks_an_incomplete_official_response_as_temporary(self) -> None:
+        self.assertEqual(
+            self.run_main_with_online_error(MODULE.TemporarySourceError("campo mancante")),
             2,
         )
 


### PR DESCRIPTION
Classifica come temporanea soltanto una risposta Senato con campi indispensabili vuoti, senza completarla dal manifesto e senza aggiornare il timestamp. Rimozioni, valori malformati, nuovi documenti e cambi di struttura restano errori bloccanti. Include test offline, documentazione e messaggi del workflow aggiornati.