### PR TITLE
fix: keep information tooltips inside the viewport

### DIFF
--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -9,6 +9,7 @@ const SERVER_TIMEOUT_MS = 60_000;
 const NAVIGATION_TIMEOUT_MS = 45_000;
 const TABLE_REGION = '[role="region"][aria-label="Redditi e variabili IRPEF per territorio"]';
 const ACTIVE_LEVEL = 'nav[aria-label="Livello territoriale"] a[aria-current="page"]';
+const INFO_TOOLTIP_IDS = ["cash-payments-tip", "spending-glossary-tip"];
 
 if (!/^https?:$/.test(baseUrl.protocol)) {
   throw new Error("DVNS_BASE_URL deve usare il protocollo HTTP oppure HTTPS.");
@@ -82,7 +83,13 @@ function relevantRequestFailure(request) {
     failure.errorText === "net::ERR_ABORTED" &&
     (resourceType === "fetch" || resourceType === "other") &&
     new URL(requestUrl).searchParams.has("_rsc");
-  if (cancelledNextPrefetch) return null;
+  const cancelledLocationLookup =
+    failure.errorText === "net::ERR_ABORTED" &&
+    resourceType === "fetch" &&
+    new URL(requestUrl).pathname === "/api/location";
+  // Location is an optional client hint and can be cancelled when a scenario
+  // closes its page; neither cancellation affects the rendered route.
+  if (cancelledNextPrefetch || cancelledLocationLookup) return null;
 
   return `${resourceType} ${requestUrl}: ${failure.errorText}`;
 }
@@ -170,6 +177,93 @@ async function assertResponsiveShell(page, label, width) {
   );
 }
 
+async function assertInfoTooltips(page, label) {
+  for (const tooltipId of INFO_TOOLTIP_IDS) {
+    const selector = `button[aria-controls="${tooltipId}"]`;
+    const button = await page.$(selector);
+    assert.ok(button, `${label}: trigger ${tooltipId} assente`);
+
+    await button.focus();
+    await page.waitForFunction(
+      (id) => {
+        const tooltip = document.getElementById(id);
+        if (
+          tooltip?.getAttribute("data-open") !== "true" ||
+          tooltip.getAttribute("data-positioned") !== "true" ||
+          getComputedStyle(tooltip).display === "none"
+        ) {
+          return false;
+        }
+        const rect = tooltip.getBoundingClientRect();
+        return rect.left >= -1 && rect.right <= window.innerWidth + 1;
+      },
+      { timeout: 2_000 },
+      tooltipId,
+    );
+
+    const openState = await page.$eval(selector, (trigger, id) => {
+      const tooltip = document.getElementById(id);
+      const triggerRect = trigger.getBoundingClientRect();
+      const tooltipRect = tooltip?.getBoundingClientRect();
+      return {
+        describedBy: trigger.getAttribute("aria-describedby"),
+        expanded: trigger.getAttribute("aria-expanded"),
+        bodyScrollWidth: document.body.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+        innerWidth: window.innerWidth,
+        triggerRect: {
+          left: triggerRect.left,
+          right: triggerRect.right,
+        },
+        tooltipDisplay: tooltip ? getComputedStyle(tooltip).display : "missing",
+        tooltipVisibility: tooltip ? getComputedStyle(tooltip).visibility : "missing",
+        tooltipRect: tooltipRect
+          ? {
+              left: tooltipRect.left,
+              right: tooltipRect.right,
+              width: tooltipRect.width,
+            }
+          : null,
+      };
+    }, tooltipId);
+
+    assert.equal(openState.expanded, "true", `${label}: ${tooltipId} non risulta aperto`);
+    assert.equal(openState.describedBy, tooltipId, `${label}: descrizione ARIA assente`);
+    assert.equal(openState.tooltipDisplay, "block", `${label}: tooltip non visibile`);
+    assert.equal(openState.tooltipVisibility, "visible", `${label}: tooltip invisibile`);
+    assert.ok(openState.tooltipRect, `${label}: rettangolo tooltip assente`);
+    assert.ok(openState.tooltipRect.width > 0, `${label}: tooltip senza larghezza`);
+    assert.ok(openState.tooltipRect.left >= -1, `${label}: tooltip ${tooltipId} esce a sinistra`);
+    assert.ok(
+      openState.tooltipRect.right <= openState.innerWidth + 1,
+      `${label}: tooltip ${tooltipId} esce a destra`,
+    );
+    assert.ok(openState.triggerRect.left >= -1, `${label}: trigger ${tooltipId} esce a sinistra`);
+    assert.ok(
+      openState.triggerRect.right <= openState.innerWidth + 1,
+      `${label}: trigger ${tooltipId} esce a destra`,
+    );
+    assert.ok(
+      openState.bodyScrollWidth <= openState.clientWidth + 1,
+      `${label}: overflow mentre ${tooltipId} è aperto`,
+    );
+
+    await page.keyboard.press("Escape");
+    await page.waitForFunction(
+      (id) => document.getElementById(id)?.getAttribute("data-open") === "false",
+      { timeout: 2_000 },
+      tooltipId,
+    );
+    const closedState = await page.$eval(selector, (trigger) => ({
+      describedBy: trigger.getAttribute("aria-describedby"),
+      expanded: trigger.getAttribute("aria-expanded"),
+    }));
+    assert.equal(closedState.expanded, "false", `${label}: Escape non chiude ${tooltipId}`);
+    assert.equal(closedState.describedBy, null, `${label}: descrizione chiusa ancora esposta`);
+    await button.dispose();
+  }
+}
+
 async function assertTableKeyboardScroll(page, label) {
   await page.waitForSelector(TABLE_REGION, { visible: true });
   const tableState = await page.$eval(TABLE_REGION, (region) => ({
@@ -243,6 +337,7 @@ async function runScenario(browser, { label, pathname, validate, width }) {
   try {
     page.setDefaultTimeout(10_000);
     page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT_MS);
+    await page.setCacheEnabled(false);
     await page.setViewport({
       width,
       height: width <= 460 ? 844 : 900,
@@ -381,6 +476,19 @@ try {
     },
   });
   completed.push("Recovery offset");
+
+  for (const width of [320, 390, 768, 901, 1024, 1280]) {
+    const label = `Tooltip home ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/",
+      width,
+      validate: async (page) => {
+        await assertInfoTooltips(page, label);
+      },
+    });
+    completed.push(label);
+  }
 
   for (const pathname of ["/", "/enti", "/partecipazioni", "/controlli", "/metodologia"]) {
     const label = `Shell 320px ${pathname}`;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -401,6 +401,22 @@ main { display: block; }
   .header-search { width: 260px; }
 }
 
+/* Keep the header's fixed actions inside the viewport before the full
+   mobile layout takes over at 900px. */
+@media (min-width: 901px) and (max-width: 980px) {
+  .header-inner {
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    padding-block: 14px 12px;
+  }
+  .header-spacer { display: none; }
+  .brand { flex: 1; min-width: 0; }
+  .brand-text strong { font-size: 19px; }
+  .brand-text small { display: none; }
+  .header-search { order: 3; width: 100%; }
+  .nav-note { display: none; }
+}
+
 @media (max-width: 900px) {
   .header-inner {
     flex-wrap: wrap;

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -39,7 +39,11 @@
   flex-wrap: wrap;
 }
 .panelHead :global(.panel-title),
-.panelHead > h2 { margin-bottom: 0; }
+.panelHead > h2 {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-bottom: 0;
+}
 
 .headNote {
   font-size: 12px;

--- a/src/components/info-tooltip.module.css
+++ b/src/components/info-tooltip.module.css
@@ -67,3 +67,6 @@
 .tooltip[data-open="true"] {
   display: block;
 }
+.tooltip[data-open="true"][data-positioned="false"] {
+  visibility: hidden;
+}

--- a/src/components/info-tooltip.tsx
+++ b/src/components/info-tooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styles from "./info-tooltip.module.css";
 
 export function InfoTooltip({
@@ -13,38 +13,87 @@ export function InfoTooltip({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const [tooltipLeft, setTooltipLeft] = useState<number | null>(null);
   const wrapperRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLSpanElement>(null);
   const pointerInteraction = useRef(false);
+
+  const closeTooltip = useCallback(() => {
+    setTooltipLeft(null);
+    setOpen(false);
+  }, []);
+
+  const positionTooltip = useCallback(() => {
+    const wrapper = wrapperRef.current;
+    const tooltip = tooltipRef.current;
+    if (!wrapper || !tooltip) return;
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const tooltipWidth = tooltip.getBoundingClientRect().width;
+    if (tooltipWidth === 0) return;
+
+    const gutter = Number.parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--gutter"),
+    );
+    const safeGutter = Number.isFinite(gutter) ? gutter : 0;
+    const minLeft = safeGutter;
+    const maxLeft = Math.max(minLeft, window.innerWidth - safeGutter - tooltipWidth);
+    const desiredLeft = wrapperRect.right - tooltipWidth;
+    const clampedLeft = Math.min(Math.max(desiredLeft, minLeft), maxLeft);
+
+    setTooltipLeft(clampedLeft - wrapperRect.left);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let frame = window.requestAnimationFrame(positionTooltip);
+    const schedulePosition = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(positionTooltip);
+    };
+
+    window.addEventListener("resize", schedulePosition);
+    window.addEventListener("orientationchange", schedulePosition);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener("resize", schedulePosition);
+      window.removeEventListener("orientationchange", schedulePosition);
+    };
+  }, [open, positionTooltip]);
 
   useEffect(() => {
     if (!open) return;
 
     function dismissOutside(event: PointerEvent) {
       if (event.target instanceof Node && !wrapperRef.current?.contains(event.target)) {
-        setOpen(false);
+        closeTooltip();
       }
     }
 
     document.addEventListener("pointerdown", dismissOutside);
     return () => document.removeEventListener("pointerdown", dismissOutside);
-  }, [open]);
+  }, [closeTooltip, open]);
 
   return (
     <span
       ref={wrapperRef}
       className={styles.wrapper}
       onPointerEnter={(event) => {
-        if (event.pointerType === "mouse") setOpen(true);
+        if (event.pointerType === "mouse") {
+          setTooltipLeft(null);
+          setOpen(true);
+        }
       }}
       onPointerLeave={(event) => {
-        if (event.pointerType === "mouse") setOpen(false);
+        if (event.pointerType === "mouse") closeTooltip();
       }}
       onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+        if (!event.currentTarget.contains(event.relatedTarget)) closeTooltip();
       }}
       onKeyDown={(event) => {
         if (event.key === "Escape") {
-          setOpen(false);
+          closeTooltip();
           event.stopPropagation();
         }
       }}
@@ -66,16 +115,32 @@ export function InfoTooltip({
           pointerInteraction.current = false;
         }}
         onFocus={() => {
-          if (!pointerInteraction.current) setOpen(true);
+          if (!pointerInteraction.current) {
+            setTooltipLeft(null);
+            setOpen(true);
+          }
         }}
         onClick={() => {
           pointerInteraction.current = false;
+          setTooltipLeft(null);
           setOpen((current) => !current);
         }}
       >
         ?
       </button>
-      <span className={styles.tooltip} data-open={open} id={id} role="tooltip">
+      <span
+        ref={tooltipRef}
+        className={styles.tooltip}
+        data-open={open}
+        data-positioned={tooltipLeft !== null}
+        id={id}
+        role="tooltip"
+        style={
+          tooltipLeft === null
+            ? undefined
+            : { left: `${tooltipLeft}px`, right: "auto" }
+        }
+      >
         {children}
       </span>
     </span>

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -43,6 +43,27 @@ test("information tooltips expose and dismiss their description", async () => {
   assert.match(tooltip, /event\.key === "Escape"/);
 });
 
+test("information tooltips clamp to the viewport and keep their heading trigger stable", async () => {
+  const [tooltip, tooltipCss, home, globals] = await Promise.all([
+    source("../src/components/info-tooltip.tsx"),
+    source("../src/components/info-tooltip.module.css"),
+    source("../src/app/home.module.css"),
+    source("../src/app/globals.css"),
+  ]);
+
+  assert.match(tooltip, /getBoundingClientRect\(\)/);
+  assert.match(tooltip, /window\.innerWidth/);
+  assert.match(tooltip, /left: `\$\{tooltipLeft\}px`/);
+  assert.match(tooltip, /data-positioned=\{tooltipLeft !== null\}/);
+  assert.match(
+    tooltipCss,
+    /\.tooltip\[data-open="true"\]\[data-positioned="false"\][\s\S]*?visibility: hidden;/,
+  );
+  assert.match(home, /\.panelHead > h2 \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
+  assert.match(globals, /@media \(min-width: 901px\) and \(max-width: 980px\)/);
+  assert.match(globals, /\.header-search \{ order: 3; width: 100%; \}/);
+});
+
 test("the regional map has a deterministic fallback and roving keyboard focus", async () => {
   const map = await source("../src/components/italy-regions-map.tsx");
 


### PR DESCRIPTION
Corregge il feedback sui punti interrogativi fuori schermo. Clamp dinamico del tooltip, stato ARIA invariato, header 901-980 px e Browser E2E a 320/390/768/901/1024/1280. Verifiche locali: 138 test Node, 43 ETL, typecheck, lint, Impeccable, build e Browser production PASS.