### PR TITLE
Fix overflow dei valori di stato su desktop

### DIFF
--- a/src/app/coesione/coesione.module.css
+++ b/src/app/coesione/coesione.module.css
@@ -24,7 +24,7 @@
   gap: var(--space-3);
   font-size: 13px;
 }
-.statusList li { grid-template-columns: minmax(0, 1fr) minmax(120px, 1.2fr) minmax(200px, max-content); }
+.statusList li { grid-template-columns: minmax(0, 1fr) minmax(120px, 1.2fr) 300px; }
 .shareList li { grid-template-columns: minmax(0, 1fr) minmax(100px, 1fr) 62px; }
 
 .statusList li > span,

--- a/src/app/coesione/coesione.module.css
+++ b/src/app/coesione/coesione.module.css
@@ -24,7 +24,7 @@
   gap: var(--space-3);
   font-size: 13px;
 }
-.statusList li { grid-template-columns: minmax(0, 1fr) minmax(120px, 1.2fr) 200px; }
+.statusList li { grid-template-columns: minmax(0, 1fr) minmax(120px, 1.2fr) minmax(200px, max-content); }
 .shareList li { grid-template-columns: minmax(0, 1fr) minmax(100px, 1fr) 62px; }
 
 .statusList li > span,


### PR DESCRIPTION
## Cosa cambia

Corregge l’overflow orizzontale dei valori nella sezione **A che punto sono i progetti** della pagina `/coesione`.

La colonna finale della griglia era fissata a `200px`, mentre i valori usano `white-space: nowrap` e la stringa più lunga richiede più spazio. La traccia ora misura `300px`: contiene il valore più lungo e mantiene identico l’inizio delle barre in tutte le righe.

Prima:
<img width="1623" height="258" alt="Screenshot 2026-08-21 alle 11 28 42" src="https://github.com/user-attachments/assets/26982b08-5905-4c3d-b5f5-cb7817fa3c32" />

Dopo:
<img width="744" height="260" alt="Screenshot 2026-08-21 alle 11 26 00" src="https://github.com/user-attachments/assets/93f6e95a-2dbf-405b-bd26-9ab2470cbabf" />

## Verifica

- Riproduzione prima della modifica a 1440 px: pannello `clientWidth 1382`, `scrollWidth 1457`
- Dopo la modifica a 1440 px: `clientWidth 1382`, `scrollWidth 1382`
- A 1440 px tutte le barre iniziano a `524px`; a 621 px iniziano tutte a `150px`
- Verificato anche a 621 px e 620 px, senza overflow
- `npm run lint`
- `npm test` — 111 test superati
- `npm run typecheck`
- `npm run design:check`
- `npm run build`

La regola mobile esistente sotto i 620 px resta invariata.
