### PR TITLE
Fix map hover outlines and pinned selection

### DIFF
--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -264,6 +264,83 @@ async function assertInfoTooltips(page, label) {
   }
 }
 
+async function assertRegionalMapSelection(page, label) {
+  const mapSelector = '[data-region-map="true"]';
+  const detailSelector = '[data-region-detail="true"] b';
+  await page.waitForSelector(mapSelector, { visible: true });
+  const regionPaths = await page.$$(
+    `${mapSelector} path[role="button"][aria-label]`,
+  );
+  assert.equal(regionPaths.length, 20, `${label}: la mappa deve esporre 20 regioni`);
+
+  const lombardia = await page.$(`${mapSelector} path[aria-label^="Lombardia:"]`);
+  const veneto = await page.$(`${mapSelector} path[aria-label^="Veneto:"]`);
+  assert.ok(lombardia, `${label}: percorso Lombardia assente`);
+  assert.ok(veneto, `${label}: percorso Veneto assente`);
+
+  await lombardia.hover();
+  await page.waitForFunction(
+    (selector) => Boolean(document.querySelector(`${selector} path[data-hovered="true"]`)),
+    { timeout: 2_000 },
+    mapSelector,
+  );
+  const previewName = await page.$eval(detailSelector, (element) => element.textContent?.trim());
+  assert.equal(previewName, "Lombardia", `${label}: hover non aggiorna l’anteprima`);
+
+  const hoveredOutline = await page.$eval(mapSelector, (map) => {
+    const outlines = [...map.querySelectorAll('path[aria-hidden="true"]')];
+    return {
+      outlineCount: outlines.length,
+      overlayStroke: outlines.map((outline) => getComputedStyle(outline).stroke),
+      overlayPointerEvents: outlines.map((outline) => getComputedStyle(outline).pointerEvents),
+    };
+  });
+  assert.ok(
+    hoveredOutline.outlineCount >= 1 && hoveredOutline.outlineCount <= 2,
+    `${label}: numero inatteso di layer di contorno (${hoveredOutline.outlineCount})`,
+  );
+  assert.ok(
+    hoveredOutline.overlayStroke.every((stroke) => stroke !== "none"),
+    `${label}: contorno overlay non visibile`,
+  );
+  assert.ok(
+    hoveredOutline.overlayPointerEvents.every((value) => value === "none"),
+    `${label}: il contorno overlay intercetta il puntatore`,
+  );
+
+  await lombardia.click();
+  await page.waitForFunction(
+    () => document.querySelector('[data-region-detail="true"] b')?.textContent?.trim() === "Lombardia",
+    { timeout: 2_000 },
+  );
+  const fixedName = await page.$eval(detailSelector, (element) => element.textContent?.trim());
+
+  await veneto.hover();
+  await page.waitForFunction(
+    (selector) => Boolean(document.querySelector(`${selector} path[data-hovered="true"]`)),
+    { timeout: 2_000 },
+    mapSelector,
+  );
+  const afterHoverName = await page.$eval(detailSelector, (element) => element.textContent?.trim());
+  assert.equal(
+    afterHoverName,
+    fixedName,
+    `${label}: l’hover sovrascrive la regione fissata con un clic`,
+  );
+
+  await veneto.click();
+  await page.waitForFunction(
+    () => document.querySelector('[data-region-detail="true"] b')?.textContent?.trim() === "Veneto",
+    { timeout: 2_000 },
+  );
+  const switchedName = await page.$eval(detailSelector, (element) => element.textContent?.trim());
+  assert.equal(switchedName, "Veneto", `${label}: il clic non cambia la selezione fissata`);
+
+  await lombardia.dispose();
+  await veneto.dispose();
+  for (const path of regionPaths) await path.dispose();
+}
+
 async function assertTableKeyboardScroll(page, label) {
   await page.waitForSelector(TABLE_REGION, { visible: true });
   const tableState = await page.$eval(TABLE_REGION, (region) => ({
@@ -503,6 +580,19 @@ try {
       width,
       validate: async (page) => {
         await assertInfoTooltips(page, label);
+      },
+    });
+    completed.push(label);
+  }
+
+  for (const width of [390, 1280]) {
+    const label = `Mappa regioni hover/selezione ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/",
+      width,
+      validate: async (page) => {
+        await assertRegionalMapSelection(page, label);
       },
     });
     completed.push(label);

--- a/src/components/italy-regions-map.module.css
+++ b/src/components/italy-regions-map.module.css
@@ -26,12 +26,27 @@
 }
 
 .region:hover,
-.region:focus,
-.active {
+.region:focus-visible,
+.region[data-hovered="true"] {
   stroke: var(--color-text);
   stroke-width: 2;
   outline: none;
 }
+
+/* SVG paints sibling paths in document order. Draw the active outlines again
+   after all fills so a later region can never cover a hovered border. */
+.outline {
+  fill: none;
+  stroke: var(--color-text);
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+  pointer-events: none;
+}
+
+.hoverOutline { stroke-width: 2; }
+.selectedOutline { stroke-width: 2.5; }
+.selectedOutline.hoverOutline { stroke-width: 3; }
 
 /* One sequential ramp, read as intensity rather than as five categories. It
    starts at accent-200 rather than accent-100: the first step has to be
@@ -69,8 +84,8 @@
   color: var(--color-neutral-600);
 }
 
-/* The reading row under the map: whichever region is hovered, focused or
-   picked from the select shows its exact figures here. */
+/* The reading row under the map: hover/focus previews until a click or an
+   explicit keyboard selection fixes the region. */
 .detail {
   grid-column: 1 / -1;
   display: grid;
@@ -151,7 +166,7 @@
 
 @media (hover: none) {
   .region:hover { stroke: var(--color-neutral-500); stroke-width: 1; }
-  .active { stroke: var(--color-text); stroke-width: 2; }
+  .region[data-hovered="true"] { stroke: var(--color-text); stroke-width: 2; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -29,6 +29,9 @@ export function ItalyRegionsMap({
   aside?: React.ReactNode;
 }) {
   const [selectedCode, setSelectedCode] = useState("03");
+  const [hoveredCode, setHoveredCode] = useState<string | null>(null);
+  const [focusedCode, setFocusedCode] = useState<string | null>(null);
+  const [selectionLocked, setSelectionLocked] = useState(false);
   const [automaticSelection, setAutomaticSelection] = useState<"ip" | null>(null);
   const userSelected = useRef(false);
   const regionPathRefs = useRef(new Map<string, SVGPathElement>());
@@ -72,12 +75,27 @@ export function ItalyRegionsMap({
 
   function selectRegion(code: string) {
     userSelected.current = true;
+    setSelectionLocked(true);
     setAutomaticSelection(null);
+    setFocusedCode(code);
+    setHoveredCode(null);
     setSelectedCode(code);
   }
 
-  const selected = byCode.get(selectedCode);
+  function previewRegion(code: string) {
+    setHoveredCode(code);
+  }
+
+  function clearPreview(code: string) {
+    setHoveredCode((current) => (current === code ? null : current));
+  }
+
+  const displayedCode = selectionLocked ? selectedCode : hoveredCode ?? selectedCode;
+  const selected = byCode.get(displayedCode);
   const navigableCodes: string[] = italyRegionGeometry.map(({ code }) => code);
+  const outlinedCodes = [selectedCode, hoveredCode].filter(
+    (code, index, codes): code is string => code !== null && codes.indexOf(code) === index,
+  );
 
   function handleRegionKeyDown(event: React.KeyboardEvent<SVGPathElement>, code: string) {
     if (event.key === "Enter" || event.key === " ") {
@@ -101,7 +119,8 @@ export function ItalyRegionsMap({
     if (nextIndex === null) return;
     event.preventDefault();
     const nextCode = navigableCodes[nextIndex];
-    selectRegion(nextCode);
+    setFocusedCode(nextCode);
+    previewRegion(nextCode);
     regionPathRefs.current.get(nextCode)?.focus();
   }
 
@@ -119,18 +138,21 @@ export function ItalyRegionsMap({
           className={styles.map}
           viewBox={ITALY_REGIONS_VIEWBOX}
           role="group"
+          data-region-map="true"
           aria-labelledby="regional-map-title regional-map-description"
         >
           <title id="regional-map-title">Pagamenti comunali per abitante coperto, per regione</title>
           <desc id="regional-map-description">
             Mappa regionale colorata in base ai pagamenti di cassa SIOPE dei Comuni. Usa Tab per
-            entrare nella mappa e i tasti freccia per cambiare regione; il valore esatto appare nel
-            pannello accanto.
+            entrare nella mappa e i tasti freccia per esplorare le regioni. Passa sopra una regione
+            per un’anteprima; fai clic o premi Invio per fissarla nel pannello accanto.
           </desc>
           {italyRegionGeometry.map((geometry) => {
             const region = byCode.get(geometry.code);
             const colorLevel = level(region?.perCapita ?? null);
-            const active = selectedCode === geometry.code;
+            const selected = selectedCode === geometry.code;
+            const focusable = (focusedCode ?? selectedCode) === geometry.code;
+            const hovered = hoveredCode === geometry.code;
             return (
               <path
                 ref={(node) => {
@@ -141,19 +163,44 @@ export function ItalyRegionsMap({
                 d={geometry.path}
                 className={`${styles.region} ${
                   colorLevel === null ? styles.noData : styles[`level${colorLevel}`]
-                } ${active ? styles.active : ""}`}
-                tabIndex={active ? 0 : -1}
+                }`}
+                tabIndex={focusable ? 0 : -1}
                 role="button"
-                aria-pressed={active}
+                aria-pressed={selected}
                 aria-label={`${REGION_NAME_BY_ISTAT_CODE[geometry.code]}: ${
                   region?.perCapita === null || region?.perCapita === undefined
                     ? "dato non disponibile"
                     : `${exactEuro(region.perCapita)} per abitante coperto`
                 }`}
-                onPointerEnter={() => selectRegion(geometry.code)}
-                onFocus={() => selectRegion(geometry.code)}
+                data-hovered={hovered ? "true" : undefined}
+                data-selected={selected ? "true" : undefined}
+                onPointerEnter={() => previewRegion(geometry.code)}
+                onPointerLeave={() => clearPreview(geometry.code)}
+                onFocus={() => {
+                  setFocusedCode(geometry.code);
+                  previewRegion(geometry.code);
+                }}
+                onBlur={() => clearPreview(geometry.code)}
                 onClick={() => selectRegion(geometry.code)}
                 onKeyDown={(event) => handleRegionKeyDown(event, geometry.code)}
+              />
+            );
+          })}
+          {outlinedCodes.map((code) => {
+            const geometry = italyRegionGeometry.find((item) => item.code === code);
+            if (!geometry) return null;
+            const isSelected = code === selectedCode;
+            const isHovered = code === hoveredCode;
+            return (
+              <path
+                key={`outline-${code}`}
+                d={geometry.path}
+                className={`${styles.outline} ${isSelected ? styles.selectedOutline : ""} ${
+                  isHovered ? styles.hoverOutline : ""
+                }`}
+                aria-hidden="true"
+                focusable="false"
+                pointerEvents="none"
               />
             );
           })}
@@ -196,7 +243,7 @@ export function ItalyRegionsMap({
 
       {aside ? <div className={styles.asideColumn}>{aside}</div> : null}
 
-      <div className={styles.detail} aria-live="polite">
+      <div className={styles.detail} data-region-detail="true" aria-live="polite">
         <b>{selected?.region ?? "Dato non disponibile"}</b>
         <span>
           <small>Totale</small>

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -69,11 +69,26 @@ test("the regional map has a deterministic fallback and roving keyboard focus", 
 
   assert.doesNotMatch(map, /randomRegionCode|scelta casualmente/);
   assert.match(map, /useState\("03"\)/);
-  assert.match(map, /tabIndex=\{active \? 0 : -1\}/);
+  assert.match(map, /useState<string \| null>\(null\)/);
+  assert.match(map, /const displayedCode = selectionLocked \? selectedCode : hoveredCode \?\? selectedCode/);
+  assert.match(map, /onPointerEnter=\{\(\) => previewRegion\(geometry\.code\)\}/);
+  assert.match(map, /onClick=\{\(\) => selectRegion\(geometry\.code\)\}/);
+  assert.match(map, /styles\.outline/);
+  assert.match(map, /pointerEvents="none"/);
+  assert.match(map, /tabIndex=\{focusable \? 0 : -1\}/);
   assert.match(map, /"ArrowRight"|"ArrowDown"/);
   assert.match(map, /"ArrowLeft"|"ArrowUp"/);
   assert.match(map, /regionPathRefs\.current\.get\(nextCode\)\?\.focus\(\)/);
   assert.match(map, /<select value=\{selectedCode\}/);
+});
+
+test("the regional map redraws selected and hovered borders above all region fills", async () => {
+  const css = await source("../src/components/italy-regions-map.module.css");
+
+  assert.match(css, /\.outline \{[\s\S]*?fill: none;[\s\S]*?pointer-events: none;/);
+  assert.match(css, /\.hoverOutline \{ stroke-width: 2; \}/);
+  assert.match(css, /\.selectedOutline \{ stroke-width: 2\.5; \}/);
+  assert.match(css, /\.selectedOutline\.hoverOutline \{ stroke-width: 3; \}/);
 });
 
 test("reported chart styles stay within the registry design tokens", async () => {


### PR DESCRIPTION
## Cosa cambia
- separa anteprima hover/focus dalla selezione fissata con click, Invio o select
- ridisegna i contorni attivi sopra tutti i riempimenti SVG, evitando bordi coperti dalle regioni adiacenti
- mantiene roving focus, ARIA e comportamento touch
- aggiunge regressioni statiche e Browser E2E a 390 e 1280 px

## Verifica
- npm test: 144/144
- npm run typecheck
- npm run lint
- npm run design:check
- npm run brand:check
- npm run build
- git diff --check
- Browser E2E production: 24 scenari, inclusi hover/click mappa mobile e desktop
- review indipendente Luna: nessun finding P0-P2

## UI/UX
| Before | After | Why |
|---|---|---|
| Hover dopo il click cambiava i dati | Il click fissa i dati finché non si seleziona un'altra regione | Evita cambi involontari e rispetta l'intento dell'utente |
| Il bordo poteva essere coperto dai path successivi | Overlay non interattivo disegnato sopra tutti i fill | Contorno completo e leggibile |
| Hover e selezione condividevano lo stesso stato | Preview e selezione persistente hanno stati distinti | Interazione prevedibile per mouse e tastiera |