### PR TITLE
Sort the mobile region selector alphabetically

### DIFF
--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -319,6 +319,13 @@ async function assertInfoTooltips(page, label) {
 async function assertRegionalMapSelection(page, label) {
   const mapSelector = '[data-region-map="true"]';
   const detailSelector = '[data-region-detail="true"] b';
+  const regionLabels = await page.$$eval(
+    'select[data-region-selector="true"] option',
+    (options) => options.map((option) => option.textContent?.trim() ?? ""),
+  );
+  const sortedRegionLabels = [...regionLabels].sort(new Intl.Collator("it").compare);
+  assert.deepEqual(regionLabels, sortedRegionLabels, `${label}: regioni non in ordine alfabetico`);
+
   await page.waitForSelector(mapSelector, { visible: true });
   const regionPaths = await page.$$(
     `${mapSelector} path[role="button"][aria-label]`,

--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -13,6 +13,11 @@ import {
 import { compactEuro, exactEuro, integer } from "@/lib/format";
 import styles from "./italy-regions-map.module.css";
 
+const italianRegionCollator = new Intl.Collator("it");
+const regionOptions = Object.entries(REGION_NAME_BY_ISTAT_CODE).sort(([, left], [, right]) =>
+  italianRegionCollator.compare(left, right),
+);
+
 function quantile(values: number[], fraction: number): number {
   const index = Math.min(values.length - 1, Math.floor(values.length * fraction));
   return values[index] ?? 0;
@@ -208,8 +213,12 @@ export function ItalyRegionsMap({
 
         <label className={styles.mobileSelector}>
           <span>Scegli una regione</span>
-          <select value={selectedCode} onChange={(event) => selectRegion(event.target.value)}>
-            {Object.entries(REGION_NAME_BY_ISTAT_CODE).map(([code, name]) => (
+          <select
+            data-region-selector="true"
+            value={selectedCode}
+            onChange={(event) => selectRegion(event.target.value)}
+          >
+            {regionOptions.map(([code, name]) => (
               <option value={code} key={code}>{name}</option>
             ))}
           </select>

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -103,7 +103,16 @@ test("the regional map has a deterministic fallback and roving keyboard focus", 
   assert.match(map, /"ArrowRight"|"ArrowDown"/);
   assert.match(map, /"ArrowLeft"|"ArrowUp"/);
   assert.match(map, /regionPathRefs\.current\.get\(nextCode\)\?\.focus\(\)/);
-  assert.match(map, /<select value=\{selectedCode\}/);
+  assert.match(map, /<select[\s\S]*?value=\{selectedCode\}/);
+});
+
+test("the mobile region selector is sorted once with Italian collation", async () => {
+  const map = await source("../src/components/italy-regions-map.tsx");
+
+  assert.match(map, /const italianRegionCollator = new Intl\.Collator\("it"\);/);
+  assert.match(map, /const regionOptions = Object\.entries\(REGION_NAME_BY_ISTAT_CODE\)\.sort/);
+  assert.match(map, /\{regionOptions\.map\(\(\[code, name\]\) => \(/);
+  assert.match(map, /data-region-selector="true"/);
 });
 
 test("the regional map redraws selected and hovered borders above all region fills", async () => {


### PR DESCRIPTION
## Cosa cambia

Port pulito della PR #35 sull’ultimo `main`, con attribuzione al contributore e copertura automatica.

- ordina alfabeticamente in italiano le 20 Regioni del selettore mobile;
- calcola l’ordinamento una sola volta a livello di modulo, non a ogni render;
- aggiunge un selettore dati stabile per il test senza alterare accessibilità o copy;
- estende il Browser E2E per confrontare l’ordine DOM effettivo con `Intl.Collator("it")` a 390 e 1280 px.

Grazie a @mameli per la segnalazione e la patch originaria in #35.

## Evidenza

- `npm test`: 149/149
- typecheck, lint, design, diff-check: PASS
- build production: PASS
- Browser E2E completo: PASS, inclusi ordine regioni, hover e selezione bloccata della mappa
- Impeccable detector: 0 finding

Supersedes #35 after merge.
