### PR TITLE
Add Province and Region context to municipality rankings

### DIFF
--- a/.github/workflows/siope-refresh.yml
+++ b/.github/workflows/siope-refresh.yml
@@ -69,7 +69,7 @@ jobs:
           if not path.exists():
               raise SystemExit("Generated SIOPE snapshot is missing")
           data = json.loads(path.read_text(encoding="utf-8"))
-          assert data["schemaVersion"] == 2
+          assert data["schemaVersion"] == 3
           assert data["scope"] == "municipalities"
           assert 1 <= data["latestMonth"] <= 12
           assert data["totalPaid"] >= 0
@@ -90,6 +90,14 @@ jobs:
           assert len(data["topMunicipalitiesByValue"]) == 100
           assert len(data["topMunicipalitiesByPerCapita"]) == 100
           assert data["topMunicipalities"] == data["topMunicipalitiesByValue"]
+          assert all(
+              item["province"].strip() and item["region"].strip()
+              for ranking in (
+                  data["topMunicipalitiesByValue"],
+                  data["topMunicipalitiesByPerCapita"],
+              )
+              for item in ranking
+          )
           assert all(
               left["value"] >= right["value"]
               for left, right in zip(

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ La home e le pagine Soldi e Territori permettono di scegliere il 2024, 2025 o 20
 
 I dati SIOPE, OpenBDAP e la serie annuale OpenCoesione cambiano con l'anno scelto. Per OpenBDAP una query annuale senza mese preferisce il consuntivo ufficiale `PBS_SPE_RND_*`; una query con mese e lo storico usano esclusivamente i rilasci mensili `PBS_SPE_Mxx_*`. Se un indicatore non esiste per quel periodo, viene mostrato come non disponibile. Non riutilizziamo un dato di un altro anno o di un'altra serie contabile.
 
-Le classifiche territoriali usano il valore per abitante come default e conservano il totale come confronto. Le due graduatorie comunali sono calcolate separatamente sull'intero insieme osservato, non riordinando una lista già tagliata per volume.
+Le classifiche territoriali usano il valore per abitante come default e conservano il totale come confronto. Le due graduatorie comunali sono calcolate separatamente sull'intero insieme osservato, non riordinando una lista già tagliata per volume. Provincia e Regione mostrate accanto al Comune provengono rispettivamente dall'anagrafica SIOPE e dalla sede legale pubblicata in IPA.
 
 ## Regole del progetto
 

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -10,6 +10,8 @@ Questa è la mappa iniziale delle fonti. Il criterio è semplice: prima fonti is
 **Join:** ente, periodo, codifica gestionale/contabile.  
 **Nota:** SIOPE contiene dati per oltre 10.000 enti. SIOPE+ è l'infrastruttura degli ordinativi di pagamento e incasso; non va confusa la frequenza del flusso operativo con la frequenza del dato pubblico esposto dalla dashboard.
 
+Nelle graduatorie comunali, la Provincia viene dall'associazione tra `ANAG_ENTI_SIOPE` e `ANAG_REG_PROV` del registro ufficiale SIOPE. La Regione è quella della sede legale ottenuta tramite codice fiscale da IPA: non indica necessariamente il luogo fisico in cui ogni pagamento produce effetti.
+
 ### OpenBDAP
 **Titolare:** Ragioneria Generale dello Stato.  
 **Uso:** bilancio dello Stato, spesa, SIOPE, opere pubbliche, PNRR e altri domini.  

--- a/docs/SIOPE_MUNICIPAL.md
+++ b/docs/SIOPE_MUNICIPAL.md
@@ -21,7 +21,7 @@ Questa distinzione è parte del contratto del dato e deve restare visibile nella
 La pipeline usa tre file ufficiali:
 
 1. `SIOPE_USCITE.<anno>.zip`: movimenti nazionali di uscita;
-2. `SIOPE_ANAGRAFICHE.zip`: anagrafiche degli enti SIOPE;
+2. `SIOPE_ANAGRAFICHE.zip`: anagrafiche degli enti e delle Province SIOPE;
 3. `amministrazioni.txt` di Indice PA: join del codice fiscale dell'ente alla regione della sede amministrativa.
 
 Il file annuale SIOPE contiene movimenti mensili puri. Non è una successione di snapshot cumulativi: per questo il grafico mensile non calcola differenze tra rilasci. Il cumulato visualizzato da DoveVannoINostriSoldi è semplicemente la somma progressiva dei flussi mensili.
@@ -30,11 +30,17 @@ Gli importi SIOPE sono elaborati come interi in centesimi e convertiti in euro s
 
 ## Join territoriale
 
-Il join usa:
+Il join regionale usa:
 
 `codice ente SIOPE → codice fiscale SIOPE → codice fiscale IPA → Regione IPA`
 
 Non vengono usati matching fuzzy sul nome dell'ente. Se un codice fiscale non produce una regione univoca, l'ente resta fuori dall'aggregazione geografica e viene contabilizzato nella metrica `unmatchedToIpaRegion`.
+
+Il contesto provinciale delle graduatorie usa invece una relazione interna allo stesso registro ufficiale:
+
+`ANAG_ENTI_SIOPE.codice provincia → ANAG_REG_PROV → Provincia`
+
+L'ETL rifiuta un codice provinciale sconosciuto: non deduce la Provincia dal nome del Comune e non distribuisce dati su territori non pubblicati dalla fonte.
 
 ## Aggiornamento
 
@@ -59,7 +65,7 @@ Lo snapshot contiene:
 - aggregazioni per regione;
 - importi per abitante coperto;
 - titoli di spesa;
-- principali Comuni per volume di pagamenti;
+- principali Comuni per volume e per abitante, con Provincia SIOPE e Regione della sede IPA;
 - copertura del join;
 - URL e `Last-Modified` upstream;
 - warning metodologico mostrato anche nella dashboard.
@@ -76,6 +82,7 @@ La CI ordinaria non dipende dalla disponibilità della rete SIOPE. Testa invece 
 - la somma delle regioni ricomponga il totale entro la tolleranza di arrotondamento;
 - il cumulato finale coincida con il totale headline;
 - i ranking restino ordinati;
+- Provincia e Regione siano presenti in ogni riga dei ranking;
 - non risultino righe malformate nello snapshot pubblicato.
 
 Il download live e la validazione dell'ETL hanno un workflow separato, così un outage dell'upstream non trasforma un cambiamento di UI innocuo in una build rossa.

--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -478,6 +478,33 @@ try {
   completed.push("Recovery offset");
 
   for (const width of [390, 1280]) {
+    const label = `Geografia Comuni ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/territori?anno=2025",
+      width,
+      validate: async (page) => {
+        const text = await bodyText(page);
+        assertTextMatches(text, /I 20 Comuni con più pagamenti per abitante/i, label);
+        const firstMunicipality = await page.$eval(
+          '[data-municipality-ranking="per-capita"] tbody tr:first-child th',
+          (heading) => ({
+            name: [...heading.childNodes]
+              .find((node) => node.nodeType === Node.TEXT_NODE)
+              ?.textContent?.trim(),
+            context: [...heading.querySelectorAll("small")].map((item) => item.textContent?.trim()),
+          }),
+        );
+        assert.match(firstMunicipality.name ?? "", /\S/);
+        assert.match(firstMunicipality.context[0] ?? "", /^\S.* · \S.*$/);
+        assert.match(firstMunicipality.context[1] ?? "", /abitanti$/);
+        await assertResponsiveShell(page, label, width);
+      },
+    });
+    completed.push(label);
+  }
+
+  for (const width of [390, 1280]) {
     const label = `Parlamento previdenza ${width}px`;
     await runScenario(browser, {
       label,

--- a/scripts/etl/siope_municipal_snapshot.py
+++ b/scripts/etl/siope_municipal_snapshot.py
@@ -209,6 +209,24 @@ def parse_population(raw: str) -> int | None:
     return round(value)
 
 
+def parse_siope_provinces(registry_zip: Path) -> dict[str, str]:
+    provinces: dict[str, str] = {}
+    for row in zip_rows(registry_zip, "ANAG_REG_PROV"):
+        if len(row) != 5:
+            raise RuntimeError("ANAG_REG_PROV: schema inatteso")
+        province_code = row[3].strip()
+        province_name = row[4].strip()
+        if not re.fullmatch(r"\d{3}", province_code) or not province_name:
+            raise RuntimeError("ANAG_REG_PROV: provincia non valida")
+        previous = provinces.get(province_code)
+        if previous is not None and previous != province_name:
+            raise RuntimeError(f"ANAG_REG_PROV: codice provincia duplicato {province_code}")
+        provinces[province_code] = province_name
+    if not provinces:
+        raise RuntimeError("ANAG_REG_PROV: nessuna provincia trovata")
+    return provinces
+
+
 def load_municipalities(
     registry_zip: Path,
     ipa_regions: dict[str, str],
@@ -216,11 +234,12 @@ def load_municipalities(
     """Return mappings by SIOPE code and canonical municipality key (CF)."""
     active: dict[str, dict] = {}
     active_municipalities = 0
+    provinces = parse_siope_provinces(registry_zip)
 
     for row in zip_rows(registry_zip, "ANAG_ENTI_SIOPE"):
         if len(row) != 9:
             continue
-        code, valid_from, valid_to, cf, name, _municipality, _province, population, entity_type = (
+        code, valid_from, valid_to, cf, name, _municipality, province_code, population, entity_type = (
             value.strip() for value in row
         )
         if valid_to != "9999-12-31" or entity_type.upper() != "COMUNE":
@@ -229,12 +248,16 @@ def load_municipalities(
         region = ipa_regions.get(cf)
         if not code or not cf or not region:
             continue
+        province = provinces.get(province_code)
+        if province is None:
+            raise RuntimeError(f"Provincia SIOPE sconosciuta per il Comune {cf}: {province_code}")
         active[code] = {
             "key": cf,
             "code": code,
             "name": name or "Comune non indicato",
             "cf": cf,
             "region": region,
+            "province": province,
             "population": parse_population(population),
             "validFrom": valid_from,
         }
@@ -380,6 +403,7 @@ def build_snapshot(
             {
                 "name": municipality["name"],
                 "region": municipality["region"],
+                "province": municipality["province"],
                 "codiceFiscale": municipality["cf"],
                 "population": population,
                 "value": euro(cents),
@@ -431,7 +455,7 @@ def build_snapshot(
     latest_total_cents = sum(national_monthly)
 
     return {
-        "schemaVersion": 2,
+        "schemaVersion": 3,
         "generatedAt": utc_now(),
         "scope": "municipalities",
         "year": year,
@@ -475,7 +499,10 @@ def build_snapshot(
         "methodology": {
             "measure": "pagamenti di cassa SIOPE dei Comuni",
             "periodicity": "movimenti mensili puri, sommati da gennaio all'ultimo mese disponibile",
-            "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA",
+            "territorialJoin": (
+                "codice fiscale SIOPE → Regione della sede legale in IPA; "
+                "Provincia pubblicata nell'anagrafica enti SIOPE"
+            ),
             "populationSource": "popolazione riportata nell'anagrafica enti SIOPE",
             "populationReference": "data di riferimento non dichiarata dalla fonte",
             "populationSourceLastModified": validators["registry"].get("lastModified"),
@@ -509,7 +536,7 @@ def is_unchanged(output: Path, year: int, validators: dict) -> bool:
         return False
     source = current.get("source", {})
     return (
-        current.get("schemaVersion") == 2
+        current.get("schemaVersion") == 3
         and current.get("year") == year
         and source.get("siopeMovementsLastModified")
         == validators["movements"].get("lastModified")

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -93,7 +93,7 @@ export default async function TerritoriesPage({
         </section>
 
         <div className={styles.aside}>
-          <section className="panel">
+          <section className="panel" data-municipality-ranking="per-capita">
             <h2 className="panel-title">I {topByPerCapita.length} Comuni con più pagamenti per abitante</h2>
             <div className="table-scroll" role="region" aria-label="Comuni ordinati per pagamenti pro capite; scorri orizzontalmente per vedere tutte le colonne" tabIndex={0}>
               <table className="table">
@@ -109,6 +109,9 @@ export default async function TerritoriesPage({
                     <tr key={municipality.codiceFiscale}>
                       <th scope="row">
                         {municipalityName(municipality.name)}
+                        <small>
+                          {municipality.province} · {municipality.region}
+                        </small>
                         <small>
                           {municipality.population === null
                             ? "abitanti non disponibili"

--- a/src/data/generated/siope-municipal-2024.json
+++ b/src/data/generated/siope-municipal-2024.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 2,
-  "generatedAt": "2026-08-20T20:10:36+00:00",
+  "schemaVersion": 3,
+  "generatedAt": "2026-08-21T11:30:50+00:00",
   "scope": "municipalities",
   "year": 2024,
   "latestMonth": 12,
@@ -317,6 +317,7 @@
     {
       "name": "ROMA CAPITALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02438750586",
       "population": 2751747,
       "value": 7041805276.75,
@@ -325,6 +326,7 @@
     {
       "name": "COMUNE DI MILANO",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "01199250158",
       "population": 1371499,
       "value": 4376669061.5,
@@ -333,6 +335,7 @@
     {
       "name": "COMUNE DI NAPOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80014890638",
       "population": 913704,
       "value": 2017015632.67,
@@ -341,6 +344,7 @@
     {
       "name": "COMUNE DI GENOVA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00856930102",
       "population": 562422,
       "value": 1956907719.48,
@@ -349,6 +353,7 @@
     {
       "name": "COMUNE DI TORINO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "00514490010",
       "population": 851199,
       "value": 1885858031.24,
@@ -357,6 +362,7 @@
     {
       "name": "COMUNE DI CATANIA",
       "region": "Sicilia",
+      "province": "Catania",
       "codiceFiscale": "00137020871",
       "population": 298680,
       "value": 1298480774.87,
@@ -365,6 +371,7 @@
     {
       "name": "COMUNE DI VENEZIA",
       "region": "Veneto",
+      "province": "Venezia",
       "codiceFiscale": "00339370272",
       "population": 250290,
       "value": 1158689223.62,
@@ -373,6 +380,7 @@
     {
       "name": "COMUNE DI FIRENZE",
       "region": "Toscana",
+      "province": "Firenze",
       "codiceFiscale": "01307110484",
       "population": 362613,
       "value": 1065127671.63,
@@ -381,6 +389,7 @@
     {
       "name": "COMUNE DI BOLOGNA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "01232710374",
       "population": 390098,
       "value": 948531655.18,
@@ -389,6 +398,7 @@
     {
       "name": "COMUNE DI PALERMO",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "80016350821",
       "population": 630427,
       "value": 892290906.24,
@@ -397,6 +407,7 @@
     {
       "name": "COMUNE DI MESSINA",
       "region": "Sicilia",
+      "province": "Messina",
       "codiceFiscale": "00080270838",
       "population": 217959,
       "value": 785435489.51,
@@ -405,6 +416,7 @@
     {
       "name": "COMUNE DI BARI",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "80015010723",
       "population": 316226,
       "value": 551093161.12,
@@ -413,6 +425,7 @@
     {
       "name": "COMUNE DI TRIESTE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Trieste",
       "codiceFiscale": "00210240321",
       "population": 198843,
       "value": 498984708.17,
@@ -421,6 +434,7 @@
     {
       "name": "COMUNE DI VERONA",
       "region": "Veneto",
+      "province": "Verona",
       "codiceFiscale": "00215150236",
       "population": 255298,
       "value": 474459542.25,
@@ -429,6 +443,7 @@
     {
       "name": "COMUNE DI PADOVA",
       "region": "Veneto",
+      "province": "Padova",
       "codiceFiscale": "00644060287",
       "population": 207502,
       "value": 472834846.77,
@@ -437,6 +452,7 @@
     {
       "name": "COMUNE DI BRESCIA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00761890177",
       "population": 198259,
       "value": 422830996.56,
@@ -445,6 +461,7 @@
     {
       "name": "COMUNE DI MODENA",
       "region": "Emilia-Romagna",
+      "province": "Modena",
       "codiceFiscale": "00221940364",
       "population": 184597,
       "value": 403708249.57,
@@ -453,6 +470,7 @@
     {
       "name": "COMUNE DI L'AQUILA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002270660",
       "population": 69717,
       "value": 393192216.15,
@@ -461,6 +479,7 @@
     {
       "name": "COMUNE DI SALERNO",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "80000330656",
       "population": 126715,
       "value": 388688018.27,
@@ -469,6 +488,7 @@
     {
       "name": "COMUNE DI CAGLIARI",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00147990923",
       "population": 147411,
       "value": 370299520.65,
@@ -477,6 +497,7 @@
     {
       "name": "COMUNE DI TARANTO",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80008750731",
       "population": 187025,
       "value": 369161940.74,
@@ -485,6 +506,7 @@
     {
       "name": "COMUNE DI PARMA",
       "region": "Emilia-Romagna",
+      "province": "Parma",
       "codiceFiscale": "00162210348",
       "population": 198121,
       "value": 331582256.76,
@@ -493,6 +515,7 @@
     {
       "name": "COMUNE DI BOLZANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00389240219",
       "population": 106357,
       "value": 311394956.8,
@@ -501,6 +524,7 @@
     {
       "name": "COMUNE DI BERGAMO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "80034840167",
       "population": 120157,
       "value": 303275058.95,
@@ -509,6 +533,7 @@
     {
       "name": "COMUNE DI RIMINI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00304260409",
       "population": 150046,
       "value": 302211711.77,
@@ -517,6 +542,7 @@
     {
       "name": "COMUNE DI RAVENNA",
       "region": "Emilia-Romagna",
+      "province": "Ravenna",
       "codiceFiscale": "00354730392",
       "population": 156304,
       "value": 297412632.52,
@@ -525,6 +551,7 @@
     {
       "name": "COMUNE DI TRENTO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00355870221",
       "population": 118504,
       "value": 285653402.9,
@@ -533,6 +560,7 @@
     {
       "name": "COMUNE DI LIVORNO",
       "region": "Toscana",
+      "province": "Livorno",
       "codiceFiscale": "00104330493",
       "population": 153418,
       "value": 275149312.88,
@@ -541,6 +569,7 @@
     {
       "name": "COMUNE DI PERUGIA",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00163570542",
       "population": 162099,
       "value": 273055359.93,
@@ -549,6 +578,7 @@
     {
       "name": "COMUNE DI REGGIO DI CALABRIA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "00136380805",
       "population": 169679,
       "value": 266531138.94,
@@ -557,6 +587,7 @@
     {
       "name": "COMUNE DI PRATO",
       "region": "Toscana",
+      "province": "Prato",
       "codiceFiscale": "84006890481",
       "population": 197088,
       "value": 262410478.09,
@@ -565,6 +596,7 @@
     {
       "name": "COMUNE DI REGGIO NELL'EMILIA",
       "region": "Emilia-Romagna",
+      "province": "Reggio nell'Emilia",
       "codiceFiscale": "00145920351",
       "population": 171207,
       "value": 252137986.48,
@@ -573,6 +605,7 @@
     {
       "name": "COMUNE DI ALESSANDRIA",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "00429440068",
       "population": 91854,
       "value": 248382575.81,
@@ -581,6 +614,7 @@
     {
       "name": "COMUNE DI COSENZA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00347720781",
       "population": 63701,
       "value": 233000594.53,
@@ -589,6 +623,7 @@
     {
       "name": "COMUNE DI FERRARA",
       "region": "Emilia-Romagna",
+      "province": "Ferrara",
       "codiceFiscale": "00297110389",
       "population": 129391,
       "value": 228087005.13,
@@ -597,6 +632,7 @@
     {
       "name": "COMUNE DI CATANZARO",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00129520797",
       "population": 84109,
       "value": 222858829.32,
@@ -605,6 +641,7 @@
     {
       "name": "COMUNE DI LECCE",
       "region": "Puglia",
+      "province": "Lecce",
       "codiceFiscale": "80008510754",
       "population": 94250,
       "value": 213465321.1,
@@ -613,6 +650,7 @@
     {
       "name": "COMUNE DI FORLI'",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00606620409",
       "population": 117050,
       "value": 211977118.97,
@@ -621,6 +659,7 @@
     {
       "name": "COMUNE DI ANCONA",
       "region": "Marche",
+      "province": "Ancona",
       "codiceFiscale": "00351040423",
       "population": 99377,
       "value": 209134728.3,
@@ -629,6 +668,7 @@
     {
       "name": "COMUNE DI SASSARI",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00239740905",
       "population": 121085,
       "value": 206497959.47,
@@ -637,6 +677,7 @@
     {
       "name": "COMUNE DI UDINE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "00168650307",
       "population": 98304,
       "value": 206180204.25,
@@ -645,6 +686,7 @@
     {
       "name": "COMUNE DI PISA",
       "region": "Toscana",
+      "province": "Pisa",
       "codiceFiscale": "00341620508",
       "population": 89117,
       "value": 199891476.23,
@@ -653,6 +695,7 @@
     {
       "name": "COMUNE DI MONZA",
       "region": "Lombardia",
+      "province": "MONZA - BRIANZA",
       "codiceFiscale": "02030880153",
       "population": 122883,
       "value": 192257628.06,
@@ -661,6 +704,7 @@
     {
       "name": "COMUNE DI VICENZA",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00516890241",
       "population": 110299,
       "value": 191545803.05,
@@ -669,6 +713,7 @@
     {
       "name": "COMUNE DI RICCIONE",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00324360403",
       "population": 34465,
       "value": 190652812.9,
@@ -677,6 +722,7 @@
     {
       "name": "COMUNE DI FOGGIA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "00363460718",
       "population": 145652,
       "value": 188686593.9,
@@ -685,6 +731,7 @@
     {
       "name": "COMUNE DI PESCARA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "00124600685",
       "population": 118461,
       "value": 184876210.58,
@@ -693,6 +740,7 @@
     {
       "name": "COMUNE DI PIACENZA",
       "region": "Emilia-Romagna",
+      "province": "Piacenza",
       "codiceFiscale": "00229080338",
       "population": 102887,
       "value": 183408317.36,
@@ -701,6 +749,7 @@
     {
       "name": "COMUNE DI POMEZIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02298490588",
       "population": 64451,
       "value": 181199817.35,
@@ -709,6 +758,7 @@
     {
       "name": "COMUNE DI TIVOLI",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02696630587",
       "population": 55061,
       "value": 178363927.46,
@@ -717,6 +767,7 @@
     {
       "name": "COMUNE DI PESARO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00272430414",
       "population": 95392,
       "value": 171726599.18,
@@ -725,6 +776,7 @@
     {
       "name": "COMUNE DI SIRACUSA",
       "region": "Sicilia",
+      "province": "Siracusa",
       "codiceFiscale": "80001010893",
       "population": 116247,
       "value": 170003100.53,
@@ -733,6 +785,7 @@
     {
       "name": "COMUNE DI NOVARA",
       "region": "Piemonte",
+      "province": "Novara",
       "codiceFiscale": "00125680033",
       "population": 102187,
       "value": 169159489.32,
@@ -741,6 +794,7 @@
     {
       "name": "COMUNE DI TERNI",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00175660554",
       "population": 106436,
       "value": 167964312.34,
@@ -749,6 +803,7 @@
     {
       "name": "COMUNE DI APRILIA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "80003450592",
       "population": 74470,
       "value": 165993577.15,
@@ -757,6 +812,7 @@
     {
       "name": "COMUNE DI FIUMICINO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "97086740582",
       "population": 82481,
       "value": 164526379.86,
@@ -765,6 +821,7 @@
     {
       "name": "COMUNE DI CORIGLIANO-ROSSANO",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "03557570789",
       "population": 74268,
       "value": 163284461.95,
@@ -773,6 +830,7 @@
     {
       "name": "COMUNE DI MACERATA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "80001650433",
       "population": 40538,
       "value": 161584540.54,
@@ -781,6 +839,7 @@
     {
       "name": "COMUNE DI POZZUOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "00508900636",
       "population": 76255,
       "value": 157666522.48,
@@ -789,6 +848,7 @@
     {
       "name": "COMUNE DI CIVITAVECCHIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02700960582",
       "population": 51697,
       "value": 157508744.74,
@@ -797,6 +857,7 @@
     {
       "name": "COMUNE DI IMPERIA",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00089700082",
       "population": 42490,
       "value": 155629264.13,
@@ -805,6 +866,7 @@
     {
       "name": "COMUNE DI LATINA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "00097020598",
       "population": 127859,
       "value": 153020388.89,
@@ -813,6 +875,7 @@
     {
       "name": "COMUNE DI LA SPEZIA",
       "region": "Liguria",
+      "province": "La Spezia",
       "codiceFiscale": "00211160114",
       "population": 92696,
       "value": 143254016.05,
@@ -821,6 +884,7 @@
     {
       "name": "COMUNE DI ASCOLI PICENO",
       "region": "Marche",
+      "province": "Ascoli Piceno",
       "codiceFiscale": "00229010442",
       "population": 45448,
       "value": 142764144.11,
@@ -829,6 +893,7 @@
     {
       "name": "COMUNE DI COMO",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80005370137",
       "population": 83586,
       "value": 140861735.75,
@@ -837,6 +902,7 @@
     {
       "name": "COMUNE DI LUCCA",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00378210462",
       "population": 89234,
       "value": 139863461.06,
@@ -845,6 +911,7 @@
     {
       "name": "COMUNE DI PORDENONE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Pordenone",
       "codiceFiscale": "80002150938",
       "population": 52147,
       "value": 139032640.72,
@@ -853,6 +920,7 @@
     {
       "name": "COMUNE DI BENEVENTO",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "00074270620",
       "population": 56048,
       "value": 138628618.99,
@@ -861,6 +929,7 @@
     {
       "name": "COMUNE DI NUORO",
       "region": "Sardegna",
+      "province": "Nuoro",
       "codiceFiscale": "00053070918",
       "population": 33622,
       "value": 138489368.65,
@@ -869,6 +938,7 @@
     {
       "name": "COMUNE DI PISTOIA",
       "region": "Toscana",
+      "province": "Pistoia",
       "codiceFiscale": "00108690470",
       "population": 89054,
       "value": 137969598.72,
@@ -877,6 +947,7 @@
     {
       "name": "COMUNE DI BAGHERIA",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "81000170829",
       "population": 53010,
       "value": 137801993.91,
@@ -885,6 +956,7 @@
     {
       "name": "COMUNE DI CESENA",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00143280402",
       "population": 96066,
       "value": 136889157.03,
@@ -893,6 +965,7 @@
     {
       "name": "COMUNE DI SANREMO",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00253750087",
       "population": 52992,
       "value": 131977904.09,
@@ -901,6 +974,7 @@
     {
       "name": "COMUNE DI AREZZO",
       "region": "Toscana",
+      "province": "Arezzo",
       "codiceFiscale": "00176820512",
       "population": 96330,
       "value": 130829595.93,
@@ -909,6 +983,7 @@
     {
       "name": "COMUNE DI VARESE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00441340122",
       "population": 78818,
       "value": 130647829.49,
@@ -917,6 +992,7 @@
     {
       "name": "COMUNE DI VIAREGGIO",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00274950468",
       "population": 60755,
       "value": 129943670.37,
@@ -925,6 +1001,7 @@
     {
       "name": "COMUNE DI SIENA",
       "region": "Toscana",
+      "province": "Siena",
       "codiceFiscale": "00050800523",
       "population": 52833,
       "value": 128878196.5,
@@ -933,6 +1010,7 @@
     {
       "name": "COMUNE DI OLBIA",
       "region": "Sardegna",
+      "province": "Gallura Nord-Est Sardegna",
       "codiceFiscale": "91008330903",
       "population": 61481,
       "value": 128232847.39,
@@ -941,6 +1019,7 @@
     {
       "name": "COMUNE DI MODICA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00175500883",
       "population": 53485,
       "value": 124987274.33,
@@ -949,6 +1028,7 @@
     {
       "name": "COMUNE DI CREMONA",
       "region": "Lombardia",
+      "province": "Cremona",
       "codiceFiscale": "00297960197",
       "population": 70675,
       "value": 124864218.25,
@@ -957,6 +1037,7 @@
     {
       "name": "COMUNE DI TREVISO",
       "region": "Veneto",
+      "province": "Treviso",
       "codiceFiscale": "80007310263",
       "population": 85322,
       "value": 120694684.47,
@@ -965,6 +1046,7 @@
     {
       "name": "COMUNE DI MANTOVA",
       "region": "Lombardia",
+      "province": "Mantova",
       "codiceFiscale": "00189800204",
       "population": 49044,
       "value": 120055724.78,
@@ -973,6 +1055,7 @@
     {
       "name": "COMUNE DI GROSSETO",
       "region": "Toscana",
+      "province": "Grosseto",
       "codiceFiscale": "00082520537",
       "population": 81482,
       "value": 118757142.48,
@@ -981,6 +1064,7 @@
     {
       "name": "COMUNE DI BUSTO ARSIZIO",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00224000125",
       "population": 83372,
       "value": 118278046.39,
@@ -989,6 +1073,7 @@
     {
       "name": "COMUNE DI RAGUSA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00180270886",
       "population": 73736,
       "value": 117493725.18,
@@ -997,6 +1082,7 @@
     {
       "name": "COMUNE DI PAVIA",
       "region": "Lombardia",
+      "province": "Pavia",
       "codiceFiscale": "00296180185",
       "population": 71297,
       "value": 113143154.09,
@@ -1005,6 +1091,7 @@
     {
       "name": "COMUNE DI BRINDISI",
       "region": "Puglia",
+      "province": "Brindisi",
       "codiceFiscale": "80000250748",
       "population": 82298,
       "value": 112589545.46,
@@ -1013,6 +1100,7 @@
     {
       "name": "COMUNE DI MAZARA DEL VALLO",
       "region": "Sicilia",
+      "province": "Trapani",
       "codiceFiscale": "82001410818",
       "population": 50029,
       "value": 110141725.96,
@@ -1021,6 +1109,7 @@
     {
       "name": "COMUNE DI SESTO SAN GIOVANNI",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "02253930156",
       "population": 78495,
       "value": 109665610.01,
@@ -1029,6 +1118,7 @@
     {
       "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80049220637",
       "population": 124209,
       "value": 108316682.62,
@@ -1037,6 +1127,7 @@
     {
       "name": "COMUNE DI VITERBO",
       "region": "Lazio",
+      "province": "Viterbo",
       "codiceFiscale": "80008850564",
       "population": 66188,
       "value": 107979687.11,
@@ -1045,6 +1136,7 @@
     {
       "name": "COMUNE DI ALBANO LAZIALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "82011210588",
       "population": 39773,
       "value": 106521288.66,
@@ -1053,6 +1145,7 @@
     {
       "name": "COMUNE DI GORIZIA",
       "region": "Friuli-Venezia Giulia",
+      "province": "Gorizia",
       "codiceFiscale": "00122500317",
       "population": 33608,
       "value": 105432507.1,
@@ -1061,6 +1154,7 @@
     {
       "name": "COMUNE DI MASSA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00181760455",
       "population": 65992,
       "value": 105113593.39,
@@ -1069,6 +1163,7 @@
     {
       "name": "COMUNE DI ASTI",
       "region": "Piemonte",
+      "province": "Asti",
       "codiceFiscale": "00072360050",
       "population": 73401,
       "value": 103567026.81,
@@ -1077,6 +1172,7 @@
     {
       "name": "COMUNE DI ROVERETO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00125390229",
       "population": 40077,
       "value": 103186965.61,
@@ -1085,6 +1181,7 @@
     {
       "name": "COMUNE DI CARRARA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00079450458",
       "population": 59757,
       "value": 103008403.78,
@@ -1093,6 +1190,7 @@
     {
       "name": "COMUNE DI ALTAMURA",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "82002590725",
       "population": 70093,
       "value": 102591941.46,
@@ -1101,6 +1199,7 @@
     {
       "name": "COMUNE DI MATERA",
       "region": "Basilicata",
+      "province": "Matera",
       "codiceFiscale": "80002870774",
       "population": 59652,
       "value": 101872743.54,
@@ -1109,6 +1208,7 @@
     {
       "name": "COMUNE DI FANO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00127440410",
       "population": 59992,
       "value": 100646882.51,
@@ -1119,6 +1219,7 @@
     {
       "name": "ROMA CAPITALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02438750586",
       "population": 2751747,
       "value": 7041805276.75,
@@ -1127,6 +1228,7 @@
     {
       "name": "COMUNE DI MILANO",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "01199250158",
       "population": 1371499,
       "value": 4376669061.5,
@@ -1135,6 +1237,7 @@
     {
       "name": "COMUNE DI NAPOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80014890638",
       "population": 913704,
       "value": 2017015632.67,
@@ -1143,6 +1246,7 @@
     {
       "name": "COMUNE DI GENOVA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00856930102",
       "population": 562422,
       "value": 1956907719.48,
@@ -1151,6 +1255,7 @@
     {
       "name": "COMUNE DI TORINO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "00514490010",
       "population": 851199,
       "value": 1885858031.24,
@@ -1159,6 +1264,7 @@
     {
       "name": "COMUNE DI CATANIA",
       "region": "Sicilia",
+      "province": "Catania",
       "codiceFiscale": "00137020871",
       "population": 298680,
       "value": 1298480774.87,
@@ -1167,6 +1273,7 @@
     {
       "name": "COMUNE DI VENEZIA",
       "region": "Veneto",
+      "province": "Venezia",
       "codiceFiscale": "00339370272",
       "population": 250290,
       "value": 1158689223.62,
@@ -1175,6 +1282,7 @@
     {
       "name": "COMUNE DI FIRENZE",
       "region": "Toscana",
+      "province": "Firenze",
       "codiceFiscale": "01307110484",
       "population": 362613,
       "value": 1065127671.63,
@@ -1183,6 +1291,7 @@
     {
       "name": "COMUNE DI BOLOGNA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "01232710374",
       "population": 390098,
       "value": 948531655.18,
@@ -1191,6 +1300,7 @@
     {
       "name": "COMUNE DI PALERMO",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "80016350821",
       "population": 630427,
       "value": 892290906.24,
@@ -1199,6 +1309,7 @@
     {
       "name": "COMUNE DI MESSINA",
       "region": "Sicilia",
+      "province": "Messina",
       "codiceFiscale": "00080270838",
       "population": 217959,
       "value": 785435489.51,
@@ -1207,6 +1318,7 @@
     {
       "name": "COMUNE DI BARI",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "80015010723",
       "population": 316226,
       "value": 551093161.12,
@@ -1215,6 +1327,7 @@
     {
       "name": "COMUNE DI TRIESTE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Trieste",
       "codiceFiscale": "00210240321",
       "population": 198843,
       "value": 498984708.17,
@@ -1223,6 +1336,7 @@
     {
       "name": "COMUNE DI VERONA",
       "region": "Veneto",
+      "province": "Verona",
       "codiceFiscale": "00215150236",
       "population": 255298,
       "value": 474459542.25,
@@ -1231,6 +1345,7 @@
     {
       "name": "COMUNE DI PADOVA",
       "region": "Veneto",
+      "province": "Padova",
       "codiceFiscale": "00644060287",
       "population": 207502,
       "value": 472834846.77,
@@ -1239,6 +1354,7 @@
     {
       "name": "COMUNE DI BRESCIA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00761890177",
       "population": 198259,
       "value": 422830996.56,
@@ -1247,6 +1363,7 @@
     {
       "name": "COMUNE DI MODENA",
       "region": "Emilia-Romagna",
+      "province": "Modena",
       "codiceFiscale": "00221940364",
       "population": 184597,
       "value": 403708249.57,
@@ -1255,6 +1372,7 @@
     {
       "name": "COMUNE DI L'AQUILA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002270660",
       "population": 69717,
       "value": 393192216.15,
@@ -1263,6 +1381,7 @@
     {
       "name": "COMUNE DI SALERNO",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "80000330656",
       "population": 126715,
       "value": 388688018.27,
@@ -1271,6 +1390,7 @@
     {
       "name": "COMUNE DI CAGLIARI",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00147990923",
       "population": 147411,
       "value": 370299520.65,
@@ -1279,6 +1399,7 @@
     {
       "name": "COMUNE DI TARANTO",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80008750731",
       "population": 187025,
       "value": 369161940.74,
@@ -1287,6 +1408,7 @@
     {
       "name": "COMUNE DI PARMA",
       "region": "Emilia-Romagna",
+      "province": "Parma",
       "codiceFiscale": "00162210348",
       "population": 198121,
       "value": 331582256.76,
@@ -1295,6 +1417,7 @@
     {
       "name": "COMUNE DI BOLZANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00389240219",
       "population": 106357,
       "value": 311394956.8,
@@ -1303,6 +1426,7 @@
     {
       "name": "COMUNE DI BERGAMO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "80034840167",
       "population": 120157,
       "value": 303275058.95,
@@ -1311,6 +1435,7 @@
     {
       "name": "COMUNE DI RIMINI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00304260409",
       "population": 150046,
       "value": 302211711.77,
@@ -1319,6 +1444,7 @@
     {
       "name": "COMUNE DI RAVENNA",
       "region": "Emilia-Romagna",
+      "province": "Ravenna",
       "codiceFiscale": "00354730392",
       "population": 156304,
       "value": 297412632.52,
@@ -1327,6 +1453,7 @@
     {
       "name": "COMUNE DI TRENTO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00355870221",
       "population": 118504,
       "value": 285653402.9,
@@ -1335,6 +1462,7 @@
     {
       "name": "COMUNE DI LIVORNO",
       "region": "Toscana",
+      "province": "Livorno",
       "codiceFiscale": "00104330493",
       "population": 153418,
       "value": 275149312.88,
@@ -1343,6 +1471,7 @@
     {
       "name": "COMUNE DI PERUGIA",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00163570542",
       "population": 162099,
       "value": 273055359.93,
@@ -1351,6 +1480,7 @@
     {
       "name": "COMUNE DI REGGIO DI CALABRIA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "00136380805",
       "population": 169679,
       "value": 266531138.94,
@@ -1359,6 +1489,7 @@
     {
       "name": "COMUNE DI PRATO",
       "region": "Toscana",
+      "province": "Prato",
       "codiceFiscale": "84006890481",
       "population": 197088,
       "value": 262410478.09,
@@ -1367,6 +1498,7 @@
     {
       "name": "COMUNE DI REGGIO NELL'EMILIA",
       "region": "Emilia-Romagna",
+      "province": "Reggio nell'Emilia",
       "codiceFiscale": "00145920351",
       "population": 171207,
       "value": 252137986.48,
@@ -1375,6 +1507,7 @@
     {
       "name": "COMUNE DI ALESSANDRIA",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "00429440068",
       "population": 91854,
       "value": 248382575.81,
@@ -1383,6 +1516,7 @@
     {
       "name": "COMUNE DI COSENZA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00347720781",
       "population": 63701,
       "value": 233000594.53,
@@ -1391,6 +1525,7 @@
     {
       "name": "COMUNE DI FERRARA",
       "region": "Emilia-Romagna",
+      "province": "Ferrara",
       "codiceFiscale": "00297110389",
       "population": 129391,
       "value": 228087005.13,
@@ -1399,6 +1534,7 @@
     {
       "name": "COMUNE DI CATANZARO",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00129520797",
       "population": 84109,
       "value": 222858829.32,
@@ -1407,6 +1543,7 @@
     {
       "name": "COMUNE DI LECCE",
       "region": "Puglia",
+      "province": "Lecce",
       "codiceFiscale": "80008510754",
       "population": 94250,
       "value": 213465321.1,
@@ -1415,6 +1552,7 @@
     {
       "name": "COMUNE DI FORLI'",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00606620409",
       "population": 117050,
       "value": 211977118.97,
@@ -1423,6 +1561,7 @@
     {
       "name": "COMUNE DI ANCONA",
       "region": "Marche",
+      "province": "Ancona",
       "codiceFiscale": "00351040423",
       "population": 99377,
       "value": 209134728.3,
@@ -1431,6 +1570,7 @@
     {
       "name": "COMUNE DI SASSARI",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00239740905",
       "population": 121085,
       "value": 206497959.47,
@@ -1439,6 +1579,7 @@
     {
       "name": "COMUNE DI UDINE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "00168650307",
       "population": 98304,
       "value": 206180204.25,
@@ -1447,6 +1588,7 @@
     {
       "name": "COMUNE DI PISA",
       "region": "Toscana",
+      "province": "Pisa",
       "codiceFiscale": "00341620508",
       "population": 89117,
       "value": 199891476.23,
@@ -1455,6 +1597,7 @@
     {
       "name": "COMUNE DI MONZA",
       "region": "Lombardia",
+      "province": "MONZA - BRIANZA",
       "codiceFiscale": "02030880153",
       "population": 122883,
       "value": 192257628.06,
@@ -1463,6 +1606,7 @@
     {
       "name": "COMUNE DI VICENZA",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00516890241",
       "population": 110299,
       "value": 191545803.05,
@@ -1471,6 +1615,7 @@
     {
       "name": "COMUNE DI RICCIONE",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00324360403",
       "population": 34465,
       "value": 190652812.9,
@@ -1479,6 +1624,7 @@
     {
       "name": "COMUNE DI FOGGIA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "00363460718",
       "population": 145652,
       "value": 188686593.9,
@@ -1487,6 +1633,7 @@
     {
       "name": "COMUNE DI PESCARA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "00124600685",
       "population": 118461,
       "value": 184876210.58,
@@ -1495,6 +1642,7 @@
     {
       "name": "COMUNE DI PIACENZA",
       "region": "Emilia-Romagna",
+      "province": "Piacenza",
       "codiceFiscale": "00229080338",
       "population": 102887,
       "value": 183408317.36,
@@ -1503,6 +1651,7 @@
     {
       "name": "COMUNE DI POMEZIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02298490588",
       "population": 64451,
       "value": 181199817.35,
@@ -1511,6 +1660,7 @@
     {
       "name": "COMUNE DI TIVOLI",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02696630587",
       "population": 55061,
       "value": 178363927.46,
@@ -1519,6 +1669,7 @@
     {
       "name": "COMUNE DI PESARO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00272430414",
       "population": 95392,
       "value": 171726599.18,
@@ -1527,6 +1678,7 @@
     {
       "name": "COMUNE DI SIRACUSA",
       "region": "Sicilia",
+      "province": "Siracusa",
       "codiceFiscale": "80001010893",
       "population": 116247,
       "value": 170003100.53,
@@ -1535,6 +1687,7 @@
     {
       "name": "COMUNE DI NOVARA",
       "region": "Piemonte",
+      "province": "Novara",
       "codiceFiscale": "00125680033",
       "population": 102187,
       "value": 169159489.32,
@@ -1543,6 +1696,7 @@
     {
       "name": "COMUNE DI TERNI",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00175660554",
       "population": 106436,
       "value": 167964312.34,
@@ -1551,6 +1705,7 @@
     {
       "name": "COMUNE DI APRILIA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "80003450592",
       "population": 74470,
       "value": 165993577.15,
@@ -1559,6 +1714,7 @@
     {
       "name": "COMUNE DI FIUMICINO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "97086740582",
       "population": 82481,
       "value": 164526379.86,
@@ -1567,6 +1723,7 @@
     {
       "name": "COMUNE DI CORIGLIANO-ROSSANO",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "03557570789",
       "population": 74268,
       "value": 163284461.95,
@@ -1575,6 +1732,7 @@
     {
       "name": "COMUNE DI MACERATA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "80001650433",
       "population": 40538,
       "value": 161584540.54,
@@ -1583,6 +1741,7 @@
     {
       "name": "COMUNE DI POZZUOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "00508900636",
       "population": 76255,
       "value": 157666522.48,
@@ -1591,6 +1750,7 @@
     {
       "name": "COMUNE DI CIVITAVECCHIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02700960582",
       "population": 51697,
       "value": 157508744.74,
@@ -1599,6 +1759,7 @@
     {
       "name": "COMUNE DI IMPERIA",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00089700082",
       "population": 42490,
       "value": 155629264.13,
@@ -1607,6 +1768,7 @@
     {
       "name": "COMUNE DI LATINA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "00097020598",
       "population": 127859,
       "value": 153020388.89,
@@ -1615,6 +1777,7 @@
     {
       "name": "COMUNE DI LA SPEZIA",
       "region": "Liguria",
+      "province": "La Spezia",
       "codiceFiscale": "00211160114",
       "population": 92696,
       "value": 143254016.05,
@@ -1623,6 +1786,7 @@
     {
       "name": "COMUNE DI ASCOLI PICENO",
       "region": "Marche",
+      "province": "Ascoli Piceno",
       "codiceFiscale": "00229010442",
       "population": 45448,
       "value": 142764144.11,
@@ -1631,6 +1795,7 @@
     {
       "name": "COMUNE DI COMO",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80005370137",
       "population": 83586,
       "value": 140861735.75,
@@ -1639,6 +1804,7 @@
     {
       "name": "COMUNE DI LUCCA",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00378210462",
       "population": 89234,
       "value": 139863461.06,
@@ -1647,6 +1813,7 @@
     {
       "name": "COMUNE DI PORDENONE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Pordenone",
       "codiceFiscale": "80002150938",
       "population": 52147,
       "value": 139032640.72,
@@ -1655,6 +1822,7 @@
     {
       "name": "COMUNE DI BENEVENTO",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "00074270620",
       "population": 56048,
       "value": 138628618.99,
@@ -1663,6 +1831,7 @@
     {
       "name": "COMUNE DI NUORO",
       "region": "Sardegna",
+      "province": "Nuoro",
       "codiceFiscale": "00053070918",
       "population": 33622,
       "value": 138489368.65,
@@ -1671,6 +1840,7 @@
     {
       "name": "COMUNE DI PISTOIA",
       "region": "Toscana",
+      "province": "Pistoia",
       "codiceFiscale": "00108690470",
       "population": 89054,
       "value": 137969598.72,
@@ -1679,6 +1849,7 @@
     {
       "name": "COMUNE DI BAGHERIA",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "81000170829",
       "population": 53010,
       "value": 137801993.91,
@@ -1687,6 +1858,7 @@
     {
       "name": "COMUNE DI CESENA",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00143280402",
       "population": 96066,
       "value": 136889157.03,
@@ -1695,6 +1867,7 @@
     {
       "name": "COMUNE DI SANREMO",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00253750087",
       "population": 52992,
       "value": 131977904.09,
@@ -1703,6 +1876,7 @@
     {
       "name": "COMUNE DI AREZZO",
       "region": "Toscana",
+      "province": "Arezzo",
       "codiceFiscale": "00176820512",
       "population": 96330,
       "value": 130829595.93,
@@ -1711,6 +1885,7 @@
     {
       "name": "COMUNE DI VARESE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00441340122",
       "population": 78818,
       "value": 130647829.49,
@@ -1719,6 +1894,7 @@
     {
       "name": "COMUNE DI VIAREGGIO",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00274950468",
       "population": 60755,
       "value": 129943670.37,
@@ -1727,6 +1903,7 @@
     {
       "name": "COMUNE DI SIENA",
       "region": "Toscana",
+      "province": "Siena",
       "codiceFiscale": "00050800523",
       "population": 52833,
       "value": 128878196.5,
@@ -1735,6 +1912,7 @@
     {
       "name": "COMUNE DI OLBIA",
       "region": "Sardegna",
+      "province": "Gallura Nord-Est Sardegna",
       "codiceFiscale": "91008330903",
       "population": 61481,
       "value": 128232847.39,
@@ -1743,6 +1921,7 @@
     {
       "name": "COMUNE DI MODICA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00175500883",
       "population": 53485,
       "value": 124987274.33,
@@ -1751,6 +1930,7 @@
     {
       "name": "COMUNE DI CREMONA",
       "region": "Lombardia",
+      "province": "Cremona",
       "codiceFiscale": "00297960197",
       "population": 70675,
       "value": 124864218.25,
@@ -1759,6 +1939,7 @@
     {
       "name": "COMUNE DI TREVISO",
       "region": "Veneto",
+      "province": "Treviso",
       "codiceFiscale": "80007310263",
       "population": 85322,
       "value": 120694684.47,
@@ -1767,6 +1948,7 @@
     {
       "name": "COMUNE DI MANTOVA",
       "region": "Lombardia",
+      "province": "Mantova",
       "codiceFiscale": "00189800204",
       "population": 49044,
       "value": 120055724.78,
@@ -1775,6 +1957,7 @@
     {
       "name": "COMUNE DI GROSSETO",
       "region": "Toscana",
+      "province": "Grosseto",
       "codiceFiscale": "00082520537",
       "population": 81482,
       "value": 118757142.48,
@@ -1783,6 +1966,7 @@
     {
       "name": "COMUNE DI BUSTO ARSIZIO",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00224000125",
       "population": 83372,
       "value": 118278046.39,
@@ -1791,6 +1975,7 @@
     {
       "name": "COMUNE DI RAGUSA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00180270886",
       "population": 73736,
       "value": 117493725.18,
@@ -1799,6 +1984,7 @@
     {
       "name": "COMUNE DI PAVIA",
       "region": "Lombardia",
+      "province": "Pavia",
       "codiceFiscale": "00296180185",
       "population": 71297,
       "value": 113143154.09,
@@ -1807,6 +1993,7 @@
     {
       "name": "COMUNE DI BRINDISI",
       "region": "Puglia",
+      "province": "Brindisi",
       "codiceFiscale": "80000250748",
       "population": 82298,
       "value": 112589545.46,
@@ -1815,6 +2002,7 @@
     {
       "name": "COMUNE DI MAZARA DEL VALLO",
       "region": "Sicilia",
+      "province": "Trapani",
       "codiceFiscale": "82001410818",
       "population": 50029,
       "value": 110141725.96,
@@ -1823,6 +2011,7 @@
     {
       "name": "COMUNE DI SESTO SAN GIOVANNI",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "02253930156",
       "population": 78495,
       "value": 109665610.01,
@@ -1831,6 +2020,7 @@
     {
       "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80049220637",
       "population": 124209,
       "value": 108316682.62,
@@ -1839,6 +2029,7 @@
     {
       "name": "COMUNE DI VITERBO",
       "region": "Lazio",
+      "province": "Viterbo",
       "codiceFiscale": "80008850564",
       "population": 66188,
       "value": 107979687.11,
@@ -1847,6 +2038,7 @@
     {
       "name": "COMUNE DI ALBANO LAZIALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "82011210588",
       "population": 39773,
       "value": 106521288.66,
@@ -1855,6 +2047,7 @@
     {
       "name": "COMUNE DI GORIZIA",
       "region": "Friuli-Venezia Giulia",
+      "province": "Gorizia",
       "codiceFiscale": "00122500317",
       "population": 33608,
       "value": 105432507.1,
@@ -1863,6 +2056,7 @@
     {
       "name": "COMUNE DI MASSA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00181760455",
       "population": 65992,
       "value": 105113593.39,
@@ -1871,6 +2065,7 @@
     {
       "name": "COMUNE DI ASTI",
       "region": "Piemonte",
+      "province": "Asti",
       "codiceFiscale": "00072360050",
       "population": 73401,
       "value": 103567026.81,
@@ -1879,6 +2074,7 @@
     {
       "name": "COMUNE DI ROVERETO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00125390229",
       "population": 40077,
       "value": 103186965.61,
@@ -1887,6 +2083,7 @@
     {
       "name": "COMUNE DI CARRARA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00079450458",
       "population": 59757,
       "value": 103008403.78,
@@ -1895,6 +2092,7 @@
     {
       "name": "COMUNE DI ALTAMURA",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "82002590725",
       "population": 70093,
       "value": 102591941.46,
@@ -1903,6 +2101,7 @@
     {
       "name": "COMUNE DI MATERA",
       "region": "Basilicata",
+      "province": "Matera",
       "codiceFiscale": "80002870774",
       "population": 59652,
       "value": 101872743.54,
@@ -1911,6 +2110,7 @@
     {
       "name": "COMUNE DI FANO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00127440410",
       "population": 59992,
       "value": 100646882.51,
@@ -1921,6 +2121,7 @@
     {
       "name": "COMUNE DI ELVA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80004570042",
       "population": 78,
       "value": 4878837.18,
@@ -1929,6 +2130,7 @@
     {
       "name": "COMUNE DI VILLA SANTA LUCIA DEGLI ABRUZZI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00193560661",
       "population": 88,
       "value": 5136466.92,
@@ -1937,6 +2139,7 @@
     {
       "name": "COMUNE DI VALLEVE",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00637290164",
       "population": 126,
       "value": 6567925.67,
@@ -1945,6 +2148,7 @@
     {
       "name": "COMUNE DI SANTO STEFANO DI SESSANIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00173470667",
       "population": 110,
       "value": 4793519.49,
@@ -1953,6 +2157,7 @@
     {
       "name": "COMUNE DI CARAPELLE CALVISIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197710668",
       "population": 78,
       "value": 3187749.96,
@@ -1961,6 +2166,7 @@
     {
       "name": "COMUNE DI CELLE DI SAN VITO",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "80003290717",
       "population": 148,
       "value": 5835207.84,
@@ -1969,6 +2175,7 @@
     {
       "name": "COMUNE DI CAMPIONE D'ITALIA",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80009700131",
       "population": 1757,
       "value": 66543587.25,
@@ -1977,6 +2184,7 @@
     {
       "name": "COMUNE DI SAN BENEDETTO IN PERILLIS",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00219500667",
       "population": 98,
       "value": 3687963.76,
@@ -1985,6 +2193,7 @@
     {
       "name": "COMUNE DI MONTELAPIANO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81002650695",
       "population": 69,
       "value": 2399020.36,
@@ -1993,6 +2202,7 @@
     {
       "name": "COMUNE DI CHAMOIS",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "81002610079",
       "population": 108,
       "value": 3385831.14,
@@ -2001,6 +2211,7 @@
     {
       "name": "COMUNE DI MASSELLO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "85000150012",
       "population": 57,
       "value": 1774686.8,
@@ -2009,6 +2220,7 @@
     {
       "name": "COMUNE DI CASTELSANTANGELO SUL NERA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "00242630432",
       "population": 221,
       "value": 6826442.5,
@@ -2017,6 +2229,7 @@
     {
       "name": "COMUNE DI BOLOGNOLA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000910430",
       "population": 147,
       "value": 4363674.53,
@@ -2025,6 +2238,7 @@
     {
       "name": "COMUNE DI GAGLIANO ATERNO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00212360663",
       "population": 225,
       "value": 6383475.12,
@@ -2033,6 +2247,7 @@
     {
       "name": "COMUNE DI ROSELLO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81002970697",
       "population": 166,
       "value": 4700935.54,
@@ -2041,6 +2256,7 @@
     {
       "name": "COMUNE DI SANT'EUSANIO FORCONESE",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002610667",
       "population": 365,
       "value": 10209437.03,
@@ -2049,6 +2265,7 @@
     {
       "name": "COMUNE DI CASTELVECCHIO CALVISIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197730666",
       "population": 120,
       "value": 3232497.46,
@@ -2057,6 +2274,7 @@
     {
       "name": "COMUNE DI PRATA D'ANSIDONIA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00195150669",
       "population": 447,
       "value": 11763687.4,
@@ -2065,6 +2283,7 @@
     {
       "name": "COMUNE DI NAVELLI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00188910665",
       "population": 569,
       "value": 14444298.76,
@@ -2073,6 +2292,7 @@
     {
       "name": "COMUNE DI MICIGLIANO",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00113670574",
       "population": 112,
       "value": 2836529.51,
@@ -2081,6 +2301,7 @@
     {
       "name": "COMUNE DI CISSONE",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00476920046",
       "population": 78,
       "value": 1930374.88,
@@ -2089,6 +2310,7 @@
     {
       "name": "COMUNE DI MARMORA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00483290045",
       "population": 58,
       "value": 1417973.58,
@@ -2097,6 +2319,7 @@
     {
       "name": "COMUNE DI USSITA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81001810431",
       "population": 360,
       "value": 8780290.19,
@@ -2105,6 +2328,7 @@
     {
       "name": "COMUNE DI PIETRACAMELA",
       "region": "Abruzzo",
+      "province": "Teramo",
       "codiceFiscale": "80005250677",
       "population": 207,
       "value": 5019518.56,
@@ -2113,6 +2337,7 @@
     {
       "name": "COMUNE DI CAPORCIANO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00187590666",
       "population": 201,
       "value": 4859087.74,
@@ -2121,6 +2346,7 @@
     {
       "name": "COMUNE DI RHEMES-NOTRE-DAME",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00138020078",
       "population": 76,
       "value": 1811302.58,
@@ -2129,6 +2355,7 @@
     {
       "name": "COMUNE DI MONTEFERRANTE",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81001690692",
       "population": 107,
       "value": 2518042.52,
@@ -2137,6 +2364,7 @@
     {
       "name": "COMUNE DI BEMA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00090830142",
       "population": 114,
       "value": 2673626.9,
@@ -2145,6 +2373,7 @@
     {
       "name": "COMUNE DI FOSSA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80001770660",
       "population": 658,
       "value": 15248094.36,
@@ -2153,6 +2382,7 @@
     {
       "name": "COMUNE DI BRIGA ALTA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00553180043",
       "population": 41,
       "value": 933670.0,
@@ -2161,6 +2391,7 @@
     {
       "name": "COMUNE DI FAGNANO ALTO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00193030665",
       "population": 351,
       "value": 7971080.8,
@@ -2169,6 +2400,7 @@
     {
       "name": "COMUNE DI LETTOPALENA",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "00230170698",
       "population": 314,
       "value": 7009936.54,
@@ -2177,6 +2409,7 @@
     {
       "name": "COMUNE DI MENDATICA",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00246330088",
       "population": 161,
       "value": 3581899.81,
@@ -2185,6 +2418,7 @@
     {
       "name": "COMUNE DI PIEVE TORINA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000190439",
       "population": 1225,
       "value": 27097508.86,
@@ -2193,6 +2427,7 @@
     {
       "name": "COMUNE DI EMARESE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00092580075",
       "population": 225,
       "value": 4850686.82,
@@ -2201,6 +2436,7 @@
     {
       "name": "COMUNE DI MONTE CAVALLO",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000130435",
       "population": 103,
       "value": 2214618.29,
@@ -2209,6 +2445,7 @@
     {
       "name": "COMUNE DI BARADILI",
       "region": "Sardegna",
+      "province": "Oristano",
       "codiceFiscale": "80007220959",
       "population": 80,
       "value": 1697596.53,
@@ -2217,6 +2454,7 @@
     {
       "name": "COMUNE DI MACRA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478030042",
       "population": 45,
       "value": 954074.88,
@@ -2225,6 +2463,7 @@
     {
       "name": "COMUNE DI PORTOFINO",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00826220105",
       "population": 358,
       "value": 7488435.84,
@@ -2233,6 +2472,7 @@
     {
       "name": "COMUNE DI MONCENISIO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01021740012",
       "population": 49,
       "value": 1023966.91,
@@ -2241,6 +2481,7 @@
     {
       "name": "COMUNE DI GEROLA ALTA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00105780142",
       "population": 165,
       "value": 3416388.8,
@@ -2249,6 +2490,7 @@
     {
       "name": "COMUNE DI BERGOLO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00511030041",
       "population": 53,
       "value": 1096436.8,
@@ -2257,6 +2499,7 @@
     {
       "name": "COMUNE DI MOLLIA",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "00433220027",
       "population": 98,
       "value": 2000941.36,
@@ -2265,6 +2508,7 @@
     {
       "name": "COMUNE DI FONTECCHIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00189210669",
       "population": 286,
       "value": 5787096.68,
@@ -2273,6 +2517,7 @@
     {
       "name": "COMUNE DI MARCETELLI",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00077920577",
       "population": 57,
       "value": 1149558.73,
@@ -2281,6 +2526,7 @@
     {
       "name": "COMUNE DI BARD",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00093700078",
       "population": 102,
       "value": 2011925.45,
@@ -2289,6 +2535,7 @@
     {
       "name": "COMUNE DI OSTANA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00453120040",
       "population": 89,
       "value": 1738207.84,
@@ -2297,6 +2544,7 @@
     {
       "name": "COMUNE DI VALPRATO SOANA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "02216150017",
       "population": 96,
       "value": 1871788.81,
@@ -2305,6 +2553,7 @@
     {
       "name": "COMUNE DI TIONE DEGLI ABRUZZI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00189270663",
       "population": 258,
       "value": 5008508.52,
@@ -2313,6 +2562,7 @@
     {
       "name": "COMUNE DI IGLIANO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "02886900048",
       "population": 66,
       "value": 1264463.32,
@@ -2321,6 +2571,7 @@
     {
       "name": "COMUNE DI MADESIMO",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00133750141",
       "population": 516,
       "value": 9689625.67,
@@ -2329,6 +2580,7 @@
     {
       "name": "COMUNE DI RONDANINA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "80044070102",
       "population": 59,
       "value": 1089759.66,
@@ -2337,6 +2589,7 @@
     {
       "name": "COMUNE DI CIVITACAMPOMARANO",
       "region": "Molise",
+      "province": "Campobasso",
       "codiceFiscale": "00067590703",
       "population": 308,
       "value": 5591719.83,
@@ -2345,6 +2598,7 @@
     {
       "name": "COMUNE DI ACCIANO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "83003750664",
       "population": 256,
       "value": 4612395.81,
@@ -2353,6 +2607,7 @@
     {
       "name": "COMUNE DI CUSIO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "85002390160",
       "population": 204,
       "value": 3623824.6,
@@ -2361,6 +2616,7 @@
     {
       "name": "COMUNE DI RIBORDONE",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01394590010",
       "population": 52,
       "value": 919311.1,
@@ -2369,6 +2625,7 @@
     {
       "name": "COMUNE DI ACQUAVIVA D'ISERNIA",
       "region": "Molise",
+      "province": "Isernia",
       "codiceFiscale": "80001830944",
       "population": 352,
       "value": 6153601.77,
@@ -2377,6 +2634,7 @@
     {
       "name": "COMUNE DI RASSA",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82001810025",
       "population": 68,
       "value": 1186806.71,
@@ -2385,6 +2643,7 @@
     {
       "name": "COMUNE DI SEMESTENE",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00254670904",
       "population": 125,
       "value": 2136551.23,
@@ -2393,6 +2652,7 @@
     {
       "name": "COMUNE DI ARGENTERA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80003430040",
       "population": 80,
       "value": 1353665.34,
@@ -2401,6 +2661,7 @@
     {
       "name": "COMUNE DI CAMPOTOSTO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00085160661",
       "population": 457,
       "value": 7667301.15,
@@ -2409,6 +2670,7 @@
     {
       "name": "COMUNE DI CANOSIO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00506090042",
       "population": 76,
       "value": 1261129.59,
@@ -2417,6 +2679,7 @@
     {
       "name": "COMUNE DI CARONA",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00637300161",
       "population": 282,
       "value": 4671692.81,
@@ -2425,6 +2688,7 @@
     {
       "name": "COMUNE DI INGRIA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01840350019",
       "population": 46,
       "value": 755763.15,
@@ -2433,6 +2697,7 @@
     {
       "name": "COMUNE DI VALSAVARENCHE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00124870072",
       "population": 154,
       "value": 2522126.24,
@@ -2441,6 +2706,7 @@
     {
       "name": "COMUNE DI DOSSENA",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "85001850164",
       "population": 882,
       "value": 14392613.57,
@@ -2449,6 +2715,7 @@
     {
       "name": "COMUNE DI VALLORIATE",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00508910049",
       "population": 101,
       "value": 1647788.85,
@@ -2457,6 +2724,7 @@
     {
       "name": "COMUNE DI MARTELLO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "82008550210",
       "population": 840,
       "value": 13601780.31,
@@ -2465,6 +2733,7 @@
     {
       "name": "COMUNE DI COCULLO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00218020667",
       "population": 211,
       "value": 3391374.6,
@@ -2473,6 +2742,7 @@
     {
       "name": "COMUNE DI SETZU",
       "region": "Sardegna",
+      "province": "Medio Campidano",
       "codiceFiscale": "82001290921",
       "population": 125,
       "value": 2007095.27,
@@ -2481,6 +2751,7 @@
     {
       "name": "COMUNE DI GUARDIA PERTICARA",
       "region": "Basilicata",
+      "province": "Potenza",
       "codiceFiscale": "80005710761",
       "population": 526,
       "value": 8424933.05,
@@ -2489,6 +2760,7 @@
     {
       "name": "COMUNE DI CASTEL DI IERI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00235390663",
       "population": 292,
       "value": 4660040.61,
@@ -2497,6 +2769,7 @@
     {
       "name": "COMUNE DI CARPINETO SINELLO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "00254060692",
       "population": 498,
       "value": 7836177.87,
@@ -2505,6 +2778,7 @@
     {
       "name": "COMUNE DI CASTELMAGNO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478910045",
       "population": 55,
       "value": 865379.58,
@@ -2513,6 +2787,7 @@
     {
       "name": "COMUNE DI SANT'ALESSIO IN ASPROMONTE",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "80003150804",
       "population": 316,
       "value": 4961884.91,
@@ -2521,6 +2796,7 @@
     {
       "name": "COMUNE DI RONCOBELLO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "85001490169",
       "population": 432,
       "value": 6660371.26,
@@ -2529,6 +2805,7 @@
     {
       "name": "COMUNE DI MONTEGROSSO PIAN LATTE",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00246350086",
       "population": 111,
       "value": 1693907.76,
@@ -2537,6 +2814,7 @@
     {
       "name": "COMUNE DI VALGRISENCHE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00101190072",
       "population": 186,
       "value": 2826255.77,
@@ -2545,6 +2823,7 @@
     {
       "name": "COMUNE DI CAMPORA",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "84000970651",
       "population": 318,
       "value": 4732232.83,
@@ -2553,6 +2832,7 @@
     {
       "name": "COMUNE DI LUCOLI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00094420668",
       "population": 824,
       "value": 12232517.22,
@@ -2561,6 +2841,7 @@
     {
       "name": "COMUNE DI PIAZZATORRE",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00675260160",
       "population": 392,
       "value": 5799799.24,
@@ -2569,6 +2850,7 @@
     {
       "name": "COMUNE DI BOVA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "80002510800",
       "population": 423,
       "value": 6224202.62,
@@ -2577,6 +2859,7 @@
     {
       "name": "COMUNE DI ROIO DEL SANGRO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81003010691",
       "population": 97,
       "value": 1394755.85,
@@ -2585,6 +2868,7 @@
     {
       "name": "COMUNE DI GINESTRA DEGLI SCHIAVONI",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "80004430627",
       "population": 388,
       "value": 5574960.5,
@@ -2593,6 +2877,7 @@
     {
       "name": "COMUNE DI RITTANA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80001890047",
       "population": 104,
       "value": 1491907.68,
@@ -2601,6 +2886,7 @@
     {
       "name": "COMUNE DI CARCOFORO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82000610020",
       "population": 75,
       "value": 1064661.28,
@@ -2609,6 +2895,7 @@
     {
       "name": "COMUNE DI CALASCIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80007890660",
       "population": 125,
       "value": 1774174.89,
@@ -2617,6 +2904,7 @@
     {
       "name": "COMUNE DI CARPINETO DELLA NORA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "80001250689",
       "population": 521,
       "value": 7278710.95,
@@ -2625,6 +2913,7 @@
     {
       "name": "COMUNE DI PIETRAPORZIO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80002350041",
       "population": 68,
       "value": 948940.87,
@@ -2633,6 +2922,7 @@
     {
       "name": "COMUNE DI MONTEBELLO SUL SANGRO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81001740695",
       "population": 87,
       "value": 1213056.05,
@@ -2641,6 +2931,7 @@
     {
       "name": "COMUNE DI CANNA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "81000970780",
       "population": 610,
       "value": 8474098.98,
@@ -2649,6 +2940,7 @@
     {
       "name": "COMUNE DI CRISSOLO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "85000690041",
       "population": 148,
       "value": 2048552.82,
@@ -2657,6 +2949,7 @@
     {
       "name": "COMUNE DI SESTRIERE",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01139410011",
       "population": 901,
       "value": 12412113.78,
@@ -2665,6 +2958,7 @@
     {
       "name": "COMUNE DI PIEDICAVALLO",
       "region": "Piemonte",
+      "province": "Biella",
       "codiceFiscale": "00390570026",
       "population": 170,
       "value": 2337187.99,
@@ -2673,6 +2967,7 @@
     {
       "name": "COMUNE DI RIMELLA",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82001890027",
       "population": 133,
       "value": 1817060.2,
@@ -2681,6 +2976,7 @@
     {
       "name": "COMUNE DI CARREGA LIGURE",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "92003030068",
       "population": 82,
       "value": 1111918.71,
@@ -2689,6 +2985,7 @@
     {
       "name": "COMUNE DI GRESSONEY-LA-TRINITE'",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00109710079",
       "population": 320,
       "value": 4312192.75,
@@ -2697,6 +2994,7 @@
     {
       "name": "COMUNE DI POLLICA",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "84001230659",
       "population": 2135,
       "value": 28290001.59,
@@ -2705,6 +3003,7 @@
     {
       "name": "COMUNE DI MONASTEROLO CASOTTO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00460700040",
       "population": 81,
       "value": 1071238.98,
@@ -2713,6 +3012,7 @@
     {
       "name": "COMUNE DI COLLOBIANO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "80002710020",
       "population": 74,
       "value": 971416.96,
@@ -2726,13 +3026,13 @@
     "ipaUrl": "https://indicepa.gov.it/ipa-dati/dataset/502ff370-1b2c-4310-94c7-f39ceb7500e3/resource/3ed63523-ff9c-41f6-a6fe-980f3d9e501f/download/amministrazioni.txt",
     "siopeMovementsLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",
     "siopeRegistryLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",
-    "ipaLastModified": "Thu, 20 Aug 2026 03:13:24 GMT",
-    "observedAt": "2026-08-20T20:10:36+00:00"
+    "ipaLastModified": "Fri, 21 Aug 2026 03:14:18 GMT",
+    "observedAt": "2026-08-21T11:30:50+00:00"
   },
   "methodology": {
     "measure": "pagamenti di cassa SIOPE dei Comuni",
     "periodicity": "movimenti mensili puri, sommati da gennaio all'ultimo mese disponibile",
-    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA",
+    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA; Provincia pubblicata nell'anagrafica enti SIOPE",
     "populationSource": "popolazione riportata nell'anagrafica enti SIOPE",
     "populationReference": "data di riferimento non dichiarata dalla fonte",
     "populationSourceLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",

--- a/src/data/generated/siope-municipal-2025.json
+++ b/src/data/generated/siope-municipal-2025.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 2,
-  "generatedAt": "2026-08-20T20:08:30+00:00",
+  "schemaVersion": 3,
+  "generatedAt": "2026-08-21T11:35:15+00:00",
   "scope": "municipalities",
   "year": 2025,
   "latestMonth": 12,
@@ -317,6 +317,7 @@
     {
       "name": "ROMA CAPITALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02438750586",
       "population": 2751747,
       "value": 7912216920.96,
@@ -325,6 +326,7 @@
     {
       "name": "COMUNE DI MILANO",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "01199250158",
       "population": 1371499,
       "value": 4484047568.47,
@@ -333,6 +335,7 @@
     {
       "name": "COMUNE DI NAPOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80014890638",
       "population": 913704,
       "value": 1974890842.15,
@@ -341,6 +344,7 @@
     {
       "name": "COMUNE DI TORINO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "00514490010",
       "population": 851199,
       "value": 1825035843.95,
@@ -349,6 +353,7 @@
     {
       "name": "COMUNE DI GENOVA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00856930102",
       "population": 562422,
       "value": 1632103818.64,
@@ -357,6 +362,7 @@
     {
       "name": "COMUNE DI CATANIA",
       "region": "Sicilia",
+      "province": "Catania",
       "codiceFiscale": "00137020871",
       "population": 298680,
       "value": 1243422297.36,
@@ -365,6 +371,7 @@
     {
       "name": "COMUNE DI FIRENZE",
       "region": "Toscana",
+      "province": "Firenze",
       "codiceFiscale": "01307110484",
       "population": 362613,
       "value": 1195937594.82,
@@ -373,6 +380,7 @@
     {
       "name": "COMUNE DI BOLOGNA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "01232710374",
       "population": 390098,
       "value": 1190197904.47,
@@ -381,6 +389,7 @@
     {
       "name": "COMUNE DI VENEZIA",
       "region": "Veneto",
+      "province": "Venezia",
       "codiceFiscale": "00339370272",
       "population": 250290,
       "value": 1093939112.17,
@@ -389,6 +398,7 @@
     {
       "name": "COMUNE DI PALERMO",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "80016350821",
       "population": 630427,
       "value": 912885322.32,
@@ -397,6 +407,7 @@
     {
       "name": "COMUNE DI MESSINA",
       "region": "Sicilia",
+      "province": "Messina",
       "codiceFiscale": "00080270838",
       "population": 217959,
       "value": 843819759.22,
@@ -405,6 +416,7 @@
     {
       "name": "COMUNE DI BARI",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "80015010723",
       "population": 316226,
       "value": 596028400.75,
@@ -413,6 +425,7 @@
     {
       "name": "COMUNE DI TRIESTE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Trieste",
       "codiceFiscale": "00210240321",
       "population": 198843,
       "value": 579467755.98,
@@ -421,6 +434,7 @@
     {
       "name": "COMUNE DI PADOVA",
       "region": "Veneto",
+      "province": "Padova",
       "codiceFiscale": "00644060287",
       "population": 207502,
       "value": 484306736.74,
@@ -429,6 +443,7 @@
     {
       "name": "COMUNE DI BRESCIA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00761890177",
       "population": 198259,
       "value": 482810041.45,
@@ -437,6 +452,7 @@
     {
       "name": "COMUNE DI VERONA",
       "region": "Veneto",
+      "province": "Verona",
       "codiceFiscale": "00215150236",
       "population": 255298,
       "value": 459109122.18,
@@ -445,6 +461,7 @@
     {
       "name": "COMUNE DI CAGLIARI",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00147990923",
       "population": 147411,
       "value": 433593529.13,
@@ -453,6 +470,7 @@
     {
       "name": "COMUNE DI L'AQUILA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002270660",
       "population": 69717,
       "value": 427629896.75,
@@ -461,6 +479,7 @@
     {
       "name": "COMUNE DI BERGAMO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "80034840167",
       "population": 120157,
       "value": 377739458.69,
@@ -469,6 +488,7 @@
     {
       "name": "COMUNE DI BOLZANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00389240219",
       "population": 106357,
       "value": 373659470.28,
@@ -477,6 +497,7 @@
     {
       "name": "COMUNE DI MODENA",
       "region": "Emilia-Romagna",
+      "province": "Modena",
       "codiceFiscale": "00221940364",
       "population": 184597,
       "value": 367333886.87,
@@ -485,6 +506,7 @@
     {
       "name": "COMUNE DI TARANTO",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80008750731",
       "population": 187025,
       "value": 356539395.36,
@@ -493,6 +515,7 @@
     {
       "name": "COMUNE DI PARMA",
       "region": "Emilia-Romagna",
+      "province": "Parma",
       "codiceFiscale": "00162210348",
       "population": 198121,
       "value": 330210968.38,
@@ -501,6 +524,7 @@
     {
       "name": "COMUNE DI RIMINI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00304260409",
       "population": 150046,
       "value": 313677657.68,
@@ -509,6 +533,7 @@
     {
       "name": "COMUNE DI REGGIO DI CALABRIA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "00136380805",
       "population": 169679,
       "value": 312890600.94,
@@ -517,6 +542,7 @@
     {
       "name": "COMUNE DI COSENZA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00347720781",
       "population": 63701,
       "value": 293661381.27,
@@ -525,6 +551,7 @@
     {
       "name": "COMUNE DI PERUGIA",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00163570542",
       "population": 162099,
       "value": 285343206.12,
@@ -533,6 +560,7 @@
     {
       "name": "COMUNE DI TRENTO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00355870221",
       "population": 118504,
       "value": 283605629.69,
@@ -541,6 +569,7 @@
     {
       "name": "COMUNE DI SALERNO",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "80000330656",
       "population": 126715,
       "value": 275527092.79,
@@ -549,6 +578,7 @@
     {
       "name": "COMUNE DI LIVORNO",
       "region": "Toscana",
+      "province": "Livorno",
       "codiceFiscale": "00104330493",
       "population": 153418,
       "value": 274344274.46,
@@ -557,6 +587,7 @@
     {
       "name": "COMUNE DI PRATO",
       "region": "Toscana",
+      "province": "Prato",
       "codiceFiscale": "84006890481",
       "population": 197088,
       "value": 273844964.43,
@@ -565,6 +596,7 @@
     {
       "name": "COMUNE DI RAVENNA",
       "region": "Emilia-Romagna",
+      "province": "Ravenna",
       "codiceFiscale": "00354730392",
       "population": 156304,
       "value": 265078438.68,
@@ -573,6 +605,7 @@
     {
       "name": "COMUNE DI REGGIO NELL'EMILIA",
       "region": "Emilia-Romagna",
+      "province": "Reggio nell'Emilia",
       "codiceFiscale": "00145920351",
       "population": 171207,
       "value": 264386706.13,
@@ -581,6 +614,7 @@
     {
       "name": "COMUNE DI UDINE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "00168650307",
       "population": 98304,
       "value": 261669105.12,
@@ -589,6 +623,7 @@
     {
       "name": "COMUNE DI ALESSANDRIA",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "00429440068",
       "population": 91854,
       "value": 242846833.6,
@@ -597,6 +632,7 @@
     {
       "name": "COMUNE DI CATANZARO",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00129520797",
       "population": 84109,
       "value": 235458694.0,
@@ -605,6 +641,7 @@
     {
       "name": "COMUNE DI SASSARI",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00239740905",
       "population": 121085,
       "value": 225771036.93,
@@ -613,6 +650,7 @@
     {
       "name": "COMUNE DI FERRARA",
       "region": "Emilia-Romagna",
+      "province": "Ferrara",
       "codiceFiscale": "00297110389",
       "population": 129391,
       "value": 220758160.54,
@@ -621,6 +659,7 @@
     {
       "name": "COMUNE DI PESCARA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "00124600685",
       "population": 118461,
       "value": 211536799.45,
@@ -629,6 +668,7 @@
     {
       "name": "COMUNE DI PISA",
       "region": "Toscana",
+      "province": "Pisa",
       "codiceFiscale": "00341620508",
       "population": 89117,
       "value": 210943233.65,
@@ -637,6 +677,7 @@
     {
       "name": "COMUNE DI ANCONA",
       "region": "Marche",
+      "province": "Ancona",
       "codiceFiscale": "00351040423",
       "population": 99377,
       "value": 210729258.34,
@@ -645,6 +686,7 @@
     {
       "name": "COMUNE DI RICCIONE",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00324360403",
       "population": 34465,
       "value": 209745868.27,
@@ -653,6 +695,7 @@
     {
       "name": "COMUNE DI MONZA",
       "region": "Lombardia",
+      "province": "MONZA - BRIANZA",
       "codiceFiscale": "02030880153",
       "population": 122883,
       "value": 206929880.4,
@@ -661,6 +704,7 @@
     {
       "name": "COMUNE DI FOGGIA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "00363460718",
       "population": 145652,
       "value": 205350480.5,
@@ -669,6 +713,7 @@
     {
       "name": "COMUNE DI ASCOLI PICENO",
       "region": "Marche",
+      "province": "Ascoli Piceno",
       "codiceFiscale": "00229010442",
       "population": 45448,
       "value": 201683299.03,
@@ -677,6 +722,7 @@
     {
       "name": "COMUNE DI PIACENZA",
       "region": "Emilia-Romagna",
+      "province": "Piacenza",
       "codiceFiscale": "00229080338",
       "population": 102887,
       "value": 201174652.0,
@@ -685,6 +731,7 @@
     {
       "name": "COMUNE DI VICENZA",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00516890241",
       "population": 110299,
       "value": 195400443.31,
@@ -693,6 +740,7 @@
     {
       "name": "COMUNE DI CORIGLIANO-ROSSANO",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "03557570789",
       "population": 74268,
       "value": 191756773.48,
@@ -701,6 +749,7 @@
     {
       "name": "COMUNE DI PORDENONE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Pordenone",
       "codiceFiscale": "80002150938",
       "population": 52147,
       "value": 187615039.75,
@@ -709,6 +758,7 @@
     {
       "name": "COMUNE DI PESARO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00272430414",
       "population": 95392,
       "value": 186563407.9,
@@ -717,6 +767,7 @@
     {
       "name": "COMUNE DI FORLI'",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00606620409",
       "population": 117050,
       "value": 184862872.74,
@@ -725,6 +776,7 @@
     {
       "name": "COMUNE DI NOVARA",
       "region": "Piemonte",
+      "province": "Novara",
       "codiceFiscale": "00125680033",
       "population": 102187,
       "value": 180626575.96,
@@ -733,6 +785,7 @@
     {
       "name": "COMUNE DI LECCE",
       "region": "Puglia",
+      "province": "Lecce",
       "codiceFiscale": "80008510754",
       "population": 94250,
       "value": 177890585.5,
@@ -741,6 +794,7 @@
     {
       "name": "COMUNE DI FIUMICINO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "97086740582",
       "population": 82481,
       "value": 174928977.17,
@@ -749,6 +803,7 @@
     {
       "name": "COMUNE DI MACERATA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "80001650433",
       "population": 40538,
       "value": 174812406.71,
@@ -757,6 +812,7 @@
     {
       "name": "COMUNE DI POMEZIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02298490588",
       "population": 64451,
       "value": 174123818.85,
@@ -765,6 +821,7 @@
     {
       "name": "COMUNE DI SIRACUSA",
       "region": "Sicilia",
+      "province": "Siracusa",
       "codiceFiscale": "80001010893",
       "population": 116247,
       "value": 165898005.57,
@@ -773,6 +830,7 @@
     {
       "name": "COMUNE DI POZZUOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "00508900636",
       "population": 76255,
       "value": 157636529.76,
@@ -781,6 +839,7 @@
     {
       "name": "COMUNE DI PISTOIA",
       "region": "Toscana",
+      "province": "Pistoia",
       "codiceFiscale": "00108690470",
       "population": 89054,
       "value": 155926492.17,
@@ -789,6 +848,7 @@
     {
       "name": "COMUNE DI TERNI",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00175660554",
       "population": 106436,
       "value": 150995208.1,
@@ -797,6 +857,7 @@
     {
       "name": "COMUNE DI TREVISO",
       "region": "Veneto",
+      "province": "Treviso",
       "codiceFiscale": "80007310263",
       "population": 85322,
       "value": 147896940.13,
@@ -805,6 +866,7 @@
     {
       "name": "COMUNE DI LUCCA",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00378210462",
       "population": 89234,
       "value": 146224816.1,
@@ -813,6 +875,7 @@
     {
       "name": "COMUNE DI LATINA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "00097020598",
       "population": 127859,
       "value": 145494142.62,
@@ -821,6 +884,7 @@
     {
       "name": "COMUNE DI OLBIA",
       "region": "Sardegna",
+      "province": "Gallura Nord-Est Sardegna",
       "codiceFiscale": "91008330903",
       "population": 61481,
       "value": 143461636.81,
@@ -829,6 +893,7 @@
     {
       "name": "COMUNE DI CESENA",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00143280402",
       "population": 96066,
       "value": 143447581.28,
@@ -837,6 +902,7 @@
     {
       "name": "COMUNE DI LA SPEZIA",
       "region": "Liguria",
+      "province": "La Spezia",
       "codiceFiscale": "00211160114",
       "population": 92696,
       "value": 141877787.82,
@@ -845,6 +911,7 @@
     {
       "name": "COMUNE DI RAGUSA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00180270886",
       "population": 73736,
       "value": 141638458.34,
@@ -853,6 +920,7 @@
     {
       "name": "COMUNE DI MODICA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00175500883",
       "population": 53485,
       "value": 140311045.59,
@@ -861,6 +929,7 @@
     {
       "name": "COMUNE DI VARESE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00441340122",
       "population": 78818,
       "value": 137597795.2,
@@ -869,6 +938,7 @@
     {
       "name": "COMUNE DI VIAREGGIO",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00274950468",
       "population": 60755,
       "value": 137146316.9,
@@ -877,6 +947,7 @@
     {
       "name": "COMUNE DI BRINDISI",
       "region": "Puglia",
+      "province": "Brindisi",
       "codiceFiscale": "80000250748",
       "population": 82298,
       "value": 136947607.67,
@@ -885,6 +956,7 @@
     {
       "name": "COMUNE DI AREZZO",
       "region": "Toscana",
+      "province": "Arezzo",
       "codiceFiscale": "00176820512",
       "population": 96330,
       "value": 136228379.15,
@@ -893,6 +965,7 @@
     {
       "name": "COMUNE DI SANREMO",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00253750087",
       "population": 52992,
       "value": 135869806.14,
@@ -901,6 +974,7 @@
     {
       "name": "COMUNE DI COMO",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80005370137",
       "population": 83586,
       "value": 134515872.78,
@@ -909,6 +983,7 @@
     {
       "name": "COMUNE DI APRILIA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "80003450592",
       "population": 74470,
       "value": 134345446.07,
@@ -917,6 +992,7 @@
     {
       "name": "COMUNE DI SIENA",
       "region": "Toscana",
+      "province": "Siena",
       "codiceFiscale": "00050800523",
       "population": 52833,
       "value": 133217421.66,
@@ -925,6 +1001,7 @@
     {
       "name": "COMUNE DI TIVOLI",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02696630587",
       "population": 55061,
       "value": 131872859.15,
@@ -933,6 +1010,7 @@
     {
       "name": "COMUNE DI BUSTO ARSIZIO",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00224000125",
       "population": 83372,
       "value": 130836796.72,
@@ -941,6 +1019,7 @@
     {
       "name": "COMUNE DI CREMONA",
       "region": "Lombardia",
+      "province": "Cremona",
       "codiceFiscale": "00297960197",
       "population": 70675,
       "value": 128946572.69,
@@ -949,6 +1028,7 @@
     {
       "name": "COMUNE DI CARRARA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00079450458",
       "population": 59757,
       "value": 127966606.76,
@@ -957,6 +1037,7 @@
     {
       "name": "COMUNE DI CUNEO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00480530047",
       "population": 55914,
       "value": 124960724.39,
@@ -965,6 +1046,7 @@
     {
       "name": "COMUNE DI BAGHERIA",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "81000170829",
       "population": 53010,
       "value": 124542421.54,
@@ -973,6 +1055,7 @@
     {
       "name": "COMUNE DI ANDRIA",
       "region": "Puglia",
+      "province": "Barletta Andria e Trani",
       "codiceFiscale": "81001210723",
       "population": 96941,
       "value": 124156230.37,
@@ -981,6 +1064,7 @@
     {
       "name": "COMUNE DI SPOLETO",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00316820547",
       "population": 36149,
       "value": 123023612.61,
@@ -989,6 +1073,7 @@
     {
       "name": "COMUNE DI BENEVENTO",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "00074270620",
       "population": 56048,
       "value": 122770867.34,
@@ -997,6 +1082,7 @@
     {
       "name": "COMUNE DI PAVIA",
       "region": "Lombardia",
+      "province": "Pavia",
       "codiceFiscale": "00296180185",
       "population": 71297,
       "value": 120046169.26,
@@ -1005,6 +1091,7 @@
     {
       "name": "COMUNE DI MANTOVA",
       "region": "Lombardia",
+      "province": "Mantova",
       "codiceFiscale": "00189800204",
       "population": 49044,
       "value": 117357883.52,
@@ -1013,6 +1100,7 @@
     {
       "name": "COMUNE DI MASSAFRA",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80009410731",
       "population": 31966,
       "value": 115986112.5,
@@ -1021,6 +1109,7 @@
     {
       "name": "COMUNE DI MASSA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00181760455",
       "population": 65992,
       "value": 115110070.37,
@@ -1029,6 +1118,7 @@
     {
       "name": "COMUNE DI MERANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00394920219",
       "population": 41404,
       "value": 114661657.13,
@@ -1037,6 +1127,7 @@
     {
       "name": "COMUNE DI GORIZIA",
       "region": "Friuli-Venezia Giulia",
+      "province": "Gorizia",
       "codiceFiscale": "00122500317",
       "population": 33608,
       "value": 114354822.45,
@@ -1045,6 +1136,7 @@
     {
       "name": "COMUNE DI FANO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00127440410",
       "population": 59992,
       "value": 114283842.34,
@@ -1053,6 +1145,7 @@
     {
       "name": "COMUNE DI VITERBO",
       "region": "Lazio",
+      "province": "Viterbo",
       "codiceFiscale": "80008850564",
       "population": 66188,
       "value": 114141611.77,
@@ -1061,6 +1154,7 @@
     {
       "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80049220637",
       "population": 124209,
       "value": 113483688.85,
@@ -1069,6 +1163,7 @@
     {
       "name": "COMUNE DI SESTO SAN GIOVANNI",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "02253930156",
       "population": 78495,
       "value": 112979080.51,
@@ -1077,6 +1172,7 @@
     {
       "name": "COMUNE DI QUARTU SANT'ELENA",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00288630924",
       "population": 68509,
       "value": 111259633.22,
@@ -1085,6 +1181,7 @@
     {
       "name": "COMUNE DI GROSSETO",
       "region": "Toscana",
+      "province": "Grosseto",
       "codiceFiscale": "00082520537",
       "population": 81482,
       "value": 111106481.52,
@@ -1093,6 +1190,7 @@
     {
       "name": "COMUNE DI SANTA MARIA CAPUA VETERE",
       "region": "Campania",
+      "province": "Caserta",
       "codiceFiscale": "00136270618",
       "population": 32122,
       "value": 109712053.38,
@@ -1101,6 +1199,7 @@
     {
       "name": "COMUNE DI AVELLINO",
       "region": "Campania",
+      "province": "Avellino",
       "codiceFiscale": "00184530640",
       "population": 52121,
       "value": 109123082.71,
@@ -1109,6 +1208,7 @@
     {
       "name": "COMUNE DI NUORO",
       "region": "Sardegna",
+      "province": "Nuoro",
       "codiceFiscale": "00053070918",
       "population": 33622,
       "value": 108268777.9,
@@ -1119,6 +1219,7 @@
     {
       "name": "ROMA CAPITALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02438750586",
       "population": 2751747,
       "value": 7912216920.96,
@@ -1127,6 +1228,7 @@
     {
       "name": "COMUNE DI MILANO",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "01199250158",
       "population": 1371499,
       "value": 4484047568.47,
@@ -1135,6 +1237,7 @@
     {
       "name": "COMUNE DI NAPOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80014890638",
       "population": 913704,
       "value": 1974890842.15,
@@ -1143,6 +1246,7 @@
     {
       "name": "COMUNE DI TORINO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "00514490010",
       "population": 851199,
       "value": 1825035843.95,
@@ -1151,6 +1255,7 @@
     {
       "name": "COMUNE DI GENOVA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00856930102",
       "population": 562422,
       "value": 1632103818.64,
@@ -1159,6 +1264,7 @@
     {
       "name": "COMUNE DI CATANIA",
       "region": "Sicilia",
+      "province": "Catania",
       "codiceFiscale": "00137020871",
       "population": 298680,
       "value": 1243422297.36,
@@ -1167,6 +1273,7 @@
     {
       "name": "COMUNE DI FIRENZE",
       "region": "Toscana",
+      "province": "Firenze",
       "codiceFiscale": "01307110484",
       "population": 362613,
       "value": 1195937594.82,
@@ -1175,6 +1282,7 @@
     {
       "name": "COMUNE DI BOLOGNA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "01232710374",
       "population": 390098,
       "value": 1190197904.47,
@@ -1183,6 +1291,7 @@
     {
       "name": "COMUNE DI VENEZIA",
       "region": "Veneto",
+      "province": "Venezia",
       "codiceFiscale": "00339370272",
       "population": 250290,
       "value": 1093939112.17,
@@ -1191,6 +1300,7 @@
     {
       "name": "COMUNE DI PALERMO",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "80016350821",
       "population": 630427,
       "value": 912885322.32,
@@ -1199,6 +1309,7 @@
     {
       "name": "COMUNE DI MESSINA",
       "region": "Sicilia",
+      "province": "Messina",
       "codiceFiscale": "00080270838",
       "population": 217959,
       "value": 843819759.22,
@@ -1207,6 +1318,7 @@
     {
       "name": "COMUNE DI BARI",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "80015010723",
       "population": 316226,
       "value": 596028400.75,
@@ -1215,6 +1327,7 @@
     {
       "name": "COMUNE DI TRIESTE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Trieste",
       "codiceFiscale": "00210240321",
       "population": 198843,
       "value": 579467755.98,
@@ -1223,6 +1336,7 @@
     {
       "name": "COMUNE DI PADOVA",
       "region": "Veneto",
+      "province": "Padova",
       "codiceFiscale": "00644060287",
       "population": 207502,
       "value": 484306736.74,
@@ -1231,6 +1345,7 @@
     {
       "name": "COMUNE DI BRESCIA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00761890177",
       "population": 198259,
       "value": 482810041.45,
@@ -1239,6 +1354,7 @@
     {
       "name": "COMUNE DI VERONA",
       "region": "Veneto",
+      "province": "Verona",
       "codiceFiscale": "00215150236",
       "population": 255298,
       "value": 459109122.18,
@@ -1247,6 +1363,7 @@
     {
       "name": "COMUNE DI CAGLIARI",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00147990923",
       "population": 147411,
       "value": 433593529.13,
@@ -1255,6 +1372,7 @@
     {
       "name": "COMUNE DI L'AQUILA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002270660",
       "population": 69717,
       "value": 427629896.75,
@@ -1263,6 +1381,7 @@
     {
       "name": "COMUNE DI BERGAMO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "80034840167",
       "population": 120157,
       "value": 377739458.69,
@@ -1271,6 +1390,7 @@
     {
       "name": "COMUNE DI BOLZANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00389240219",
       "population": 106357,
       "value": 373659470.28,
@@ -1279,6 +1399,7 @@
     {
       "name": "COMUNE DI MODENA",
       "region": "Emilia-Romagna",
+      "province": "Modena",
       "codiceFiscale": "00221940364",
       "population": 184597,
       "value": 367333886.87,
@@ -1287,6 +1408,7 @@
     {
       "name": "COMUNE DI TARANTO",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80008750731",
       "population": 187025,
       "value": 356539395.36,
@@ -1295,6 +1417,7 @@
     {
       "name": "COMUNE DI PARMA",
       "region": "Emilia-Romagna",
+      "province": "Parma",
       "codiceFiscale": "00162210348",
       "population": 198121,
       "value": 330210968.38,
@@ -1303,6 +1426,7 @@
     {
       "name": "COMUNE DI RIMINI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00304260409",
       "population": 150046,
       "value": 313677657.68,
@@ -1311,6 +1435,7 @@
     {
       "name": "COMUNE DI REGGIO DI CALABRIA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "00136380805",
       "population": 169679,
       "value": 312890600.94,
@@ -1319,6 +1444,7 @@
     {
       "name": "COMUNE DI COSENZA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00347720781",
       "population": 63701,
       "value": 293661381.27,
@@ -1327,6 +1453,7 @@
     {
       "name": "COMUNE DI PERUGIA",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00163570542",
       "population": 162099,
       "value": 285343206.12,
@@ -1335,6 +1462,7 @@
     {
       "name": "COMUNE DI TRENTO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00355870221",
       "population": 118504,
       "value": 283605629.69,
@@ -1343,6 +1471,7 @@
     {
       "name": "COMUNE DI SALERNO",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "80000330656",
       "population": 126715,
       "value": 275527092.79,
@@ -1351,6 +1480,7 @@
     {
       "name": "COMUNE DI LIVORNO",
       "region": "Toscana",
+      "province": "Livorno",
       "codiceFiscale": "00104330493",
       "population": 153418,
       "value": 274344274.46,
@@ -1359,6 +1489,7 @@
     {
       "name": "COMUNE DI PRATO",
       "region": "Toscana",
+      "province": "Prato",
       "codiceFiscale": "84006890481",
       "population": 197088,
       "value": 273844964.43,
@@ -1367,6 +1498,7 @@
     {
       "name": "COMUNE DI RAVENNA",
       "region": "Emilia-Romagna",
+      "province": "Ravenna",
       "codiceFiscale": "00354730392",
       "population": 156304,
       "value": 265078438.68,
@@ -1375,6 +1507,7 @@
     {
       "name": "COMUNE DI REGGIO NELL'EMILIA",
       "region": "Emilia-Romagna",
+      "province": "Reggio nell'Emilia",
       "codiceFiscale": "00145920351",
       "population": 171207,
       "value": 264386706.13,
@@ -1383,6 +1516,7 @@
     {
       "name": "COMUNE DI UDINE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "00168650307",
       "population": 98304,
       "value": 261669105.12,
@@ -1391,6 +1525,7 @@
     {
       "name": "COMUNE DI ALESSANDRIA",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "00429440068",
       "population": 91854,
       "value": 242846833.6,
@@ -1399,6 +1534,7 @@
     {
       "name": "COMUNE DI CATANZARO",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00129520797",
       "population": 84109,
       "value": 235458694.0,
@@ -1407,6 +1543,7 @@
     {
       "name": "COMUNE DI SASSARI",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00239740905",
       "population": 121085,
       "value": 225771036.93,
@@ -1415,6 +1552,7 @@
     {
       "name": "COMUNE DI FERRARA",
       "region": "Emilia-Romagna",
+      "province": "Ferrara",
       "codiceFiscale": "00297110389",
       "population": 129391,
       "value": 220758160.54,
@@ -1423,6 +1561,7 @@
     {
       "name": "COMUNE DI PESCARA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "00124600685",
       "population": 118461,
       "value": 211536799.45,
@@ -1431,6 +1570,7 @@
     {
       "name": "COMUNE DI PISA",
       "region": "Toscana",
+      "province": "Pisa",
       "codiceFiscale": "00341620508",
       "population": 89117,
       "value": 210943233.65,
@@ -1439,6 +1579,7 @@
     {
       "name": "COMUNE DI ANCONA",
       "region": "Marche",
+      "province": "Ancona",
       "codiceFiscale": "00351040423",
       "population": 99377,
       "value": 210729258.34,
@@ -1447,6 +1588,7 @@
     {
       "name": "COMUNE DI RICCIONE",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00324360403",
       "population": 34465,
       "value": 209745868.27,
@@ -1455,6 +1597,7 @@
     {
       "name": "COMUNE DI MONZA",
       "region": "Lombardia",
+      "province": "MONZA - BRIANZA",
       "codiceFiscale": "02030880153",
       "population": 122883,
       "value": 206929880.4,
@@ -1463,6 +1606,7 @@
     {
       "name": "COMUNE DI FOGGIA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "00363460718",
       "population": 145652,
       "value": 205350480.5,
@@ -1471,6 +1615,7 @@
     {
       "name": "COMUNE DI ASCOLI PICENO",
       "region": "Marche",
+      "province": "Ascoli Piceno",
       "codiceFiscale": "00229010442",
       "population": 45448,
       "value": 201683299.03,
@@ -1479,6 +1624,7 @@
     {
       "name": "COMUNE DI PIACENZA",
       "region": "Emilia-Romagna",
+      "province": "Piacenza",
       "codiceFiscale": "00229080338",
       "population": 102887,
       "value": 201174652.0,
@@ -1487,6 +1633,7 @@
     {
       "name": "COMUNE DI VICENZA",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00516890241",
       "population": 110299,
       "value": 195400443.31,
@@ -1495,6 +1642,7 @@
     {
       "name": "COMUNE DI CORIGLIANO-ROSSANO",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "03557570789",
       "population": 74268,
       "value": 191756773.48,
@@ -1503,6 +1651,7 @@
     {
       "name": "COMUNE DI PORDENONE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Pordenone",
       "codiceFiscale": "80002150938",
       "population": 52147,
       "value": 187615039.75,
@@ -1511,6 +1660,7 @@
     {
       "name": "COMUNE DI PESARO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00272430414",
       "population": 95392,
       "value": 186563407.9,
@@ -1519,6 +1669,7 @@
     {
       "name": "COMUNE DI FORLI'",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00606620409",
       "population": 117050,
       "value": 184862872.74,
@@ -1527,6 +1678,7 @@
     {
       "name": "COMUNE DI NOVARA",
       "region": "Piemonte",
+      "province": "Novara",
       "codiceFiscale": "00125680033",
       "population": 102187,
       "value": 180626575.96,
@@ -1535,6 +1687,7 @@
     {
       "name": "COMUNE DI LECCE",
       "region": "Puglia",
+      "province": "Lecce",
       "codiceFiscale": "80008510754",
       "population": 94250,
       "value": 177890585.5,
@@ -1543,6 +1696,7 @@
     {
       "name": "COMUNE DI FIUMICINO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "97086740582",
       "population": 82481,
       "value": 174928977.17,
@@ -1551,6 +1705,7 @@
     {
       "name": "COMUNE DI MACERATA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "80001650433",
       "population": 40538,
       "value": 174812406.71,
@@ -1559,6 +1714,7 @@
     {
       "name": "COMUNE DI POMEZIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02298490588",
       "population": 64451,
       "value": 174123818.85,
@@ -1567,6 +1723,7 @@
     {
       "name": "COMUNE DI SIRACUSA",
       "region": "Sicilia",
+      "province": "Siracusa",
       "codiceFiscale": "80001010893",
       "population": 116247,
       "value": 165898005.57,
@@ -1575,6 +1732,7 @@
     {
       "name": "COMUNE DI POZZUOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "00508900636",
       "population": 76255,
       "value": 157636529.76,
@@ -1583,6 +1741,7 @@
     {
       "name": "COMUNE DI PISTOIA",
       "region": "Toscana",
+      "province": "Pistoia",
       "codiceFiscale": "00108690470",
       "population": 89054,
       "value": 155926492.17,
@@ -1591,6 +1750,7 @@
     {
       "name": "COMUNE DI TERNI",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00175660554",
       "population": 106436,
       "value": 150995208.1,
@@ -1599,6 +1759,7 @@
     {
       "name": "COMUNE DI TREVISO",
       "region": "Veneto",
+      "province": "Treviso",
       "codiceFiscale": "80007310263",
       "population": 85322,
       "value": 147896940.13,
@@ -1607,6 +1768,7 @@
     {
       "name": "COMUNE DI LUCCA",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00378210462",
       "population": 89234,
       "value": 146224816.1,
@@ -1615,6 +1777,7 @@
     {
       "name": "COMUNE DI LATINA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "00097020598",
       "population": 127859,
       "value": 145494142.62,
@@ -1623,6 +1786,7 @@
     {
       "name": "COMUNE DI OLBIA",
       "region": "Sardegna",
+      "province": "Gallura Nord-Est Sardegna",
       "codiceFiscale": "91008330903",
       "population": 61481,
       "value": 143461636.81,
@@ -1631,6 +1795,7 @@
     {
       "name": "COMUNE DI CESENA",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00143280402",
       "population": 96066,
       "value": 143447581.28,
@@ -1639,6 +1804,7 @@
     {
       "name": "COMUNE DI LA SPEZIA",
       "region": "Liguria",
+      "province": "La Spezia",
       "codiceFiscale": "00211160114",
       "population": 92696,
       "value": 141877787.82,
@@ -1647,6 +1813,7 @@
     {
       "name": "COMUNE DI RAGUSA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00180270886",
       "population": 73736,
       "value": 141638458.34,
@@ -1655,6 +1822,7 @@
     {
       "name": "COMUNE DI MODICA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00175500883",
       "population": 53485,
       "value": 140311045.59,
@@ -1663,6 +1831,7 @@
     {
       "name": "COMUNE DI VARESE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00441340122",
       "population": 78818,
       "value": 137597795.2,
@@ -1671,6 +1840,7 @@
     {
       "name": "COMUNE DI VIAREGGIO",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00274950468",
       "population": 60755,
       "value": 137146316.9,
@@ -1679,6 +1849,7 @@
     {
       "name": "COMUNE DI BRINDISI",
       "region": "Puglia",
+      "province": "Brindisi",
       "codiceFiscale": "80000250748",
       "population": 82298,
       "value": 136947607.67,
@@ -1687,6 +1858,7 @@
     {
       "name": "COMUNE DI AREZZO",
       "region": "Toscana",
+      "province": "Arezzo",
       "codiceFiscale": "00176820512",
       "population": 96330,
       "value": 136228379.15,
@@ -1695,6 +1867,7 @@
     {
       "name": "COMUNE DI SANREMO",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00253750087",
       "population": 52992,
       "value": 135869806.14,
@@ -1703,6 +1876,7 @@
     {
       "name": "COMUNE DI COMO",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80005370137",
       "population": 83586,
       "value": 134515872.78,
@@ -1711,6 +1885,7 @@
     {
       "name": "COMUNE DI APRILIA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "80003450592",
       "population": 74470,
       "value": 134345446.07,
@@ -1719,6 +1894,7 @@
     {
       "name": "COMUNE DI SIENA",
       "region": "Toscana",
+      "province": "Siena",
       "codiceFiscale": "00050800523",
       "population": 52833,
       "value": 133217421.66,
@@ -1727,6 +1903,7 @@
     {
       "name": "COMUNE DI TIVOLI",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02696630587",
       "population": 55061,
       "value": 131872859.15,
@@ -1735,6 +1912,7 @@
     {
       "name": "COMUNE DI BUSTO ARSIZIO",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00224000125",
       "population": 83372,
       "value": 130836796.72,
@@ -1743,6 +1921,7 @@
     {
       "name": "COMUNE DI CREMONA",
       "region": "Lombardia",
+      "province": "Cremona",
       "codiceFiscale": "00297960197",
       "population": 70675,
       "value": 128946572.69,
@@ -1751,6 +1930,7 @@
     {
       "name": "COMUNE DI CARRARA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00079450458",
       "population": 59757,
       "value": 127966606.76,
@@ -1759,6 +1939,7 @@
     {
       "name": "COMUNE DI CUNEO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00480530047",
       "population": 55914,
       "value": 124960724.39,
@@ -1767,6 +1948,7 @@
     {
       "name": "COMUNE DI BAGHERIA",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "81000170829",
       "population": 53010,
       "value": 124542421.54,
@@ -1775,6 +1957,7 @@
     {
       "name": "COMUNE DI ANDRIA",
       "region": "Puglia",
+      "province": "Barletta Andria e Trani",
       "codiceFiscale": "81001210723",
       "population": 96941,
       "value": 124156230.37,
@@ -1783,6 +1966,7 @@
     {
       "name": "COMUNE DI SPOLETO",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00316820547",
       "population": 36149,
       "value": 123023612.61,
@@ -1791,6 +1975,7 @@
     {
       "name": "COMUNE DI BENEVENTO",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "00074270620",
       "population": 56048,
       "value": 122770867.34,
@@ -1799,6 +1984,7 @@
     {
       "name": "COMUNE DI PAVIA",
       "region": "Lombardia",
+      "province": "Pavia",
       "codiceFiscale": "00296180185",
       "population": 71297,
       "value": 120046169.26,
@@ -1807,6 +1993,7 @@
     {
       "name": "COMUNE DI MANTOVA",
       "region": "Lombardia",
+      "province": "Mantova",
       "codiceFiscale": "00189800204",
       "population": 49044,
       "value": 117357883.52,
@@ -1815,6 +2002,7 @@
     {
       "name": "COMUNE DI MASSAFRA",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80009410731",
       "population": 31966,
       "value": 115986112.5,
@@ -1823,6 +2011,7 @@
     {
       "name": "COMUNE DI MASSA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00181760455",
       "population": 65992,
       "value": 115110070.37,
@@ -1831,6 +2020,7 @@
     {
       "name": "COMUNE DI MERANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00394920219",
       "population": 41404,
       "value": 114661657.13,
@@ -1839,6 +2029,7 @@
     {
       "name": "COMUNE DI GORIZIA",
       "region": "Friuli-Venezia Giulia",
+      "province": "Gorizia",
       "codiceFiscale": "00122500317",
       "population": 33608,
       "value": 114354822.45,
@@ -1847,6 +2038,7 @@
     {
       "name": "COMUNE DI FANO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00127440410",
       "population": 59992,
       "value": 114283842.34,
@@ -1855,6 +2047,7 @@
     {
       "name": "COMUNE DI VITERBO",
       "region": "Lazio",
+      "province": "Viterbo",
       "codiceFiscale": "80008850564",
       "population": 66188,
       "value": 114141611.77,
@@ -1863,6 +2056,7 @@
     {
       "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80049220637",
       "population": 124209,
       "value": 113483688.85,
@@ -1871,6 +2065,7 @@
     {
       "name": "COMUNE DI SESTO SAN GIOVANNI",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "02253930156",
       "population": 78495,
       "value": 112979080.51,
@@ -1879,6 +2074,7 @@
     {
       "name": "COMUNE DI QUARTU SANT'ELENA",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00288630924",
       "population": 68509,
       "value": 111259633.22,
@@ -1887,6 +2083,7 @@
     {
       "name": "COMUNE DI GROSSETO",
       "region": "Toscana",
+      "province": "Grosseto",
       "codiceFiscale": "00082520537",
       "population": 81482,
       "value": 111106481.52,
@@ -1895,6 +2092,7 @@
     {
       "name": "COMUNE DI SANTA MARIA CAPUA VETERE",
       "region": "Campania",
+      "province": "Caserta",
       "codiceFiscale": "00136270618",
       "population": 32122,
       "value": 109712053.38,
@@ -1903,6 +2101,7 @@
     {
       "name": "COMUNE DI AVELLINO",
       "region": "Campania",
+      "province": "Avellino",
       "codiceFiscale": "00184530640",
       "population": 52121,
       "value": 109123082.71,
@@ -1911,6 +2110,7 @@
     {
       "name": "COMUNE DI NUORO",
       "region": "Sardegna",
+      "province": "Nuoro",
       "codiceFiscale": "00053070918",
       "population": 33622,
       "value": 108268777.9,
@@ -1921,6 +2121,7 @@
     {
       "name": "COMUNE DI BEMA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00090830142",
       "population": 114,
       "value": 16167022.93,
@@ -1929,6 +2130,7 @@
     {
       "name": "COMUNE DI ELVA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80004570042",
       "population": 78,
       "value": 6567622.91,
@@ -1937,6 +2139,7 @@
     {
       "name": "COMUNE DI VILLA SANTA LUCIA DEGLI ABRUZZI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00193560661",
       "population": 88,
       "value": 6259669.6,
@@ -1945,6 +2148,7 @@
     {
       "name": "COMUNE DI MONTELAPIANO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81002650695",
       "population": 69,
       "value": 4141701.63,
@@ -1953,6 +2157,7 @@
     {
       "name": "COMUNE DI SAN BENEDETTO IN PERILLIS",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00219500667",
       "population": 98,
       "value": 4985202.62,
@@ -1961,6 +2166,7 @@
     {
       "name": "COMUNE DI SANTO STEFANO DI SESSANIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00173470667",
       "population": 110,
       "value": 4868248.54,
@@ -1969,6 +2175,7 @@
     {
       "name": "COMUNE DI RHEMES-NOTRE-DAME",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00138020078",
       "population": 76,
       "value": 3312740.64,
@@ -1977,6 +2184,7 @@
     {
       "name": "COMUNE DI BOLOGNOLA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000910430",
       "population": 147,
       "value": 6094408.07,
@@ -1985,6 +2193,7 @@
     {
       "name": "COMUNE DI VALLEVE",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00637290164",
       "population": 126,
       "value": 4492556.21,
@@ -1993,6 +2202,7 @@
     {
       "name": "COMUNE DI FAGNANO ALTO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00193030665",
       "population": 351,
       "value": 12285775.36,
@@ -2001,6 +2211,7 @@
     {
       "name": "COMUNE DI CARAPELLE CALVISIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197710668",
       "population": 78,
       "value": 2718447.14,
@@ -2009,6 +2220,7 @@
     {
       "name": "COMUNE DI CALASCIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80007890660",
       "population": 125,
       "value": 3938112.68,
@@ -2017,6 +2229,7 @@
     {
       "name": "COMUNE DI CAPORCIANO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00187590666",
       "population": 201,
       "value": 6198600.13,
@@ -2025,6 +2238,7 @@
     {
       "name": "COMUNE DI ROSELLO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81002970697",
       "population": 166,
       "value": 5069876.92,
@@ -2033,6 +2247,7 @@
     {
       "name": "COMUNE DI CHAMOIS",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "81002610079",
       "population": 108,
       "value": 3168004.35,
@@ -2041,6 +2256,7 @@
     {
       "name": "COMUNE DI BRIGA ALTA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00553180043",
       "population": 41,
       "value": 1197998.94,
@@ -2049,6 +2265,7 @@
     {
       "name": "COMUNE DI ARGENTERA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80003430040",
       "population": 80,
       "value": 2307243.97,
@@ -2057,6 +2274,7 @@
     {
       "name": "COMUNE DI MONCENISIO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01021740012",
       "population": 49,
       "value": 1357001.0,
@@ -2065,6 +2283,7 @@
     {
       "name": "COMUNE DI MONTEGROSSO PIAN LATTE",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00246350086",
       "population": 111,
       "value": 3067161.28,
@@ -2073,6 +2292,7 @@
     {
       "name": "COMUNE DI FONTECCHIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00189210669",
       "population": 286,
       "value": 7728464.5,
@@ -2081,6 +2301,7 @@
     {
       "name": "COMUNE DI SARACINESCO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "86001790582",
       "population": 172,
       "value": 4616656.45,
@@ -2089,6 +2310,7 @@
     {
       "name": "COMUNE DI MONTE CAVALLO",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000130435",
       "population": 103,
       "value": 2763782.45,
@@ -2097,6 +2319,7 @@
     {
       "name": "COMUNE DI GAGLIANO ATERNO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00212360663",
       "population": 225,
       "value": 5885817.51,
@@ -2105,6 +2328,7 @@
     {
       "name": "COMUNE DI BLELLO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00707790168",
       "population": 74,
       "value": 1916931.36,
@@ -2113,6 +2337,7 @@
     {
       "name": "COMUNE DI PORTOFINO",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00826220105",
       "population": 358,
       "value": 8983939.7,
@@ -2121,6 +2346,7 @@
     {
       "name": "COMUNE DI FOSSA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80001770660",
       "population": 658,
       "value": 16360265.51,
@@ -2129,6 +2355,7 @@
     {
       "name": "COMUNE DI CARCOFORO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82000610020",
       "population": 75,
       "value": 1835638.61,
@@ -2137,6 +2364,7 @@
     {
       "name": "COMUNE DI CASTELMAGNO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478910045",
       "population": 55,
       "value": 1329609.0,
@@ -2145,6 +2373,7 @@
     {
       "name": "COMUNE DI CASTELSANTANGELO SUL NERA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "00242630432",
       "population": 221,
       "value": 5342247.83,
@@ -2153,6 +2382,7 @@
     {
       "name": "COMUNE DI SANT'EUSANIO FORCONESE",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002610667",
       "population": 365,
       "value": 8779112.04,
@@ -2161,6 +2391,7 @@
     {
       "name": "COMUNE DI CASTELVECCHIO CALVISIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197730666",
       "population": 120,
       "value": 2865742.28,
@@ -2169,6 +2400,7 @@
     {
       "name": "COMUNE DI ACCIANO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "83003750664",
       "population": 256,
       "value": 6059034.75,
@@ -2177,6 +2409,7 @@
     {
       "name": "COMUNE DI VALSAVARENCHE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00124870072",
       "population": 154,
       "value": 3538036.68,
@@ -2185,6 +2418,7 @@
     {
       "name": "COMUNE DI PIETRACAMELA",
       "region": "Abruzzo",
+      "province": "Teramo",
       "codiceFiscale": "80005250677",
       "population": 207,
       "value": 4733740.94,
@@ -2193,6 +2427,7 @@
     {
       "name": "COMUNE DI GRESSONEY-LA-TRINITE'",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00109710079",
       "population": 320,
       "value": 7308147.81,
@@ -2201,6 +2436,7 @@
     {
       "name": "COMUNE DI GORRETO",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00860910108",
       "population": 92,
       "value": 2096552.61,
@@ -2209,6 +2445,7 @@
     {
       "name": "COMUNE DI TIONE DEGLI ABRUZZI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00189270663",
       "population": 258,
       "value": 5866915.06,
@@ -2217,6 +2454,7 @@
     {
       "name": "COMUNE DI NAVELLI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00188910665",
       "population": 569,
       "value": 12796369.72,
@@ -2225,6 +2463,7 @@
     {
       "name": "COMUNE DI CELLE DI SAN VITO",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "80003290717",
       "population": 148,
       "value": 3278844.48,
@@ -2233,6 +2472,7 @@
     {
       "name": "COMUNE DI CASTEL DEL GIUDICE",
       "region": "Molise",
+      "province": "Isernia",
       "codiceFiscale": "80000990947",
       "population": 305,
       "value": 6698778.16,
@@ -2241,6 +2481,7 @@
     {
       "name": "COMUNE DI CASTELVERRINO",
       "region": "Molise",
+      "province": "Isernia",
       "codiceFiscale": "80002490946",
       "population": 93,
       "value": 2006132.41,
@@ -2249,6 +2490,7 @@
     {
       "name": "COMUNE DI RIBORDONE",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01394590010",
       "population": 52,
       "value": 1107012.02,
@@ -2257,6 +2499,7 @@
     {
       "name": "COMUNE DI OSTANA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00453120040",
       "population": 89,
       "value": 1864296.79,
@@ -2265,6 +2508,7 @@
     {
       "name": "COMUNE DI MICIGLIANO",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00113670574",
       "population": 112,
       "value": 2342917.85,
@@ -2273,6 +2517,7 @@
     {
       "name": "COMUNE DI PANETTIERI",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00391660784",
       "population": 310,
       "value": 6384139.09,
@@ -2281,6 +2526,7 @@
     {
       "name": "COMUNE DI EMARESE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00092580075",
       "population": 225,
       "value": 4595375.02,
@@ -2289,6 +2535,7 @@
     {
       "name": "COMUNE DI SANT'ALESSIO IN ASPROMONTE",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "80003150804",
       "population": 316,
       "value": 6382756.41,
@@ -2297,6 +2544,7 @@
     {
       "name": "COMUNE DI USSITA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81001810431",
       "population": 360,
       "value": 7166904.22,
@@ -2305,6 +2553,7 @@
     {
       "name": "COMUNE DI MONTEFERRANTE",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81001690692",
       "population": 107,
       "value": 2123316.85,
@@ -2313,6 +2562,7 @@
     {
       "name": "COMUNE DI BARADILI",
       "region": "Sardegna",
+      "province": "Oristano",
       "codiceFiscale": "80007220959",
       "population": 80,
       "value": 1586000.34,
@@ -2321,6 +2571,7 @@
     {
       "name": "COMUNE DI BARD",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00093700078",
       "population": 102,
       "value": 1974560.59,
@@ -2329,6 +2580,7 @@
     {
       "name": "COMUNE DI BRITTOLI",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "80001450685",
       "population": 249,
       "value": 4790611.17,
@@ -2337,6 +2589,7 @@
     {
       "name": "COMUNE DI FOPPOLO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00637310160",
       "population": 152,
       "value": 2872158.98,
@@ -2345,6 +2598,7 @@
     {
       "name": "COMUNE DI ROSAZZA",
       "region": "Piemonte",
+      "province": "Biella",
       "codiceFiscale": "00390580025",
       "population": 97,
       "value": 1829553.31,
@@ -2353,6 +2607,7 @@
     {
       "name": "COMUNE DI FORNI AVOLTRI",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "84001050305",
       "population": 501,
       "value": 9414598.93,
@@ -2361,6 +2616,7 @@
     {
       "name": "COMUNE DI PRATA D'ANSIDONIA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00195150669",
       "population": 447,
       "value": 8393629.74,
@@ -2369,6 +2625,7 @@
     {
       "name": "COMUNE DI LUCOLI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00094420668",
       "population": 824,
       "value": 15447741.25,
@@ -2377,6 +2634,7 @@
     {
       "name": "COMUNE DI MASSELLO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "85000150012",
       "population": 57,
       "value": 1061017.19,
@@ -2385,6 +2643,7 @@
     {
       "name": "COMUNE DI MONTELEONE ROCCA DORIA",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00222250904",
       "population": 103,
       "value": 1871513.01,
@@ -2393,6 +2652,7 @@
     {
       "name": "COMUNE DI MARMORA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00483290045",
       "population": 58,
       "value": 1044042.51,
@@ -2401,6 +2661,7 @@
     {
       "name": "COMUNE DI MACRA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478030042",
       "population": 45,
       "value": 794918.46,
@@ -2409,6 +2670,7 @@
     {
       "name": "COMUNE DI SODDI'",
       "region": "Sardegna",
+      "province": "Oristano",
       "codiceFiscale": "80036030957",
       "population": 121,
       "value": 2097153.43,
@@ -2417,6 +2679,7 @@
     {
       "name": "COMUNE DI CARREGA LIGURE",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "92003030068",
       "population": 82,
       "value": 1408407.04,
@@ -2425,6 +2688,7 @@
     {
       "name": "COMUNE DI MOLLIA",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "00433220027",
       "population": 98,
       "value": 1679189.1,
@@ -2433,6 +2697,7 @@
     {
       "name": "COMUNE DI MENDATICA",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00246330088",
       "population": 161,
       "value": 2732529.87,
@@ -2441,6 +2706,7 @@
     {
       "name": "COMUNE DI CAMPORA",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "84000970651",
       "population": 318,
       "value": 5381064.0,
@@ -2449,6 +2715,7 @@
     {
       "name": "COMUNE DI PEDESINA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00098670144",
       "population": 35,
       "value": 590700.26,
@@ -2457,6 +2724,7 @@
     {
       "name": "COMUNE DI SETZU",
       "region": "Sardegna",
+      "province": "Medio Campidano",
       "codiceFiscale": "82001290921",
       "population": 125,
       "value": 2089718.73,
@@ -2465,6 +2733,7 @@
     {
       "name": "COMUNE DI LETTOPALENA",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "00230170698",
       "population": 314,
       "value": 5240658.61,
@@ -2473,6 +2742,7 @@
     {
       "name": "COMUNE DI VALPRATO SOANA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "02216150017",
       "population": 96,
       "value": 1595709.31,
@@ -2481,6 +2751,7 @@
     {
       "name": "COMUNE DI OFENA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80004410660",
       "population": 434,
       "value": 7157369.63,
@@ -2489,6 +2760,7 @@
     {
       "name": "COMUNE DI NOASCA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "83500090010",
       "population": 106,
       "value": 1743400.01,
@@ -2497,6 +2769,7 @@
     {
       "name": "COMUNE DI TADASUNI",
       "region": "Sardegna",
+      "province": "Oristano",
       "codiceFiscale": "00074760950",
       "population": 126,
       "value": 2071306.36,
@@ -2505,6 +2778,7 @@
     {
       "name": "COMUNE DI IGLIANO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "02886900048",
       "population": 66,
       "value": 1083090.46,
@@ -2513,6 +2787,7 @@
     {
       "name": "COMUNE DI ROIO DEL SANGRO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81003010691",
       "population": 97,
       "value": 1585103.99,
@@ -2521,6 +2796,7 @@
     {
       "name": "COMUNE DI LA MAGDELEINE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00096590070",
       "population": 99,
       "value": 1612106.24,
@@ -2529,6 +2805,7 @@
     {
       "name": "COMUNE DI RIMELLA",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82001890027",
       "population": 133,
       "value": 2158223.95,
@@ -2537,6 +2814,7 @@
     {
       "name": "COMUNE DI CANOSIO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00506090042",
       "population": 76,
       "value": 1228812.53,
@@ -2545,6 +2823,7 @@
     {
       "name": "COMUNE DI PALU' DEL FERSINA",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00272300229",
       "population": 158,
       "value": 2535973.06,
@@ -2553,6 +2832,7 @@
     {
       "name": "COMUNE DI SAURIS",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "84001370307",
       "population": 390,
       "value": 6223913.08,
@@ -2561,6 +2841,7 @@
     {
       "name": "COMUNE DI SPRIANA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00091740142",
       "population": 83,
       "value": 1311587.92,
@@ -2569,6 +2850,7 @@
     {
       "name": "COMUNE DI MARTELLO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "82008550210",
       "population": 840,
       "value": 13235808.04,
@@ -2577,6 +2859,7 @@
     {
       "name": "COMUNE DI BERGOLO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00511030041",
       "population": 53,
       "value": 828525.64,
@@ -2585,6 +2868,7 @@
     {
       "name": "COMUNE DI PAISCO LOVENO",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00589400175",
       "population": 167,
       "value": 2607462.59,
@@ -2593,6 +2877,7 @@
     {
       "name": "COMUNE DI CAMPIONE D'ITALIA",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80009700131",
       "population": 1757,
       "value": 27425001.21,
@@ -2601,6 +2886,7 @@
     {
       "name": "COMUNE DI AQUILA D'ARROSCIA",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00246520084",
       "population": 138,
       "value": 2148902.61,
@@ -2609,6 +2895,7 @@
     {
       "name": "COMUNE DI CIVITACAMPOMARANO",
       "region": "Molise",
+      "province": "Campobasso",
       "codiceFiscale": "00067590703",
       "population": 308,
       "value": 4783515.58,
@@ -2617,6 +2904,7 @@
     {
       "name": "COMUNE DI ENTRACQUE",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00507800043",
       "population": 760,
       "value": 11741110.14,
@@ -2625,6 +2913,7 @@
     {
       "name": "COMUNE DI INGRIA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01840350019",
       "population": 46,
       "value": 698003.48,
@@ -2633,6 +2922,7 @@
     {
       "name": "COMUNE DI CANNA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "81000970780",
       "population": 610,
       "value": 9253528.78,
@@ -2641,6 +2931,7 @@
     {
       "name": "COMUNE DI GUARDIA PERTICARA",
       "region": "Basilicata",
+      "province": "Potenza",
       "codiceFiscale": "80005710761",
       "population": 526,
       "value": 7969696.72,
@@ -2649,6 +2940,7 @@
     {
       "name": "COMUNE DI MARCETELLI",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00077920577",
       "population": 57,
       "value": 859393.65,
@@ -2657,6 +2949,7 @@
     {
       "name": "COMUNE DI SAN PIO DELLE CAMERE",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197690662",
       "population": 650,
       "value": 9794997.45,
@@ -2665,6 +2958,7 @@
     {
       "name": "COMUNE DI CERVATTO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82000730026",
       "population": 47,
       "value": 707793.22,
@@ -2673,6 +2967,7 @@
     {
       "name": "COMUNE DI CAMPOTOSTO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00085160661",
       "population": 457,
       "value": 6858344.95,
@@ -2681,6 +2976,7 @@
     {
       "name": "COMUNE DI FANO ADRIANO",
       "region": "Abruzzo",
+      "province": "Teramo",
       "codiceFiscale": "92001400677",
       "population": 262,
       "value": 3890353.78,
@@ -2689,6 +2985,7 @@
     {
       "name": "COMUNE DI GEROLA ALTA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00105780142",
       "population": 165,
       "value": 2447558.73,
@@ -2697,6 +2994,7 @@
     {
       "name": "COMUNE DI CASSIGLIO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "94001130163",
       "population": 104,
       "value": 1541168.0,
@@ -2705,6 +3003,7 @@
     {
       "name": "COMUNE DI MONTEBELLO SUL SANGRO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81001740695",
       "population": 87,
       "value": 1287720.97,
@@ -2713,6 +3012,7 @@
     {
       "name": "COMUNE DI VALGRISENCHE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00101190072",
       "population": 186,
       "value": 2751193.15,
@@ -2726,13 +3026,13 @@
     "ipaUrl": "https://indicepa.gov.it/ipa-dati/dataset/502ff370-1b2c-4310-94c7-f39ceb7500e3/resource/3ed63523-ff9c-41f6-a6fe-980f3d9e501f/download/amministrazioni.txt",
     "siopeMovementsLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",
     "siopeRegistryLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",
-    "ipaLastModified": "Thu, 20 Aug 2026 03:13:24 GMT",
-    "observedAt": "2026-08-20T20:08:30+00:00"
+    "ipaLastModified": "Fri, 21 Aug 2026 03:14:18 GMT",
+    "observedAt": "2026-08-21T11:35:15+00:00"
   },
   "methodology": {
     "measure": "pagamenti di cassa SIOPE dei Comuni",
     "periodicity": "movimenti mensili puri, sommati da gennaio all'ultimo mese disponibile",
-    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA",
+    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA; Provincia pubblicata nell'anagrafica enti SIOPE",
     "populationSource": "popolazione riportata nell'anagrafica enti SIOPE",
     "populationReference": "data di riferimento non dichiarata dalla fonte",
     "populationSourceLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",

--- a/src/data/generated/siope-municipal.json
+++ b/src/data/generated/siope-municipal.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 2,
-  "generatedAt": "2026-08-21T03:31:16+00:00",
+  "schemaVersion": 3,
+  "generatedAt": "2026-08-21T11:34:54+00:00",
   "scope": "municipalities",
   "year": 2026,
   "latestMonth": 8,
@@ -293,6 +293,7 @@
     {
       "name": "ROMA CAPITALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02438750586",
       "population": 2751747,
       "value": 4868753534.45,
@@ -301,6 +302,7 @@
     {
       "name": "COMUNE DI MILANO",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "01199250158",
       "population": 1371499,
       "value": 3139192280.58,
@@ -309,6 +311,7 @@
     {
       "name": "COMUNE DI NAPOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80014890638",
       "population": 913704,
       "value": 1246016360.89,
@@ -317,6 +320,7 @@
     {
       "name": "COMUNE DI TORINO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "00514490010",
       "population": 851199,
       "value": 1145435497.51,
@@ -325,6 +329,7 @@
     {
       "name": "COMUNE DI GENOVA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00856930102",
       "population": 562422,
       "value": 979007371.18,
@@ -333,6 +338,7 @@
     {
       "name": "COMUNE DI VENEZIA",
       "region": "Veneto",
+      "province": "Venezia",
       "codiceFiscale": "00339370272",
       "population": 250290,
       "value": 848000169.35,
@@ -341,6 +347,7 @@
     {
       "name": "COMUNE DI BOLOGNA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "01232710374",
       "population": 390098,
       "value": 775249659.99,
@@ -349,6 +356,7 @@
     {
       "name": "COMUNE DI FIRENZE",
       "region": "Toscana",
+      "province": "Firenze",
       "codiceFiscale": "01307110484",
       "population": 362613,
       "value": 728294504.97,
@@ -357,6 +365,7 @@
     {
       "name": "COMUNE DI MESSINA",
       "region": "Sicilia",
+      "province": "Messina",
       "codiceFiscale": "00080270838",
       "population": 217959,
       "value": 607220140.01,
@@ -365,6 +374,7 @@
     {
       "name": "COMUNE DI PALERMO",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "80016350821",
       "population": 630427,
       "value": 551685282.84,
@@ -373,6 +383,7 @@
     {
       "name": "COMUNE DI BARI",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "80015010723",
       "population": 316226,
       "value": 501924463.74,
@@ -381,6 +392,7 @@
     {
       "name": "COMUNE DI CATANIA",
       "region": "Sicilia",
+      "province": "Catania",
       "codiceFiscale": "00137020871",
       "population": 298680,
       "value": 393892253.52,
@@ -389,6 +401,7 @@
     {
       "name": "COMUNE DI PADOVA",
       "region": "Veneto",
+      "province": "Padova",
       "codiceFiscale": "00644060287",
       "population": 207502,
       "value": 367888998.81,
@@ -397,6 +410,7 @@
     {
       "name": "COMUNE DI TARANTO",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80008750731",
       "population": 187025,
       "value": 354017329.58,
@@ -405,6 +419,7 @@
     {
       "name": "COMUNE DI BRESCIA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00761890177",
       "population": 198259,
       "value": 324459688.16,
@@ -413,6 +428,7 @@
     {
       "name": "COMUNE DI VERONA",
       "region": "Veneto",
+      "province": "Verona",
       "codiceFiscale": "00215150236",
       "population": 255298,
       "value": 318529220.51,
@@ -421,6 +437,7 @@
     {
       "name": "COMUNE DI BOLZANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00389240219",
       "population": 106357,
       "value": 306730503.03,
@@ -429,6 +446,7 @@
     {
       "name": "COMUNE DI TRIESTE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Trieste",
       "codiceFiscale": "00210240321",
       "population": 198843,
       "value": 285757192.6,
@@ -437,6 +455,7 @@
     {
       "name": "COMUNE DI CAGLIARI",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00147990923",
       "population": 147411,
       "value": 243088910.3,
@@ -445,6 +464,7 @@
     {
       "name": "COMUNE DI PARMA",
       "region": "Emilia-Romagna",
+      "province": "Parma",
       "codiceFiscale": "00162210348",
       "population": 198121,
       "value": 228311495.31,
@@ -453,6 +473,7 @@
     {
       "name": "COMUNE DI L'AQUILA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002270660",
       "population": 69717,
       "value": 225877862.5,
@@ -461,6 +482,7 @@
     {
       "name": "COMUNE DI MODENA",
       "region": "Emilia-Romagna",
+      "province": "Modena",
       "codiceFiscale": "00221940364",
       "population": 184597,
       "value": 207321360.36,
@@ -469,6 +491,7 @@
     {
       "name": "COMUNE DI RIMINI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00304260409",
       "population": 150046,
       "value": 204041303.29,
@@ -477,6 +500,7 @@
     {
       "name": "COMUNE DI CORIGLIANO-ROSSANO",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "03557570789",
       "population": 74268,
       "value": 199457280.53,
@@ -485,6 +509,7 @@
     {
       "name": "COMUNE DI ANCONA",
       "region": "Marche",
+      "province": "Ancona",
       "codiceFiscale": "00351040423",
       "population": 99377,
       "value": 196879670.6,
@@ -493,6 +518,7 @@
     {
       "name": "COMUNE DI BERGAMO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "80034840167",
       "population": 120157,
       "value": 196357433.94,
@@ -501,6 +527,7 @@
     {
       "name": "COMUNE DI TRENTO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00355870221",
       "population": 118504,
       "value": 193611779.62,
@@ -509,6 +536,7 @@
     {
       "name": "COMUNE DI ALESSANDRIA",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "00429440068",
       "population": 91854,
       "value": 188799903.87,
@@ -517,6 +545,7 @@
     {
       "name": "COMUNE DI REGGIO DI CALABRIA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "00136380805",
       "population": 169679,
       "value": 185301503.79,
@@ -525,6 +554,7 @@
     {
       "name": "COMUNE DI PERUGIA",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00163570542",
       "population": 162099,
       "value": 183024820.59,
@@ -533,6 +563,7 @@
     {
       "name": "COMUNE DI PRATO",
       "region": "Toscana",
+      "province": "Prato",
       "codiceFiscale": "84006890481",
       "population": 197088,
       "value": 182494323.01,
@@ -541,6 +572,7 @@
     {
       "name": "COMUNE DI SALERNO",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "80000330656",
       "population": 126715,
       "value": 181409754.16,
@@ -549,6 +581,7 @@
     {
       "name": "COMUNE DI REGGIO NELL'EMILIA",
       "region": "Emilia-Romagna",
+      "province": "Reggio nell'Emilia",
       "codiceFiscale": "00145920351",
       "population": 171207,
       "value": 180647741.41,
@@ -557,6 +590,7 @@
     {
       "name": "COMUNE DI LIVORNO",
       "region": "Toscana",
+      "province": "Livorno",
       "codiceFiscale": "00104330493",
       "population": 153418,
       "value": 175375570.05,
@@ -565,6 +599,7 @@
     {
       "name": "COMUNE DI RAVENNA",
       "region": "Emilia-Romagna",
+      "province": "Ravenna",
       "codiceFiscale": "00354730392",
       "population": 156304,
       "value": 174398740.46,
@@ -573,6 +608,7 @@
     {
       "name": "COMUNE DI UDINE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "00168650307",
       "population": 98304,
       "value": 169928730.38,
@@ -581,6 +617,7 @@
     {
       "name": "COMUNE DI FERRARA",
       "region": "Emilia-Romagna",
+      "province": "Ferrara",
       "codiceFiscale": "00297110389",
       "population": 129391,
       "value": 166472637.51,
@@ -589,6 +626,7 @@
     {
       "name": "COMUNE DI CATANZARO",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00129520797",
       "population": 84109,
       "value": 162851957.33,
@@ -597,6 +635,7 @@
     {
       "name": "COMUNE DI COSENZA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00347720781",
       "population": 63701,
       "value": 156231516.63,
@@ -605,6 +644,7 @@
     {
       "name": "COMUNE DI SASSARI",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00239740905",
       "population": 121085,
       "value": 151583109.01,
@@ -613,6 +653,7 @@
     {
       "name": "COMUNE DI LECCE",
       "region": "Puglia",
+      "province": "Lecce",
       "codiceFiscale": "80008510754",
       "population": 94250,
       "value": 149928503.29,
@@ -621,6 +662,7 @@
     {
       "name": "COMUNE DI PISA",
       "region": "Toscana",
+      "province": "Pisa",
       "codiceFiscale": "00341620508",
       "population": 89117,
       "value": 146758258.73,
@@ -629,6 +671,7 @@
     {
       "name": "COMUNE DI FIUMICINO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "97086740582",
       "population": 82481,
       "value": 142202249.31,
@@ -637,6 +680,7 @@
     {
       "name": "COMUNE DI FOGGIA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "00363460718",
       "population": 145652,
       "value": 137837524.22,
@@ -645,6 +689,7 @@
     {
       "name": "COMUNE DI VICENZA",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00516890241",
       "population": 110299,
       "value": 134975436.76,
@@ -653,6 +698,7 @@
     {
       "name": "COMUNE DI RICCIONE",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00324360403",
       "population": 34465,
       "value": 134164250.96,
@@ -661,6 +707,7 @@
     {
       "name": "COMUNE DI PIACENZA",
       "region": "Emilia-Romagna",
+      "province": "Piacenza",
       "codiceFiscale": "00229080338",
       "population": 102887,
       "value": 130796224.95,
@@ -669,6 +716,7 @@
     {
       "name": "COMUNE DI MONZA",
       "region": "Lombardia",
+      "province": "MONZA - BRIANZA",
       "codiceFiscale": "02030880153",
       "population": 122883,
       "value": 130769279.22,
@@ -677,6 +725,7 @@
     {
       "name": "COMUNE DI NOVARA",
       "region": "Piemonte",
+      "province": "Novara",
       "codiceFiscale": "00125680033",
       "population": 102187,
       "value": 123261211.46,
@@ -685,6 +734,7 @@
     {
       "name": "COMUNE DI MACERATA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "80001650433",
       "population": 40538,
       "value": 121895723.24,
@@ -693,6 +743,7 @@
     {
       "name": "COMUNE DI LECCO",
       "region": "Lombardia",
+      "province": "Lecco",
       "codiceFiscale": "00623530136",
       "population": 47125,
       "value": 117142168.45,
@@ -701,6 +752,7 @@
     {
       "name": "COMUNE DI FORLI'",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00606620409",
       "population": 117050,
       "value": 116795115.45,
@@ -709,6 +761,7 @@
     {
       "name": "COMUNE DI PESCARA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "00124600685",
       "population": 118461,
       "value": 115551479.08,
@@ -717,6 +770,7 @@
     {
       "name": "COMUNE DI LATINA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "00097020598",
       "population": 127859,
       "value": 113172920.52,
@@ -725,6 +779,7 @@
     {
       "name": "COMUNE DI PESARO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00272430414",
       "population": 95392,
       "value": 112953245.34,
@@ -733,6 +788,7 @@
     {
       "name": "COMUNE DI POZZUOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "00508900636",
       "population": 76255,
       "value": 110458983.13,
@@ -741,6 +797,7 @@
     {
       "name": "COMUNE DI SIRACUSA",
       "region": "Sicilia",
+      "province": "Siracusa",
       "codiceFiscale": "80001010893",
       "population": 116247,
       "value": 106296502.55,
@@ -749,6 +806,7 @@
     {
       "name": "COMUNE DI POMEZIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02298490588",
       "population": 64451,
       "value": 105061996.57,
@@ -757,6 +815,7 @@
     {
       "name": "COMUNE DI ASCOLI PICENO",
       "region": "Marche",
+      "province": "Ascoli Piceno",
       "codiceFiscale": "00229010442",
       "population": 45448,
       "value": 101510391.35,
@@ -765,6 +824,7 @@
     {
       "name": "COMUNE DI LUCCA",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00378210462",
       "population": 89234,
       "value": 98961765.65,
@@ -773,6 +833,7 @@
     {
       "name": "COMUNE DI PORDENONE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Pordenone",
       "codiceFiscale": "80002150938",
       "population": 52147,
       "value": 97630657.69,
@@ -781,6 +842,7 @@
     {
       "name": "COMUNE DI TREVISO",
       "region": "Veneto",
+      "province": "Treviso",
       "codiceFiscale": "80007310263",
       "population": 85322,
       "value": 96667741.6,
@@ -789,6 +851,7 @@
     {
       "name": "COMUNE DI AREZZO",
       "region": "Toscana",
+      "province": "Arezzo",
       "codiceFiscale": "00176820512",
       "population": 96330,
       "value": 96608904.66,
@@ -797,6 +860,7 @@
     {
       "name": "COMUNE DI CESENA",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00143280402",
       "population": 96066,
       "value": 95055799.65,
@@ -805,6 +869,7 @@
     {
       "name": "COMUNE DI SANREMO",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00253750087",
       "population": 52992,
       "value": 94842898.65,
@@ -813,6 +878,7 @@
     {
       "name": "COMUNE DI BRINDISI",
       "region": "Puglia",
+      "province": "Brindisi",
       "codiceFiscale": "80000250748",
       "population": 82298,
       "value": 94685192.24,
@@ -821,6 +887,7 @@
     {
       "name": "COMUNE DI PISTOIA",
       "region": "Toscana",
+      "province": "Pistoia",
       "codiceFiscale": "00108690470",
       "population": 89054,
       "value": 94039283.04,
@@ -829,6 +896,7 @@
     {
       "name": "COMUNE DI OLBIA",
       "region": "Sardegna",
+      "province": "Gallura Nord-Est Sardegna",
       "codiceFiscale": "91008330903",
       "population": 61481,
       "value": 93065110.94,
@@ -837,6 +905,7 @@
     {
       "name": "COMUNE DI LA SPEZIA",
       "region": "Liguria",
+      "province": "La Spezia",
       "codiceFiscale": "00211160114",
       "population": 92696,
       "value": 92588450.49,
@@ -845,6 +914,7 @@
     {
       "name": "COMUNE DI GROSSETO",
       "region": "Toscana",
+      "province": "Grosseto",
       "codiceFiscale": "00082520537",
       "population": 81482,
       "value": 92225027.48,
@@ -853,6 +923,7 @@
     {
       "name": "COMUNE DI SIENA",
       "region": "Toscana",
+      "province": "Siena",
       "codiceFiscale": "00050800523",
       "population": 52833,
       "value": 91429257.38,
@@ -861,6 +932,7 @@
     {
       "name": "COMUNE DI MASSA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00181760455",
       "population": 65992,
       "value": 89953062.4,
@@ -869,6 +941,7 @@
     {
       "name": "COMUNE DI TERNI",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00175660554",
       "population": 106436,
       "value": 89535999.34,
@@ -877,6 +950,7 @@
     {
       "name": "COMUNE DI MANTOVA",
       "region": "Lombardia",
+      "province": "Mantova",
       "codiceFiscale": "00189800204",
       "population": 49044,
       "value": 87388340.03,
@@ -885,6 +959,7 @@
     {
       "name": "COMUNE DI FERMO",
       "region": "Marche",
+      "province": "FERMO",
       "codiceFiscale": "00334990447",
       "population": 35842,
       "value": 87069786.5,
@@ -893,6 +968,7 @@
     {
       "name": "COMUNE DI VARESE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00441340122",
       "population": 78818,
       "value": 86573158.48,
@@ -901,6 +977,7 @@
     {
       "name": "COMUNE DI LAMEZIA TERME",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00301390795",
       "population": 67246,
       "value": 86506727.46,
@@ -909,6 +986,7 @@
     {
       "name": "COMUNE DI COMO",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80005370137",
       "population": 83586,
       "value": 84341258.66,
@@ -917,6 +995,7 @@
     {
       "name": "COMUNE DI VIAREGGIO",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00274950468",
       "population": 60755,
       "value": 82900113.98,
@@ -925,6 +1004,7 @@
     {
       "name": "COMUNE DI GALLARATE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00560180127",
       "population": 52963,
       "value": 82779847.18,
@@ -933,6 +1013,7 @@
     {
       "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80049220637",
       "population": 124209,
       "value": 81772539.33,
@@ -941,6 +1022,7 @@
     {
       "name": "COMUNE DI SANTA MARIA CAPUA VETERE",
       "region": "Campania",
+      "province": "Caserta",
       "codiceFiscale": "00136270618",
       "population": 32122,
       "value": 81094495.92,
@@ -949,6 +1031,7 @@
     {
       "name": "COMUNE DI CREMONA",
       "region": "Lombardia",
+      "province": "Cremona",
       "codiceFiscale": "00297960197",
       "population": 70675,
       "value": 80955785.2,
@@ -957,6 +1040,7 @@
     {
       "name": "COMUNE DI MAZARA DEL VALLO",
       "region": "Sicilia",
+      "province": "Trapani",
       "codiceFiscale": "82001410818",
       "population": 50029,
       "value": 80145968.42,
@@ -965,6 +1049,7 @@
     {
       "name": "COMUNE DI ANDRIA",
       "region": "Puglia",
+      "province": "Barletta Andria e Trani",
       "codiceFiscale": "81001210723",
       "population": 96941,
       "value": 80129601.7,
@@ -973,6 +1058,7 @@
     {
       "name": "COMUNE DI PAVIA",
       "region": "Lombardia",
+      "province": "Pavia",
       "codiceFiscale": "00296180185",
       "population": 71297,
       "value": 79201232.3,
@@ -981,6 +1067,7 @@
     {
       "name": "COMUNE DI BENEVENTO",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "00074270620",
       "population": 56048,
       "value": 78578865.66,
@@ -989,6 +1076,7 @@
     {
       "name": "COMUNE DI CUNEO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00480530047",
       "population": 55914,
       "value": 78266510.59,
@@ -997,6 +1085,7 @@
     {
       "name": "COMUNE DI RAGUSA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00180270886",
       "population": 73736,
       "value": 77520401.72,
@@ -1005,6 +1094,7 @@
     {
       "name": "COMUNE DI VITERBO",
       "region": "Lazio",
+      "province": "Viterbo",
       "codiceFiscale": "80008850564",
       "population": 66188,
       "value": 76332994.75,
@@ -1013,6 +1103,7 @@
     {
       "name": "COMUNE DI BAGHERIA",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "81000170829",
       "population": 53010,
       "value": 75696849.79,
@@ -1021,6 +1112,7 @@
     {
       "name": "COMUNE DI SESTO SAN GIOVANNI",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "02253930156",
       "population": 78495,
       "value": 75428795.24,
@@ -1029,6 +1121,7 @@
     {
       "name": "COMUNE DI CARRARA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00079450458",
       "population": 59757,
       "value": 74863378.75,
@@ -1037,6 +1130,7 @@
     {
       "name": "COMUNE DI QUARTU SANT'ELENA",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00288630924",
       "population": 68509,
       "value": 74692666.24,
@@ -1045,6 +1139,7 @@
     {
       "name": "COMUNE DI BUSTO ARSIZIO",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00224000125",
       "population": 83372,
       "value": 73971898.22,
@@ -1053,6 +1148,7 @@
     {
       "name": "COMUNE DI IMOLA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "00794470377",
       "population": 69332,
       "value": 72198429.28,
@@ -1061,6 +1157,7 @@
     {
       "name": "COMUNE DI MARSALA",
       "region": "Sicilia",
+      "province": "Trapani",
       "codiceFiscale": "00139550818",
       "population": 79835,
       "value": 71073992.65,
@@ -1069,6 +1166,7 @@
     {
       "name": "COMUNE DI CAMAIORE",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00190560466",
       "population": 31864,
       "value": 68544112.67,
@@ -1077,6 +1175,7 @@
     {
       "name": "COMUNE DI LODI",
       "region": "Lombardia",
+      "province": "Lodi",
       "codiceFiscale": "84507570152",
       "population": 45158,
       "value": 68353290.88,
@@ -1085,6 +1184,7 @@
     {
       "name": "COMUNE DI SAN GIORGIO A CREMANO",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "01435550635",
       "population": 42096,
       "value": 68249049.56,
@@ -1095,6 +1195,7 @@
     {
       "name": "ROMA CAPITALE",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02438750586",
       "population": 2751747,
       "value": 4868753534.45,
@@ -1103,6 +1204,7 @@
     {
       "name": "COMUNE DI MILANO",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "01199250158",
       "population": 1371499,
       "value": 3139192280.58,
@@ -1111,6 +1213,7 @@
     {
       "name": "COMUNE DI NAPOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80014890638",
       "population": 913704,
       "value": 1246016360.89,
@@ -1119,6 +1222,7 @@
     {
       "name": "COMUNE DI TORINO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "00514490010",
       "population": 851199,
       "value": 1145435497.51,
@@ -1127,6 +1231,7 @@
     {
       "name": "COMUNE DI GENOVA",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00856930102",
       "population": 562422,
       "value": 979007371.18,
@@ -1135,6 +1240,7 @@
     {
       "name": "COMUNE DI VENEZIA",
       "region": "Veneto",
+      "province": "Venezia",
       "codiceFiscale": "00339370272",
       "population": 250290,
       "value": 848000169.35,
@@ -1143,6 +1249,7 @@
     {
       "name": "COMUNE DI BOLOGNA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "01232710374",
       "population": 390098,
       "value": 775249659.99,
@@ -1151,6 +1258,7 @@
     {
       "name": "COMUNE DI FIRENZE",
       "region": "Toscana",
+      "province": "Firenze",
       "codiceFiscale": "01307110484",
       "population": 362613,
       "value": 728294504.97,
@@ -1159,6 +1267,7 @@
     {
       "name": "COMUNE DI MESSINA",
       "region": "Sicilia",
+      "province": "Messina",
       "codiceFiscale": "00080270838",
       "population": 217959,
       "value": 607220140.01,
@@ -1167,6 +1276,7 @@
     {
       "name": "COMUNE DI PALERMO",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "80016350821",
       "population": 630427,
       "value": 551685282.84,
@@ -1175,6 +1285,7 @@
     {
       "name": "COMUNE DI BARI",
       "region": "Puglia",
+      "province": "Bari",
       "codiceFiscale": "80015010723",
       "population": 316226,
       "value": 501924463.74,
@@ -1183,6 +1294,7 @@
     {
       "name": "COMUNE DI CATANIA",
       "region": "Sicilia",
+      "province": "Catania",
       "codiceFiscale": "00137020871",
       "population": 298680,
       "value": 393892253.52,
@@ -1191,6 +1303,7 @@
     {
       "name": "COMUNE DI PADOVA",
       "region": "Veneto",
+      "province": "Padova",
       "codiceFiscale": "00644060287",
       "population": 207502,
       "value": 367888998.81,
@@ -1199,6 +1312,7 @@
     {
       "name": "COMUNE DI TARANTO",
       "region": "Puglia",
+      "province": "Taranto",
       "codiceFiscale": "80008750731",
       "population": 187025,
       "value": 354017329.58,
@@ -1207,6 +1321,7 @@
     {
       "name": "COMUNE DI BRESCIA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "00761890177",
       "population": 198259,
       "value": 324459688.16,
@@ -1215,6 +1330,7 @@
     {
       "name": "COMUNE DI VERONA",
       "region": "Veneto",
+      "province": "Verona",
       "codiceFiscale": "00215150236",
       "population": 255298,
       "value": 318529220.51,
@@ -1223,6 +1339,7 @@
     {
       "name": "COMUNE DI BOLZANO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "00389240219",
       "population": 106357,
       "value": 306730503.03,
@@ -1231,6 +1348,7 @@
     {
       "name": "COMUNE DI TRIESTE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Trieste",
       "codiceFiscale": "00210240321",
       "population": 198843,
       "value": 285757192.6,
@@ -1239,6 +1357,7 @@
     {
       "name": "COMUNE DI CAGLIARI",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00147990923",
       "population": 147411,
       "value": 243088910.3,
@@ -1247,6 +1366,7 @@
     {
       "name": "COMUNE DI PARMA",
       "region": "Emilia-Romagna",
+      "province": "Parma",
       "codiceFiscale": "00162210348",
       "population": 198121,
       "value": 228311495.31,
@@ -1255,6 +1375,7 @@
     {
       "name": "COMUNE DI L'AQUILA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002270660",
       "population": 69717,
       "value": 225877862.5,
@@ -1263,6 +1384,7 @@
     {
       "name": "COMUNE DI MODENA",
       "region": "Emilia-Romagna",
+      "province": "Modena",
       "codiceFiscale": "00221940364",
       "population": 184597,
       "value": 207321360.36,
@@ -1271,6 +1393,7 @@
     {
       "name": "COMUNE DI RIMINI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00304260409",
       "population": 150046,
       "value": 204041303.29,
@@ -1279,6 +1402,7 @@
     {
       "name": "COMUNE DI CORIGLIANO-ROSSANO",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "03557570789",
       "population": 74268,
       "value": 199457280.53,
@@ -1287,6 +1411,7 @@
     {
       "name": "COMUNE DI ANCONA",
       "region": "Marche",
+      "province": "Ancona",
       "codiceFiscale": "00351040423",
       "population": 99377,
       "value": 196879670.6,
@@ -1295,6 +1420,7 @@
     {
       "name": "COMUNE DI BERGAMO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "80034840167",
       "population": 120157,
       "value": 196357433.94,
@@ -1303,6 +1429,7 @@
     {
       "name": "COMUNE DI TRENTO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00355870221",
       "population": 118504,
       "value": 193611779.62,
@@ -1311,6 +1438,7 @@
     {
       "name": "COMUNE DI ALESSANDRIA",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "00429440068",
       "population": 91854,
       "value": 188799903.87,
@@ -1319,6 +1447,7 @@
     {
       "name": "COMUNE DI REGGIO DI CALABRIA",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "00136380805",
       "population": 169679,
       "value": 185301503.79,
@@ -1327,6 +1456,7 @@
     {
       "name": "COMUNE DI PERUGIA",
       "region": "Umbria",
+      "province": "Perugia",
       "codiceFiscale": "00163570542",
       "population": 162099,
       "value": 183024820.59,
@@ -1335,6 +1465,7 @@
     {
       "name": "COMUNE DI PRATO",
       "region": "Toscana",
+      "province": "Prato",
       "codiceFiscale": "84006890481",
       "population": 197088,
       "value": 182494323.01,
@@ -1343,6 +1474,7 @@
     {
       "name": "COMUNE DI SALERNO",
       "region": "Campania",
+      "province": "Salerno",
       "codiceFiscale": "80000330656",
       "population": 126715,
       "value": 181409754.16,
@@ -1351,6 +1483,7 @@
     {
       "name": "COMUNE DI REGGIO NELL'EMILIA",
       "region": "Emilia-Romagna",
+      "province": "Reggio nell'Emilia",
       "codiceFiscale": "00145920351",
       "population": 171207,
       "value": 180647741.41,
@@ -1359,6 +1492,7 @@
     {
       "name": "COMUNE DI LIVORNO",
       "region": "Toscana",
+      "province": "Livorno",
       "codiceFiscale": "00104330493",
       "population": 153418,
       "value": 175375570.05,
@@ -1367,6 +1501,7 @@
     {
       "name": "COMUNE DI RAVENNA",
       "region": "Emilia-Romagna",
+      "province": "Ravenna",
       "codiceFiscale": "00354730392",
       "population": 156304,
       "value": 174398740.46,
@@ -1375,6 +1510,7 @@
     {
       "name": "COMUNE DI UDINE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "00168650307",
       "population": 98304,
       "value": 169928730.38,
@@ -1383,6 +1519,7 @@
     {
       "name": "COMUNE DI FERRARA",
       "region": "Emilia-Romagna",
+      "province": "Ferrara",
       "codiceFiscale": "00297110389",
       "population": 129391,
       "value": 166472637.51,
@@ -1391,6 +1528,7 @@
     {
       "name": "COMUNE DI CATANZARO",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00129520797",
       "population": 84109,
       "value": 162851957.33,
@@ -1399,6 +1537,7 @@
     {
       "name": "COMUNE DI COSENZA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "00347720781",
       "population": 63701,
       "value": 156231516.63,
@@ -1407,6 +1546,7 @@
     {
       "name": "COMUNE DI SASSARI",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00239740905",
       "population": 121085,
       "value": 151583109.01,
@@ -1415,6 +1555,7 @@
     {
       "name": "COMUNE DI LECCE",
       "region": "Puglia",
+      "province": "Lecce",
       "codiceFiscale": "80008510754",
       "population": 94250,
       "value": 149928503.29,
@@ -1423,6 +1564,7 @@
     {
       "name": "COMUNE DI PISA",
       "region": "Toscana",
+      "province": "Pisa",
       "codiceFiscale": "00341620508",
       "population": 89117,
       "value": 146758258.73,
@@ -1431,6 +1573,7 @@
     {
       "name": "COMUNE DI FIUMICINO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "97086740582",
       "population": 82481,
       "value": 142202249.31,
@@ -1439,6 +1582,7 @@
     {
       "name": "COMUNE DI FOGGIA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "00363460718",
       "population": 145652,
       "value": 137837524.22,
@@ -1447,6 +1591,7 @@
     {
       "name": "COMUNE DI VICENZA",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00516890241",
       "population": 110299,
       "value": 134975436.76,
@@ -1455,6 +1600,7 @@
     {
       "name": "COMUNE DI RICCIONE",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "00324360403",
       "population": 34465,
       "value": 134164250.96,
@@ -1463,6 +1609,7 @@
     {
       "name": "COMUNE DI PIACENZA",
       "region": "Emilia-Romagna",
+      "province": "Piacenza",
       "codiceFiscale": "00229080338",
       "population": 102887,
       "value": 130796224.95,
@@ -1471,6 +1618,7 @@
     {
       "name": "COMUNE DI MONZA",
       "region": "Lombardia",
+      "province": "MONZA - BRIANZA",
       "codiceFiscale": "02030880153",
       "population": 122883,
       "value": 130769279.22,
@@ -1479,6 +1627,7 @@
     {
       "name": "COMUNE DI NOVARA",
       "region": "Piemonte",
+      "province": "Novara",
       "codiceFiscale": "00125680033",
       "population": 102187,
       "value": 123261211.46,
@@ -1487,6 +1636,7 @@
     {
       "name": "COMUNE DI MACERATA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "80001650433",
       "population": 40538,
       "value": 121895723.24,
@@ -1495,6 +1645,7 @@
     {
       "name": "COMUNE DI LECCO",
       "region": "Lombardia",
+      "province": "Lecco",
       "codiceFiscale": "00623530136",
       "population": 47125,
       "value": 117142168.45,
@@ -1503,6 +1654,7 @@
     {
       "name": "COMUNE DI FORLI'",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00606620409",
       "population": 117050,
       "value": 116795115.45,
@@ -1511,6 +1663,7 @@
     {
       "name": "COMUNE DI PESCARA",
       "region": "Abruzzo",
+      "province": "Pescara",
       "codiceFiscale": "00124600685",
       "population": 118461,
       "value": 115551479.08,
@@ -1519,6 +1672,7 @@
     {
       "name": "COMUNE DI LATINA",
       "region": "Lazio",
+      "province": "Latina",
       "codiceFiscale": "00097020598",
       "population": 127859,
       "value": 113172920.52,
@@ -1527,6 +1681,7 @@
     {
       "name": "COMUNE DI PESARO",
       "region": "Marche",
+      "province": "Pesaro Urbino",
       "codiceFiscale": "00272430414",
       "population": 95392,
       "value": 112953245.34,
@@ -1535,6 +1690,7 @@
     {
       "name": "COMUNE DI POZZUOLI",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "00508900636",
       "population": 76255,
       "value": 110458983.13,
@@ -1543,6 +1699,7 @@
     {
       "name": "COMUNE DI SIRACUSA",
       "region": "Sicilia",
+      "province": "Siracusa",
       "codiceFiscale": "80001010893",
       "population": 116247,
       "value": 106296502.55,
@@ -1551,6 +1708,7 @@
     {
       "name": "COMUNE DI POMEZIA",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "02298490588",
       "population": 64451,
       "value": 105061996.57,
@@ -1559,6 +1717,7 @@
     {
       "name": "COMUNE DI ASCOLI PICENO",
       "region": "Marche",
+      "province": "Ascoli Piceno",
       "codiceFiscale": "00229010442",
       "population": 45448,
       "value": 101510391.35,
@@ -1567,6 +1726,7 @@
     {
       "name": "COMUNE DI LUCCA",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00378210462",
       "population": 89234,
       "value": 98961765.65,
@@ -1575,6 +1735,7 @@
     {
       "name": "COMUNE DI PORDENONE",
       "region": "Friuli-Venezia Giulia",
+      "province": "Pordenone",
       "codiceFiscale": "80002150938",
       "population": 52147,
       "value": 97630657.69,
@@ -1583,6 +1744,7 @@
     {
       "name": "COMUNE DI TREVISO",
       "region": "Veneto",
+      "province": "Treviso",
       "codiceFiscale": "80007310263",
       "population": 85322,
       "value": 96667741.6,
@@ -1591,6 +1753,7 @@
     {
       "name": "COMUNE DI AREZZO",
       "region": "Toscana",
+      "province": "Arezzo",
       "codiceFiscale": "00176820512",
       "population": 96330,
       "value": 96608904.66,
@@ -1599,6 +1762,7 @@
     {
       "name": "COMUNE DI CESENA",
       "region": "Emilia-Romagna",
+      "province": "Forli'-Cesena",
       "codiceFiscale": "00143280402",
       "population": 96066,
       "value": 95055799.65,
@@ -1607,6 +1771,7 @@
     {
       "name": "COMUNE DI SANREMO",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00253750087",
       "population": 52992,
       "value": 94842898.65,
@@ -1615,6 +1780,7 @@
     {
       "name": "COMUNE DI BRINDISI",
       "region": "Puglia",
+      "province": "Brindisi",
       "codiceFiscale": "80000250748",
       "population": 82298,
       "value": 94685192.24,
@@ -1623,6 +1789,7 @@
     {
       "name": "COMUNE DI PISTOIA",
       "region": "Toscana",
+      "province": "Pistoia",
       "codiceFiscale": "00108690470",
       "population": 89054,
       "value": 94039283.04,
@@ -1631,6 +1798,7 @@
     {
       "name": "COMUNE DI OLBIA",
       "region": "Sardegna",
+      "province": "Gallura Nord-Est Sardegna",
       "codiceFiscale": "91008330903",
       "population": 61481,
       "value": 93065110.94,
@@ -1639,6 +1807,7 @@
     {
       "name": "COMUNE DI LA SPEZIA",
       "region": "Liguria",
+      "province": "La Spezia",
       "codiceFiscale": "00211160114",
       "population": 92696,
       "value": 92588450.49,
@@ -1647,6 +1816,7 @@
     {
       "name": "COMUNE DI GROSSETO",
       "region": "Toscana",
+      "province": "Grosseto",
       "codiceFiscale": "00082520537",
       "population": 81482,
       "value": 92225027.48,
@@ -1655,6 +1825,7 @@
     {
       "name": "COMUNE DI SIENA",
       "region": "Toscana",
+      "province": "Siena",
       "codiceFiscale": "00050800523",
       "population": 52833,
       "value": 91429257.38,
@@ -1663,6 +1834,7 @@
     {
       "name": "COMUNE DI MASSA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00181760455",
       "population": 65992,
       "value": 89953062.4,
@@ -1671,6 +1843,7 @@
     {
       "name": "COMUNE DI TERNI",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00175660554",
       "population": 106436,
       "value": 89535999.34,
@@ -1679,6 +1852,7 @@
     {
       "name": "COMUNE DI MANTOVA",
       "region": "Lombardia",
+      "province": "Mantova",
       "codiceFiscale": "00189800204",
       "population": 49044,
       "value": 87388340.03,
@@ -1687,6 +1861,7 @@
     {
       "name": "COMUNE DI FERMO",
       "region": "Marche",
+      "province": "FERMO",
       "codiceFiscale": "00334990447",
       "population": 35842,
       "value": 87069786.5,
@@ -1695,6 +1870,7 @@
     {
       "name": "COMUNE DI VARESE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00441340122",
       "population": 78818,
       "value": 86573158.48,
@@ -1703,6 +1879,7 @@
     {
       "name": "COMUNE DI LAMEZIA TERME",
       "region": "Calabria",
+      "province": "Catanzaro",
       "codiceFiscale": "00301390795",
       "population": 67246,
       "value": 86506727.46,
@@ -1711,6 +1888,7 @@
     {
       "name": "COMUNE DI COMO",
       "region": "Lombardia",
+      "province": "Como",
       "codiceFiscale": "80005370137",
       "population": 83586,
       "value": 84341258.66,
@@ -1719,6 +1897,7 @@
     {
       "name": "COMUNE DI VIAREGGIO",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00274950468",
       "population": 60755,
       "value": 82900113.98,
@@ -1727,6 +1906,7 @@
     {
       "name": "COMUNE DI GALLARATE",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00560180127",
       "population": 52963,
       "value": 82779847.18,
@@ -1735,6 +1915,7 @@
     {
       "name": "COMUNE DI GIUGLIANO IN CAMPANIA",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "80049220637",
       "population": 124209,
       "value": 81772539.33,
@@ -1743,6 +1924,7 @@
     {
       "name": "COMUNE DI SANTA MARIA CAPUA VETERE",
       "region": "Campania",
+      "province": "Caserta",
       "codiceFiscale": "00136270618",
       "population": 32122,
       "value": 81094495.92,
@@ -1751,6 +1933,7 @@
     {
       "name": "COMUNE DI CREMONA",
       "region": "Lombardia",
+      "province": "Cremona",
       "codiceFiscale": "00297960197",
       "population": 70675,
       "value": 80955785.2,
@@ -1759,6 +1942,7 @@
     {
       "name": "COMUNE DI MAZARA DEL VALLO",
       "region": "Sicilia",
+      "province": "Trapani",
       "codiceFiscale": "82001410818",
       "population": 50029,
       "value": 80145968.42,
@@ -1767,6 +1951,7 @@
     {
       "name": "COMUNE DI ANDRIA",
       "region": "Puglia",
+      "province": "Barletta Andria e Trani",
       "codiceFiscale": "81001210723",
       "population": 96941,
       "value": 80129601.7,
@@ -1775,6 +1960,7 @@
     {
       "name": "COMUNE DI PAVIA",
       "region": "Lombardia",
+      "province": "Pavia",
       "codiceFiscale": "00296180185",
       "population": 71297,
       "value": 79201232.3,
@@ -1783,6 +1969,7 @@
     {
       "name": "COMUNE DI BENEVENTO",
       "region": "Campania",
+      "province": "Benevento",
       "codiceFiscale": "00074270620",
       "population": 56048,
       "value": 78578865.66,
@@ -1791,6 +1978,7 @@
     {
       "name": "COMUNE DI CUNEO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00480530047",
       "population": 55914,
       "value": 78266510.59,
@@ -1799,6 +1987,7 @@
     {
       "name": "COMUNE DI RAGUSA",
       "region": "Sicilia",
+      "province": "Ragusa",
       "codiceFiscale": "00180270886",
       "population": 73736,
       "value": 77520401.72,
@@ -1807,6 +1996,7 @@
     {
       "name": "COMUNE DI VITERBO",
       "region": "Lazio",
+      "province": "Viterbo",
       "codiceFiscale": "80008850564",
       "population": 66188,
       "value": 76332994.75,
@@ -1815,6 +2005,7 @@
     {
       "name": "COMUNE DI BAGHERIA",
       "region": "Sicilia",
+      "province": "Palermo",
       "codiceFiscale": "81000170829",
       "population": 53010,
       "value": 75696849.79,
@@ -1823,6 +2014,7 @@
     {
       "name": "COMUNE DI SESTO SAN GIOVANNI",
       "region": "Lombardia",
+      "province": "Milano",
       "codiceFiscale": "02253930156",
       "population": 78495,
       "value": 75428795.24,
@@ -1831,6 +2023,7 @@
     {
       "name": "COMUNE DI CARRARA",
       "region": "Toscana",
+      "province": "Massa-Carrara",
       "codiceFiscale": "00079450458",
       "population": 59757,
       "value": 74863378.75,
@@ -1839,6 +2032,7 @@
     {
       "name": "COMUNE DI QUARTU SANT'ELENA",
       "region": "Sardegna",
+      "province": "Cagliari",
       "codiceFiscale": "00288630924",
       "population": 68509,
       "value": 74692666.24,
@@ -1847,6 +2041,7 @@
     {
       "name": "COMUNE DI BUSTO ARSIZIO",
       "region": "Lombardia",
+      "province": "Varese",
       "codiceFiscale": "00224000125",
       "population": 83372,
       "value": 73971898.22,
@@ -1855,6 +2050,7 @@
     {
       "name": "COMUNE DI IMOLA",
       "region": "Emilia-Romagna",
+      "province": "Bologna",
       "codiceFiscale": "00794470377",
       "population": 69332,
       "value": 72198429.28,
@@ -1863,6 +2059,7 @@
     {
       "name": "COMUNE DI MARSALA",
       "region": "Sicilia",
+      "province": "Trapani",
       "codiceFiscale": "00139550818",
       "population": 79835,
       "value": 71073992.65,
@@ -1871,6 +2068,7 @@
     {
       "name": "COMUNE DI CAMAIORE",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "00190560466",
       "population": 31864,
       "value": 68544112.67,
@@ -1879,6 +2077,7 @@
     {
       "name": "COMUNE DI LODI",
       "region": "Lombardia",
+      "province": "Lodi",
       "codiceFiscale": "84507570152",
       "population": 45158,
       "value": 68353290.88,
@@ -1887,6 +2086,7 @@
     {
       "name": "COMUNE DI SAN GIORGIO A CREMANO",
       "region": "Campania",
+      "province": "Napoli",
       "codiceFiscale": "01435550635",
       "population": 42096,
       "value": 68249049.56,
@@ -1897,6 +2097,7 @@
     {
       "name": "COMUNE DI CALASCIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80007890660",
       "population": 125,
       "value": 9411472.55,
@@ -1905,6 +2106,7 @@
     {
       "name": "COMUNE DI BEMA",
       "region": "Lombardia",
+      "province": "Sondrio",
       "codiceFiscale": "00090830142",
       "population": 114,
       "value": 7916906.78,
@@ -1913,6 +2115,7 @@
     {
       "name": "COMUNE DI ELVA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80004570042",
       "population": 78,
       "value": 5313418.08,
@@ -1921,6 +2124,7 @@
     {
       "name": "COMUNE DI VILLA SANTA LUCIA DEGLI ABRUZZI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00193560661",
       "population": 88,
       "value": 5532533.77,
@@ -1929,6 +2133,7 @@
     {
       "name": "COMUNE DI USSITA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81001810431",
       "population": 360,
       "value": 11867737.48,
@@ -1937,6 +2142,7 @@
     {
       "name": "COMUNE DI SANTO STEFANO DI SESSANIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00173470667",
       "population": 110,
       "value": 2712250.66,
@@ -1945,6 +2151,7 @@
     {
       "name": "COMUNE DI CARAPELLE CALVISIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197710668",
       "population": 78,
       "value": 1867924.86,
@@ -1953,6 +2160,7 @@
     {
       "name": "COMUNE DI PALU' DEL FERSINA",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Trento",
       "codiceFiscale": "00272300229",
       "population": 158,
       "value": 3737063.72,
@@ -1961,6 +2169,7 @@
     {
       "name": "COMUNE DI BOLOGNOLA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000910430",
       "population": 147,
       "value": 3362333.51,
@@ -1969,6 +2178,7 @@
     {
       "name": "COMUNE DI FOSSA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80001770660",
       "population": 658,
       "value": 14988199.48,
@@ -1977,6 +2187,7 @@
     {
       "name": "COMUNE DI SARACINESCO",
       "region": "Lazio",
+      "province": "Roma",
       "codiceFiscale": "86001790582",
       "population": 172,
       "value": 3740079.69,
@@ -1985,6 +2196,7 @@
     {
       "name": "COMUNE DI FAGNANO ALTO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00193030665",
       "population": 351,
       "value": 7457024.39,
@@ -1993,6 +2205,7 @@
     {
       "name": "COMUNE DI MONTELAPIANO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81002650695",
       "population": 69,
       "value": 1449810.35,
@@ -2001,6 +2214,7 @@
     {
       "name": "COMUNE DI CASTEL DEL GIUDICE",
       "region": "Molise",
+      "province": "Isernia",
       "codiceFiscale": "80000990947",
       "population": 305,
       "value": 6342467.3,
@@ -2009,6 +2223,7 @@
     {
       "name": "COMUNE DI SAURIS",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "84001370307",
       "population": 390,
       "value": 7898356.58,
@@ -2017,6 +2232,7 @@
     {
       "name": "COMUNE DI ARGENTERA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80003430040",
       "population": 80,
       "value": 1509189.91,
@@ -2025,6 +2241,7 @@
     {
       "name": "COMUNE DI VALPRATO SOANA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "02216150017",
       "population": 96,
       "value": 1798038.08,
@@ -2033,6 +2250,7 @@
     {
       "name": "COMUNE DI MONCENISIO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01021740012",
       "population": 49,
       "value": 906187.69,
@@ -2041,6 +2259,7 @@
     {
       "name": "COMUNE DI OSTANA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00453120040",
       "population": 89,
       "value": 1616256.38,
@@ -2049,6 +2268,7 @@
     {
       "name": "COMUNE DI ROSELLO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81002970697",
       "population": 166,
       "value": 2963151.47,
@@ -2057,6 +2277,7 @@
     {
       "name": "COMUNE DI PRATA D'ANSIDONIA",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00195150669",
       "population": 447,
       "value": 7829414.97,
@@ -2065,6 +2286,7 @@
     {
       "name": "COMUNE DI PIETRACAMELA",
       "region": "Abruzzo",
+      "province": "Teramo",
       "codiceFiscale": "80005250677",
       "population": 207,
       "value": 3330138.97,
@@ -2073,6 +2295,7 @@
     {
       "name": "COMUNE DI MONTE CAVALLO",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "81000130435",
       "population": 103,
       "value": 1653082.62,
@@ -2081,6 +2304,7 @@
     {
       "name": "COMUNE DI CHAMOIS",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "81002610079",
       "population": 108,
       "value": 1728264.17,
@@ -2089,6 +2313,7 @@
     {
       "name": "COMUNE DI ACCIANO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "83003750664",
       "population": 256,
       "value": 4007676.39,
@@ -2097,6 +2322,7 @@
     {
       "name": "COMUNE DI INGRIA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "01840350019",
       "population": 46,
       "value": 711008.43,
@@ -2105,6 +2331,7 @@
     {
       "name": "COMUNE DI RHEMES-NOTRE-DAME",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00138020078",
       "population": 76,
       "value": 1172105.5,
@@ -2113,6 +2340,7 @@
     {
       "name": "COMUNE DI MACRA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478030042",
       "population": 45,
       "value": 682502.36,
@@ -2121,6 +2349,7 @@
     {
       "name": "COMUNE DI BALOCCO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "00425380029",
       "population": 214,
       "value": 3244496.92,
@@ -2129,6 +2358,7 @@
     {
       "name": "COMUNE DI SAN BENEDETTO IN PERILLIS",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00219500667",
       "population": 98,
       "value": 1476046.77,
@@ -2137,6 +2367,7 @@
     {
       "name": "COMUNE DI NAVELLI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00188910665",
       "population": 569,
       "value": 8353803.2,
@@ -2145,6 +2376,7 @@
     {
       "name": "COMUNE DI BRIGA ALTA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00553180043",
       "population": 41,
       "value": 596257.95,
@@ -2153,6 +2385,7 @@
     {
       "name": "COMUNE DI SANT'ALESSIO IN ASPROMONTE",
       "region": "Calabria",
+      "province": "Reggio di Calabria",
       "codiceFiscale": "80003150804",
       "population": 316,
       "value": 4506072.33,
@@ -2161,6 +2394,7 @@
     {
       "name": "COMUNE DI BARD",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00093700078",
       "population": 102,
       "value": 1422340.68,
@@ -2169,6 +2403,7 @@
     {
       "name": "COMUNE DI FALLO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81001730696",
       "population": 116,
       "value": 1600428.3,
@@ -2177,6 +2412,7 @@
     {
       "name": "COMUNE DI ROIO DEL SANGRO",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "81003010691",
       "population": 97,
       "value": 1338037.84,
@@ -2185,6 +2421,7 @@
     {
       "name": "COMUNE DI GAGLIANO ATERNO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00212360663",
       "population": 225,
       "value": 3049564.91,
@@ -2193,6 +2430,7 @@
     {
       "name": "COMUNE DI VALLEVE",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00637290164",
       "population": 126,
       "value": 1635304.1,
@@ -2201,6 +2439,7 @@
     {
       "name": "COMUNE DI MARMORA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00483290045",
       "population": 58,
       "value": 735047.93,
@@ -2209,6 +2448,7 @@
     {
       "name": "COMUNE DI TIONE DEGLI ABRUZZI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00189270663",
       "population": 258,
       "value": 3258020.43,
@@ -2217,6 +2457,7 @@
     {
       "name": "COMUNE DI ROSAZZA",
       "region": "Piemonte",
+      "province": "Biella",
       "codiceFiscale": "00390580025",
       "population": 97,
       "value": 1222478.76,
@@ -2225,6 +2466,7 @@
     {
       "name": "COMUNE DI FABBRICHE DI VERGEMOLI",
       "region": "Toscana",
+      "province": "Lucca",
       "codiceFiscale": "02335530461",
       "population": 705,
       "value": 8842941.55,
@@ -2233,6 +2475,7 @@
     {
       "name": "COMUNE DI NOASCA",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "83500090010",
       "population": 106,
       "value": 1320660.62,
@@ -2241,6 +2484,7 @@
     {
       "name": "COMUNE DI FANO ADRIANO",
       "region": "Abruzzo",
+      "province": "Teramo",
       "codiceFiscale": "92001400677",
       "population": 262,
       "value": 3249211.13,
@@ -2249,6 +2493,7 @@
     {
       "name": "COMUNE DI BARADILI",
       "region": "Sardegna",
+      "province": "Oristano",
       "codiceFiscale": "80007220959",
       "population": 80,
       "value": 983507.3,
@@ -2257,6 +2502,7 @@
     {
       "name": "COMUNE DI CASTELVECCHIO CALVISIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197730666",
       "population": 120,
       "value": 1473304.61,
@@ -2265,6 +2511,7 @@
     {
       "name": "COMUNE DI PAGANICO SABINO",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00113470579",
       "population": 157,
       "value": 1915005.74,
@@ -2273,6 +2520,7 @@
     {
       "name": "COMUNE DI MASSIMINO",
       "region": "Liguria",
+      "province": "Savona",
       "codiceFiscale": "00261180095",
       "population": 104,
       "value": 1256205.8,
@@ -2281,6 +2529,7 @@
     {
       "name": "COMUNE DI ROCCA DI CAMBIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00213130669",
       "population": 506,
       "value": 5969051.05,
@@ -2289,6 +2538,7 @@
     {
       "name": "COMUNE DI FONTECCHIO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00189210669",
       "population": 286,
       "value": 3356251.03,
@@ -2297,6 +2547,7 @@
     {
       "name": "COMUNE DI SEMESTENE",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00254670904",
       "population": 125,
       "value": 1459445.04,
@@ -2305,6 +2556,7 @@
     {
       "name": "COMUNE DI PERTICA ALTA",
       "region": "Lombardia",
+      "province": "Brescia",
       "codiceFiscale": "87000290178",
       "population": 553,
       "value": 6247208.28,
@@ -2313,6 +2565,7 @@
     {
       "name": "COMUNE DI CELLE DI SAN VITO",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "80003290717",
       "population": 148,
       "value": 1670895.42,
@@ -2321,6 +2574,7 @@
     {
       "name": "COMUNE DI CIRIGLIANO",
       "region": "Basilicata",
+      "province": "Matera",
       "codiceFiscale": "83000370771",
       "population": 273,
       "value": 3055791.15,
@@ -2329,6 +2583,7 @@
     {
       "name": "COMUNE DI GUARDIA PERTICARA",
       "region": "Basilicata",
+      "province": "Potenza",
       "codiceFiscale": "80005710761",
       "population": 526,
       "value": 5819316.61,
@@ -2337,6 +2592,7 @@
     {
       "name": "COMUNE DI CARCOFORO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82000610020",
       "population": 75,
       "value": 812760.26,
@@ -2345,6 +2601,7 @@
     {
       "name": "COMUNE DI CERVATTO",
       "region": "Piemonte",
+      "province": "Vercelli",
       "codiceFiscale": "82000730026",
       "population": 47,
       "value": 508801.3,
@@ -2353,6 +2610,7 @@
     {
       "name": "COMUNE DI LETTOPALENA",
       "region": "Abruzzo",
+      "province": "Chieti",
       "codiceFiscale": "00230170698",
       "population": 314,
       "value": 3397548.22,
@@ -2361,6 +2619,7 @@
     {
       "name": "COMUNE DI CAMPOTOSTO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00085160661",
       "population": 457,
       "value": 4915056.83,
@@ -2369,6 +2628,7 @@
     {
       "name": "COMUNE DI CELLE DI MACRA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478050040",
       "population": 89,
       "value": 955467.76,
@@ -2377,6 +2637,7 @@
     {
       "name": "COMUNE DI ENTRACQUE",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00507800043",
       "population": 760,
       "value": 8144744.52,
@@ -2385,6 +2646,7 @@
     {
       "name": "COMUNE DI CARREGA LIGURE",
       "region": "Piemonte",
+      "province": "Alessandria",
       "codiceFiscale": "92003030068",
       "population": 82,
       "value": 870486.95,
@@ -2393,6 +2655,7 @@
     {
       "name": "COMUNE DI ARVIER",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "80003210079",
       "population": 806,
       "value": 8419600.31,
@@ -2401,6 +2664,7 @@
     {
       "name": "COMUNE DI CASTELMAGNO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00478910045",
       "population": 55,
       "value": 572017.36,
@@ -2409,6 +2673,7 @@
     {
       "name": "COMUNE DI SAMBUCO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80003270040",
       "population": 83,
       "value": 851249.7,
@@ -2417,6 +2682,7 @@
     {
       "name": "COMUNE DI BLELLO",
       "region": "Lombardia",
+      "province": "Bergamo",
       "codiceFiscale": "00707790168",
       "population": 74,
       "value": 758315.72,
@@ -2425,6 +2691,7 @@
     {
       "name": "COMUNE DI PORTOFINO",
       "region": "Liguria",
+      "province": "Genova",
       "codiceFiscale": "00826220105",
       "population": 358,
       "value": 3660262.82,
@@ -2433,6 +2700,7 @@
     {
       "name": "COMUNE DI LASTEBASSE",
       "region": "Veneto",
+      "province": "Vicenza",
       "codiceFiscale": "00577360241",
       "population": 178,
       "value": 1819811.76,
@@ -2441,6 +2709,7 @@
     {
       "name": "COMUNE DI MUCCIA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "00263210437",
       "population": 800,
       "value": 8145791.71,
@@ -2449,6 +2718,7 @@
     {
       "name": "COMUNE DI LUCOLI",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00094420668",
       "population": 824,
       "value": 8230216.88,
@@ -2457,6 +2727,7 @@
     {
       "name": "COMUNE DI MARCETELLI",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00077920577",
       "population": 57,
       "value": 568015.89,
@@ -2465,6 +2736,7 @@
     {
       "name": "COMUNE DI PETRURO IRPINO",
       "region": "Campania",
+      "province": "Avellino",
       "codiceFiscale": "80010890640",
       "population": 295,
       "value": 2915687.75,
@@ -2473,6 +2745,7 @@
     {
       "name": "COMUNE DI CISSONE",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00476920046",
       "population": 78,
       "value": 762087.68,
@@ -2481,6 +2754,7 @@
     {
       "name": "COMUNE DI AQUILA D'ARROSCIA",
       "region": "Liguria",
+      "province": "Imperia",
       "codiceFiscale": "00246520084",
       "population": 138,
       "value": 1319365.16,
@@ -2489,6 +2763,7 @@
     {
       "name": "COMUNE DI CANNA",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "81000970780",
       "population": 610,
       "value": 5829644.09,
@@ -2497,6 +2772,7 @@
     {
       "name": "COMUNE DI SAN PIO DELLE CAMERE",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00197690662",
       "population": 650,
       "value": 6205906.09,
@@ -2505,6 +2781,7 @@
     {
       "name": "COMUNE DI PONTE GARDENA",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "94055150216",
       "population": 219,
       "value": 2088906.81,
@@ -2513,6 +2790,7 @@
     {
       "name": "COMUNE DI BELLINO",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "00534820048",
       "population": 96,
       "value": 915254.26,
@@ -2521,6 +2799,7 @@
     {
       "name": "COMUNE DI VALSAVARENCHE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00124870072",
       "population": 154,
       "value": 1460886.86,
@@ -2529,6 +2808,7 @@
     {
       "name": "COMUNE DI MASSELLO",
       "region": "Piemonte",
+      "province": "Torino",
       "codiceFiscale": "85000150012",
       "population": 57,
       "value": 540245.84,
@@ -2537,6 +2817,7 @@
     {
       "name": "COMUNE DI CASTELVECCHIO DI ROCCA BARBENA",
       "region": "Liguria",
+      "province": "Savona",
       "codiceFiscale": "00379280092",
       "population": 127,
       "value": 1195672.49,
@@ -2545,6 +2826,7 @@
     {
       "name": "COMUNE DI STELVIO",
       "region": "Trentino-Alto Adige/Südtirol",
+      "province": "Bolzano - Bozen",
       "codiceFiscale": "82008420216",
       "population": 1146,
       "value": 10787451.28,
@@ -2553,6 +2835,7 @@
     {
       "name": "COMUNE DI CITTAREALE",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00122890577",
       "population": 388,
       "value": 3577497.06,
@@ -2561,6 +2844,7 @@
     {
       "name": "COMUNE DI RITTANA",
       "region": "Piemonte",
+      "province": "Cuneo",
       "codiceFiscale": "80001890047",
       "population": 104,
       "value": 945162.8,
@@ -2569,6 +2853,7 @@
     {
       "name": "COMUNE DI VALGRISENCHE",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00101190072",
       "population": 186,
       "value": 1687918.04,
@@ -2577,6 +2862,7 @@
     {
       "name": "COMUNE DI GRESSONEY-LA-TRINITE'",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00109710079",
       "population": 320,
       "value": 2892220.53,
@@ -2585,6 +2871,7 @@
     {
       "name": "COMUNE DI CAPORCIANO",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "00187590666",
       "population": 201,
       "value": 1811001.34,
@@ -2593,6 +2880,7 @@
     {
       "name": "COMUNE DI VACCARIZZO ALBANESE",
       "region": "Calabria",
+      "province": "Cosenza",
       "codiceFiscale": "84000210785",
       "population": 1001,
       "value": 8900008.02,
@@ -2601,6 +2889,7 @@
     {
       "name": "COMUNE DI VOLTURARA APPULA",
       "region": "Puglia",
+      "province": "Foggia",
       "codiceFiscale": "82000370716",
       "population": 366,
       "value": 3252638.38,
@@ -2609,6 +2898,7 @@
     {
       "name": "COMUNE DI CASTELSANTANGELO SUL NERA",
       "region": "Marche",
+      "province": "Macerata",
       "codiceFiscale": "00242630432",
       "population": 221,
       "value": 1962861.44,
@@ -2617,6 +2907,7 @@
     {
       "name": "COMUNE DI DOGNA",
       "region": "Friuli-Venezia Giulia",
+      "province": "Udine",
       "codiceFiscale": "84005290303",
       "population": 150,
       "value": 1314535.08,
@@ -2625,6 +2916,7 @@
     {
       "name": "COMUNE DI CASTELDELCI",
       "region": "Emilia-Romagna",
+      "province": "Rimini",
       "codiceFiscale": "80008970412",
       "population": 364,
       "value": 3184033.52,
@@ -2633,6 +2925,7 @@
     {
       "name": "COMUNE DI PIEDICAVALLO",
       "region": "Piemonte",
+      "province": "Biella",
       "codiceFiscale": "00390570026",
       "population": 170,
       "value": 1484742.25,
@@ -2641,6 +2934,7 @@
     {
       "name": "COMUNE DI MONTELEONE ROCCA DORIA",
       "region": "Sardegna",
+      "province": "Sassari",
       "codiceFiscale": "00222250904",
       "population": 103,
       "value": 898034.55,
@@ -2649,6 +2943,7 @@
     {
       "name": "COMUNE DI SETZU",
       "region": "Sardegna",
+      "province": "Medio Campidano",
       "codiceFiscale": "82001290921",
       "population": 125,
       "value": 1085155.69,
@@ -2657,6 +2952,7 @@
     {
       "name": "COMUNE DI MICIGLIANO",
       "region": "Lazio",
+      "province": "Rieti",
       "codiceFiscale": "00113670574",
       "population": 112,
       "value": 970590.11,
@@ -2665,6 +2961,7 @@
     {
       "name": "COMUNE DI ZUCCARELLO",
       "region": "Liguria",
+      "province": "Savona",
       "codiceFiscale": "00331480095",
       "population": 284,
       "value": 2452512.26,
@@ -2673,6 +2970,7 @@
     {
       "name": "COMUNE DI POLINO",
       "region": "Umbria",
+      "province": "Terni",
       "codiceFiscale": "00178250551",
       "population": 204,
       "value": 1729644.92,
@@ -2681,6 +2979,7 @@
     {
       "name": "COMUNE DI OLLOMONT",
       "region": "Valle d'Aosta/Vallée d'Aoste",
+      "province": "Valle d'Aosta",
       "codiceFiscale": "00101810075",
       "population": 165,
       "value": 1395540.43,
@@ -2689,6 +2988,7 @@
     {
       "name": "COMUNE DI SANT'EUSANIO FORCONESE",
       "region": "Abruzzo",
+      "province": "L'Aquila",
       "codiceFiscale": "80002610667",
       "population": 365,
       "value": 3059631.54,
@@ -2703,12 +3003,12 @@
     "siopeMovementsLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",
     "siopeRegistryLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",
     "ipaLastModified": "Fri, 21 Aug 2026 03:14:18 GMT",
-    "observedAt": "2026-08-21T03:31:16+00:00"
+    "observedAt": "2026-08-21T11:34:54+00:00"
   },
   "methodology": {
     "measure": "pagamenti di cassa SIOPE dei Comuni",
     "periodicity": "movimenti mensili puri, sommati da gennaio all'ultimo mese disponibile",
-    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA",
+    "territorialJoin": "codice fiscale SIOPE → Regione della sede legale in IPA; Provincia pubblicata nell'anagrafica enti SIOPE",
     "populationSource": "popolazione riportata nell'anagrafica enti SIOPE",
     "populationReference": "data di riferimento non dichiarata dalla fonte",
     "populationSourceLastModified": "Thu, 20 Aug 2026 18:53:54 GMT",

--- a/src/lib/siope-snapshot.ts
+++ b/src/lib/siope-snapshot.ts
@@ -28,6 +28,7 @@ export type SiopeSpendingTitle = {
 
 export type SiopeMunicipalityPoint = {
   name: string;
+  province: string;
   region: string;
   codiceFiscale: string;
   population: number | null;
@@ -36,7 +37,7 @@ export type SiopeMunicipalityPoint = {
 };
 
 export type SiopeMunicipalSnapshot = {
-  schemaVersion: 2;
+  schemaVersion: 3;
   generatedAt: string;
   scope: "municipalities";
   year: number;

--- a/tests/mcp-datasets.test.mjs
+++ b/tests/mcp-datasets.test.mjs
@@ -38,6 +38,7 @@ test("SIOPE query validates years and can filter a region", async () => {
   assert.ok(result.topMunicipalities.every((item) => item.region === "Lazio"));
   assert.ok(result.topMunicipalitiesByValue.every((item) => item.region === "Lazio"));
   assert.ok(result.topMunicipalitiesByPerCapita.every((item) => item.region === "Lazio"));
+  assert.ok(result.topMunicipalitiesByPerCapita.every((item) => item.province.length > 0));
   assert.equal(result.queryLimitations.regionAggregateComplete, true);
   assert.match(result.queryLimitations.municipalityLists, /non elenco completo/i);
 });

--- a/tests/siope-etl-ranking.test.mjs
+++ b/tests/siope-etl-ranking.test.mjs
@@ -27,3 +27,34 @@ test("SIOPE ETL ranks a low-volume municipality first per capita", async () => {
   assert.equal(result.sentinel, null);
   assert.equal(result.valid, 125);
 });
+
+test("SIOPE ETL resolves official provinces and rejects unknown province codes", async () => {
+  const code = [
+    "import json, tempfile, zipfile",
+    "from pathlib import Path",
+    "from scripts.etl.siope_municipal_snapshot import load_municipalities",
+    "with tempfile.TemporaryDirectory() as directory:",
+    "    archive = Path(directory) / 'registry.zip'",
+    "    with zipfile.ZipFile(archive, 'w') as target:",
+    "        target.writestr('ANAG_REG_PROV.csv', 'ITALIA NORD-OCCIDENTALE,01,PIEMONTE,004,Cuneo\\n')",
+    "        target.writestr('ANAG_ENTI_SIOPE.csv', '1,2020-01-01,9999-12-31,CF1,COMUNE DI TEST,001,004,100,COMUNE\\n')",
+    "    active, _, count = load_municipalities(archive, {'CF1': 'Piemonte'})",
+    "    province = active['1']['province']",
+    "    with zipfile.ZipFile(archive, 'w') as target:",
+    "        target.writestr('ANAG_REG_PROV.csv', 'ITALIA NORD-OCCIDENTALE,01,PIEMONTE,004,Cuneo\\n')",
+    "        target.writestr('ANAG_ENTI_SIOPE.csv', '1,2020-01-01,9999-12-31,CF1,COMUNE DI TEST,001,999,100,COMUNE\\n')",
+    "    try:",
+    "        load_municipalities(archive, {'CF1': 'Piemonte'})",
+    "    except RuntimeError as error:",
+    "        rejected = 'Provincia SIOPE sconosciuta' in str(error)",
+    "    else:",
+    "        rejected = False",
+    "    print(json.dumps({'province': province, 'count': count, 'rejected': rejected}))",
+  ].join("\n");
+  const { stdout } = await execFileAsync("python3", ["-c", code], {
+    cwd: new URL("..", import.meta.url),
+  });
+  const result = JSON.parse(stdout);
+
+  assert.deepEqual(result, { province: "Cuneo", count: 1, rejected: true });
+});

--- a/tests/siope-snapshot.test.mjs
+++ b/tests/siope-snapshot.test.mjs
@@ -27,7 +27,7 @@ function assertMoneyClose(actual, expected, tolerance = 0.25) {
 test("SIOPE snapshot exposes a complete national municipal aggregation", async () => {
   const data = await loadSnapshot();
 
-  assert.equal(data.schemaVersion, 2);
+  assert.equal(data.schemaVersion, 3);
   assert.equal(data.scope, "municipalities");
   assert.equal(data.regions.length, 20);
   assert.ok(data.coverage.activeSiopeMunicipalities > 7_000);
@@ -85,6 +85,10 @@ test("regional and independent municipal rankings are sorted and numerically san
         data.topMunicipalitiesByPerCapita[index].perCapita,
     );
   }
+  for (const municipality of data.topMunicipalitiesByPerCapita) {
+    assert.match(municipality.province, /\S/);
+    assert.match(municipality.region, /\S/);
+  }
   assert.ok(
     data.topMunicipalitiesByPerCapita.some(
       (item) => !data.topMunicipalitiesByValue.some(
@@ -113,7 +117,7 @@ test("the period selector is backed by three reconciled SIOPE years", async () =
   assert.deepEqual(snapshots.map((data) => data.year), [2024, 2025, 2026]);
   for (const data of snapshots) {
     assert.equal(data.regions.length, 20);
-    assert.equal(data.schemaVersion, 2);
+    assert.equal(data.schemaVersion, 3);
     assert.equal(data.topMunicipalitiesByValue.length, 100);
     assert.equal(data.topMunicipalitiesByPerCapita.length, 100);
     assert.ok(data.monthly.length > 0);

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -103,3 +103,14 @@ test("the fiscal layout uses only defined spacing tokens", async () => {
   assert.doesNotMatch(css, /var\(--space-5\)/);
   assert.match(css, /margin-bottom: var\(--space-6\)/);
 });
+
+test("municipality rankings expose province and region as visible context", async () => {
+  const [page, contract] = await Promise.all([
+    source("../src/app/territori/page.tsx"),
+    source("../src/lib/siope-snapshot.ts"),
+  ]);
+
+  assert.match(contract, /province: string;/);
+  assert.match(page, /data-municipality-ranking="per-capita"/);
+  assert.match(page, /\{municipality\.province\} · \{municipality\.region\}/);
+});


### PR DESCRIPTION
## Cosa cambia
- mostra Provincia · Regione sotto ogni Comune nella classifica pro capite
- ricava la Provincia dall'associazione ufficiale SIOPE ANAG_ENTI_SIOPE → ANAG_REG_PROV, senza inferenze geografiche
- porta lo snapshot SIOPE allo schema v3 e aggiorna 2024, 2025 e 2026 senza variazioni a totali, mesi, copertura o ranking
- aggiorna contratto TypeScript, output MCP, documentazione e workflow schedulato
- aggiunge controlli fail-closed per codici provincia sconosciuti e campi territoriali vuoti
- aggiunge Browser E2E strutturale a 390 e 1280 px

## Verifica
- confronto semantico snapshot: totali/ranking/copertura invariati per tutti e tre gli anni
- npm test: 146/146
- Python ETL: 50/50
- npm run typecheck
- npm run lint
- npm run design:check
- npm run brand:check
- actionlint
- npm run build
- git diff --check
- Browser E2E production: 26 scenari combinati, inclusi Comuni e mappa mobile/desktop
- ETL live idempotente: snapshot 2026 unchanged, nessun download richiesto

## UI/UX
| Before | After | Why |
|---|---|---|
| Il Comune era mostrato senza contesto geografico | Provincia · Regione è visibile sotto il nome | Comprensibile anche senza conoscere la geografia locale |
| Un tooltip sarebbe stato necessario su mobile | Informazione persistente e leggibile su touch | Accessibilità e scansione migliori |
| Il test dipendeva da un Comune specifico | Valida struttura e contenuto della prima riga pubblicata | Evita falsi fallimenti quando cambia la graduatoria |

## Fonte
Registro ufficiale SIOPE: https://www.siope.it/documenti/siope2/open/last/SIOPE_ANAGRAFICHE.zip