### PR TITLE
Regional IP personalization and public MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 # Generate a long random value in production and configure the same value as
 # the GitHub repository secret SOURCE_REFRESH_SECRET.
 SOURCE_REFRESH_SECRET=
+# Origini browser aggiuntive autorizzate a chiamare il server MCP, separate da virgole.
+# I client MCP server-side normalmente non inviano Origin e non richiedono questa variabile.
+MCP_ALLOWED_ORIGINS=

--- a/README.md
+++ b/README.md
@@ -34,6 +34,50 @@ Il backend espone inoltre:
 - `GET /api/parlamento`, con i dati strutturati verificati della Camera; il monitor segue anche i nuovi documenti del Senato senza pubblicare valori non ancora estraibili in modo affidabile;
 - `GET /api/controlli`, con indicatori classificati, scenari separati e regole per il loro uso.
 
+## MCP per assistenti AI
+
+Il sito include un server [Model Context Protocol](https://modelcontextprotocol.io/) pubblico e in sola lettura. Un client MCP compatibile può scoprire e interrogare i dataset del portale senza dover conoscere ogni API separatamente.
+
+Endpoint di produzione:
+
+```text
+https://<dominio-del-sito>/api/mcp
+```
+
+In locale è `http://localhost:3000/api/mcp`. La pagina `/mcp` mostra l'indirizzo corretto del deployment e il catalogo corrente.
+
+Il server espone:
+
+- `list_datasets`, per elencare dataset, filtri, freschezza e cautele interpretative;
+- `query_dataset`, per interrogare snapshot verificati e fonti ufficiali live con filtri e paginazione;
+- la risorsa `dvns://datasets`, che contiene il catalogo machine-readable.
+
+Esempio di configurazione per un client che accetta server HTTP remoti:
+
+```json
+{
+  "mcpServers": {
+    "dove-vanno-i-nostri-soldi": {
+      "type": "http",
+      "url": "https://<dominio-del-sito>/api/mcp"
+    }
+  }
+}
+```
+
+Verifica rapida del protocollo:
+
+```bash
+curl -X POST http://localhost:3000/api/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+L'accesso anonimo è intenzionale perché il server espone esclusivamente dati pubblici e operazioni read-only. Le richieste hanno input limitati, paginazione massima e controllo dell'header `Origin`; eventuali origini browser aggiuntive si configurano con `MCP_ALLOWED_ORIGINS`. Non vengono esposte credenziali di ingestione.
+
+Per aggiungere una fonte all'MCP si registra la descrizione in `src/lib/mcp/catalog.ts` e l'adapter in `src/lib/mcp/datasets.ts`. Gli strumenti restano gli stessi, quindi i client non devono essere riconfigurati quando il catalogo cresce. Dettagli e checklist sono in [docs/MCP.md](docs/MCP.md).
+
 Per OpenCivitas, la differenza tra spesa storica e spesa standard non viene chiamata spreco. L'API restituisce anche i valori per abitante, il confronto sui servizi e i limiti territoriali della fonte.
 
 Per le opere pubbliche, l'API può segnalare date da controllare, crescita dei costi, finanziamenti ancora da trovare o problemi di qualità del dato. Sono indicazioni per scegliere cosa approfondire, non prove automatiche di spreco.
@@ -114,6 +158,7 @@ Dettagli: [docs/FRESHNESS_AND_REFRESH.md](docs/FRESHNESS_AND_REFRESH.md).
 src/app/                 pagine e servizi web
 src/components/          grafici, mappa e controlli dell'interfaccia
 src/lib/                 lettura, controllo e collegamento dei dati
+src/lib/mcp/             catalogo e adapter del server MCP
 src/data/generated/      copie ridotte e verificate usate dal sito
 scripts/etl/             aggiornamento delle fonti
 tests/                   controlli automatici

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,6 +107,8 @@ Ogni metrica ha una `metric_version` e una definizione pubblica.
 
 Next.js serve UI e API BFF. Con la prima vera ingestione persistente introdurremo PostgreSQL come datastore analitico-operativo; oggetti raw di grandi dimensioni potranno vivere in object storage.
 
+Il route handler `/api/mcp` espone gli stessi moduli di dominio tramite MCP Streamable HTTP. Il catalogo e gli adapter vivono in `src/lib/mcp/`: una nuova fonte viene registrata una volta e diventa interrogabile senza creare tool ad hoc o duplicare la normalizzazione. Tutti i tool pubblici sono read-only, con input limitati e paginazione.
+
 Nessuna credenziale di ingestione deve essere esposta al browser.
 
 ## 7. Freshness

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,39 @@
+# Server MCP
+
+## Scopo
+
+Il server MCP espone i dati pubblici già disponibili nel portale attraverso un contratto unico, read-only ed estensibile. Non sostituisce provenance, metodologia o cautele: le restituisce insieme ai dati.
+
+L'endpoint Streamable HTTP è `/api/mcp`. L'implementazione usa l'SDK TypeScript ufficiale e mantiene compatibilità stateless con i client MCP della generazione precedente.
+
+## Superficie pubblica
+
+- Tool `list_datasets`: catalogo completo con identificativo stabile, filtri, freschezza e caveat.
+- Tool `query_dataset`: query tipizzata con limite massimo di 100 record per pagina.
+- Resource `dvns://datasets`: copia JSON del catalogo.
+
+I dataset live interrogano soltanto adapter ufficiali già usati dalle API del sito. I dataset snapshot leggono gli artefatti versionati e validati dagli ETL.
+
+## Aggiungere una fonte
+
+1. Integrare e validare la fonte secondo `docs/ARCHITECTURE.md`.
+2. Aggiungere un identificativo stabile a `DATASET_IDS` in `src/lib/mcp/catalog.ts`.
+3. Aggiungere il descrittore a `datasetCatalog`, compresi filtri e caveat.
+4. Implementare il ramo dell'adapter in `src/lib/mcp/datasets.ts`, riusando il modulo di dominio senza duplicare fetch o normalizzazione.
+5. Aggiungere test offline per filtri, limiti, paginazione e semantica.
+6. Verificare `tools/list` e almeno una `tools/call` sul server Next.js avviato localmente.
+
+Un adapter non deve accettare URL arbitrari, SQL, percorsi file o nomi di funzione dal client. Gli input devono essere enum o campi di dominio con lunghezza e intervalli limitati.
+
+## Sicurezza e privacy
+
+- Nessun tool modifica dati o avvia refresh.
+- Nessuna credenziale di ingestione passa al client.
+- Il body HTTP dichiarato è limitato a 1 MB.
+- Se `Origin` è presente, deve coincidere con l'origine del deployment o con una voce esplicita in `MCP_ALLOWED_ORIGINS`.
+- Le risposte non sono memorizzate in cache condivise dal route handler MCP.
+- L'autenticazione MCP non è richiesta finché la superficie resta composta esclusivamente da dati pubblici e operazioni read-only. Prima di introdurre dati privati o mutazioni occorre aggiungere OAuth 2.1 e Protected Resource Metadata.
+
+## Limiti operativi
+
+Le fonti live possono essere indisponibili o lente. In quel caso il tool restituisce un errore esplicito e non sostituisce il dato con valori simulati. I limiti e le date di riferimento delle singole fonti restano quelli documentati nel catalogo del portale.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@hugeicons/core-free-icons": "^4.2.3",
         "@hugeicons/react": "^1.1.9",
+        "@modelcontextprotocol/server": "^2.0.0",
         "next": "16.3.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-is": "19.2.7",
-        "recharts": "3.10.1"
+        "recharts": "3.10.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -1076,6 +1078,31 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7177,7 +7204,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   "dependencies": {
     "@hugeicons/core-free-icons": "^4.2.3",
     "@hugeicons/react": "^1.1.9",
+    "@modelcontextprotocol/server": "^2.0.0",
     "next": "16.3.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-is": "19.2.7",
-    "recharts": "3.10.1"
+    "recharts": "3.10.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/src/app/api/location/route.ts
+++ b/src/app/api/location/route.ts
@@ -1,0 +1,22 @@
+import { italianRegionFromVercelHeaders } from "@/lib/ip-region";
+
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request) {
+  const region = italianRegionFromVercelHeaders(request.headers);
+
+  return Response.json(
+    {
+      ok: true,
+      region: region
+        ? { code: region.istatCode, name: region.name, source: "vercel-ip-region" }
+        : null,
+    },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+        "Vary": "X-Vercel-IP-Country, X-Vercel-IP-Country-Region",
+      },
+    },
+  );
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,100 @@
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { createDvnsMcpServer } from "@/lib/mcp/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const MAX_REQUEST_BYTES = 1_000_000;
+
+function reportMcpError(error: Error) {
+  if (error.message.startsWith("Rejected inbound request")) return;
+  console.error("MCP request failed", error);
+}
+
+const handler = createMcpHandler(createDvnsMcpServer, {
+  legacy: "stateless",
+  onerror: reportMcpError,
+});
+
+function secureResponse(response: Response): Response {
+  response.headers.set("Cache-Control", "private, no-store");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  return response;
+}
+
+function normalizedOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+function allowedOrigins(request: Request): Set<string> {
+  const configured = (process.env.MCP_ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map(normalizedOrigin)
+    .filter((value): value is string => value !== null);
+  return new Set([new URL(request.url).origin, ...configured]);
+}
+
+function validateRequest(request: Request): Response | null {
+  const origin = request.headers.get("origin");
+  if (origin && !allowedOrigins(request).has(origin)) {
+    return Response.json({ error: "Origin non consentita" }, { status: 403 });
+  }
+  const declaredLength = request.headers.get("content-length");
+  const contentLength = declaredLength === null ? null : Number.parseInt(declaredLength, 10);
+  if (contentLength !== null && Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+    return Response.json({ error: "Richiesta troppo grande" }, { status: 413 });
+  }
+  return null;
+}
+
+async function requestWithBoundedBody(request: Request): Promise<Request | Response> {
+  if (!request.body) return request;
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_REQUEST_BYTES) {
+      await reader.cancel("MCP request body limit exceeded").catch(() => undefined);
+      return Response.json({ error: "Richiesta troppo grande" }, { status: 413 });
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("Content-Length", String(body.byteLength));
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body,
+    signal: request.signal,
+  });
+}
+
+export async function POST(request: Request) {
+  const rejected = validateRequest(request);
+  if (rejected) return secureResponse(rejected);
+  const boundedRequest = await requestWithBoundedBody(request);
+  if (boundedRequest instanceof Response) return secureResponse(boundedRequest);
+
+  return secureResponse(await handler.fetch(boundedRequest));
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,6 +135,13 @@ img, svg { display: block; max-width: 100%; }
 }
 .header-search button:hover { color: var(--color-accent); }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+}
+
 .header-action {
   flex: none;
   padding: 11px 18px;
@@ -145,6 +152,10 @@ img, svg { display: block; max-width: 100%; }
   white-space: nowrap;
 }
 .header-action:hover { color: var(--color-text); background: var(--color-neutral-200); }
+.header-action-accent {
+  border-color: var(--color-accent);
+  color: var(--color-accent-700);
+}
 
 /* ── primary navigation ─────────────────────────────────────────────────── */
 
@@ -370,7 +381,8 @@ main { display: block; }
   .site-header { position: static; }
   .brand-mark { width: 38px; height: 38px; }
   .brand-text strong { font-size: 17px; }
-  .header-action { display: none; }
+  .header-actions .header-action:first-child { display: none; }
+  .header-action { padding-inline: 14px; }
   .primary-nav a { padding: 12px 12px; font-size: 13px; }
   .page-intro h1 { font-size: 24px; }
   .stat-strip { grid-template-columns: 1fr; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,7 @@ export default function RootLayout({
             >
               Codice su GitHub ↗
             </a>
+            <a className="footer-link" href="/mcp">MCP</a>
           </div>
           <div className="footer-row">
             <span className="footer-credit">Fatto da</span>

--- a/src/app/mcp/mcp.module.css
+++ b/src/app/mcp/mcp.module.css
@@ -1,0 +1,56 @@
+.endpointPanel { margin-bottom: var(--space-4); }
+
+.index {
+  display: block;
+  margin-bottom: var(--space-2);
+  font: 600 11px var(--font-mono);
+  letter-spacing: .08em;
+  color: var(--color-accent);
+}
+
+.endpointPanel h2,
+.columns h2 { margin: 0 0 var(--space-3); font-size: 18px; }
+.endpointPanel p,
+.columns p { margin: var(--space-3) 0 0; max-width: 80ch; color: var(--color-neutral-700); }
+
+.endpointRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.endpointRow code {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+  padding: 12px 14px;
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-100);
+}
+.endpointRow button { flex: none; }
+
+.columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.toolList { margin: 0; }
+.toolList div { padding: 9px 0; border-top: 1px solid var(--color-neutral-200); }
+.toolList dt { font-weight: 600; }
+.toolList dd { margin: 3px 0 0; color: var(--color-neutral-700); }
+
+.datasetTable { width: 100%; border-collapse: collapse; text-align: left; }
+.datasetTable th,
+.datasetTable td { padding: 11px 12px; border-bottom: 1px solid var(--color-neutral-200); vertical-align: top; }
+.datasetTable th { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--color-neutral-600); }
+.datasetTable td { font-size: 13px; }
+.datasetTable strong,
+.datasetTable small { display: block; }
+.datasetTable small { margin-top: 3px; max-width: 70ch; color: var(--color-neutral-600); }
+
+@media (max-width: 760px) {
+  .columns { grid-template-columns: 1fr; }
+  .endpointRow { align-items: stretch; flex-direction: column; }
+  .endpointRow button { width: 100%; }
+}

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import { McpEndpoint } from "@/components/mcp-endpoint";
+import { datasetCatalog } from "@/lib/mcp/catalog";
+import styles from "./mcp.module.css";
+
+export const metadata: Metadata = {
+  title: "MCP per i dati pubblici",
+  description: "Collega un assistente AI ai dataset verificati di DoveVannoINostriSoldi.",
+};
+
+export default function McpPage() {
+  return (
+    <main className="shell page-shell">
+      <header className="page-intro">
+        <span className="eyebrow">Dati per assistenti AI</span>
+        <h1>Interroga il portale con MCP</h1>
+        <p>
+          Il server MCP pubblico espone gli stessi dati e le stesse cautele del sito. È in sola
+          lettura: non modifica fonti, record o configurazioni e non richiede credenziali.
+        </p>
+      </header>
+
+      <section className={`panel ${styles.endpointPanel}`} aria-labelledby="endpoint-title">
+        <span className={styles.index}>01</span>
+        <h2 id="endpoint-title">Endpoint Streamable HTTP</h2>
+        <McpEndpoint />
+        <p>
+          Aggiungi questo indirizzo come server MCP remoto nel client compatibile. Il catalogo è
+          disponibile anche come risorsa <code>dvns://datasets</code>.
+        </p>
+      </section>
+
+      <section className={styles.columns} aria-label="Come funziona">
+        <article className="panel">
+          <span className={styles.index}>02</span>
+          <h2>Strumenti</h2>
+          <dl className={styles.toolList}>
+            <div><dt><code>list_datasets</code></dt><dd>Scopre fonti, filtri e limiti.</dd></div>
+            <div><dt><code>query_dataset</code></dt><dd>Interroga snapshot locali o fonti ufficiali live.</dd></div>
+          </dl>
+        </article>
+        <article className="panel">
+          <span className={styles.index}>03</span>
+          <h2>Uso responsabile</h2>
+          <p>
+            Pagamenti, costi, scostamenti e segnali non diventano automaticamente completamento,
+            qualità, spreco o responsabilità. Ogni risposta conserva provenienza e metodologia.
+          </p>
+        </article>
+      </section>
+
+      <section className="panel" aria-labelledby="datasets-title">
+        <span className={styles.index}>04</span>
+        <h2 id="datasets-title">{datasetCatalog.length} dataset interrogabili</h2>
+        <div className="table-scroll">
+          <table className={styles.datasetTable}>
+            <thead><tr><th>Dataset</th><th>Aggiornamento</th><th>Filtri</th></tr></thead>
+            <tbody>
+              {datasetCatalog.map((dataset) => (
+                <tr key={dataset.id}>
+                  <td><strong>{dataset.title}</strong><small>{dataset.summary}</small></td>
+                  <td>{dataset.freshness === "live" ? "Fonte live" : "Snapshot verificato"}</td>
+                  <td>{dataset.filters.length > 0 ? dataset.filters.join(", ") : "nessuno"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/italy-regions-map.module.css
+++ b/src/components/italy-regions-map.module.css
@@ -63,6 +63,12 @@
 
 .mobileSelector { display: none; }
 
+.geoNote {
+  margin: var(--space-2) 0 0;
+  font-size: 11px;
+  color: var(--color-neutral-600);
+}
+
 /* The reading row under the map: whichever region is hovered, focused or
    picked from the select shows its exact figures here. */
 .detail {

--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ITALY_REGIONS_VIEWBOX,
   italyRegionGeometry,
@@ -10,6 +10,7 @@ import {
   REGION_NAME_BY_ISTAT_CODE,
   regionDataByIstatCode,
 } from "@/lib/italy-regions";
+import { randomRegionCode } from "@/lib/ip-region";
 import { compactEuro, exactEuro, integer } from "@/lib/format";
 import styles from "./italy-regions-map.module.css";
 
@@ -29,6 +30,8 @@ export function ItalyRegionsMap({
   aside?: React.ReactNode;
 }) {
   const [selectedCode, setSelectedCode] = useState("03");
+  const [automaticSelection, setAutomaticSelection] = useState<"ip" | "random" | null>(null);
+  const userSelected = useRef(false);
   const { byCode, thresholds } = useMemo(() => {
     const mapped = regionDataByIstatCode(regions);
     const values = regions
@@ -40,6 +43,46 @@ export function ItalyRegionsMap({
       thresholds: [0.2, 0.4, 0.6, 0.8].map((fraction) => quantile(values, fraction)),
     };
   }, [regions]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const availableCodes = Object.keys(REGION_NAME_BY_ISTAT_CODE).filter((code) => byCode.has(code));
+
+    async function chooseInitialRegion() {
+      try {
+        const response = await fetch("/api/location", {
+          cache: "no-store",
+          credentials: "omit",
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error(`Location HTTP ${response.status}`);
+        const payload = (await response.json()) as { region?: { code?: string } | null };
+        const code = payload.region?.code;
+        if (!userSelected.current && code && byCode.has(code)) {
+          setSelectedCode(code);
+          setAutomaticSelection("ip");
+          return;
+        }
+      } catch {
+        if (controller.signal.aborted) return;
+      }
+
+      const fallback = randomRegionCode(availableCodes);
+      if (!userSelected.current && fallback) {
+        setSelectedCode(fallback);
+        setAutomaticSelection("random");
+      }
+    }
+
+    void chooseInitialRegion();
+    return () => controller.abort();
+  }, [byCode]);
+
+  function selectRegion(code: string) {
+    userSelected.current = true;
+    setAutomaticSelection(null);
+    setSelectedCode(code);
+  }
 
   const selected = byCode.get(selectedCode) ?? regions[0];
 
@@ -83,13 +126,13 @@ export function ItalyRegionsMap({
                     ? "dato non disponibile"
                     : `${exactEuro(region.perCapita)} per abitante coperto`
                 }`}
-                onPointerEnter={() => setSelectedCode(geometry.code)}
-                onFocus={() => setSelectedCode(geometry.code)}
-                onClick={() => setSelectedCode(geometry.code)}
+                onPointerEnter={() => selectRegion(geometry.code)}
+                onFocus={() => selectRegion(geometry.code)}
+                onClick={() => selectRegion(geometry.code)}
                 onKeyDown={(event) => {
                   if (event.key === "Enter" || event.key === " ") {
                     event.preventDefault();
-                    setSelectedCode(geometry.code);
+                    selectRegion(geometry.code);
                   }
                 }}
               />
@@ -99,12 +142,20 @@ export function ItalyRegionsMap({
 
         <label className={styles.mobileSelector}>
           <span>Scegli una regione</span>
-          <select value={selectedCode} onChange={(event) => setSelectedCode(event.target.value)}>
+          <select value={selectedCode} onChange={(event) => selectRegion(event.target.value)}>
             {Object.entries(REGION_NAME_BY_ISTAT_CODE).map(([code, name]) => (
               <option value={code} key={code}>{name}</option>
             ))}
           </select>
         </label>
+
+        {automaticSelection ? (
+          <p className={styles.geoNote}>
+            {automaticSelection === "ip"
+              ? "Regione proposta dalla posizione approssimativa dell’IP; l’indirizzo non viene mostrato né salvato."
+              : "Posizione non disponibile: regione iniziale scelta casualmente."}
+          </p>
+        ) : null}
 
         <div className={styles.legend} aria-label="Scala dei pagamenti pro capite">
           <span className={styles.legendEnd}>Meno spesa per abitante</span>

--- a/src/components/mcp-endpoint.tsx
+++ b/src/components/mcp-endpoint.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import styles from "@/app/mcp/mcp.module.css";
+
+export function McpEndpoint() {
+  const [copied, setCopied] = useState(false);
+  const origin = useSyncExternalStore(
+    () => () => undefined,
+    () => window.location.origin,
+    () => "",
+  );
+  const endpoint = `${origin}/api/mcp`;
+
+  async function copyEndpoint() {
+    await navigator.clipboard.writeText(endpoint);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <div className={styles.endpointRow}>
+      <code>{endpoint}</code>
+      <button className="btn" type="button" onClick={copyEndpoint}>
+        {copied ? "Copiato" : "Copia endpoint"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -55,9 +55,14 @@ export function Navigation() {
           </button>
         </form>
 
-        <Link className="header-action" href="/fonti">
-          Scarica i dati
-        </Link>
+        <div className="header-actions">
+          <Link className="header-action" href="/fonti">
+            Scarica i dati
+          </Link>
+          <Link className="header-action header-action-accent" href="/mcp">
+            MCP
+          </Link>
+        </div>
       </div>
 
       <div className="shell nav-row">

--- a/src/lib/ip-region.ts
+++ b/src/lib/ip-region.ts
@@ -1,0 +1,55 @@
+import { REGION_NAME_BY_ISTAT_CODE } from "@/lib/italy-regions";
+
+const ISTAT_REGION_BY_ISO_SUBDIVISION: Readonly<Record<string, string>> = {
+  "21": "01",
+  "23": "02",
+  "25": "03",
+  "32": "04",
+  "34": "05",
+  "36": "06",
+  "42": "07",
+  "45": "08",
+  "52": "09",
+  "55": "10",
+  "57": "11",
+  "62": "12",
+  "65": "13",
+  "67": "14",
+  "72": "15",
+  "75": "16",
+  "77": "17",
+  "78": "18",
+  "82": "19",
+  "88": "20",
+};
+
+export type ItalianIpRegion = {
+  istatCode: keyof typeof REGION_NAME_BY_ISTAT_CODE;
+  name: string;
+};
+
+export function italianRegionFromVercelHeaders(headers: Headers): ItalianIpRegion | null {
+  if (headers.get("x-vercel-ip-country")?.trim().toUpperCase() !== "IT") return null;
+
+  const subdivision = headers
+    .get("x-vercel-ip-country-region")
+    ?.trim()
+    .toUpperCase()
+    .replace(/^IT-/, "");
+  if (!subdivision) return null;
+
+  const istatCode = ISTAT_REGION_BY_ISO_SUBDIVISION[subdivision];
+  if (!istatCode || !(istatCode in REGION_NAME_BY_ISTAT_CODE)) return null;
+
+  const typedCode = istatCode as keyof typeof REGION_NAME_BY_ISTAT_CODE;
+  return { istatCode: typedCode, name: REGION_NAME_BY_ISTAT_CODE[typedCode] };
+}
+
+export function randomRegionCode(
+  availableCodes: readonly string[],
+  random: () => number = Math.random,
+): string | null {
+  if (availableCodes.length === 0) return null;
+  const index = Math.min(availableCodes.length - 1, Math.floor(random() * availableCodes.length));
+  return availableCodes[index] ?? null;
+}

--- a/src/lib/mcp/catalog.ts
+++ b/src/lib/mcp/catalog.ts
@@ -1,0 +1,57 @@
+export const DATASET_IDS = [
+  "siope_comuni",
+  "openbdap_spesa_stato",
+  "openbdap_amministrazione",
+  "openbdap_opere_pubbliche",
+  "opencivitas_fabbisogni",
+  "opencoesione_progetti",
+  "ipa_enti",
+  "ipa_struttura",
+  "mef_partecipazioni",
+  "consulenti_incarichi",
+  "parlamento_bilanci",
+  "controlli_segnali",
+  "registro_fonti",
+] as const;
+
+export type DatasetId = (typeof DATASET_IDS)[number];
+
+export type DatasetQuery = {
+  dataset: DatasetId;
+  year?: number;
+  month?: number;
+  query?: string;
+  region?: string;
+  code?: string;
+  cup?: string;
+  area?: string;
+  chamber?: "camera" | "senato";
+  limit?: number;
+  offset?: number;
+};
+
+export type DatasetDescriptor = {
+  id: DatasetId;
+  title: string;
+  summary: string;
+  sourceIds: string[];
+  freshness: "snapshot" | "live";
+  filters: string[];
+  caveat?: string;
+};
+
+export const datasetCatalog: DatasetDescriptor[] = [
+  { id: "siope_comuni", title: "Pagamenti dei Comuni", summary: "Pagamenti di cassa SIOPE, serie mensile, titoli, regioni e principali Comuni.", sourceIds: ["siope", "ipa"], freshness: "snapshot", filters: ["year", "region"] },
+  { id: "openbdap_spesa_stato", title: "Spesa dello Stato", summary: "Pagamenti cumulati dello Stato per missione, amministrazione e categoria economica.", sourceIds: ["openbdap"], freshness: "live", filters: ["year", "month"] },
+  { id: "openbdap_amministrazione", title: "Spesa di una amministrazione statale", summary: "Dettaglio OpenBDAP di una amministrazione per missione e categoria.", sourceIds: ["openbdap"], freshness: "live", filters: ["code", "year", "month"] },
+  { id: "openbdap_opere_pubbliche", title: "Opere pubbliche per CUP", summary: "Stato, date, costi e finanziamenti delle opere pubbliche MOP.", sourceIds: ["openbdap"], freshness: "live", filters: ["cup"], caveat: "I segnali di qualità o ritardo richiedono verifica e non provano uno spreco." },
+  { id: "opencivitas_fabbisogni", title: "Fabbisogni e servizi comunali", summary: "Spesa storica, spesa standard e livelli dei servizi dei Comuni coperti da OpenCivitas.", sourceIds: ["opencivitas"], freshness: "snapshot", filters: ["year", "region", "code", "limit", "offset"], caveat: "La differenza dalla spesa standard non è una misura automatica di spreco." },
+  { id: "opencoesione_progetti", title: "OpenCoesione", summary: "Aggregati nazionali su costo pubblico, pagamenti, temi, natura e stato dei progetti.", sourceIds: ["opencoesione"], freshness: "snapshot", filters: [], caveat: "Il rapporto pagamenti/costo non misura il completamento o la qualità dei progetti." },
+  { id: "ipa_enti", title: "Enti pubblici IPA", summary: "Ricerca e scheda degli enti nell’Indice PA.", sourceIds: ["ipa"], freshness: "live", filters: ["query", "code", "limit", "offset"] },
+  { id: "ipa_struttura", title: "Struttura organizzativa IPA", summary: "Unità organizzative e aree organizzative omogenee di un ente.", sourceIds: ["ipa-struttura"], freshness: "live", filters: ["code", "limit", "offset"] },
+  { id: "mef_partecipazioni", title: "Partecipazioni pubbliche", summary: "Aggregati della rilevazione annuale MEF sulle partecipazioni pubbliche.", sourceIds: ["partecipazioni-pubbliche"], freshness: "snapshot", filters: [] },
+  { id: "consulenti_incarichi", title: "Incarichi e consulenze", summary: "Statistiche nazionali ufficiali su incarichi esterni e a dipendenti pubblici.", sourceIds: ["consulenti"], freshness: "snapshot", filters: ["year"] },
+  { id: "parlamento_bilanci", title: "Bilanci del Parlamento", summary: "Documenti e valori strutturati verificati per Camera e Senato quando disponibili.", sourceIds: ["camera"], freshness: "snapshot", filters: ["chamber", "year"] },
+  { id: "controlli_segnali", title: "Segnali da controllare", summary: "Indicatori, classificazioni e confronti che orientano verifiche ulteriori.", sourceIds: [], freshness: "snapshot", filters: ["area", "year"], caveat: "Un segnale non attribuisce responsabilità e non dimostra da solo spreco o illecito." },
+  { id: "registro_fonti", title: "Registro delle fonti", summary: "Proprietari, copertura, formati, cadenza e stato di integrazione delle fonti censite.", sourceIds: [], freshness: "snapshot", filters: ["query"] },
+];

--- a/src/lib/mcp/datasets.ts
+++ b/src/lib/mcp/datasets.ts
@@ -1,0 +1,150 @@
+import type { DatasetQuery } from "@/lib/mcp/catalog";
+
+function boundedInteger(value: number | undefined, fallback: number, minimum: number, maximum: number) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(maximum, Math.max(minimum, Math.trunc(value as number)));
+}
+
+function requireText(value: string | undefined, label: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`Il filtro ${label} è obbligatorio per questo dataset.`);
+  return normalized;
+}
+
+function referencePeriod(query: DatasetQuery) {
+  if (query.month !== undefined && query.year === undefined) {
+    throw new Error("Per scegliere il mese devi indicare anche l’anno.");
+  }
+  return {
+    year: query.year,
+    month: query.month,
+  };
+}
+
+function jsonSafe<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export async function queryPublicDataset(query: DatasetQuery): Promise<unknown> {
+  const limit = boundedInteger(query.limit, 50, 1, 100);
+  const offset = boundedInteger(query.offset, 0, 0, 100_000);
+
+  switch (query.dataset) {
+    case "siope_comuni": {
+      const { availableSiopeYears, getSiopeMunicipalSnapshot } = await import("@/lib/siope-snapshot");
+      const year = query.year ?? availableSiopeYears[0];
+      if (!availableSiopeYears.includes(year)) {
+        throw new Error(`Anno SIOPE non disponibile. Anni validi: ${availableSiopeYears.join(", ")}.`);
+      }
+      const snapshot = getSiopeMunicipalSnapshot(year);
+      const region = query.region?.trim().toLocaleLowerCase("it-IT");
+      if (!region) return jsonSafe(snapshot);
+      return jsonSafe({
+        ...snapshot,
+        regions: snapshot.regions.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
+        topMunicipalities: snapshot.topMunicipalities.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
+      });
+    }
+    case "openbdap_spesa_stato": {
+      const period = referencePeriod(query);
+      const { getStateSpendingSnapshot } = await import("@/lib/bdap-payments");
+      return jsonSafe(await getStateSpendingSnapshot(period));
+    }
+    case "openbdap_amministrazione": {
+      const code = requireText(query.code, "code");
+      const period = referencePeriod(query);
+      const { getStateAdministrationSpending } = await import("@/lib/bdap-payments");
+      return jsonSafe(await getStateAdministrationSpending(code, period));
+    }
+    case "openbdap_opere_pubbliche": {
+      const cup = requireText(query.cup, "cup");
+      const { getPublicWorksByCup } = await import("@/lib/bdap-public-works");
+      return jsonSafe(await getPublicWorksByCup(cup));
+    }
+    case "opencivitas_fabbisogni": {
+      const { openCivitasSnapshot } = await import("@/lib/opencivitas-snapshot");
+      if (query.year && query.year !== openCivitasSnapshot.referenceYear) {
+        throw new Error(`OpenCivitas è disponibile per il ${openCivitasSnapshot.referenceYear}.`);
+      }
+      const region = query.region?.trim().toLocaleUpperCase("it-IT");
+      const code = query.code?.trim();
+      const matches = openCivitasSnapshot.municipalities.filter((item) =>
+        (!region || item.region === region) && (!code || item.istatCode === code));
+      return jsonSafe({
+        referenceYear: openCivitasSnapshot.referenceYear,
+        publishedAt: openCivitasSnapshot.publishedAt,
+        pagination: { total: matches.length, offset, limit, returned: matches.slice(offset, offset + limit).length },
+        data: matches.slice(offset, offset + limit),
+        coverage: openCivitasSnapshot.coverage,
+        methodology: openCivitasSnapshot.methodology,
+        provenance: openCivitasSnapshot.source,
+      });
+    }
+    case "opencoesione_progetti": {
+      const { openCoesionePaymentCostRatio, openCoesioneSnapshot } = await import("@/lib/opencoesione-snapshot");
+      return jsonSafe({ ...openCoesioneSnapshot, derived: { paymentCostRatio: openCoesionePaymentCostRatio } });
+    }
+    case "ipa_enti": {
+      const { getIpaEntityByCode, searchIpaEntities } = await import("@/lib/ipa");
+      if (query.code?.trim()) {
+        const record = await getIpaEntityByCode(query.code.trim());
+        return jsonSafe({ record, found: record !== null });
+      }
+      return jsonSafe(await searchIpaEntities({ query: query.query, limit, offset }));
+    }
+    case "ipa_struttura": {
+      const code = requireText(query.code, "code");
+      const { getIpaOrganizationStructure } = await import("@/lib/ipa-structure");
+      return jsonSafe(await getIpaOrganizationStructure(code, limit, offset));
+    }
+    case "mef_partecipazioni": {
+      const { mefParticipationsSnapshot } = await import("@/lib/mef-participations-snapshot");
+      return jsonSafe(mefParticipationsSnapshot);
+    }
+    case "consulenti_incarichi": {
+      const { consulentiSnapshot } = await import("@/lib/consulenti-snapshot");
+      const year = query.year;
+      const filterYear = <T extends { year: number }>(items: T[]) => year ? items.filter((item) => item.year === year) : items;
+      return jsonSafe({
+        ...consulentiSnapshot,
+        externalAppointments: filterYear(consulentiSnapshot.externalAppointments),
+        employeeAppointments: filterYear(consulentiSnapshot.employeeAppointments),
+      });
+    }
+    case "parlamento_bilanci": {
+      const { parliamentSnapshot } = await import("@/lib/parliament-snapshot");
+      return jsonSafe({
+        ...parliamentSnapshot,
+        chambers: parliamentSnapshot.chambers
+          .filter((item) => !query.chamber || item.id === query.chamber)
+          .map((item) => ({ ...item, statements: item.statements.filter((statement) => !query.year || statement.year === query.year) }))
+          .filter((item) => item.statements.length > 0),
+      });
+    }
+    case "controlli_segnali": {
+      const {
+        auditClassifications,
+        auditMethodology,
+        auditReviewedAt,
+        auditSignals,
+        procurementComparisons,
+      } = await import("@/lib/audit-data");
+      const area = query.area?.trim().toLocaleLowerCase("it-IT");
+      return jsonSafe({
+        reviewedAt: auditReviewedAt,
+        signals: auditSignals.filter((signal) =>
+          (!area || signal.area.toLocaleLowerCase("it-IT") === area) &&
+          (!query.year || signal.referenceDate.startsWith(String(query.year)))),
+        classifications: auditClassifications,
+        procurementComparisons,
+        methodology: auditMethodology,
+      });
+    }
+    case "registro_fonti": {
+      const { publicSources } = await import("@/lib/sources");
+      const term = query.query?.trim().toLocaleLowerCase("it-IT");
+      return jsonSafe(publicSources.filter((source) => !term || [source.name, source.owner, source.area, source.note]
+        .some((value) => value.toLocaleLowerCase("it-IT").includes(term))));
+    }
+  }
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,78 @@
+import { McpServer } from "@modelcontextprotocol/server";
+import * as z from "zod/v4";
+import { DATASET_IDS, datasetCatalog } from "@/lib/mcp/catalog";
+import { queryPublicDataset } from "@/lib/mcp/datasets";
+
+const querySchema = z.object({
+  dataset: z.enum(DATASET_IDS).describe("Identificativo restituito da list_datasets."),
+  year: z.number().int().min(2000).max(2100).optional(),
+  month: z.number().int().min(1).max(12).optional(),
+  query: z.string().max(200).optional(),
+  region: z.string().max(100).optional(),
+  code: z.string().max(100).optional(),
+  cup: z.string().max(15).optional(),
+  area: z.string().max(100).optional(),
+  chamber: z.enum(["camera", "senato"]).optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  offset: z.number().int().min(0).max(100_000).optional(),
+});
+
+function toolResult(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+    structuredContent: value as Record<string, unknown>,
+  };
+}
+
+export function createDvnsMcpServer() {
+  const server = new McpServer({
+    name: "dove-vanno-i-nostri-soldi",
+    version: "1.0.0",
+  });
+
+  server.registerResource(
+    "dataset-catalog",
+    "dvns://datasets",
+    {
+      title: "Catalogo dei dataset pubblici",
+      description: "Dataset interrogabili, filtri, fonti e avvertenze semantiche.",
+      mimeType: "application/json",
+    },
+    async (uri) => ({ contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify(datasetCatalog) }] }),
+  );
+
+  server.registerTool(
+    "list_datasets",
+    {
+      title: "Elenca i dataset",
+      description: "Elenca tutti i dataset disponibili, i filtri ammessi, la freschezza e le cautele interpretative.",
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async () => toolResult({ datasets: datasetCatalog }),
+  );
+
+  server.registerTool(
+    "query_dataset",
+    {
+      title: "Interroga un dataset",
+      description: "Interroga un dataset del portale. Usa prima list_datasets per conoscere filtri e limiti. Le fonti live possono essere temporaneamente indisponibili.",
+      inputSchema: querySchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async (input) => {
+      try {
+        const data = await queryPublicDataset(input);
+        return toolResult({ ok: true, dataset: input.dataset, query: input, data });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Errore sconosciuto";
+        return {
+          isError: true,
+          content: [{ type: "text", text: message }],
+          structuredContent: { ok: false, dataset: input.dataset, error: message },
+        };
+      }
+    },
+  );
+
+  return server;
+}

--- a/tests/helpers/register-ts-alias.mjs
+++ b/tests/helpers/register-ts-alias.mjs
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+const sourceRoot = resolve(fileURLToPath(new URL("../../src/", import.meta.url)));
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (!specifier.startsWith("@/")) return nextResolve(specifier, context);
+    const base = resolve(sourceRoot, specifier.slice(2));
+    const target = [base, `${base}.ts`, `${base}.tsx`, `${base}.json`, resolve(base, "index.ts")]
+      .find((candidate) => existsSync(candidate));
+    if (!target) throw new Error(`Test alias non risolto: ${specifier}`);
+    return nextResolve(pathToFileURL(target).href, context);
+  },
+  load(url, context, nextLoad) {
+    if (!url.endsWith(".json")) return nextLoad(url, context);
+    return nextLoad(url, {
+      ...context,
+      importAttributes: { ...context.importAttributes, type: "json" },
+    });
+  },
+});

--- a/tests/ip-region.test.mjs
+++ b/tests/ip-region.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { italianRegionFromVercelHeaders, randomRegionCode } = await import("../src/lib/ip-region.ts");
+
+test("maps every Italian ISO 3166-2 subdivision used by Vercel", () => {
+  const cases = [
+    ["21", "01", "Piemonte"], ["23", "02", "Valle d'Aosta/Vallée d'Aoste"],
+    ["25", "03", "Lombardia"], ["32", "04", "Trentino-Alto Adige/Südtirol"],
+    ["34", "05", "Veneto"], ["36", "06", "Friuli-Venezia Giulia"],
+    ["42", "07", "Liguria"], ["45", "08", "Emilia-Romagna"],
+    ["52", "09", "Toscana"], ["55", "10", "Umbria"], ["57", "11", "Marche"],
+    ["62", "12", "Lazio"], ["65", "13", "Abruzzo"], ["67", "14", "Molise"],
+    ["72", "15", "Campania"], ["75", "16", "Puglia"], ["77", "17", "Basilicata"],
+    ["78", "18", "Calabria"], ["82", "19", "Sicilia"], ["88", "20", "Sardegna"],
+  ];
+
+  for (const [subdivision, istatCode, name] of cases) {
+    const result = italianRegionFromVercelHeaders(new Headers({
+      "x-vercel-ip-country": "IT",
+      "x-vercel-ip-country-region": subdivision,
+    }));
+    assert.deepEqual(result, { istatCode, name });
+  }
+});
+
+test("accepts a prefixed subdivision and rejects foreign or malformed headers", () => {
+  assert.equal(
+    italianRegionFromVercelHeaders(new Headers({
+      "x-vercel-ip-country": "it",
+      "x-vercel-ip-country-region": "IT-62",
+    }))?.istatCode,
+    "12",
+  );
+  assert.equal(italianRegionFromVercelHeaders(new Headers()), null);
+  assert.equal(italianRegionFromVercelHeaders(new Headers({
+    "x-vercel-ip-country": "FR",
+    "x-vercel-ip-country-region": "IDF",
+  })), null);
+  assert.equal(italianRegionFromVercelHeaders(new Headers({
+    "x-vercel-ip-country": "IT",
+    "x-vercel-ip-country-region": "invalid",
+  })), null);
+});
+
+test("random fallback is bounded and handles an empty list", () => {
+  assert.equal(randomRegionCode([], () => 0.5), null);
+  assert.equal(randomRegionCode(["01", "02", "03"], () => 0), "01");
+  assert.equal(randomRegionCode(["01", "02", "03"], () => 0.999999), "03");
+  assert.equal(randomRegionCode(["01", "02", "03"], () => 1), "03");
+});

--- a/tests/mcp-datasets.test.mjs
+++ b/tests/mcp-datasets.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { DATASET_IDS, datasetCatalog } = await import("../src/lib/mcp/catalog.ts");
+const { queryPublicDataset } = await import("../src/lib/mcp/datasets.ts");
+const { publicSources } = await import("../src/lib/sources.ts");
+
+test("MCP catalog has one descriptor per stable dataset id and valid source references", () => {
+  assert.deepEqual(datasetCatalog.map((dataset) => dataset.id).sort(), [...DATASET_IDS].sort());
+  assert.equal(new Set(DATASET_IDS).size, DATASET_IDS.length);
+  const knownSources = new Set(publicSources.map((source) => source.slug));
+  for (const dataset of datasetCatalog) {
+    assert.ok(dataset.title.length > 0);
+    assert.ok(dataset.summary.length > 0);
+    for (const sourceId of dataset.sourceIds) assert.ok(knownSources.has(sourceId), sourceId);
+  }
+});
+
+test("SIOPE query validates years and can filter a region", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "siope_comuni", year: 1999 }),
+    /Anno SIOPE non disponibile/,
+  );
+  const result = await queryPublicDataset({ dataset: "siope_comuni", year: 2025, region: "Lazio" });
+  assert.equal(result.year, 2025);
+  assert.ok(result.regions.length <= 1);
+  assert.ok(result.regions.every((item) => item.region === "Lazio"));
+  assert.ok(result.topMunicipalities.every((item) => item.region === "Lazio"));
+});
+
+test("OpenCivitas query bounds pagination and rejects unavailable years", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "opencivitas_fabbisogni", year: 2020 }),
+    /OpenCivitas è disponibile/,
+  );
+  const result = await queryPublicDataset({
+    dataset: "opencivitas_fabbisogni",
+    limit: 10_000,
+    offset: -10,
+  });
+  assert.equal(result.pagination.limit, 100);
+  assert.equal(result.pagination.offset, 0);
+  assert.ok(result.data.length <= 100);
+});
+
+test("datasets requiring a domain identifier fail closed", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "ipa_struttura" }),
+    /filtro code è obbligatorio/,
+  );
+  await assert.rejects(
+    queryPublicDataset({ dataset: "openbdap_opere_pubbliche" }),
+    /filtro cup è obbligatorio/,
+  );
+});
+
+test("OpenBDAP month cannot be detached from its reference year", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "openbdap_spesa_stato", month: 3 }),
+    /indicare anche l’anno/,
+  );
+});
+
+test("every snapshot-backed MCP adapter returns real structured data", async () => {
+  const [cohesion, participations, appointments, parliament, controls, sources] = await Promise.all([
+    queryPublicDataset({ dataset: "opencoesione_progetti" }),
+    queryPublicDataset({ dataset: "mef_partecipazioni" }),
+    queryPublicDataset({ dataset: "consulenti_incarichi" }),
+    queryPublicDataset({ dataset: "parlamento_bilanci" }),
+    queryPublicDataset({ dataset: "controlli_segnali" }),
+    queryPublicDataset({ dataset: "registro_fonti" }),
+  ]);
+
+  assert.ok(cohesion.totals.publicCostCents > 0);
+  assert.ok(participations.totals.participationRecords > 0);
+  assert.ok(appointments.externalAppointments.length > 0);
+  assert.ok(parliament.chambers.length > 0);
+  assert.ok(controls.signals.length > 0);
+  assert.ok(sources.length > 0);
+});

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { POST } = await import("../src/app/api/mcp/route.ts");
+
+const requestBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+function request(headers = {}, body = requestBody) {
+  return new Request("https://example.test/api/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body,
+  });
+}
+
+test("MCP endpoint rejects an untrusted browser origin", async () => {
+  const response = await POST(request({ Origin: "https://attacker.test" }));
+  assert.equal(response.status, 403);
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+  assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+});
+
+test("MCP endpoint rejects an oversized declared body", async () => {
+  const response = await POST(request({ "Content-Length": "1000001" }));
+  assert.equal(response.status, 413);
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+});
+
+test("MCP endpoint enforces the body limit when Content-Length is absent", async () => {
+  const response = await POST(request({}, "x".repeat(1_000_001)));
+  assert.equal(response.status, 413);
+});
+
+test("MCP endpoint exposes the read-only tools over Streamable HTTP", async () => {
+  const response = await POST(request({ Origin: "https://example.test" }));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /list_datasets/);
+  assert.match(body, /query_dataset/);
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+});
+
+test("MCP endpoint exposes the machine-readable dataset catalog resource", async () => {
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "resources/list",
+  })));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /dvns:\/\/datasets/);
+  assert.match(body, /dataset-catalog/);
+});
+
+test("MCP endpoint supports the modern 2026 protocol envelope", async () => {
+  const meta = {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+  };
+  const response = await POST(request(
+    { "MCP-Protocol-Version": "2026-07-28", "MCP-Method": "tools/list" },
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/list",
+      params: { _meta: meta },
+    }),
+  ));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /"resultType":"complete"/);
+  assert.match(body, /list_datasets/);
+  assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+});
+
+test("MCP endpoint executes a modern tool call with mirrored request headers", async () => {
+  const meta = {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+  };
+  const response = await POST(request(
+    {
+      "MCP-Protocol-Version": "2026-07-28",
+      "MCP-Method": "tools/call",
+      "MCP-Name": "query_dataset",
+    },
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: {
+        _meta: meta,
+        name: "query_dataset",
+        arguments: { dataset: "registro_fonti", query: "SIOPE" },
+      },
+    }),
+  ));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /"resultType":"complete"/);
+  assert.match(body, /SIOPE \/ SIOPE\+/);
+});
+
+test("MCP endpoint reads the catalog resource with the modern protocol", async () => {
+  const meta = {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+  };
+  const response = await POST(request(
+    {
+      "MCP-Protocol-Version": "2026-07-28",
+      "MCP-Method": "resources/read",
+      "MCP-Name": "dvns://datasets",
+    },
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "resources/read",
+      params: { _meta: meta, uri: "dvns://datasets" },
+    }),
+  ));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /"resultType":"complete"/);
+  assert.match(body, /siope_comuni/);
+});
+
+test("MCP endpoint rejects a malformed modern envelope", async () => {
+  const response = await POST(request(
+    { "MCP-Protocol-Version": "2026-07-28", "MCP-Method": "tools/list" },
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/list",
+      params: {
+        _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
+      },
+    }),
+  ));
+  assert.equal(response.status, 400);
+  assert.match(await response.text(), /clientCapabilities/);
+});
+
+test("MCP endpoint keeps stateless requests isolated under concurrency", async () => {
+  const responses = await Promise.all(
+    Array.from({ length: 20 }, () => POST(request())),
+  );
+  assert.ok(responses.every((response) => response.status === 200));
+  const bodies = await Promise.all(responses.map((response) => response.text()));
+  assert.ok(bodies.every((body) => body.includes("query_dataset")));
+});
+
+test("MCP tool input schema rejects out-of-range pagination", async () => {
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 7,
+    method: "tools/call",
+    params: {
+      name: "query_dataset",
+      arguments: { dataset: "opencivitas_fabbisogni", limit: 101 },
+    },
+  })));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /Invalid arguments/);
+  assert.match(body, /Too big/);
+});


### PR DESCRIPTION
## Sintesi

- propone automaticamente la regione usando gli header geografici Vercel, con fallback casuale e senza esporre o salvare l’IP
- aggiunge un server MCP pubblico Streamable HTTP, read-only ed estensibile, con 13 dataset, catalogo risorsa e validazione Zod
- integra MCP nella navigazione, nella pagina dedicata, nel README e nella documentazione architetturale
- limita payload e origini browser, applica no-store/nosniff e carica gli adapter dati in modo lazy

## Verifica

- 68 test passati
- ESLint e TypeScript passati
- build Next.js 16.3 di produzione passata (22 pagine)
- npm audit: 0 vulnerabilità
- probe end-to-end passati su IPA, OpenBDAP Stato e opere pubbliche
- controllo Impeccable e asset brand passati
