### PR TITLE
fix: harden consulting lead delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ MCP_ALLOWED_HOSTS=
 # Chiave Resend per le richieste di consulenza (https://resend.com/api-keys).
 # Senza questa variabile il form risponde 503.
 RESEND_API_KEY=
-# Destinatario delle lead. Se vuoto si usa gagliardidomenico46@gmail.com.
+# Destinatario delle richieste. Obbligatorio: nessun fallback in produzione.
 LEAD_INBOX_EMAIL=
-# Mittente sul dominio verificato in Resend.
+# Mittente sul dominio verificato in Resend. Obbligatorio.
 # RESEND_FROM_EMAIL=Consulenza <consulenza@dovevannoinostrisoldi.com>
 RESEND_FROM_EMAIL=

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ considerata presente; la configurazione proposta è documentata in [docs/MCP.md]
 
 Per aggiungere una fonte all'MCP si registra la descrizione in `src/lib/mcp/catalog.ts` e l'adapter in `src/lib/mcp/datasets.ts`. Gli strumenti restano gli stessi, quindi i client non devono essere riconfigurati quando il catalogo cresce. Dettagli e checklist sono in [docs/MCP.md](docs/MCP.md).
 
+Il form di consulenza usa configurazione email fail-closed, richieste same-origin limitate e invii
+idempotenti. Honeypot e validazione non vengono presentati come rate limit: la regola WAF e la
+procedura di cancellazione restano controlli operativi del deployment, descritti in
+[docs/CONSULTING.md](docs/CONSULTING.md).
+
 Per OpenCivitas, la differenza tra spesa storica e spesa standard non viene chiamata spreco. L'API restituisce anche i valori per abitante, il confronto sui servizi e i limiti territoriali della fonte.
 
 Per le opere pubbliche, l'API può segnalare date da controllare, crescita dei costi, finanziamenti ancora da trovare o problemi di qualità del dato. Sono indicazioni per scegliere cosa approfondire, non prove automatiche di spreco.

--- a/docs/CONSULTING.md
+++ b/docs/CONSULTING.md
@@ -1,0 +1,35 @@
+# Form di consulenza
+
+La pagina `/consulenza` invia richieste testuali a Resend e alla casella del progetto. Non crea
+un database applicativo di contatti e non espone le credenziali al browser.
+
+## Configurazione obbligatoria
+
+- `RESEND_API_KEY`: chiave con solo permesso di invio e, quando possibile, limitata al dominio;
+- `RESEND_FROM_EMAIL`: mittente appartenente a un dominio verificato in Resend;
+- `LEAD_INBOX_EMAIL`: destinatario gestito dal titolare indicato in `/privacy`.
+
+Se una variabile manca o contiene un indirizzo non valido, l'endpoint risponde `503`: non usa
+fallback impliciti. Le richieste a Resend hanno timeout e `Idempotency-Key`; un retry dello stesso
+contenuto non deve produrre una seconda email nell'arco supportato dal provider.
+
+## Controlli applicativi e limite dichiarato
+
+L'endpoint accetta solo JSON same-origin, limita il corpo a 16 KiB e valida campi, consenso e
+honeypot. Questi controlli non costituiscono un rate limit distribuito e non fermano un client che
+imita una richiesta lecita. In produzione va configurata una regola WAF per `/api/consulenza`,
+partendo in modalità log e scegliendo la soglia dopo aver osservato traffico reale e falsi positivi.
+
+## Operazioni privacy
+
+Il titolare deve mantenere una procedura verificabile per cancellare le richieste dalla casella e
+da Resend entro il periodo dichiarato nella pagina privacy, gestire le richieste degli interessati e
+conservare il DPA del provider. Prima di cambiare provider, inbox, periodo o scopo vanno aggiornati
+informativa, test e configurazione nello stesso rilascio.
+
+Fonti operative:
+
+- [Resend: idempotency keys](https://resend.com/docs/dashboard/emails/idempotency-keys)
+- [Resend: data residency](https://resend.com/docs/dashboard/domains/regions)
+- [Resend: GDPR e DPA](https://resend.com/security/gdpr)
+- [Vercel WAF custom rules](https://vercel.com/docs/vercel-firewall/vercel-waf/custom-rules)

--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -673,6 +673,46 @@ try {
     completed.push(label);
   }
 
+  for (const width of [320, 390, 768, 1024, 1280]) {
+    const label = `Consulenza ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/consulenza",
+      width,
+      validate: async (page) => {
+        assertTextMatches(
+          await bodyText(page),
+          /Intelligenza artificiale per aziende e PA/i,
+          label,
+        );
+        const form = await page.$eval("main form", (element) => ({
+          hasPrivacyLink: Boolean(element.querySelector('a[href="/privacy"]')),
+          invalidBeforeSubmit: !element.checkValidity(),
+          requiredFields: element.querySelectorAll("[required]").length,
+        }));
+        assert.equal(form.hasPrivacyLink, true, `${label}: informativa privacy non collegata`);
+        assert.equal(form.invalidBeforeSubmit, true, `${label}: form vuoto considerato valido`);
+        assert.ok(form.requiredFields >= 7, `${label}: campi obbligatori inattesi`);
+      },
+    });
+    completed.push(label);
+  }
+
+  for (const width of [390, 1280]) {
+    const label = `Privacy consulenza ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/privacy",
+      width,
+      validate: async (page) => {
+        const text = await bodyText(page);
+        assertTextMatches(text, /Resend/i, label);
+        assertTextMatches(text, /Stati Uniti/i, label);
+      },
+    });
+    completed.push(label);
+  }
+
   for (const width of [320, 390, 768, 901, 1024, 1280]) {
     const label = `Tooltip home ${width}px`;
     await runScenario(browser, {

--- a/scripts/lighthouse_budget.mjs
+++ b/scripts/lighthouse_budget.mjs
@@ -16,9 +16,31 @@ const JSON_REPORT_PATH = resolve(REPORT_DIR, "irpef-lighthouse.json");
 const HTML_REPORT_PATH = resolve(REPORT_DIR, "irpef-lighthouse.html");
 const SUMMARY_REPORT_PATH = resolve(REPORT_DIR, "irpef-lighthouse-summary.json");
 const LIGHTHOUSE_RUN_COUNT = 3;
+const BROWSER_CLOSE_TIMEOUT_MS = 5_000;
 
 const sleep = (milliseconds) =>
   new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+
+async function closeBrowser(browser) {
+  let timeout;
+  try {
+    await Promise.race([
+      browser.close(),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Timeout durante la chiusura di Chromium.")),
+          BROWSER_CLOSE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } catch (error) {
+    const browserProcess = browser.process();
+    if (browserProcess && !browserProcess.killed) browserProcess.kill("SIGKILL");
+    console.warn(error instanceof Error ? error.message : String(error));
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 function auditUrl() {
   const baseUrl = new URL(process.env.DVNS_BASE_URL ?? DEFAULT_BASE_URL);
@@ -290,7 +312,7 @@ async function main() {
 
     if (errors.length > 0) process.exitCode = 1;
   } finally {
-    await browser.close();
+    await closeBrowser(browser);
   }
 }
 

--- a/src/app/api/consulenza/route.ts
+++ b/src/app/api/consulenza/route.ts
@@ -2,17 +2,99 @@ import { parseLead, sendLeadEmail } from "@/lib/leads";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const maxDuration = 15;
 
-const NO_STORE = { "cache-control": "private, no-store" };
+const MAX_REQUEST_BYTES = 16_384;
+const NO_STORE = {
+  "cache-control": "private, no-store",
+  "x-content-type-options": "nosniff",
+};
 
-function json(body: unknown, status = 200) {
-  return Response.json(body, { status, headers: NO_STORE });
+function json(body: unknown, status = 200, headers?: HeadersInit) {
+  return Response.json(body, { status, headers: { ...NO_STORE, ...headers } });
+}
+
+function isLoopbackHost(host: string): boolean {
+  const hostname = host.replace(/^\[|\](?::\d+)?$|:\d+$/g, "").toLowerCase();
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function rejectRequest(request: Request): Response | null {
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim();
+  if (contentType !== "application/json") {
+    return json({ ok: false, error: "Content-Type non supportato" }, 415);
+  }
+
+  const origin = request.headers.get("origin");
+  let originUrl: URL;
+  try {
+    originUrl = new URL(origin ?? "");
+  } catch {
+    return json({ ok: false, error: "Origin non consentita" }, 403);
+  }
+  const requestUrl = new URL(request.url);
+  const requestHost = (request.headers.get("host") ?? requestUrl.host).trim().toLowerCase();
+  const allowedProtocol =
+    originUrl.protocol === "https:" ||
+    (originUrl.protocol === "http:" && isLoopbackHost(requestHost));
+  if (originUrl.host.toLowerCase() !== requestHost || !allowedProtocol) {
+    return json({ ok: false, error: "Origin non consentita" }, 403);
+  }
+
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength)) {
+      return json({ ok: false, error: "Content-Length non valido" }, 400);
+    }
+    if (Number(declaredLength) > MAX_REQUEST_BYTES) {
+      return json({ ok: false, error: "Richiesta troppo grande" }, 413);
+    }
+  }
+
+  return null;
+}
+
+async function boundedBody(request: Request): Promise<string | Response> {
+  if (!request.body) return json({ ok: false, error: "Corpo richiesta assente" }, 400);
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_REQUEST_BYTES) {
+      await reader.cancel("Consulting request body limit exceeded").catch(() => undefined);
+      return json({ ok: false, error: "Richiesta troppo grande" }, 413);
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8", { fatal: true }).decode(body);
 }
 
 export async function POST(request: Request) {
+  const rejected = rejectRequest(request);
+  if (rejected) return rejected;
+
+  let rawBody: string | Response;
+  try {
+    rawBody = await boundedBody(request);
+  } catch {
+    return json({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
+  }
+  if (rawBody instanceof Response) return rawBody;
+
   let payload: unknown;
   try {
-    payload = await request.json();
+    payload = JSON.parse(rawBody);
   } catch {
     return json({ ok: false, error: "Richiesta non valida" }, 400);
   }
@@ -31,8 +113,13 @@ export async function POST(request: Request) {
     if (sent.status === 503) {
       return json({ ok: false, error: "Invio non configurato sul deployment" }, 503);
     }
+    if (sent.status === 429) {
+      return json({ ok: false, error: "Servizio temporaneamente occupato" }, 429, {
+        "retry-after": "60",
+      });
+    }
 
-    console.error("Resend ha rifiutato la lead", sent.status, sent.detail);
+    console.error("Resend ha rifiutato una richiesta", sent.status, sent.detail);
     return json({ ok: false, error: "Non siamo riusciti a inviare la richiesta" }, 502);
   } catch (error) {
     console.error("Invio lead non riuscito", error);

--- a/src/app/consulenza/lead-form.tsx
+++ b/src/app/consulenza/lead-form.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useState, type FormEvent } from "react";
-import { CONSULTING_TOPICS, ORGANIZATION_TYPES, PROJECT_BUDGETS } from "@/lib/leads";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import {
+  CONSULTING_TOPICS,
+  ORGANIZATION_TYPES,
+  PROJECT_BUDGETS,
+} from "@/lib/consulting-contract";
 import styles from "./consulenza.module.css";
 
 type FormStatus = "idle" | "sending" | "success" | "error";
@@ -12,14 +16,21 @@ const TYPE_KEYS = Object.keys(ORGANIZATION_TYPES) as Array<keyof typeof ORGANIZA
 const BUDGET_KEYS = Object.keys(PROJECT_BUDGETS) as Array<keyof typeof PROJECT_BUDGETS>;
 
 export function LeadForm() {
-  const [startedAt] = useState(() => Date.now());
   const [status, setStatus] = useState<FormStatus>("idle");
   const [error, setError] = useState<string | null>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const successRef = useRef<HTMLDivElement>(null);
+  const submissionRef = useRef<{ fingerprint: string; id: string } | null>(null);
   const sending = status === "sending";
+
+  useEffect(() => {
+    if (status === "success") successRef.current?.focus();
+    else if (error) errorRef.current?.focus();
+  }, [error, status]);
 
   if (status === "success") {
     return (
-      <div className="notice" role="status">
+      <div className="notice" role="status" tabIndex={-1} ref={successRef}>
         <strong>Richiesta inviata</strong>
         <p>
           Grazie. Rispondiamo di solito entro due giorni lavorativi, sullo stesso indirizzo
@@ -37,7 +48,7 @@ export function LeadForm() {
     setStatus("sending");
     setError(null);
 
-    const body = {
+    const draft = {
       name: String(data.get("name") ?? ""),
       email: String(data.get("email") ?? ""),
       organization: String(data.get("organization") ?? ""),
@@ -49,8 +60,12 @@ export function LeadForm() {
       message: String(data.get("message") ?? ""),
       consent: data.get("consent") === "on",
       company_fax: String(data.get("company_fax") ?? ""),
-      startedAt,
     };
+    const fingerprint = JSON.stringify(draft);
+    if (submissionRef.current?.fingerprint !== fingerprint) {
+      submissionRef.current = { fingerprint, id: crypto.randomUUID() };
+    }
+    const body = { ...draft, submissionId: submissionRef.current.id };
 
     try {
       const response = await fetch("/api/consulenza", {
@@ -74,7 +89,12 @@ export function LeadForm() {
   }
 
   return (
-    <form className={styles.form} onSubmit={onSubmit} noValidate aria-busy={sending}>
+    <form
+      className={styles.form}
+      onSubmit={onSubmit}
+      aria-busy={sending}
+      aria-describedby={error ? "consulting-form-error" : undefined}
+    >
       <p className={styles.requiredNote}>I campi con * sono obbligatori.</p>
 
       <label>
@@ -104,7 +124,7 @@ export function LeadForm() {
         <input
           className="input"
           name="organizationWebsite"
-          type="url"
+          type="text"
           inputMode="url"
           autoComplete="url"
           maxLength={300}
@@ -187,7 +207,13 @@ export function LeadForm() {
       </label>
 
       {error ? (
-        <p className={styles.error} role="alert">
+        <p
+          className={styles.error}
+          id="consulting-form-error"
+          role="alert"
+          tabIndex={-1}
+          ref={errorRef}
+        >
           {error}
         </p>
       ) : null}

--- a/src/app/consulenza/page.tsx
+++ b/src/app/consulenza/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CONSULTING_TOPICS } from "@/lib/leads";
+import { CONSULTING_TOPICS } from "@/lib/consulting-contract";
 import styles from "./consulenza.module.css";
 import { LeadForm } from "./lead-form";
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -13,8 +13,8 @@ export default function PrivacyPage() {
       <div className="page-intro">
         <h1>Informativa privacy</h1>
         <p>
-          Questa pagina riguarda solo i dati che invii dal form di consulenza. Il resto del
-          sito legge fonti pubbliche e non chiede un account.
+          Questa pagina descrive il form di consulenza e i dati tecnici necessari a erogare
+          il sito. Il sito legge fonti pubbliche e non chiede un account.
         </p>
       </div>
 
@@ -32,23 +32,47 @@ export default function PrivacyPage() {
           Nome, email, organizzazione, sito web se indicato, tipo di ente, ruolo, oggetto
           della richiesta, budget del progetto e messaggio. Li usiamo solo per rispondere
           e, se ha senso, per un eventuale incarico. Base giuridica: consenso e, se
-          avviamo una trattativa, misure precontrattuali.
+          avviamo una trattativa, misure precontrattuali. Ruolo e sito web sono facoltativi;
+          senza gli altri dati non possiamo ricontattarti o inquadrare il progetto.
         </p>
       </section>
 
       <section className="panel">
         <h2 className="panel-title">Quanto restano e chi li vede</h2>
         <p>
-          Conserviamo la richiesta fino a 24 mesi, o meno se chiedi la cancellazione
-          prima. L&apos;email di notifica passa da Resend e arriva nella casella indicata
-          sopra. Non vendiamo i contatti e non facciamo profilazione pubblicitaria.
+          L&apos;applicazione non crea un database di contatti: la richiesta passa da Resend e
+          arriva nella casella del progetto. La conserviamo fino a 24 mesi dalla ricezione,
+          salvo cancellazione anticipata o obblighi collegati a un eventuale incarico. Resend
+          agisce come fornitore del servizio email; i suoi metadati, log e record API sono
+          conservati negli Stati Uniti anche quando l&apos;invio parte dalla regione europea. Il
+          suo DPA include le clausole contrattuali standard per il trasferimento dei dati. Vedi
+          le informazioni ufficiali su{" "}
+          <a href="https://resend.com/docs/dashboard/domains/regions" target="_blank" rel="noreferrer">
+            residenza dei dati
+          </a>{" "}
+          e{" "}
+          <a href="https://resend.com/security/gdpr" target="_blank" rel="noreferrer">
+            GDPR e DPA
+          </a>. Non vendiamo i contatti e non facciamo profilazione pubblicitaria.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Dati tecnici</h2>
+        <p>
+          Il provider di hosting può trattare log tecnici, come indirizzo IP, user agent,
+          orario e percorso richiesto, per consegnare e proteggere il servizio. La home può
+          ricavare dal provider una Regione approssimativa per proporre la mappa iniziale:
+          l&apos;applicazione non mostra né salva l&apos;indirizzo IP e puoi cambiare Regione in ogni
+          momento.
         </p>
       </section>
 
       <section className="panel">
         <h2 className="panel-title">I tuoi diritti</h2>
         <p>
-          Puoi chiedere accesso, correzione, cancellazione, limitazione o opposizione
+          Puoi chiedere accesso, correzione, cancellazione, limitazione, portabilità quando
+          applicabile o opposizione
           scrivendo alla stessa email. Puoi anche revocare il consenso e presentare
           reclamo al Garante per la protezione dei dati personali.
         </p>

--- a/src/lib/consulting-contract.ts
+++ b/src/lib/consulting-contract.ts
@@ -1,0 +1,25 @@
+export const ORGANIZATION_TYPES = {
+  azienda: "Azienda",
+  pa: "Ente pubblico o PA",
+  altro: "Altro",
+} as const;
+
+export const CONSULTING_TOPICS = {
+  lettura: "Lettura con AI di un problema, un dataset o un progetto",
+  dashboard: "Report o cruscotto interno con AI",
+  formazione: "Formazione all'uso dell'AI",
+  applicazione: "Strumento AI per l'impresa o per la PA",
+  altro: "Altro",
+} as const;
+
+export const PROJECT_BUDGETS = {
+  fino_5k: "Fino a 5.000 euro",
+  da_5k_a_15k: "Da 5.000 a 15.000 euro",
+  da_15k_a_30k: "Da 15.000 a 30.000 euro",
+  oltre_30k: "Oltre 30.000 euro",
+  non_so: "Non so ancora",
+} as const;
+
+export type OrganizationType = keyof typeof ORGANIZATION_TYPES;
+export type ConsultingTopic = keyof typeof CONSULTING_TOPICS;
+export type ProjectBudget = keyof typeof PROJECT_BUDGETS;

--- a/src/lib/leads.ts
+++ b/src/lib/leads.ts
@@ -1,33 +1,14 @@
 import { z } from "zod";
-import { CONTACT_EMAIL } from "@/lib/site";
+import {
+  CONSULTING_TOPICS,
+  ORGANIZATION_TYPES,
+  PROJECT_BUDGETS,
+  type ConsultingTopic,
+  type OrganizationType,
+  type ProjectBudget,
+} from "@/lib/consulting-contract";
 
-export const ORGANIZATION_TYPES = {
-  azienda: "Azienda",
-  pa: "Ente pubblico o PA",
-  altro: "Altro",
-} as const;
-
-export const CONSULTING_TOPICS = {
-  lettura: "Lettura con AI di un problema, un dataset o un progetto",
-  dashboard: "Report o cruscotto interno con AI",
-  formazione: "Formazione all'uso dell'AI",
-  applicazione: "Strumento AI per l'impresa o per la PA",
-  altro: "Altro",
-} as const;
-
-export const PROJECT_BUDGETS = {
-  fino_5k: "Fino a 5.000 euro",
-  da_5k_a_15k: "Da 5.000 a 15.000 euro",
-  da_15k_a_30k: "Da 15.000 a 30.000 euro",
-  oltre_30k: "Oltre 30.000 euro",
-  non_so: "Non so ancora",
-} as const;
-
-export type OrganizationType = keyof typeof ORGANIZATION_TYPES;
-export type ConsultingTopic = keyof typeof CONSULTING_TOPICS;
-export type ProjectBudget = keyof typeof PROJECT_BUDGETS;
-
-const MIN_SUBMIT_MS = 4_000;
+const RESEND_TIMEOUT_MS = 8_000;
 
 const leadFields = z.object({
   name: z.string().trim().min(2, "Indica nome e cognome.").max(120),
@@ -53,6 +34,7 @@ const leadFields = z.object({
     .min(30, "Scrivi almeno 30 caratteri su che cosa ti serve.")
     .max(4000),
   consent: z.literal(true, { error: "Serve il consenso al trattamento dei dati." }),
+  submissionId: z.uuid("Identificativo richiesta non valido."),
 });
 
 export type Lead = z.infer<typeof leadFields>;
@@ -73,12 +55,6 @@ function isFilledHoneypot(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function isTooFast(startedAt: unknown, now: number): boolean {
-  if (typeof startedAt !== "number" || !Number.isFinite(startedAt)) return true;
-  if (startedAt > now) return true;
-  return now - startedAt < MIN_SUBMIT_MS;
-}
-
 function emptyToUndefined(value: unknown): unknown {
   if (typeof value !== "string") return value;
   const trimmed = value.trim();
@@ -93,10 +69,10 @@ function normalizeOptionalWebsite(value: unknown): unknown {
   return `https://${trimmed}`;
 }
 
-export function parseLead(payload: unknown, now = Date.now()): LeadParseResult {
+export function parseLead(payload: unknown): LeadParseResult {
   const record = asRecord(payload);
 
-  if (isFilledHoneypot(record.company_fax) || isFilledHoneypot(record.website) || isTooFast(record.startedAt, now)) {
+  if (isFilledHoneypot(record.company_fax) || isFilledHoneypot(record.website)) {
     return { status: "discarded" };
   }
 
@@ -111,6 +87,7 @@ export function parseLead(payload: unknown, now = Date.now()): LeadParseResult {
     budget: record.budget,
     message: record.message,
     consent: record.consent === true || record.consent === "true" || record.consent === "on",
+    submissionId: record.submissionId,
   });
 
   if (!parsed.success) {
@@ -149,25 +126,26 @@ export function formatLeadEmail(lead: Lead, receivedAt: Date): string {
 }
 
 export function leadEmailSubject(lead: Lead): string {
-  return `Richiesta consulenza: ${lead.organization}`;
+  const organization = lead.organization
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return `Richiesta consulenza: ${organization}`;
 }
 
-const RESEND_DEFAULT_FROM = "Consulenza <consulenza@dovevannoinostrisoldi.com>";
-const BLOCKED_FROM_DOMAINS = /@(gmail|googlemail|yahoo|outlook|hotmail|icloud|example)\./i;
+const mailbox = z.email();
+const namedMailbox = /^[^<>\r\n]+<([^<>\r\n]+)>$/;
 
-export function leadInbox(): string {
-  return process.env.LEAD_INBOX_EMAIL?.trim() || CONTACT_EMAIL;
+export function leadInbox(): string | null {
+  const configured = process.env.LEAD_INBOX_EMAIL?.trim();
+  return configured && mailbox.safeParse(configured).success ? configured : null;
 }
 
-export function leadFromAddress(): string {
+export function leadFromAddress(): string | null {
   const configured = process.env.RESEND_FROM_EMAIL?.trim();
-  if (!configured) return RESEND_DEFAULT_FROM;
-
-  const address = configured.includes("<")
-    ? configured.slice(configured.indexOf("<") + 1, configured.lastIndexOf(">")).trim()
-    : configured;
-  if (!address || BLOCKED_FROM_DOMAINS.test(address)) return RESEND_DEFAULT_FROM;
-  return configured;
+  if (!configured) return null;
+  const address = namedMailbox.exec(configured)?.[1]?.trim() ?? configured;
+  return mailbox.safeParse(address).success ? configured : null;
 }
 
 export const RESEND_EMAILS_URL = "https://api.resend.com/emails";
@@ -178,24 +156,31 @@ export async function sendLeadEmail(
   fetchImpl: typeof fetch = fetch,
 ): Promise<{ ok: true } | { ok: false; status: number; detail: string }> {
   const apiKey = process.env.RESEND_API_KEY?.trim();
-  if (!apiKey) return { ok: false, status: 503, detail: "missing-key" };
+  const from = leadFromAddress();
+  const inbox = leadInbox();
+  if (!apiKey || !from || !inbox) {
+    return { ok: false, status: 503, detail: "missing-or-invalid-email-config" };
+  }
 
   const response = await fetchImpl(RESEND_EMAILS_URL, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
+      "Idempotency-Key": `consulting/${lead.submissionId}`,
     },
     body: JSON.stringify({
-      from: leadFromAddress(),
-      to: [leadInbox()],
+      from,
+      to: [inbox],
+      reply_to: lead.email,
       subject: leadEmailSubject(lead),
       text: formatLeadEmail(lead, receivedAt),
     }),
+    signal: AbortSignal.timeout(RESEND_TIMEOUT_MS),
   });
 
   if (response.ok) return { ok: true };
 
-  const detail = await response.text();
-  return { ok: false, status: response.status, detail };
+  await response.body?.cancel().catch(() => undefined);
+  return { ok: false, status: response.status, detail: "provider-rejected" };
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -6,5 +6,5 @@
 
 export const REPO_URL = "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi";
 
-/** Inbox for consulting leads. Override in production with LEAD_INBOX_EMAIL. */
+/** Public contact shown in the privacy notice; delivery is configured separately. */
 export const CONTACT_EMAIL = "gagliardidomenico46@gmail.com";

--- a/tests/leads.test.mjs
+++ b/tests/leads.test.mjs
@@ -6,12 +6,12 @@ const {
   formatLeadEmail,
   leadEmailSubject,
   leadFromAddress,
+  leadInbox,
   parseLead,
+  sendLeadEmail,
 } = await import("../src/lib/leads.ts");
 const { POST } = await import("../src/app/api/consulenza/route.ts");
 const { CONTACT_EMAIL } = await import("../src/lib/site.ts");
-
-const startedAt = Date.now() - 10_000;
 
 const validLead = {
   name: "Anna Rossi",
@@ -23,19 +23,23 @@ const validLead = {
   budget: "da_5k_a_15k",
   message: "Vorremmo una lettura dei pagamenti comunali 2025 e un confronto con i capoluoghi vicini.",
   consent: true,
-  startedAt,
+  submissionId: "b5b05a55-22df-4dc1-a6a4-175cd1b8490f",
 };
 
 function request(body, headers = {}) {
   return new Request("https://example.test/api/consulenza", {
     method: "POST",
-    headers: { "Content-Type": "application/json", ...headers },
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://example.test",
+      ...headers,
+    },
     body: JSON.stringify(body),
   });
 }
 
 test("parseLead accepts a complete consulting request", () => {
-  const parsed = parseLead(validLead, startedAt + 10_000);
+  const parsed = parseLead(validLead);
   assert.equal(parsed.status, "valid");
   if (parsed.status !== "valid") return;
   assert.equal(parsed.lead.organizationType, "pa");
@@ -49,30 +53,30 @@ test("parseLead accepts a complete consulting request", () => {
 });
 
 test("parseLead rejects a missing consent and a short message", () => {
-  const withoutConsent = parseLead({ ...validLead, consent: false }, startedAt + 10_000);
+  const withoutConsent = parseLead({ ...validLead, consent: false });
   assert.equal(withoutConsent.status, "invalid");
   if (withoutConsent.status === "invalid") {
     assert.match(withoutConsent.error, /consenso/i);
   }
 
-  const short = parseLead({ ...validLead, message: "Ciao" }, startedAt + 10_000);
+  const short = parseLead({ ...validLead, message: "Ciao" });
   assert.equal(short.status, "invalid");
   if (short.status === "invalid") {
     assert.match(short.error, /30 caratteri/);
   }
 
-  const almost = parseLead({ ...validLead, message: "a".repeat(29) }, startedAt + 10_000);
+  const almost = parseLead({ ...validLead, message: "a".repeat(29) });
   assert.equal(almost.status, "invalid");
-  const enough = parseLead({ ...validLead, message: "a".repeat(30) }, startedAt + 10_000);
+  const enough = parseLead({ ...validLead, message: "a".repeat(30) });
   assert.equal(enough.status, "valid");
 
-  const withoutBudget = parseLead({ ...validLead, budget: undefined }, startedAt + 10_000);
+  const withoutBudget = parseLead({ ...validLead, budget: undefined });
   assert.equal(withoutBudget.status, "invalid");
   if (withoutBudget.status === "invalid") {
     assert.match(withoutBudget.error, /budget/i);
   }
 
-  const unknownBudget = parseLead({ ...validLead, budget: "non_so" }, startedAt + 10_000);
+  const unknownBudget = parseLead({ ...validLead, budget: "non_so" });
   assert.equal(unknownBudget.status, "valid");
   if (unknownBudget.status === "valid") {
     assert.equal(unknownBudget.lead.budget, "non_so");
@@ -80,7 +84,6 @@ test("parseLead rejects a missing consent and a short message", () => {
 
   const withSite = parseLead(
     { ...validLead, organizationWebsite: "comune.esempio.it" },
-    startedAt + 10_000,
   );
   assert.equal(withSite.status, "valid");
   if (withSite.status === "valid") {
@@ -88,24 +91,24 @@ test("parseLead rejects a missing consent and a short message", () => {
     assert.match(formatLeadEmail(withSite.lead, new Date("2026-08-21T12:00:00Z")), /https:\/\/comune\.esempio\.it/);
   }
 
-  const badSite = parseLead({ ...validLead, organizationWebsite: "not a site" }, startedAt + 10_000);
+  const badSite = parseLead({ ...validLead, organizationWebsite: "not a site" });
   assert.equal(badSite.status, "invalid");
   if (badSite.status === "invalid") {
     assert.match(badSite.error, /sito/i);
   }
 });
 
-test("parseLead discards honeypot and too-fast submissions", () => {
-  assert.equal(parseLead({ ...validLead, company_fax: "https://spam.test" }, startedAt + 10_000).status, "discarded");
-  assert.equal(parseLead({ ...validLead, website: "https://spam.test" }, startedAt + 10_000).status, "discarded");
-  assert.equal(parseLead({ ...validLead, startedAt: Date.now() }, Date.now()).status, "discarded");
+test("parseLead discards honeypots without rejecting fast human submissions", () => {
+  assert.equal(parseLead({ ...validLead, company_fax: "https://spam.test" }).status, "discarded");
+  assert.equal(parseLead({ ...validLead, website: "https://spam.test" }).status, "discarded");
+  assert.equal(parseLead({ ...validLead, startedAt: Date.now() }).status, "valid");
 });
 
 test("consulting API rejects invalid JSON and incomplete leads", async () => {
   const invalidJson = await POST(
     new Request("https://example.test/api/consulenza", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Origin: "https://example.test" },
       body: "{",
     }),
   );
@@ -136,8 +139,10 @@ test("consulting API pretends success on spam and needs Resend for real leads", 
 test("consulting API sends a plain-text email to the configured inbox", async () => {
   const previousKey = process.env.RESEND_API_KEY;
   const previousInbox = process.env.LEAD_INBOX_EMAIL;
+  const previousFrom = process.env.RESEND_FROM_EMAIL;
   process.env.RESEND_API_KEY = "re_test";
   process.env.LEAD_INBOX_EMAIL = CONTACT_EMAIL;
+  process.env.RESEND_FROM_EMAIL = "Consulenza <consulenza@dovevannoinostrisoldi.com>";
 
   const calls = [];
   const originalFetch = globalThis.fetch;
@@ -152,10 +157,12 @@ test("consulting API sends a plain-text email to the configured inbox", async ()
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, "https://api.resend.com/emails");
     assert.match(calls[0].init.headers.Authorization, /Bearer re_test/);
+    assert.equal(calls[0].init.headers["Idempotency-Key"], `consulting/${validLead.submissionId}`);
+    assert.ok(calls[0].init.signal instanceof AbortSignal);
     const sent = JSON.parse(calls[0].init.body);
     assert.deepEqual(sent.to, [CONTACT_EMAIL]);
     assert.equal(sent.from, "Consulenza <consulenza@dovevannoinostrisoldi.com>");
-    assert.equal(sent.reply_to, undefined);
+    assert.equal(sent.reply_to, validLead.email);
     assert.match(sent.text, /anna\.rossi@example\.com/);
     assert.match(sent.subject, /Comune di Esempio/);
     assert.match(sent.text, /Dirigente finanziario/);
@@ -166,24 +173,102 @@ test("consulting API sends a plain-text email to the configured inbox", async ()
     else process.env.RESEND_API_KEY = previousKey;
     if (previousInbox === undefined) delete process.env.LEAD_INBOX_EMAIL;
     else process.env.LEAD_INBOX_EMAIL = previousInbox;
+    if (previousFrom === undefined) delete process.env.RESEND_FROM_EMAIL;
+    else process.env.RESEND_FROM_EMAIL = previousFrom;
   }
 });
 
-test("leadFromAddress ignores consumer mailboxes that Resend cannot send from", () => {
-  const previous = process.env.RESEND_FROM_EMAIL;
-  process.env.RESEND_FROM_EMAIL = "gagliardidomenico46@gmail.com";
+test("lead email configuration fails closed", () => {
+  const previousFrom = process.env.RESEND_FROM_EMAIL;
+  const previousInbox = process.env.LEAD_INBOX_EMAIL;
+  delete process.env.RESEND_FROM_EMAIL;
+  delete process.env.LEAD_INBOX_EMAIL;
   try {
-    assert.equal(leadFromAddress(), "Consulenza <consulenza@dovevannoinostrisoldi.com>");
+    assert.equal(leadFromAddress(), null);
+    assert.equal(leadInbox(), null);
   } finally {
-    if (previous === undefined) delete process.env.RESEND_FROM_EMAIL;
-    else process.env.RESEND_FROM_EMAIL = previous;
+    if (previousFrom === undefined) delete process.env.RESEND_FROM_EMAIL;
+    else process.env.RESEND_FROM_EMAIL = previousFrom;
+    if (previousInbox === undefined) delete process.env.LEAD_INBOX_EMAIL;
+    else process.env.LEAD_INBOX_EMAIL = previousInbox;
   }
 
   process.env.RESEND_FROM_EMAIL = "Acme <hello@example.com>";
+  process.env.LEAD_INBOX_EMAIL = "not-an-email";
   try {
-    assert.equal(leadFromAddress(), "Consulenza <consulenza@dovevannoinostrisoldi.com>");
+    assert.equal(leadFromAddress(), "Acme <hello@example.com>");
+    assert.equal(leadInbox(), null);
   } finally {
-    if (previous === undefined) delete process.env.RESEND_FROM_EMAIL;
-    else process.env.RESEND_FROM_EMAIL = previous;
+    if (previousFrom === undefined) delete process.env.RESEND_FROM_EMAIL;
+    else process.env.RESEND_FROM_EMAIL = previousFrom;
+    if (previousInbox === undefined) delete process.env.LEAD_INBOX_EMAIL;
+    else process.env.LEAD_INBOX_EMAIL = previousInbox;
+  }
+});
+
+test("consulting API rejects cross-origin, wrong content type and oversized bodies", async () => {
+  const crossOrigin = await POST(request(validLead, { Origin: "https://attacker.test" }));
+  assert.equal(crossOrigin.status, 403);
+
+  const wrongType = await POST(request(validLead, { "Content-Type": "text/plain" }));
+  assert.equal(wrongType.status, 415);
+
+  const oversized = await POST(request({ ...validLead, message: "a".repeat(17_000) }));
+  assert.equal(oversized.status, 413);
+});
+
+test("consulting API accepts a same-host origin when Next normalizes request.url", async () => {
+  const previousKey = process.env.RESEND_API_KEY;
+  delete process.env.RESEND_API_KEY;
+  try {
+    const response = await POST(
+      new Request("http://localhost:3107/api/consulenza", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Host: "127.0.0.1:3107",
+          Origin: "http://127.0.0.1:3107",
+        },
+        body: JSON.stringify(validLead),
+      }),
+    );
+    assert.equal(response.status, 503);
+  } finally {
+    if (previousKey === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = previousKey;
+  }
+});
+
+test("email subjects cannot inject additional headers", () => {
+  const parsed = parseLead({ ...validLead, organization: "Comune\r\nBcc: victim@example.com" });
+  assert.equal(parsed.status, "valid");
+  if (parsed.status !== "valid") return;
+  assert.equal(leadEmailSubject(parsed.lead), "Richiesta consulenza: Comune Bcc: victim@example.com");
+});
+
+test("Resend rejection bodies are not retained or returned for logging", async () => {
+  const previousKey = process.env.RESEND_API_KEY;
+  const previousInbox = process.env.LEAD_INBOX_EMAIL;
+  const previousFrom = process.env.RESEND_FROM_EMAIL;
+  process.env.RESEND_API_KEY = "re_test";
+  process.env.LEAD_INBOX_EMAIL = CONTACT_EMAIL;
+  process.env.RESEND_FROM_EMAIL = "Consulenza <consulenza@dovevannoinostrisoldi.com>";
+  try {
+    const parsed = parseLead(validLead);
+    assert.equal(parsed.status, "valid");
+    if (parsed.status !== "valid") return;
+    const result = await sendLeadEmail(
+      parsed.lead,
+      new Date("2026-08-21T12:00:00Z"),
+      async () => new Response("echoed PII and\nforged log line", { status: 422 }),
+    );
+    assert.deepEqual(result, { ok: false, status: 422, detail: "provider-rejected" });
+  } finally {
+    if (previousKey === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = previousKey;
+    if (previousInbox === undefined) delete process.env.LEAD_INBOX_EMAIL;
+    else process.env.LEAD_INBOX_EMAIL = previousInbox;
+    if (previousFrom === undefined) delete process.env.RESEND_FROM_EMAIL;
+    else process.env.RESEND_FROM_EMAIL = previousFrom;
   }
 });

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -89,6 +89,21 @@ test("Lighthouse budgets use a three-run median instead of a single noisy sample
   assert.match(lighthouse, /irpef-lighthouse-summary\.json/);
 });
 
+test("consulting keeps client contracts separate from server email delivery", async () => {
+  const [form, page, leads] = await Promise.all([
+    source("../src/app/consulenza/lead-form.tsx"),
+    source("../src/app/consulenza/page.tsx"),
+    source("../src/lib/leads.ts"),
+  ]);
+
+  assert.match(form, /@\/lib\/consulting-contract/);
+  assert.doesNotMatch(form, /@\/lib\/leads/);
+  assert.match(page, /@\/lib\/consulting-contract/);
+  assert.match(leads, /Idempotency-Key/);
+  assert.match(form, /aria-describedby=\{error \? "consulting-form-error" : undefined\}/);
+  assert.doesNotMatch(form, /noValidate|startedAt/);
+});
+
 test("the regional map has a deterministic fallback and roving keyboard focus", async () => {
   const map = await source("../src/components/italy-regions-map.tsx");
 


### PR DESCRIPTION
## Cosa cambia

- preserva integralmente la nuova proposta AI, il sito dell'organizzazione e il budget aggiunti su `main`;
- separa il contratto client dal modulo server di invio;
- elimina il filtro temporale client-controlled che poteva perdere richieste umane;
- rende configurazione Resend, mittente e inbox fail-closed;
- aggiunge idempotenza, `reply_to`, timeout e nessun logging dei body di errore del provider;
- limita body e content type, verifica same-host origin e risponde senza cache;
- completa focus/error handling, privacy e documentazione operativa;
- aggiunge Browser E2E di `/consulenza` a 320/390/768/1024/1280 e `/privacy`.

## Verifiche

- Node: 160/160 (più 11/11 test consulenza finali)
- Python ETL: 50/50
- typecheck, lint, Impeccable design, brand, actionlint, diff-check: PASS
- build Next production: PASS
- Browser E2E completo: PASS, inclusi i nuovi viewport consulenza
- API build reale: richiesta same-host raggiunge correttamente il fail-closed 503 senza configurazione
- Lighthouse mediana 3 run: 99 performance, 100 accessibility, 100 best practices, 100 SEO; CLS 0.000
- review indipendente Luna max: nessun blocker di codice residuo

## Gate operativi dichiarati

Questa PR non finge che honeypot/origin siano un rate limit. Prima di considerare il form pienamente operativo servono una regola WAF monitorata su `/api/consulenza` e una procedura verificabile di cancellazione da inbox/Resend entro il periodo pubblicato. Sono documentate in `docs/CONSULTING.md` e verranno tracciate separatamente.

