### PR TITLE
Repo GitHub nell'header, via la tagline dal footer

### DIFF
--- a/src/app/fonti/page.tsx
+++ b/src/app/fonti/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { shortDate } from "@/lib/format";
+import { REPO_URL } from "@/lib/site";
 import { latestDataBySlug } from "@/lib/source-latest-data";
 import { publicSources, sourceCounts } from "@/lib/sources";
 import styles from "./fonti.module.css";
@@ -96,11 +97,7 @@ export default function SourcesPage() {
           <p>
             Ogni dato mantiene le condizioni di riuso indicate dalla fonte che lo pubblica. Il
             codice di questa piattaforma è open source su{" "}
-            <a
-              href="https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi"
-              target="_blank"
-              rel="noreferrer"
-            >
+            <a href={REPO_URL} target="_blank" rel="noreferrer">
               GitHub
             </a>
             .

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,6 +180,14 @@ main td a:not(.btn) {
   border-color: var(--color-accent);
   color: var(--color-accent-700);
 }
+/* Icon-only action: a square the same height as its lettered siblings. */
+.header-action-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  padding-inline: 0;
+}
+.header-action-icon:hover { color: var(--color-accent-700); }
 
 /* ── primary navigation ─────────────────────────────────────────────────── */
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Archivo } from "next/font/google";
 import { Navigation } from "@/components/navigation";
+import { REPO_URL } from "@/lib/site";
 import { siopeMunicipalSnapshot } from "@/lib/siope-snapshot";
 import "./design-system.css";
 import "./globals.css";
@@ -51,12 +52,7 @@ export default function RootLayout({
             <span>Ultimo controllo dei dati: {lastCheckedLabel}</span>
             <span>Dati pubblici, liberi da riusare</span>
             <span className="footer-spacer" />
-            <a
-              className="footer-link"
-              href="https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi"
-              target="_blank"
-              rel="noreferrer"
-            >
+            <a className="footer-link" href={REPO_URL} target="_blank" rel="noreferrer">
               Codice su GitHub ↗
             </a>
             <a className="footer-link" href="/mcp">MCP</a>
@@ -66,8 +62,6 @@ export default function RootLayout({
             <a href="https://x.com/fragiannicola" target="_blank" rel="noreferrer">@fragiannicola</a>
             <span aria-hidden="true">·</span>
             <a href="https://x.com/dom_gag_96" target="_blank" rel="noreferrer">@dom_gag_96</a>
-            <span className="footer-spacer" />
-            <span>Progetto civico indipendente, open source</span>
           </div>
         </footer>
       </body>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -5,7 +5,8 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Search01Icon } from "@hugeicons/core-free-icons";
+import { GithubIcon, Search01Icon } from "@hugeicons/core-free-icons";
+import { REPO_URL } from "@/lib/site";
 
 const primary = [
   { href: "/", label: "Home" },
@@ -76,6 +77,16 @@ export function Navigation() {
           <Link className="header-action header-action-accent" href="/mcp">
             MCP
           </Link>
+          <a
+            className="header-action header-action-icon"
+            href={REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Codice su GitHub, si apre in una nuova scheda"
+            title="Codice su GitHub"
+          >
+            <HugeiconsIcon icon={GithubIcon} size={19} strokeWidth={1.7} aria-hidden="true" />
+          </a>
         </div>
       </div>
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,7 @@
+/**
+ * Fixed addresses of the project itself, as opposed to the public sources it
+ * reads. Kept in one place so a link that appears in the header, the footer
+ * and the sources page cannot drift apart.
+ */
+
+export const REPO_URL = "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi";


### PR DESCRIPTION
## Cosa cambia

**Header**: il link al repository compare accanto a MCP, come azione con sola icona. Prima era raggiungibile solo dal fondo pagina.

**Footer**: sparisce "Progetto civico indipendente, open source". Restano "Codice su GitHub ↗" e "MCP", con gli stessi indirizzi di prima.

**Codice**: l'URL del repository era ripetuto in tre punti dell'interfaccia. Ora sta in `src/lib/site.ts`.

## Perché

La tagline era un'affermazione sul progetto, non un modo per entrarci. I due link accanto dicono la stessa cosa, con il vantaggio di essere cliccabili.

Il link nell'header è 44x44, quindi mantiene lo stesso target tattile dei fratelli con testo e supera il breakpoint mobile: sotto i 620px l'azione che si ritira è "Scarica i dati", mentre MCP e GitHub restano.

## Verifica

Su build di produzione, 26 route incluse le pagine nuove (`/mcp`, `/parlamento`, `/spese/invalidita`, `/territori/fisco`, `/territori/confronto`):

- ogni pagina espone il link al repository sia nell'header sia nel footer;
- il link dell'header conserva il nome accessibile ("Codice su GitHub, si apre in una nuova scheda") e apre in una nuova scheda;
- il link MCP è invariato;
- la tagline non compare più da nessuna parte;
- nessun errore, nessun `undefined`/`NaN` nel markup, nessun overflow orizzontale a 375px.

`npm test` 111/111, `lint`, `tsc --noEmit`, `design:check` e `build` puliti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)