### PR TITLE
fix: clarify ANAC percentage scopes

### DIFF
--- a/src/app/controlli/controlli.module.css
+++ b/src/app/controlli/controlli.module.css
@@ -63,6 +63,12 @@
   font-weight: 650;
 }
 
+.signalDetails summary {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+}
+
 .readingGuide summary {
   font-family: var(--font-heading);
   font-size: 18px;

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -267,20 +267,20 @@ export default async function ControlsPage({ searchParams }: PageProps) {
 
       {(selectedYear === null || selectedYear === 2025) && (
         <section className="panel">
-          <h2 className="panel-title">Appalti 2025: perché le percentuali cambiano</h2>
+          <h2 className="panel-title">Appalti 2025: 55,3% e quasi 95% usano calcoli diversi</h2>
           <div className="stat-strip">
             <div>
-              <span className="stat-label">Procedure da 40.000 euro in su</span>
+              <span className="stat-label">Tutte le procedure da 40.000 euro in su</span>
               <span className="stat-value">{percent(procurementComparisons[2025].byNumber)}</span>
-              <span className="stat-note">affidamenti diretti</span>
+              <span className="stat-note">sono affidamenti diretti</span>
             </div>
             <div>
-              <span className="stat-label">Servizi e forniture, perimetro ANAC</span>
+              <span className="stat-label">Studio ANAC su servizi e forniture</span>
               <span className="stat-value">
                 {procurementServicesAndSupplies2025.directAwardShareQualifier}{" "}
                 {percent(procurementServicesAndSupplies2025.directAwardShare)}
               </span>
-              <span className="stat-note">affidamenti diretti</span>
+              <span className="stat-note">dato ufficiale sugli affidamenti diretti</span>
             </div>
             <div>
               <span className="stat-label">Tra 135.000 e 140.000 euro nel 2025</span>
@@ -298,14 +298,50 @@ export default async function ControlsPage({ searchParams }: PageProps) {
             </div>
           </div>
           <p className={styles.note}>
-            Il {percent(procurementComparisons[2025].byNumber)} e il quasi{" "}
-            {percent(procurementServicesAndSupplies2025.directAwardShare)} usano insiemi diversi,
-            quindi non si contraddicono. La concentrazione vicino alla soglia indica casi da
-            approfondire, ma non prova da sola un&apos;irregolarità.{" "}
+            Il {percent(procurementComparisons[2025].byNumber)} considera tutte le procedure da
+            40.000 euro in su. Il quasi {percent(procurementServicesAndSupplies2025.directAwardShare)}
+            viene da uno studio diverso di ANAC su servizi e forniture. Non è il 95% di tutti gli
+            appalti. La concentrazione vicino alla soglia indica casi da approfondire, ma non prova
+            da sola un&apos;irregolarità.{" "}
             <a href={procurementServicesAndSupplies2025.sourceUrl} target="_blank" rel="noreferrer">
               Leggi la fonte ANAC ↗
             </a>
           </p>
+          <details className={styles.signalDetails}>
+            <summary>Come abbiamo controllato il quasi 95%</summary>
+            <dl>
+              <div>
+                <dt>Che cosa scrive ANAC</dt>
+                <dd>
+                  Quasi il 95% nel gruppo specifico di contratti usato nel suo studio su servizi e
+                  forniture.
+                </dd>
+              </div>
+              <div>
+                <dt>Che cosa otteniamo dai file aperti</dt>
+                <dd>
+                  {percent(procurementServicesAndSupplies2025.replicatedDirectAwardShare)} usando i
+                  dodici file mensili 2025 disponibili il{" "}
+                  {longDate(procurementServicesAndSupplies2025.replicationObservedAt)}. La differenza
+                  può dipendere da rettifiche successive o da ulteriori dettagli del perimetro.
+                </dd>
+              </div>
+              <div>
+                <dt>Come lo presentiamo</dt>
+                <dd>
+                  Manteniamo il dato ufficiale e mostriamo separatamente il nostro controllo. Non
+                  correggiamo i dati per farli coincidere.{" "}
+                  <a
+                    href={procurementServicesAndSupplies2025.replicationUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Vedi metodo e risultati ↗
+                  </a>
+                </dd>
+              </div>
+            </dl>
+          </details>
         </section>
       )}
 

--- a/src/lib/audit-data.ts
+++ b/src/lib/audit-data.ts
@@ -79,6 +79,8 @@ export const procurementReducedCompetition2025 = {
 export const procurementServicesAndSupplies2025 = {
   directAwardShare: 95,
   directAwardShareQualifier: "quasi",
+  replicatedDirectAwardShare: 93.00067,
+  replicationObservedAt: "2026-08-20",
   thresholdBandLowerEuro: 135_000,
   thresholdBandUpperEuro: 140_000,
   thresholdBandCount2021: 1_549,
@@ -91,6 +93,8 @@ export const procurementServicesAndSupplies2025 = {
   sourcePublishedAt: "2026-04-21",
   sourceUrl:
     "https://www.anticorruzione.it/documents/91439/393633199/Anac%2B-%2BPresentazione%2Bdella%2BRelazione%2Bannuale%2B2026%2Bsu%2Battivit%C3%A0%2B2025.pdf/a35c6b4a-db50-13be-8d6f-7fba8fa4d4dd?t=1776760814307",
+  replicationUrl:
+    "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/blob/main/docs/research/ANAC_2025_REPLICATION.md",
 } as const;
 
 const auditSignalsWithoutComparableProcurement: AuditSignal[] = [

--- a/tests/audit-data.test.mjs
+++ b/tests/audit-data.test.mjs
@@ -108,8 +108,11 @@ test("procurement series keeps the same scope across annual reports", () => {
   assert.equal(procurementReducedCompetition2025.directAwardsBillion, 15.702);
   assert.equal(procurementReducedCompetition2025.negotiatedWithoutTenderBillion, 44.084);
   assert.equal(procurementServicesAndSupplies2025.directAwardShare, 95);
+  assert.equal(procurementServicesAndSupplies2025.replicatedDirectAwardShare, 93.00067);
+  assert.match(procurementServicesAndSupplies2025.replicationObservedAt, /^20\d{2}-\d{2}-\d{2}$/);
   assert.equal(procurementServicesAndSupplies2025.thresholdBandCount2025, 13_879);
   assert.match(procurementServicesAndSupplies2025.sourceUrl, /^https:\/\/www\.anticorruzione\.it\//);
+  assert.match(procurementServicesAndSupplies2025.replicationUrl, /^https:\/\/github\.com\//);
   assert.equal(reducedCompetition?.value, procurementReducedCompetition2025.totalBillion);
   assert.ok(reducedCompetition?.evidenceStatus.includes("44,084"));
   assert.ok(reducedCompetition?.evidenceStatus.includes("15,702"));


### PR DESCRIPTION
Rende autosufficiente il confronto ANAC 2025: mostra nel titolo 55,3% e quasi 95%, spiega le due basi di calcolo e aggiunge il controllo riproducibile al 93,0% sui dodici file mensili correnti. Mantiene separati dato ufficiale e replica, senza trasformare il segnale in accusa. Include test e area tocco da 44 px per il dettaglio mobile.