### PR TITLE
fix: harden accessibility and MCP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ SOURCE_REFRESH_SECRET=
 # Origini browser aggiuntive autorizzate a chiamare il server MCP, separate da virgole.
 # I client MCP server-side normalmente non inviano Origin e non richiedono questa variabile.
 MCP_ALLOWED_ORIGINS=
+# Host pubblici autorizzati per /api/mcp, separati da virgole e senza schema.
+# Su Vercel vengono inclusi automaticamente anche i domini VERCEL_URL.
+MCP_ALLOWED_HOSTS=

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl -X POST http://localhost:3000/api/mcp \
   --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
-L'accesso anonimo è intenzionale perché il server espone esclusivamente dati pubblici e operazioni read-only. Le richieste hanno input limitati, paginazione massima e controllo dell'header `Origin`; eventuali origini browser aggiuntive si configurano con `MCP_ALLOWED_ORIGINS`. Non vengono esposte credenziali di ingestione.
+L'accesso anonimo è intenzionale perché il server espone esclusivamente dati pubblici e operazioni read-only. Le richieste hanno input limitati, paginazione massima e controlli sugli header `Origin` e `Host`; eventuali origini browser aggiuntive si configurano con `MCP_ALLOWED_ORIGINS`, mentre i domini pubblici ammessi si dichiarano in `MCP_ALLOWED_HOSTS`. I filtri estranei al dataset vengono rifiutati esplicitamente, senza produrre risultati che sembrino filtrati ma non lo siano. Non vengono esposte credenziali di ingestione.
 
 Per aggiungere una fonte all'MCP si registra la descrizione in `src/lib/mcp/catalog.ts` e l'adapter in `src/lib/mcp/datasets.ts`. Gli strumenti restano gli stessi, quindi i client non devono essere riconfigurati quando il catalogo cresce. Dettagli e checklist sono in [docs/MCP.md](docs/MCP.md).
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -31,9 +31,14 @@ Un adapter non deve accettare URL arbitrari, SQL, percorsi file o nomi di funzio
 - Nessuna credenziale di ingestione passa al client.
 - Il body HTTP dichiarato è limitato a 1 MB.
 - Se `Origin` è presente, deve coincidere con l'origine del deployment o con una voce esplicita in `MCP_ALLOWED_ORIGINS`.
+- Le richieste browser ricevono una preflight CORS solo per origini autorizzate. La superficie HTTP pubblica è intenzionalmente stateless e limitata a `POST` e `OPTIONS`; non espone sessioni SSE tramite `GET` o `DELETE`.
+- In produzione gli host pubblici ammessi vanno dichiarati, separati da virgola, in `MCP_ALLOWED_HOSTS`. Su Vercel vengono considerati anche `VERCEL_PROJECT_PRODUCTION_URL` e `VERCEL_URL`.
+- Ogni dataset accetta soltanto i filtri dichiarati nel catalogo. Un filtro incompatibile produce un errore esplicito e non viene ignorato.
 - Le risposte non sono memorizzate in cache condivise dal route handler MCP.
 - L'autenticazione MCP non è richiesta finché la superficie resta composta esclusivamente da dati pubblici e operazioni read-only. Prima di introdurre dati privati o mutazioni occorre aggiungere OAuth 2.1 e Protected Resource Metadata.
 
 ## Limiti operativi
 
 Le fonti live possono essere indisponibili o lente. In quel caso il tool restituisce un errore esplicito e non sostituisce il dato con valori simulati. I limiti e le date di riferimento delle singole fonti restano quelli documentati nel catalogo del portale.
+
+Il rate limiting va applicato a livello edge o con uno storage distribuito: una mappa in memoria nel processo non garantirebbe limiti coerenti in un deployment serverless. Allo stesso modo, prima di ampliare gli adapter live con catene di fetch più costose va introdotto un budget temporale complessivo propagato tramite `AbortSignal`, oltre ai timeout delle singole fonti già presenti.

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -17,9 +17,17 @@ const handler = createMcpHandler(createDvnsMcpServer, {
   onerror: reportMcpError,
 });
 
-function secureResponse(response: Response): Response {
+function secureResponse(response: Response, request?: Request): Response {
   response.headers.set("Cache-Control", "private, no-store");
   response.headers.set("X-Content-Type-Options", "nosniff");
+  if (request) {
+    const origin = request.headers.get("origin");
+    const normalized = origin ? normalizedOrigin(origin) : null;
+    if (normalized && allowedOrigins(request).has(normalized)) {
+      response.headers.set("Access-Control-Allow-Origin", normalized);
+      response.headers.append("Vary", "Origin");
+    }
+  }
   return response;
 }
 
@@ -42,9 +50,35 @@ function allowedOrigins(request: Request): Set<string> {
   return new Set([new URL(request.url).origin, ...configured]);
 }
 
+function normalizedHost(value: string): string | null {
+  const candidate = value.trim().toLocaleLowerCase("en-US").replace(/\.$/, "");
+  if (!candidate || /[\s/@]/.test(candidate)) return null;
+  return candidate;
+}
+
+function allowedHosts(request: Request): Set<string> {
+  const configured = [
+    ...(process.env.MCP_ALLOWED_HOSTS ?? "").split(","),
+    process.env.VERCEL_PROJECT_PRODUCTION_URL,
+    process.env.VERCEL_URL,
+  ]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map((value) => value.replace(/^https?:\/\//i, ""))
+    .map(normalizedHost)
+    .filter((value): value is string => value !== null);
+
+  if (configured.length > 0) return new Set(configured);
+  return new Set([new URL(request.url).host.toLocaleLowerCase("en-US")]);
+}
+
 function validateRequest(request: Request): Response | null {
+  const host = normalizedHost(request.headers.get("host") ?? new URL(request.url).host);
+  if (!host || !allowedHosts(request).has(host)) {
+    return Response.json({ error: "Host non consentito" }, { status: 403 });
+  }
   const origin = request.headers.get("origin");
-  if (origin && !allowedOrigins(request).has(origin)) {
+  const normalized = origin ? normalizedOrigin(origin) : null;
+  if (origin && (!normalized || !allowedOrigins(request).has(normalized))) {
     return Response.json({ error: "Origin non consentita" }, { status: 403 });
   }
   const declaredLength = request.headers.get("content-length");
@@ -92,9 +126,31 @@ async function requestWithBoundedBody(request: Request): Promise<Request | Respo
 
 export async function POST(request: Request) {
   const rejected = validateRequest(request);
-  if (rejected) return secureResponse(rejected);
-  const boundedRequest = await requestWithBoundedBody(request);
-  if (boundedRequest instanceof Response) return secureResponse(boundedRequest);
+  if (rejected) return secureResponse(rejected, request);
+  let boundedRequest: Request | Response;
+  try {
+    boundedRequest = await requestWithBoundedBody(request);
+  } catch {
+    return secureResponse(Response.json(
+      { error: "Richiesta interrotta o non leggibile" },
+      { status: 400 },
+    ), request);
+  }
+  if (boundedRequest instanceof Response) return secureResponse(boundedRequest, request);
 
-  return secureResponse(await handler.fetch(boundedRequest));
+  return secureResponse(await handler.fetch(boundedRequest), request);
+}
+
+export function OPTIONS(request: Request) {
+  const rejected = validateRequest(request);
+  if (rejected) return secureResponse(rejected, request);
+
+  const response = new Response(null, { status: 204 });
+  response.headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "Accept, Content-Type, Last-Event-ID, MCP-Method, MCP-Name, MCP-Protocol-Version, MCP-Session-ID",
+  );
+  response.headers.set("Access-Control-Max-Age", "600");
+  return secureResponse(response, request);
 }

--- a/src/app/coesione/page.tsx
+++ b/src/app/coesione/page.tsx
@@ -94,7 +94,7 @@ export default function CohesionPage() {
       <div className={styles.tables}>
         <section className="panel">
           <h2 className="panel-title">Dove vanno questi soldi · per tema</h2>
-          <div className="table-scroll">
+          <div className="table-scroll" role="region" aria-label="Spesa di coesione per tema" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>
@@ -120,7 +120,7 @@ export default function CohesionPage() {
 
         <section className="panel">
           <h2 className="panel-title">Come vengono spesi · per natura</h2>
-          <div className="table-scroll">
+          <div className="table-scroll" role="region" aria-label="Spesa di coesione per natura" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>
@@ -176,7 +176,7 @@ export default function CohesionPage() {
         <section className="panel">
           <h2 className="panel-title">La serie storica · cumulata</h2>
           <CohesionHistoryChart data={snapshot.annualSeries} />
-          <div className="table-scroll">
+          <div className="table-scroll" role="region" aria-label="Serie annuale OpenCoesione" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>

--- a/src/app/controlli/controlli.module.css
+++ b/src/app/controlli/controlli.module.css
@@ -28,7 +28,7 @@
 .yearFilter a {
   display: grid;
   min-width: 56px;
-  min-height: 38px;
+  min-height: 44px;
   place-items: center;
   padding-inline: 10px;
   color: var(--color-neutral-700);
@@ -49,7 +49,7 @@
 
 .yearFilter a[aria-current="page"] {
   color: var(--color-raised);
-  background: var(--color-accent);
+  background: var(--color-accent-700);
 }
 
 .signals article {
@@ -90,7 +90,7 @@
 .readingGuide dl {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0 var(--space-5);
+  gap: 0 var(--space-6);
   border-top: 1px solid var(--color-neutral-300);
 }
 

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -22,7 +22,7 @@
   --color-neutral-300: #d7d3d3;
   --color-neutral-400: #bab6b6;
   --color-neutral-500: #9b9797;
-  --color-neutral-600: #7d7979;
+  --color-neutral-600: #6a6666;
   --color-neutral-700: #605d5d;
   --color-neutral-800: #444141;
   --color-neutral-900: #2d2b2b;
@@ -120,17 +120,18 @@
   background: transparent;
   border: 1px solid transparent;
   padding: 7px var(--space-3);
+  min-height: 44px;
   border-radius: var(--radius-md);
 }
 .btn svg { display: block; }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
-.btn-primary { background: var(--color-accent); color: var(--color-bg); }
-.btn-primary:hover { background: var(--color-accent-600); }
-.btn-primary:active { background: var(--color-accent-700); }
+.btn-primary { background: var(--color-accent-700); color: var(--color-raised); }
+.btn-primary:hover { background: var(--color-accent-800); }
+.btn-primary:active { background: var(--color-accent-900); }
 .btn-secondary { border-color: var(--color-neutral-400); }
 .btn-secondary:hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
 .btn-secondary:active { background: color-mix(in srgb, var(--color-text) 14%, transparent); }
-.btn-ghost { color: var(--color-accent); padding-inline: var(--space-1); }
+.btn-ghost { color: var(--color-accent-700); padding-inline: var(--space-1); }
 .btn-ghost:hover { background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
 .btn-block {
   width: 100%;
@@ -146,7 +147,7 @@
 /* — forms — */
 .input {
   width: 100%;
-  min-height: 40px;
+  min-height: 44px;
   padding: 9px 12px;
   font: inherit;
   font-size: 13px;
@@ -196,7 +197,7 @@
 }
 .tag-accent { background: var(--color-accent-100); color: var(--color-accent-800); }
 .tag-neutral { background: var(--color-neutral-200); color: var(--color-neutral-800); }
-.tag-outline { border: 1px solid var(--color-accent); color: var(--color-accent); }
+.tag-outline { border: 1px solid var(--color-accent); color: var(--color-accent-700); }
 
 /* — tables — */
 .table {

--- a/src/app/enti/[codice]/page.tsx
+++ b/src/app/enti/[codice]/page.tsx
@@ -175,7 +175,7 @@ export default async function EntityPage({ params }: PageProps) {
                 </dl>
 
                 {structure.unitaOrganizzative.records.length > 0 ? (
-                  <div className="table-scroll">
+                  <div className="table-scroll" role="region" aria-label="Unità organizzative dell’ente" tabIndex={0}>
                     <table className="table">
                       <thead>
                         <tr>

--- a/src/app/enti/[codice]/scheda.module.css
+++ b/src/app/enti/[codice]/scheda.module.css
@@ -6,7 +6,7 @@
   color: var(--color-neutral-600);
 }
 .breadcrumb a { color: var(--color-neutral-700); }
-.breadcrumb a:hover { color: var(--color-accent); }
+.breadcrumb a:hover { color: var(--color-accent-800); }
 
 .head {
   display: flex;

--- a/src/app/enti/enti.module.css
+++ b/src/app/enti/enti.module.css
@@ -91,7 +91,7 @@
   text-transform: uppercase;
   color: var(--color-neutral-700);
 }
-.details summary:hover { color: var(--color-accent); }
+.details summary:hover { color: var(--color-accent-700); }
 .details p {
   margin: var(--space-3) 0 0;
   font-size: 13px;

--- a/src/app/enti/page.tsx
+++ b/src/app/enti/page.tsx
@@ -194,7 +194,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
           </div>
 
           {result.records.length > 0 ? (
-            <div className="table-scroll">
+            <div className="table-scroll" role="region" aria-label="Risultati della ricerca enti" tabIndex={0}>
               <table className="table">
                 <thead>
                   <tr>
@@ -243,7 +243,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
             <h2 className="panel-title">Ministeri, Presidenza e Avvocatura</h2>
             <span>{integer(centralAdministrations.total)} enti · aggiornamento giornaliero</span>
           </div>
-          <div className="table-scroll">
+          <div className="table-scroll" role="region" aria-label="Principali enti pubblici" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>
@@ -340,7 +340,7 @@ export default async function EntiPage({ searchParams }: PageProps) {
           <h2 className="panel-title">Le società con più enti soci</h2>
           <Link href="/partecipazioni">Tutte le partecipazioni →</Link>
         </div>
-        <div className="table-scroll">
+        <div className="table-scroll" role="region" aria-label="Partecipazioni pubbliche" tabIndex={0}>
           <table className="table">
             <thead>
               <tr>

--- a/src/app/fonti/page.tsx
+++ b/src/app/fonti/page.tsx
@@ -47,7 +47,7 @@ export default function SourcesPage() {
       </div>
 
       <section className="panel">
-        <div className="table-scroll">
+        <div className="table-scroll" role="region" aria-label="Registro delle fonti" tabIndex={0}>
           <table className="table">
             <thead>
               <tr>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,13 +35,36 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 a { color: var(--color-accent-700); text-decoration: none; }
-a:hover { color: var(--color-accent); }
+a:hover { color: var(--color-accent-800); }
 button, input, select, textarea { font: inherit; }
 code { font: 500 .92em var(--font-mono); color: var(--color-neutral-700); }
 img, svg { display: block; max-width: 100%; }
 ::selection { background: var(--color-accent-200); }
 :focus { outline: none; }
 :focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+
+.skip-link {
+  position: fixed;
+  inset-block-start: var(--space-2);
+  inset-inline-start: var(--space-2);
+  z-index: 100;
+  padding: 10px 14px;
+  color: var(--color-raised);
+  background: var(--color-accent-800);
+  font-weight: 700;
+  transform: translateY(calc(-100% - var(--space-4)));
+}
+.skip-link:focus-visible { color: var(--color-raised); transform: translateY(0); }
+
+main p a,
+main li a,
+main dd a,
+main figcaption a,
+main td a:not(.btn) {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: .18em;
+}
 
 /* The shell bounds every band of the page — header, nav, main and footer all
    share one measure so their rules line up vertically. */
@@ -133,7 +156,7 @@ img, svg { display: block; max-width: 100%; }
   background: transparent;
   cursor: pointer;
 }
-.header-search button:hover { color: var(--color-accent); }
+.header-search button:hover { color: var(--color-accent-700); }
 
 .header-actions {
   display: flex;
@@ -144,6 +167,7 @@ img, svg { display: block; max-width: 100%; }
 
 .header-action {
   flex: none;
+  min-height: 44px;
   padding: 11px 18px;
   border: 1px solid var(--color-neutral-400);
   font-size: 13px;
@@ -239,9 +263,8 @@ main { display: block; }
 }
 .footer-row .footer-spacer { flex: 1; }
 .footer-row strong { font-weight: 600; color: var(--color-text); }
+.footer-row a { display: inline-flex; align-items: center; min-height: 44px; }
 .footer-link {
-  display: inline-flex;
-  align-items: center;
   gap: var(--space-2);
   padding: 9px 14px;
   border: 1px solid var(--color-neutral-400);
@@ -348,6 +371,20 @@ main { display: block; }
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
+
+.chart-data {
+  margin-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-300);
+}
+.chart-data summary {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--color-accent-700);
+  font-weight: 700;
+}
+.chart-data .table-scroll { max-height: 360px; }
 
 /* ── responsive ─────────────────────────────────────────────────────────── */
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,8 +43,9 @@ export default function RootLayout({
   return (
     <html lang="it" className={archivo.variable}>
       <body>
+        <a className="skip-link" href="#contenuto-principale">Salta al contenuto principale</a>
         <Navigation />
-        {children}
+        <div id="contenuto-principale" tabIndex={-1}>{children}</div>
         <footer className="shell site-footer">
           <div className="footer-row">
             <span>Ultimo controllo dei dati: {lastCheckedLabel}</span>

--- a/src/app/mcp/mcp.module.css
+++ b/src/app/mcp/mcp.module.css
@@ -5,7 +5,7 @@
   margin-bottom: var(--space-2);
   font: 600 11px var(--font-mono);
   letter-spacing: .08em;
-  color: var(--color-accent);
+  color: var(--color-accent-700);
 }
 
 .endpointPanel h2,
@@ -27,6 +27,14 @@
   background: var(--color-neutral-100);
 }
 .endpointRow button { flex: none; }
+.srStatus {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
 
 .columns {
   display: grid;

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function McpPage() {
   return (
-    <main className="shell page-shell">
+    <main className="shell page">
       <header className="page-intro">
         <span className="eyebrow">Dati per assistenti AI</span>
         <h1>Interroga il portale con MCP</h1>
@@ -52,7 +52,7 @@ export default function McpPage() {
       <section className="panel" aria-labelledby="datasets-title">
         <span className={styles.index}>04</span>
         <h2 id="datasets-title">{datasetCatalog.length} dataset interrogabili</h2>
-        <div className="table-scroll">
+        <div className="table-scroll" role="region" aria-label="Catalogo dei dataset MCP" tabIndex={0}>
           <table className={styles.datasetTable}>
             <thead><tr><th>Dataset</th><th>Aggiornamento</th><th>Filtri</th></tr></thead>
             <tbody>

--- a/src/app/metodologia/metodologia.module.css
+++ b/src/app/metodologia/metodologia.module.css
@@ -10,7 +10,7 @@
   margin-bottom: var(--space-3);
   font: 600 11px var(--font-mono);
   letter-spacing: .08em;
-  color: var(--color-accent);
+  color: var(--color-accent-700);
 }
 
 .rules h2 {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -270,7 +270,7 @@ export default async function HomePage({
             <h2 className="panel-title">Le regioni che pagano di più</h2>
             <span className={styles.headNote}>Comuni con sede nella regione</span>
           </div>
-          <div className="table-scroll">
+          <div className="table-scroll" role="region" aria-label="Spese dei principali Comuni" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>

--- a/src/app/partecipazioni/page.tsx
+++ b/src/app/partecipazioni/page.tsx
@@ -101,7 +101,7 @@ export default function ParticipationsPage() {
 
       <section className="panel">
         <h2 className="panel-title">Organizzazioni dichiarate da più amministrazioni</h2>
-        <div className="table-scroll">
+        <div className="table-scroll" role="region" aria-label="Organizzazioni partecipate da più amministrazioni" tabIndex={0}>
           <table className="table">
             <thead>
               <tr>

--- a/src/app/partecipazioni/partecipazioni.module.css
+++ b/src/app/partecipazioni/partecipazioni.module.css
@@ -6,7 +6,7 @@
   color: var(--color-neutral-600);
 }
 .breadcrumb a { color: var(--color-neutral-700); }
-.breadcrumb a:hover { color: var(--color-accent); }
+.breadcrumb a:hover { color: var(--color-accent-800); }
 
 .split {
   display: grid;

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -162,7 +162,7 @@ export default async function MoneyPage({
 
           <section className="panel">
             <h2 className="panel-title">Flusso e cumulato · mld €</h2>
-            <div className="table-scroll">
+            <div className="table-scroll" role="region" aria-label="Flusso mensile e cumulato delle spese" tabIndex={0}>
               <table className="table">
                 <thead>
                   <tr>

--- a/src/app/spese/spese.module.css
+++ b/src/app/spese/spese.module.css
@@ -139,7 +139,7 @@
   text-transform: uppercase;
   color: var(--color-neutral-700);
 }
-.method summary:hover { color: var(--color-accent); }
+.method summary:hover { color: var(--color-accent-700); }
 .method p {
   margin: var(--space-3) 0 0;
   font-size: 13px;

--- a/src/app/stato/amministrazioni/[codice]/page.tsx
+++ b/src/app/stato/amministrazioni/[codice]/page.tsx
@@ -46,8 +46,8 @@ function SourceRow({ dataset }: { dataset: BdapDataset }) {
         <small>Identificativo {dataset.packageId}</small>
       </div>
       <div className={styles.provenanceActions}>
-        <a href={dataset.csvUrl} target="_blank" rel="noreferrer">CSV RGS ↗</a>
-        <a href={dataset.apiUrl} target="_blank" rel="noreferrer">API ↗</a>
+        <a href={dataset.csvUrl} target="_blank" rel="noreferrer" aria-label={`Scarica il CSV RGS ${datasetLabel(dataset)} (si apre in una nuova scheda)`}>CSV RGS ↗</a>
+        <a href={dataset.apiUrl} target="_blank" rel="noreferrer" aria-label={`Apri l’API OpenBDAP ${datasetLabel(dataset)} (si apre in una nuova scheda)`}>API ↗</a>
       </div>
     </div>
   );
@@ -156,7 +156,7 @@ function AdministrationDashboard({ data }: { data: StateAdministrationSpending }
           <div className={styles.chartBlock}>
             <div className={styles.chartTitle}>
               <h3>Missioni principali</h3>
-              <a href={data.sources.missionAdministration.csvUrl} target="_blank" rel="noreferrer">CSV ↗</a>
+              <a href={data.sources.missionAdministration.csvUrl} target="_blank" rel="noreferrer" aria-label="Scarica il CSV RGS delle missioni dell’amministrazione (si apre in una nuova scheda)">CSV ↗</a>
             </div>
             <SpendingBarChart
               data={data.missions}
@@ -169,7 +169,7 @@ function AdministrationDashboard({ data }: { data: StateAdministrationSpending }
             <div className={styles.chartTitle}>
               <h3>Tipi di spesa</h3>
               {data.sources.administrationEconomic && (
-                <a href={data.sources.administrationEconomic.csvUrl} target="_blank" rel="noreferrer">CSV ↗</a>
+                <a href={data.sources.administrationEconomic.csvUrl} target="_blank" rel="noreferrer" aria-label="Scarica il CSV RGS delle categorie economiche dell’amministrazione (si apre in una nuova scheda)">CSV ↗</a>
               )}
             </div>
             {data.economicCategories.length > 0 ? (

--- a/src/app/stato/page.tsx
+++ b/src/app/stato/page.tsx
@@ -85,8 +85,8 @@ function SourceRow({ dataset }: { dataset: BdapDataset }) {
         <small>Identificativo {dataset.packageId}</small>
       </div>
       <div className={styles.provenanceActions}>
-        <a href={dataset.csvUrl} target="_blank" rel="noreferrer">CSV RGS ↗</a>
-        <a href={dataset.apiUrl} target="_blank" rel="noreferrer">API ↗</a>
+        <a href={dataset.csvUrl} target="_blank" rel="noreferrer" aria-label={`Scarica il CSV RGS ${datasetLabel(dataset)} (si apre in una nuova scheda)`}>CSV RGS ↗</a>
+        <a href={dataset.apiUrl} target="_blank" rel="noreferrer" aria-label={`Apri l’API OpenBDAP ${datasetLabel(dataset)} (si apre in una nuova scheda)`}>API ↗</a>
       </div>
     </div>
   );
@@ -127,7 +127,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           </div>
           <div className={styles.sourceSummaryRow}>
             <span>File originale</span>
-            <a href={snapshot.sources.mission.csvUrl} target="_blank" rel="noreferrer">apri CSV ufficiale ↗</a>
+            <a href={snapshot.sources.mission.csvUrl} target="_blank" rel="noreferrer" aria-label="Scarica il CSV RGS delle missioni (si apre in una nuova scheda)">apri CSV ufficiale ↗</a>
           </div>
         </aside>
       </header>
@@ -185,7 +185,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
         <div className={styles.chartBlock}>
           <div className={styles.chartTitle}>
             <h3>Missioni principali, {snapshot.period.label}</h3>
-            <a href={snapshot.sources.mission.csvUrl} target="_blank" rel="noreferrer">fonte CSV ↗</a>
+            <a href={snapshot.sources.mission.csvUrl} target="_blank" rel="noreferrer" aria-label="Scarica il CSV RGS delle missioni (si apre in una nuova scheda)">fonte CSV ↗</a>
           </div>
           <SpendingBarChart
             data={snapshot.missions}
@@ -216,7 +216,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             <div className={styles.chartTitle}>
               <h3>Amministrazioni</h3>
               {snapshot.sources.missionAdministration && (
-                <a href={snapshot.sources.missionAdministration.csvUrl} target="_blank" rel="noreferrer">CSV ↗</a>
+                <a href={snapshot.sources.missionAdministration.csvUrl} target="_blank" rel="noreferrer" aria-label="Scarica il CSV RGS delle amministrazioni (si apre in una nuova scheda)">CSV ↗</a>
               )}
             </div>
             <SpendingBarChart
@@ -225,7 +225,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
               maxItems={10}
               height={430}
             />
-            <div className={`table-scroll ${styles.administrationTable}`} tabIndex={0}>
+            <div className={`table-scroll ${styles.administrationTable}`} role="region" aria-label="Amministrazioni per totale pagato" tabIndex={0}>
               <table className="table">
                 <thead>
                   <tr>
@@ -267,7 +267,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             <div className={styles.chartTitle}>
               <h3>Categorie economiche</h3>
               {snapshot.sources.administrationEconomic && (
-                <a href={snapshot.sources.administrationEconomic.csvUrl} target="_blank" rel="noreferrer">CSV ↗</a>
+                <a href={snapshot.sources.administrationEconomic.csvUrl} target="_blank" rel="noreferrer" aria-label="Scarica il CSV RGS delle categorie economiche (si apre in una nuova scheda)">CSV ↗</a>
               )}
             </div>
             <SpendingBarChart

--- a/src/app/stato/stato.module.css
+++ b/src/app/stato/stato.module.css
@@ -400,7 +400,7 @@
 }
 
 .provenanceActions a {
-  min-height: 38px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   padding: 0 11px;

--- a/src/app/territori/confronto/confronto.module.css
+++ b/src/app/territori/confronto/confronto.module.css
@@ -26,7 +26,7 @@
 }
 
 .filterActions :global(.btn) {
-  min-height: 40px;
+  min-height: 44px;
 }
 
 .resultsHeader {

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -55,7 +55,7 @@ export default async function TerritoriesPage({
       <div className={styles.split}>
         <section className="panel">
           <h2 className="panel-title">Tutte le {regions.length} regioni</h2>
-          <div className="table-scroll">
+          <div className="table-scroll" role="region" aria-label="Pagamenti di tutte le regioni" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>
@@ -89,7 +89,7 @@ export default async function TerritoriesPage({
         <div className={styles.aside}>
           <section className="panel">
             <h2 className="panel-title">I {topByVolume.length} Comuni che pagano di più</h2>
-            <div className="table-scroll">
+            <div className="table-scroll" role="region" aria-label="Comuni con i pagamenti più alti" tabIndex={0}>
               <table className="table">
                 <thead>
                   <tr>
@@ -126,7 +126,7 @@ export default async function TerritoriesPage({
 
           <section className="panel">
             <h2 className="panel-title">Top {topByPerCapita.length} per abitante</h2>
-            <div className="table-scroll">
+            <div className="table-scroll" role="region" aria-label="Comuni con i pagamenti pro capite più alti" tabIndex={0}>
               <table className="table">
                 <thead>
                   <tr>

--- a/src/components/charts/chart-data-table.tsx
+++ b/src/components/charts/chart-data-table.tsx
@@ -1,0 +1,38 @@
+export type ChartTableRow = {
+  label: string;
+  values: string[];
+};
+
+export function ChartDataTable({
+  label,
+  columns,
+  rows,
+}: {
+  label: string;
+  columns: string[];
+  rows: ChartTableRow[];
+}) {
+  return (
+    <details className="chart-data">
+      <summary>Dati del grafico in tabella</summary>
+      <div className="table-scroll" role="region" aria-label={label} tabIndex={0}>
+        <table className="table">
+          <thead>
+            <tr>
+              <th scope="col">Voce</th>
+              {columns.map((column) => <th scope="col" className="num" key={column}>{column}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label}>
+                <th scope="row">{row.label}</th>
+                {row.values.map((value, index) => <td className="num" key={`${row.label}-${index}`}>{value}</td>)}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}

--- a/src/components/charts/cohesion-history-chart.tsx
+++ b/src/components/charts/cohesion-history-chart.tsx
@@ -105,7 +105,7 @@ export function CohesionHistoryChart({ data }: { data: OpenCoesioneAnnualPoint[]
       <figcaption>
         Ogni punto contiene il totale registrato fino a quell&apos;anno, non il valore del solo anno indicato.
       </figcaption>
-      <div className={styles.tableWrap}>
+      <div className={styles.tableWrap} role="region" aria-label="Totali annuali OpenCoesione" tabIndex={0}>
         <table>
           <caption>Totali annuali pubblicati da OpenCoesione</caption>
           <thead>

--- a/src/components/charts/registry-type-chart.tsx
+++ b/src/components/charts/registry-type-chart.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import type { IpaTypeStat } from "@/lib/ipa-stats";
 import styles from "./registry-type-chart.module.css";
+import { ChartDataTable } from "./chart-data-table";
 
 const integerFormatter = new Intl.NumberFormat("it-IT", { useGrouping: "always" });
 
@@ -107,6 +108,14 @@ export function RegistryTypeChart({ data }: { data: IpaTypeStat[] }) {
         Conteggio dei record per le tipologie più presenti nel datastore IPA. Il grafico viene calcolato
         tramite query SQL sull&apos;API ufficiale, non da un campione locale.
       </figcaption>
+      <ChartDataTable
+        label="Distribuzione dei record IPA per tipologia di ente"
+        columns={["Record"]}
+        rows={chartData.map((record) => ({
+          label: record.label,
+          values: [integerFormatter.format(record.value)],
+        }))}
+      />
     </figure>
   );
 }

--- a/src/components/charts/spending-bar-chart.tsx
+++ b/src/components/charts/spending-bar-chart.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import styles from "./spending-bar-chart.module.css";
 import { chartColor } from "@/lib/chart-colors";
+import { ChartDataTable } from "./chart-data-table";
 
 export type SpendingChartPoint = {
   label: string;
@@ -119,6 +120,14 @@ export function SpendingBarChart({
           </BarChart>
         </ResponsiveContainer>
       </div>
+      <ChartDataTable
+        label={`${ariaLabel}: valori esatti`}
+        columns={["Importo"]}
+        rows={chartData.map((point) => ({
+          label: point.code ? `${point.label} (${point.code})` : point.label,
+          values: [exactEuro.format(point.value)],
+        }))}
+      />
     </figure>
   );
 }

--- a/src/components/charts/spending-history-chart.tsx
+++ b/src/components/charts/spending-history-chart.tsx
@@ -13,6 +13,7 @@ import {
 } from "recharts";
 import type { StateSpendingHistoryPoint } from "@/lib/bdap-history";
 import styles from "./spending-history-chart.module.css";
+import { ChartDataTable } from "./chart-data-table";
 
 const exactEuro = new Intl.NumberFormat("it-IT", {
   style: "currency",
@@ -111,6 +112,14 @@ export function SpendingHistoryChart({
         <figcaption>
           Ogni punto è il totale ufficiale dal 1° gennaio fino alla fine del mese indicato.
         </figcaption>
+        <ChartDataTable
+          label="Pagamenti cumulati del Bilancio dello Stato"
+          columns={["Totale da gennaio"]}
+          rows={data.map((point) => ({
+            label: `${point.monthName} ${point.year}`,
+            values: [point.cumulativePaid === null ? "Non disponibile" : exactEuro.format(point.cumulativePaid)],
+          }))}
+        />
       </figure>
 
       <figure className={styles.figure}>
@@ -159,6 +168,14 @@ export function SpendingHistoryChart({
         <figcaption>
           Da febbraio sottraiamo il totale del mese precedente. Se manca uno dei due mesi, non calcoliamo il valore.
         </figcaption>
+        <ChartDataTable
+          label="Pagamenti mensili calcolati del Bilancio dello Stato"
+          columns={["Pagamento del mese"]}
+          rows={data.map((point) => ({
+            label: `${point.monthName} ${point.year}`,
+            values: [point.monthlyPaid === null ? "Non calcolabile" : exactEuro.format(point.monthlyPaid)],
+          }))}
+        />
       </figure>
     </div>
   );

--- a/src/components/info-tooltip.module.css
+++ b/src/components/info-tooltip.module.css
@@ -8,20 +8,34 @@
 .trigger {
   display: grid;
   place-items: center;
-  width: 18px;
-  height: 18px;
+  width: 44px;
+  height: 44px;
   padding: 0;
-  border: 1px solid var(--color-neutral-400);
-  background: var(--color-raised);
+  border: 0;
+  background: transparent;
   color: var(--color-neutral-700);
   font-size: 11px;
   font-weight: 600;
   line-height: 1;
   cursor: help;
+  position: relative;
+  isolation: isolate;
 }
-.trigger:hover {
-  color: var(--color-accent);
-  border-color: var(--color-accent);
+.trigger::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border: 1px solid var(--color-neutral-400);
+  background: var(--color-raised);
+  z-index: -1;
+}
+.trigger:hover,
+.trigger[aria-expanded="true"] {
+  color: var(--color-accent-700);
+}
+.trigger:hover::before,
+.trigger[aria-expanded="true"]::before {
+  border-color: var(--color-accent-700);
 }
 
 .tooltip {
@@ -48,9 +62,8 @@
   display: block;
   margin-top: 6px;
 }
-.tooltip b { color: #ffffff; }
+.tooltip b { color: var(--color-raised); }
 
-.wrapper:hover .tooltip,
-.trigger:focus-visible + .tooltip {
+.tooltip[data-open="true"] {
   display: block;
 }

--- a/src/components/info-tooltip.tsx
+++ b/src/components/info-tooltip.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import styles from "./info-tooltip.module.css";
 
 export function InfoTooltip({
@@ -9,17 +12,35 @@ export function InfoTooltip({
   label: string;
   children: React.ReactNode;
 }) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <span className={styles.wrapper}>
+    <span
+      className={styles.wrapper}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          setOpen(false);
+          event.stopPropagation();
+        }
+      }}
+    >
       <button
         type="button"
         className={styles.trigger}
         aria-label={label}
-        aria-describedby={id}
+        aria-controls={id}
+        aria-expanded={open}
+        onFocus={() => setOpen(true)}
+        onClick={() => setOpen(true)}
       >
         ?
       </button>
-      <span className={styles.tooltip} id={id} role="tooltip">
+      <span className={styles.tooltip} data-open={open} id={id} role="tooltip">
         {children}
       </span>
     </span>

--- a/src/components/mcp-endpoint.tsx
+++ b/src/components/mcp-endpoint.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import styles from "@/app/mcp/mcp.module.css";
 
 export function McpEndpoint() {
-  const [copied, setCopied] = useState(false);
+  const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+  const resetTimer = useRef<number | null>(null);
   const origin = useSyncExternalStore(
     () => () => undefined,
     () => window.location.origin,
@@ -12,18 +13,31 @@ export function McpEndpoint() {
   );
   const endpoint = `${origin}/api/mcp`;
 
+  useEffect(() => () => {
+    if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
+  }, []);
+
   async function copyEndpoint() {
-    await navigator.clipboard.writeText(endpoint);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1800);
+    if (!origin) return;
+    if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
+    try {
+      await navigator.clipboard.writeText(endpoint);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+    }
+    resetTimer.current = window.setTimeout(() => setStatus("idle"), 2400);
   }
 
   return (
     <div className={styles.endpointRow}>
       <code>{endpoint}</code>
-      <button className="btn" type="button" onClick={copyEndpoint}>
-        {copied ? "Copiato" : "Copia endpoint"}
+      <button className="btn" type="button" onClick={copyEndpoint} disabled={!origin}>
+        {status === "copied" ? "Copiato" : status === "error" ? "Copia non riuscita" : "Copia endpoint"}
       </button>
+      <span className={styles.srStatus} role="status" aria-live="polite">
+        {status === "copied" ? "Endpoint MCP copiato negli appunti." : status === "error" ? "Copia non riuscita. Seleziona e copia manualmente l’indirizzo." : ""}
+      </span>
     </div>
   );
 }

--- a/src/components/period-selector.module.css
+++ b/src/components/period-selector.module.css
@@ -20,7 +20,7 @@
 .wrapper a {
   display: grid;
   min-width: 56px;
-  min-height: 32px;
+  min-height: 44px;
   place-items: center;
   padding-inline: 10px;
   color: var(--color-neutral-700);
@@ -33,10 +33,10 @@
 .wrapper a:hover { color: var(--color-text); background: var(--color-neutral-200); }
 
 .wrapper a[aria-current="page"] {
-  color: #ffffff;
-  background: var(--color-accent);
+  color: var(--color-raised);
+  background: var(--color-accent-700);
 }
-.wrapper a[aria-current="page"]:hover { background: var(--color-accent-600); }
+.wrapper a[aria-current="page"]:hover { background: var(--color-accent-800); }
 
 @media (max-width: 560px) {
   .wrapper {

--- a/src/components/state-spending-history-section.module.css
+++ b/src/components/state-spending-history-section.module.css
@@ -21,7 +21,7 @@
 
 .header h2 {
   margin: 6px 0 0;
-  color: var(--color-neutral-100);
+  color: var(--color-text);
   font-size: 27px;
   font-weight: 560;
   letter-spacing: -.03em;
@@ -73,7 +73,7 @@
 
 .metrics strong {
   margin: 9px 0 4px;
-  color: var(--color-neutral-100);
+  color: var(--color-text);
   font-size: 23px;
   font-weight: 550;
   letter-spacing: -.025em;
@@ -156,7 +156,7 @@
 .error strong {
   display: block;
   margin-bottom: 7px;
-  color: var(--color-neutral-100);
+  color: var(--color-text);
   font-size: 15px;
 }
 

--- a/src/lib/mcp/datasets.ts
+++ b/src/lib/mcp/datasets.ts
@@ -1,4 +1,27 @@
-import type { DatasetQuery } from "@/lib/mcp/catalog";
+import { datasetCatalog, type DatasetQuery } from "@/lib/mcp/catalog";
+
+const datasetFilters = new Map(datasetCatalog.map((dataset) => [dataset.id, new Set(dataset.filters)]));
+
+function rejectUnsupportedFilters(query: DatasetQuery) {
+  const supported = datasetFilters.get(query.dataset) ?? new Set<string>();
+  const provided = Object.entries(query)
+    .filter(([key, value]) => key !== "dataset" && value !== undefined)
+    .map(([key]) => key);
+  const unsupported = provided.filter((key) => !supported.has(key));
+  if (unsupported.length > 0) {
+    const accepted = [...supported];
+    throw new Error(
+      `Filtri non supportati per ${query.dataset}: ${unsupported.join(", ")}. ` +
+      `Filtri ammessi: ${accepted.length > 0 ? accepted.join(", ") : "nessuno"}.`,
+    );
+  }
+}
+
+function rejectAmbiguousFilters(query: DatasetQuery) {
+  if (query.dataset === "ipa_enti" && query.code !== undefined && query.query !== undefined) {
+    throw new Error("Per ipa_enti usa code oppure query, non entrambi.");
+  }
+}
 
 function boundedInteger(value: number | undefined, fallback: number, minimum: number, maximum: number) {
   if (!Number.isFinite(value)) return fallback;
@@ -26,6 +49,8 @@ function jsonSafe<T>(value: T): T {
 }
 
 export async function queryPublicDataset(query: DatasetQuery): Promise<unknown> {
+  rejectUnsupportedFilters(query);
+  rejectAmbiguousFilters(query);
   const limit = boundedInteger(query.limit, 50, 1, 100);
   const offset = boundedInteger(query.offset, 0, 0, 100_000);
 

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -15,7 +15,7 @@ const querySchema = z.object({
   chamber: z.enum(["camera", "senato"]).optional(),
   limit: z.number().int().min(1).max(100).optional(),
   offset: z.number().int().min(0).max(100_000).optional(),
-});
+}).strict();
 
 function toolResult(value: unknown) {
   return {

--- a/tests/accessibility-tokens.test.mjs
+++ b/tests/accessibility-tokens.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const css = await readFile(new URL("../src/app/design-system.css", import.meta.url), "utf8");
+
+function token(name) {
+  const match = css.match(new RegExp(`--${name}:\\s*(#[0-9a-f]{6})`, "i"));
+  assert.ok(match, `token --${name} non trovato`);
+  return match[1];
+}
+
+function luminance(hex) {
+  const channels = hex.slice(1).match(/.{2}/g).map((value) => Number.parseInt(value, 16) / 255);
+  const linear = channels.map((value) => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrast(first, second) {
+  const [lighter, darker] = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+test("secondary text token meets WCAG AA on every shared light surface", () => {
+  const foreground = token("color-neutral-600");
+  for (const surface of ["color-bg", "color-surface", "color-raised"]) {
+    assert.ok(contrast(foreground, token(surface)) >= 4.5, `${surface} sotto 4.5:1`);
+  }
+});
+
+test("primary button pair meets WCAG AA", () => {
+  assert.ok(contrast(token("color-accent-700"), token("color-raised")) >= 4.5);
+  assert.match(css, /\.btn-primary\s*\{[^}]*background:\s*var\(--color-accent-700\)[^}]*color:\s*var\(--color-raised\)/s);
+});

--- a/tests/mcp-datasets.test.mjs
+++ b/tests/mcp-datasets.test.mjs
@@ -62,6 +62,24 @@ test("OpenBDAP month cannot be detached from its reference year", async () => {
   );
 });
 
+test("dataset adapters reject filters they do not implement", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "siope_comuni", year: 2025, month: 1 }),
+    /Filtri non supportati.*month/,
+  );
+  await assert.rejects(
+    queryPublicDataset({ dataset: "opencoesione_progetti", year: 2025 }),
+    /Filtri non supportati.*year/,
+  );
+});
+
+test("IPA entity lookup does not silently ignore an ambiguous search filter", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "ipa_enti", code: "agid", query: "ministero" }),
+    /code oppure query, non entrambi/,
+  );
+});
+
 test("every snapshot-backed MCP adapter returns real structured data", async () => {
   const [cohesion, participations, appointments, parliament, controls, sources] = await Promise.all([
     queryPublicDataset({ dataset: "opencoesione_progetti" }),

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
-const { POST } = await import("../src/app/api/mcp/route.ts");
+const { OPTIONS, POST } = await import("../src/app/api/mcp/route.ts");
 
 const requestBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
 
@@ -25,6 +25,64 @@ test("MCP endpoint rejects an untrusted browser origin", async () => {
   assert.equal(response.headers.get("x-content-type-options"), "nosniff");
 });
 
+test("MCP endpoint answers browser preflight only for an allowed origin", async () => {
+  const response = OPTIONS(new Request("https://example.test/api/mcp", {
+    method: "OPTIONS",
+    headers: {
+      Origin: "https://example.test",
+      "Access-Control-Request-Method": "POST",
+      "Access-Control-Request-Headers": "content-type,mcp-protocol-version",
+    },
+  }));
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("access-control-allow-origin"), "https://example.test");
+  assert.match(response.headers.get("access-control-allow-methods"), /POST/);
+  assert.match(response.headers.get("access-control-allow-headers"), /MCP-Protocol-Version/i);
+  assert.match(response.headers.get("vary"), /Origin/);
+
+  const rejected = OPTIONS(new Request("https://example.test/api/mcp", {
+    method: "OPTIONS",
+    headers: { Origin: "https://attacker.test" },
+  }));
+  assert.equal(rejected.status, 403);
+  assert.equal(rejected.headers.get("access-control-allow-origin"), null);
+});
+
+test("MCP endpoint enforces an explicit host allowlist", async () => {
+  const previous = process.env.MCP_ALLOWED_HOSTS;
+  process.env.MCP_ALLOWED_HOSTS = "mcp.example.test";
+  try {
+    const rejected = await POST(request());
+    assert.equal(rejected.status, 403);
+    assert.match(await rejected.text(), /Host non consentito/);
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ALLOWED_HOSTS;
+    else process.env.MCP_ALLOWED_HOSTS = previous;
+  }
+});
+
+test("MCP endpoint does not trust a client supplied forwarded host", async () => {
+  const previous = process.env.MCP_ALLOWED_HOSTS;
+  process.env.MCP_ALLOWED_HOSTS = "mcp.example.test";
+  try {
+    const response = await POST(new Request("https://evil.test/api/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Host: "evil.test",
+        "X-Forwarded-Host": "mcp.example.test",
+      },
+      body: requestBody,
+    }));
+    assert.equal(response.status, 403);
+    assert.match(await response.text(), /Host non consentito/);
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ALLOWED_HOSTS;
+    else process.env.MCP_ALLOWED_HOSTS = previous;
+  }
+});
+
 test("MCP endpoint rejects an oversized declared body", async () => {
   const response = await POST(request({ "Content-Length": "1000001" }));
   assert.equal(response.status, 413);
@@ -34,6 +92,22 @@ test("MCP endpoint rejects an oversized declared body", async () => {
 test("MCP endpoint enforces the body limit when Content-Length is absent", async () => {
   const response = await POST(request({}, "x".repeat(1_000_001)));
   assert.equal(response.status, 413);
+});
+
+test("MCP endpoint converts a broken request stream into a controlled response", async () => {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.error(new Error("synthetic disconnect"));
+    },
+  });
+  const response = await POST(new Request("https://example.test/api/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    duplex: "half",
+  }));
+  assert.equal(response.status, 400);
+  assert.match(await response.text(), /interrotta o non leggibile/);
 });
 
 test("MCP endpoint exposes the read-only tools over Streamable HTTP", async () => {
@@ -104,6 +178,22 @@ test("MCP endpoint executes a modern tool call with mirrored request headers", a
   assert.equal(response.status, 200);
   assert.match(body, /"resultType":"complete"/);
   assert.match(body, /SIOPE \/ SIOPE\+/);
+});
+
+test("MCP endpoint rejects filters unsupported by the selected dataset", async () => {
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 8,
+    method: "tools/call",
+    params: {
+      name: "query_dataset",
+      arguments: { dataset: "opencoesione_progetti", year: 2025 },
+    },
+  })));
+  const body = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(body, /Filtri non supportati/);
+  assert.match(body, /year/);
 });
 
 test("MCP endpoint reads the catalog resource with the modern protocol", async () => {


### PR DESCRIPTION
Rende sistemiche le correzioni WCAG AA e irrobustisce il server MCP. Include contrasto, target da 44 px, skip link, tooltip dismissibile, tabelle accessibili per grafici e contenitori scrollabili, feedback clipboard, CORS e Host allowlist, filtri MCP fail-closed e test di regressione. Verifiche locali: 77 test, lint, typecheck, brand check, npm audit e build Next.js di produzione.