### PR TITLE
fix: sort region dropdown alphabetically

### DIFF
--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -162,9 +162,11 @@ export function ItalyRegionsMap({
         <label className={styles.mobileSelector}>
           <span>Scegli una regione</span>
           <select value={selectedCode} onChange={(event) => selectRegion(event.target.value)}>
-            {Object.entries(REGION_NAME_BY_ISTAT_CODE).map(([code, name]) => (
-              <option value={code} key={code}>{name}</option>
-            ))}
+            {Object.entries(REGION_NAME_BY_ISTAT_CODE)
+              .sort(([, a], [, b]) => a.localeCompare(b, "it"))
+              .map(([code, name]) => (
+                <option value={code} key={code}>{name}</option>
+              ))}
           </select>
         </label>
 


### PR DESCRIPTION
The mobile region selector ("Scegli una regione") in the homepage section "Dove si spende di più, regione per regione" listed regions in ISTAT code order (geographic, north to south), which looked random. Options are now sorted alphabetically using Italian locale collation.