### PR TITLE
feat: macro-aree territoriali e ricerca globale accessibile

### DIFF
--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -95,7 +95,7 @@ function relevantRequestFailure(request) {
   return `${resourceType} ${requestUrl}: ${failure.errorText}`;
 }
 
-function installDiagnostics(page, label) {
+function installDiagnostics(page, label, isExpectedFailure = () => false) {
   const failures = [];
 
   page.on("pageerror", (error) => {
@@ -120,7 +120,12 @@ function installDiagnostics(page, label) {
 
   return async function assertNoBrowserErrors() {
     await delay(150);
-    assert.deepEqual(failures, [], `${label}: errori browser:\n${failures.join("\n")}`);
+    const unexpectedFailures = failures.filter((failure) => !isExpectedFailure(failure));
+    assert.deepEqual(
+      unexpectedFailures,
+      [],
+      `${label}: errori browser:\n${unexpectedFailures.join("\n")}`,
+    );
   };
 }
 
@@ -466,7 +471,7 @@ async function navigate(page, pathname, label) {
   await page.waitForNetworkIdle({ idleTime: 350, timeout: 10_000 });
 }
 
-async function runScenario(browser, { label, pathname, validate, width }) {
+async function runScenario(browser, { expectedFailure, label, pathname, validate, width }) {
   const page = await browser.newPage();
   let thrown;
 
@@ -481,7 +486,7 @@ async function runScenario(browser, { label, pathname, validate, width }) {
       hasTouch: width <= 390,
       isMobile: width <= 390,
     });
-    const assertNoBrowserErrors = installDiagnostics(page, label);
+    const assertNoBrowserErrors = installDiagnostics(page, label, expectedFailure);
     await navigate(page, pathname, label);
     await assertResponsiveShell(page, label, width);
     await validate(page);
@@ -713,9 +718,77 @@ try {
       await page.waitForSelector('[role="listbox"] [role="option"]', { visible: true });
       await page.keyboard.press("Escape");
       assert.equal(await input.evaluate((element) => element.getAttribute("aria-expanded")), "false");
+      assert.equal(await input.evaluate((element) => element.value), "Roma");
     },
   });
   completed.push("Ricerca header Escape 390px");
+
+  await runScenario(browser, {
+    label: "Ricerca header errore 390px",
+    pathname: "/",
+    width: 390,
+    expectedFailure: (failure) => failure.includes("/api/enti?q=Roma&limit=7"),
+    validate: async (page) => {
+      await page.setRequestInterception(true);
+      page.on("request", (request) => {
+        if (new URL(request.url()).pathname === "/api/enti") {
+          void request.respond({
+            status: 503,
+            contentType: "application/json",
+            body: JSON.stringify({ ok: false }),
+          });
+        } else {
+          void request.continue();
+        }
+      });
+      const input = await page.$("#global-entity-search");
+      assert.ok(input, "Ricerca header errore: campo assente");
+      await input.type("Roma");
+      await page.waitForFunction(() =>
+        document.body.innerText.includes("La ricerca rapida non è disponibile"),
+      );
+      await page.keyboard.press("Escape");
+      assert.equal(await input.evaluate((element) => element.getAttribute("aria-expanded")), "false");
+    },
+  });
+  completed.push("Ricerca header errore 390px");
+
+  await runScenario(browser, {
+    label: "Ricerca header testo lungo 320px",
+    pathname: "/",
+    width: 320,
+    validate: async (page) => {
+      await page.setRequestInterception(true);
+      page.on("request", (request) => {
+        if (new URL(request.url()).pathname === "/api/enti") {
+          void request.respond({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ok: true,
+              records: [{
+                codiceIpa: "ente_test",
+                denominazione: "Amministrazione straordinariamente lunga senza separatori utili alla visualizzazione",
+                tipologia: "Pubblica amministrazione territoriale",
+              }],
+            }),
+          });
+        } else {
+          void request.continue();
+        }
+      });
+      const input = await page.$("#global-entity-search");
+      assert.ok(input, "Ricerca header testo lungo: campo assente");
+      await input.type("ente");
+      await page.waitForSelector('[role="listbox"] [role="option"]', { visible: true });
+      const widths = await page.$eval(".header-search-dropdown", (dropdown) => ({
+        client: dropdown.clientWidth,
+        scroll: dropdown.scrollWidth,
+      }));
+      assert.ok(widths.scroll <= widths.client + 1, "Ricerca header: testo lungo oltre il dropdown");
+    },
+  });
+  completed.push("Ricerca header testo lungo 320px");
 
   for (const width of [390, 1280]) {
     const label = `Parlamento previdenza ${width}px`;

--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -642,6 +642,82 @@ try {
   }
 
   for (const width of [390, 1280]) {
+    const label = `Macro-aree territori ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/territori?anno=2024",
+      width,
+      validate: async (page) => {
+        const groups = await page.$$eval("main table tbody", (bodies) =>
+          bodies.slice(0, 3).map((body) => ({
+            heading: body.querySelector("tr:first-child th")?.textContent?.trim(),
+            rows: body.querySelectorAll("tr").length,
+          })),
+        );
+        assert.deepEqual(groups, [
+          { heading: "Nord", rows: 9 },
+          { heading: "Centro", rows: 5 },
+          { heading: "Sud e Isole", rows: 9 },
+        ]);
+        assert.equal(
+          await page.$$eval('main a[href^="/territori/fisco#regione-"]', (links) => links.length),
+          19,
+          `${label}: numero inatteso di link CPT univoci`,
+        );
+        const trentinoHasLink = await page.$$eval("main table tbody th", (headings) => {
+          const heading = headings.find((item) =>
+            item.textContent?.includes("Trentino-Alto Adige"),
+          );
+          return Boolean(heading?.querySelector("a"));
+        });
+        assert.equal(trentinoHasLink, false, `${label}: il Trentino non deve avere un link CPT ambiguo`);
+      },
+    });
+    completed.push(label);
+  }
+
+  for (const width of [390, 1280]) {
+    const label = `Ricerca header ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/",
+      width,
+      validate: async (page) => {
+        const input = await page.$("#global-entity-search");
+        assert.ok(input, `${label}: campo di ricerca assente`);
+        await input.type("Roma");
+        await page.waitForSelector('[role="listbox"] [role="option"]', { visible: true });
+        assert.equal(await input.evaluate((element) => element.getAttribute("aria-expanded")), "true");
+
+        await page.keyboard.press("ArrowDown");
+        assert.ok(
+          await input.evaluate((element) => element.getAttribute("aria-activedescendant")),
+          `${label}: opzione attiva non esposta`,
+        );
+        await page.keyboard.press("Enter");
+        await page.waitForFunction(() => /^\/enti\//.test(window.location.pathname));
+        assert.match(new URL(page.url()).pathname, /^\/enti\//, `${label}: destinazione inattesa`);
+      },
+    });
+    completed.push(label);
+  }
+
+  await runScenario(browser, {
+    label: "Ricerca header Escape 390px",
+    pathname: "/",
+    width: 390,
+    validate: async (page) => {
+      const input = await page.$("#global-entity-search");
+      assert.ok(input, "Ricerca header Escape: campo assente");
+      await input.type("Roma");
+      await page.waitForSelector('[role="listbox"] [role="option"]', { visible: true });
+      await page.keyboard.press("Escape");
+      assert.equal(await input.evaluate((element) => element.getAttribute("aria-expanded")), "false");
+    },
+  });
+  completed.push("Ricerca header Escape 390px");
+
+  for (const width of [390, 1280]) {
     const label = `Parlamento previdenza ${width}px`;
     await runScenario(browser, {
       label,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,6 +158,54 @@ main td a:not(.btn) {
 }
 .header-search button:hover { color: var(--color-accent-700); }
 
+.header-search-dropdown {
+  position: absolute;
+  inset-inline: 0;
+  top: calc(100% + 6px);
+  z-index: 50;
+  overflow: hidden;
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-400);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+.header-search-empty {
+  margin: 0;
+  padding: 10px 12px;
+  font-size: 12.5px;
+  color: var(--color-neutral-600);
+}
+.header-search-option {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: 9px 12px;
+  color: var(--color-text);
+  border-top: 1px solid var(--color-neutral-200);
+}
+.header-search-option:first-child { border-top: 0; }
+.header-search-option:hover,
+.header-search-option[data-active="true"] { background: var(--color-accent-100); color: var(--color-text); }
+.header-search-option-name { font-weight: 700; font-size: 13px; }
+.header-search-option-type {
+  flex: none;
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--color-neutral-600);
+  white-space: nowrap;
+}
+.header-search-all {
+  display: block;
+  padding: 9px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  color: var(--color-accent-700);
+  background: var(--color-neutral-100);
+  border-top: 1px solid var(--color-neutral-200);
+}
+.header-search-all:hover { background: var(--color-accent-100); color: var(--color-accent-800); }
+
 .header-actions {
   display: flex;
   align-items: center;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -186,7 +186,12 @@ main td a:not(.btn) {
 .header-search-option:first-child { border-top: 0; }
 .header-search-option:hover,
 .header-search-option[data-active="true"] { background: var(--color-accent-100); color: var(--color-text); }
-.header-search-option-name { font-weight: 700; font-size: 13px; }
+.header-search-option-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-weight: 700;
+  font-size: 13px;
+}
 .header-search-option-type {
   flex: none;
   margin-left: auto;

--- a/src/app/territori/fisco/page.tsx
+++ b/src/app/territori/fisco/page.tsx
@@ -131,7 +131,7 @@ export default function RegionalFiscalPage() {
             </thead>
             <tbody>
               {rows.map((row) => (
-                <tr key={row.regionCode}>
+                <tr key={row.regionCode} id={`regione-${row.regionCode}`}>
                   <th scope="row">{row.region}</th>
                   <td className="num">{exactFromCents(row.revenuePerCapitaCents ?? 0)}</td>
                   <td className="num">{exactFromCents(row.expenditurePerCapitaCents ?? 0)}</td>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { PeriodSelector } from "@/components/period-selector";
 import { compactEuro, compactEuroLike, exactEuro, integer, longDate } from "@/lib/format";
 import { municipalityName } from "@/lib/municipality-name";
-import { groupRegionsByMacroArea } from "@/lib/italy-regions";
+import { groupRegionsByMacroArea, istatCodeOfRegion } from "@/lib/italy-regions";
 import {
   availableSiopeYears,
   getSiopeMunicipalSnapshot,
@@ -93,22 +93,33 @@ export default async function TerritoriesPage({
                         {integer(summary.municipalities)}
                       </td>
                     </tr>
-                    {areaRegions.map((region) => (
-                      <tr key={region.region}>
-                        <th scope="row">{region.region}</th>
-                        <td className="num">
-                          {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
-                        </td>
-                        <td className="num">{compactEuroLike(region.value, regionScale)}</td>
-                        <td className="num">
-                          {region.population === null ? "n.d." : integer(region.population)}
-                        </td>
-                        <td className="num">
-                          {integer(region.municipalitiesWithPopulation)} /{" "}
-                          {integer(region.municipalities)}
-                        </td>
-                      </tr>
-                    ))}
+                    {areaRegions.map((region) => {
+                      const istatCode = istatCodeOfRegion(region.region);
+                      return (
+                        <tr key={region.region}>
+                          <th scope="row">
+                            {istatCode ? (
+                              <Link href={`/territori/fisco#regione-${istatCode}`}>
+                                {region.region}
+                              </Link>
+                            ) : (
+                              region.region
+                            )}
+                          </th>
+                          <td className="num">
+                            {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
+                          </td>
+                          <td className="num">{compactEuroLike(region.value, regionScale)}</td>
+                          <td className="num">
+                            {region.population === null ? "n.d." : integer(region.population)}
+                          </td>
+                          <td className="num">
+                            {integer(region.municipalitiesWithPopulation)} /{" "}
+                            {integer(region.municipalities)}
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </Fragment>
                 ))}
               </tbody>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -1,8 +1,10 @@
+import { Fragment } from "react";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { PeriodSelector } from "@/components/period-selector";
 import { compactEuro, compactEuroLike, exactEuro, integer, longDate } from "@/lib/format";
 import { municipalityName } from "@/lib/municipality-name";
+import { groupRegionsByMacroArea } from "@/lib/italy-regions";
 import {
   availableSiopeYears,
   getSiopeMunicipalSnapshot,
@@ -32,9 +34,14 @@ export default async function TerritoriesPage({
   const monthLabel = data.latestMonthLabel.toLocaleLowerCase("it-IT");
 
   const regions = regionsByPerCapita(data);
+  const regionsByArea = groupRegionsByMacroArea(regions);
   const topByPerCapita = data.topMunicipalitiesByPerCapita.slice(0, 20);
   const topByVolume = data.topMunicipalitiesByValue.slice(0, 10);
-  const regionScale = Math.max(...regions.map((region) => region.value), 0);
+  const regionScale = Math.max(
+    ...regions.map((region) => region.value),
+    ...regionsByArea.map(({ summary }) => summary.value),
+    0,
+  );
   const municipalityScale = topByVolume[0]?.value ?? 0;
 
   return (
@@ -70,20 +77,39 @@ export default async function TerritoriesPage({
                 </tr>
               </thead>
               <tbody>
-                {regions.map((region) => (
-                  <tr key={region.region}>
-                    <th scope="row">{region.region}</th>
-                    <td className="num">
-                      {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
-                    </td>
-                    <td className="num">{compactEuroLike(region.value, regionScale)}</td>
-                    <td className="num">
-                      {region.population === null ? "n.d." : integer(region.population)}
-                    </td>
-                    <td className="num">
-                      {integer(region.municipalitiesWithPopulation)} / {integer(region.municipalities)}
-                    </td>
-                  </tr>
+                {regionsByArea.map(({ area, regions: areaRegions, summary }) => (
+                  <Fragment key={area}>
+                    <tr className={styles.areaRow}>
+                      <th scope="rowgroup">{area}</th>
+                      <td className="num">
+                        {summary.perCapita === null ? "n.d." : exactEuro(summary.perCapita)}
+                      </td>
+                      <td className="num">{compactEuroLike(summary.value, regionScale)}</td>
+                      <td className="num">
+                        {summary.population === null ? "n.d." : integer(summary.population)}
+                      </td>
+                      <td className="num">
+                        {integer(summary.municipalitiesWithPopulation)} /{" "}
+                        {integer(summary.municipalities)}
+                      </td>
+                    </tr>
+                    {areaRegions.map((region) => (
+                      <tr key={region.region}>
+                        <th scope="row">{region.region}</th>
+                        <td className="num">
+                          {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
+                        </td>
+                        <td className="num">{compactEuroLike(region.value, regionScale)}</td>
+                        <td className="num">
+                          {region.population === null ? "n.d." : integer(region.population)}
+                        </td>
+                        <td className="num">
+                          {integer(region.municipalitiesWithPopulation)} /{" "}
+                          {integer(region.municipalities)}
+                        </td>
+                      </tr>
+                    ))}
+                  </Fragment>
                 ))}
               </tbody>
             </table>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -1,10 +1,9 @@
-import { Fragment } from "react";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { PeriodSelector } from "@/components/period-selector";
 import { compactEuro, compactEuroLike, exactEuro, integer, longDate } from "@/lib/format";
 import { municipalityName } from "@/lib/municipality-name";
-import { groupRegionsByMacroArea, istatCodeOfRegion } from "@/lib/italy-regions";
+import { cptRegionAnchorOf, groupRegionsByMacroArea } from "@/lib/italy-regions";
 import {
   availableSiopeYears,
   getSiopeMunicipalSnapshot,
@@ -76,57 +75,59 @@ export default async function TerritoriesPage({
                   <th scope="col" className="num">Comuni nel rapporto</th>
                 </tr>
               </thead>
-              <tbody>
-                {regionsByArea.map(({ area, regions: areaRegions, summary }) => (
-                  <Fragment key={area}>
-                    <tr className={styles.areaRow}>
-                      <th scope="rowgroup">{area}</th>
-                      <td className="num">
-                        {summary.perCapita === null ? "n.d." : exactEuro(summary.perCapita)}
-                      </td>
-                      <td className="num">{compactEuroLike(summary.value, regionScale)}</td>
-                      <td className="num">
-                        {summary.population === null ? "n.d." : integer(summary.population)}
-                      </td>
-                      <td className="num">
-                        {integer(summary.municipalitiesWithPopulation)} /{" "}
-                        {integer(summary.municipalities)}
-                      </td>
-                    </tr>
-                    {areaRegions.map((region) => {
-                      const istatCode = istatCodeOfRegion(region.region);
-                      return (
-                        <tr key={region.region}>
-                          <th scope="row">
-                            {istatCode ? (
-                              <Link href={`/territori/fisco#regione-${istatCode}`}>
-                                {region.region}
-                              </Link>
-                            ) : (
-                              region.region
-                            )}
-                          </th>
-                          <td className="num">
-                            {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
-                          </td>
-                          <td className="num">{compactEuroLike(region.value, regionScale)}</td>
-                          <td className="num">
-                            {region.population === null ? "n.d." : integer(region.population)}
-                          </td>
-                          <td className="num">
-                            {integer(region.municipalitiesWithPopulation)} /{" "}
-                            {integer(region.municipalities)}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </Fragment>
-                ))}
-              </tbody>
+              {regionsByArea.map(({ area, regions: areaRegions, summary }) => (
+                <tbody key={area}>
+                  <tr className={styles.areaRow}>
+                    <th scope="rowgroup">{area}</th>
+                    <td className="num">
+                      {summary.perCapita === null ? "n.d." : exactEuro(summary.perCapita)}
+                    </td>
+                    <td className="num">{compactEuroLike(summary.value, regionScale)}</td>
+                    <td className="num">
+                      {summary.population === null ? "n.d." : integer(summary.population)}
+                    </td>
+                    <td className="num">
+                      {integer(summary.municipalitiesWithPopulation)} /{" "}
+                      {integer(summary.municipalities)}
+                    </td>
+                  </tr>
+                  {areaRegions.map((region) => {
+                    const cptAnchor = cptRegionAnchorOf(region.region);
+                    return (
+                      <tr key={region.region}>
+                        <th scope="row">
+                          {cptAnchor ? (
+                            <Link href={`/territori/fisco#${cptAnchor}`}>
+                              {region.region}
+                            </Link>
+                          ) : (
+                            region.region
+                          )}
+                        </th>
+                        <td className="num">
+                          {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
+                        </td>
+                        <td className="num">{compactEuroLike(region.value, regionScale)}</td>
+                        <td className="num">
+                          {region.population === null ? "n.d." : integer(region.population)}
+                        </td>
+                        <td className="num">
+                          {integer(region.municipalitiesWithPopulation)} /{" "}
+                          {integer(region.municipalities)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              ))}
             </table>
           </div>
           <p className={styles.note}>Nota di metodo: {data.methodology.warning}</p>
           <p className={styles.note}>Copertura pro capite: {data.methodology.perCapitaCoverage}.</p>
+          <p className={styles.note}>
+            Nei CPT, Trento e Bolzano sono pubblicati come due Province autonome: il dato SIOPE
+            aggregato del Trentino-Alto Adige non viene collegato artificialmente a una sola voce.
+          </p>
         </section>
 
         <div className={styles.aside}>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -97,7 +97,10 @@ export default async function TerritoriesPage({
                       <tr key={region.region}>
                         <th scope="row">
                           {cptAnchor ? (
-                            <Link href={`/territori/fisco#${cptAnchor}`}>
+                            <Link
+                              href={`/territori/fisco#${cptAnchor}`}
+                              aria-label={`${region.region}: apri dati CPT 2023`}
+                            >
                               {region.region}
                             </Link>
                           ) : (
@@ -125,8 +128,9 @@ export default async function TerritoriesPage({
           <p className={styles.note}>Nota di metodo: {data.methodology.warning}</p>
           <p className={styles.note}>Copertura pro capite: {data.methodology.perCapitaCoverage}.</p>
           <p className={styles.note}>
-            Nei CPT, Trento e Bolzano sono pubblicati come due Province autonome: il dato SIOPE
-            aggregato del Trentino-Alto Adige non viene collegato artificialmente a una sola voce.
+            I link regionali aprono i dati CPT 2023, un perimetro distinto da SIOPE. Nei CPT,
+            Trento e Bolzano sono pubblicati come due Province autonome: il dato SIOPE aggregato
+            del Trentino-Alto Adige non viene collegato artificialmente a una sola voce.
           </p>
         </section>
 

--- a/src/app/territori/territori.module.css
+++ b/src/app/territori/territori.module.css
@@ -20,6 +20,22 @@
   min-width: 0;
 }
 
+.areaRow th,
+.areaRow td {
+  background: var(--color-neutral-100);
+  border-bottom: 1px solid var(--color-neutral-200);
+  font-weight: 600;
+}
+
+.areaRow th {
+  text-align: left;
+  padding: var(--space-2);
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-600);
+}
+
 .note {
   margin: var(--space-3) 0 0;
   font-size: 12px;

--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -31,19 +31,22 @@ export function HeaderSearch() {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const rootRef = useRef<HTMLFormElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
     const trimmed = query.trim();
+    const requestId = ++requestIdRef.current;
+    abortRef.current?.abort();
+
     if (trimmed.length < MIN_QUERY_LENGTH) {
-      abortRef.current?.abort();
       return;
     }
 
     const timer = setTimeout(() => {
-      abortRef.current?.abort();
       const controller = new AbortController();
       abortRef.current = controller;
       setLoading(true);
@@ -51,11 +54,14 @@ export function HeaderSearch() {
       fetch(`/api/enti?q=${encodeURIComponent(trimmed)}&limit=7`, {
         signal: controller.signal,
       })
-        .then((response) => response.json() as Promise<EntiSearchResponse>)
+        .then((response) => {
+          if (!response.ok) throw new Error(`Ricerca IPA HTTP ${response.status}`);
+          return response.json() as Promise<EntiSearchResponse>;
+        })
         .then((payload) => {
+          if (requestId !== requestIdRef.current) return;
           if (!payload.ok || !payload.records) {
-            setSuggestions([]);
-            return;
+            throw new Error("Risposta della ricerca IPA non valida");
           }
           setSuggestions(
             payload.records.map((record) => ({
@@ -65,26 +71,33 @@ export function HeaderSearch() {
             })),
           );
           setActiveIndex(-1);
+          setSearchError(false);
         })
         .catch((error: unknown) => {
           if (error instanceof DOMException && error.name === "AbortError") return;
+          if (requestId !== requestIdRef.current) return;
           setSuggestions([]);
+          setActiveIndex(-1);
+          setSearchError(true);
         })
-        .finally(() => setLoading(false));
+        .finally(() => {
+          if (requestId === requestIdRef.current) setLoading(false);
+        });
     }, DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timer);
       abortRef.current?.abort();
+      if (requestId === requestIdRef.current) requestIdRef.current += 1;
     };
   }, [query]);
 
   useEffect(() => {
-    function handlePointerDown(event: MouseEvent) {
+    function handlePointerDown(event: PointerEvent) {
       if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
     }
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
   }, []);
 
   const showDropdown = open && query.trim().length >= MIN_QUERY_LENGTH;
@@ -95,6 +108,13 @@ export function HeaderSearch() {
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+      setActiveIndex(-1);
+      return;
+    }
+
     if (!showDropdown || suggestions.length === 0) return;
 
     if (event.key === "ArrowDown") {
@@ -108,8 +128,6 @@ export function HeaderSearch() {
         event.preventDefault();
         goToSuggestion(suggestions[activeIndex]);
       }
-    } else if (event.key === "Escape") {
-      setOpen(false);
     }
   }
 
@@ -133,34 +151,52 @@ export function HeaderSearch() {
         autoComplete="off"
         value={query}
         onChange={(event) => {
-          setQuery(event.target.value);
+          const nextQuery = event.target.value;
+          abortRef.current?.abort();
+          setQuery(nextQuery);
+          setSuggestions([]);
+          setActiveIndex(-1);
+          setSearchError(false);
+          setLoading(nextQuery.trim().length >= MIN_QUERY_LENGTH);
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
         onKeyDown={handleKeyDown}
         role="combobox"
         aria-expanded={showDropdown}
-        aria-controls={listboxId}
+        aria-controls={showDropdown ? listboxId : undefined}
         aria-autocomplete="list"
-        aria-activedescendant={activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined}
+        aria-activedescendant={
+          showDropdown && activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined
+        }
       />
       <button type="submit" aria-label="Cerca">
         <HugeiconsIcon icon={Search01Icon} size={18} strokeWidth={1.7} aria-hidden="true" />
       </button>
 
       {showDropdown ? (
-        <div className="header-search-dropdown" id={listboxId} role="listbox">
-          {loading && suggestions.length === 0 ? (
-            <p className="header-search-empty">Cerco…</p>
+        <div className="header-search-dropdown">
+          {loading ? (
+            <p className="header-search-empty" role="status" aria-live="polite">
+              Cerco…
+            </p>
+          ) : searchError ? (
+            <p className="header-search-empty" role="status" aria-live="polite">
+              La ricerca rapida non è disponibile. Premi Invio per cercare nella pagina Enti.
+            </p>
           ) : suggestions.length === 0 ? (
-            <p className="header-search-empty">Nessun risultato in IPA per &ldquo;{query.trim()}&rdquo;</p>
-          ) : (
-            suggestions.map((suggestion, index) => (
+            <p className="header-search-empty" role="status" aria-live="polite">
+              Nessun risultato in IPA per &ldquo;{query.trim()}&rdquo;
+            </p>
+          ) : null}
+          <div id={listboxId} role="listbox" aria-label="Enti suggeriti" aria-busy={loading}>
+            {suggestions.map((suggestion, index) => (
               <Link
                 key={suggestion.codiceIpa}
                 href={`/enti/${encodeURIComponent(suggestion.codiceIpa)}`}
                 id={`${listboxId}-${index}`}
                 role="option"
+                tabIndex={-1}
                 aria-selected={index === activeIndex}
                 className="header-search-option"
                 data-active={index === activeIndex ? "true" : undefined}
@@ -172,8 +208,8 @@ export function HeaderSearch() {
                   <span className="header-search-option-type">{suggestion.tipologia}</span>
                 ) : null}
               </Link>
-            ))
-          )}
+            ))}
+          </div>
           <Link
             href={`/enti?q=${encodeURIComponent(query.trim())}`}
             className="header-search-all"

--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -38,8 +38,6 @@ export function HeaderSearch() {
   useEffect(() => {
     const trimmed = query.trim();
     if (trimmed.length < MIN_QUERY_LENGTH) {
-      setSuggestions([]);
-      setLoading(false);
       abortRef.current?.abort();
       return;
     }
@@ -75,7 +73,10 @@ export function HeaderSearch() {
         .finally(() => setLoading(false));
     }, DEBOUNCE_MS);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      abortRef.current?.abort();
+    };
   }, [query]);
 
   useEffect(() => {

--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useRef, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Search01Icon } from "@hugeicons/core-free-icons";
+
+type Suggestion = {
+  codiceIpa: string;
+  denominazione: string;
+  tipologia: string | null;
+};
+
+type EntiSearchResponse = {
+  ok: boolean;
+  records?: Array<{
+    codiceIpa: string;
+    denominazione: string;
+    tipologia: string | null;
+  }>;
+};
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 200;
+
+export function HeaderSearch() {
+  const router = useRouter();
+  const listboxId = useId();
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rootRef = useRef<HTMLFormElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setSuggestions([]);
+      setLoading(false);
+      abortRef.current?.abort();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setLoading(true);
+
+      fetch(`/api/enti?q=${encodeURIComponent(trimmed)}&limit=7`, {
+        signal: controller.signal,
+      })
+        .then((response) => response.json() as Promise<EntiSearchResponse>)
+        .then((payload) => {
+          if (!payload.ok || !payload.records) {
+            setSuggestions([]);
+            return;
+          }
+          setSuggestions(
+            payload.records.map((record) => ({
+              codiceIpa: record.codiceIpa,
+              denominazione: record.denominazione,
+              tipologia: record.tipologia,
+            })),
+          );
+          setActiveIndex(-1);
+        })
+        .catch((error: unknown) => {
+          if (error instanceof DOMException && error.name === "AbortError") return;
+          setSuggestions([]);
+        })
+        .finally(() => setLoading(false));
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  const showDropdown = open && query.trim().length >= MIN_QUERY_LENGTH;
+
+  function goToSuggestion(suggestion: Suggestion) {
+    setOpen(false);
+    router.push(`/enti/${encodeURIComponent(suggestion.codiceIpa)}`);
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!showDropdown || suggestions.length === 0) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % suggestions.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index <= 0 ? suggestions.length - 1 : index - 1));
+    } else if (event.key === "Enter") {
+      if (activeIndex >= 0) {
+        event.preventDefault();
+        goToSuggestion(suggestions[activeIndex]);
+      }
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <form
+      className="header-search"
+      action="/enti"
+      method="get"
+      role="search"
+      autoComplete="off"
+      ref={rootRef}
+      onSubmit={() => setOpen(false)}
+    >
+      <label htmlFor="global-entity-search">Cerca nel registro degli enti</label>
+      <input
+        className="input"
+        id="global-entity-search"
+        name="q"
+        type="search"
+        placeholder="Cerca un Comune, un ente o un ministero"
+        autoComplete="off"
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        role="combobox"
+        aria-expanded={showDropdown}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined}
+      />
+      <button type="submit" aria-label="Cerca">
+        <HugeiconsIcon icon={Search01Icon} size={18} strokeWidth={1.7} aria-hidden="true" />
+      </button>
+
+      {showDropdown ? (
+        <div className="header-search-dropdown" id={listboxId} role="listbox">
+          {loading && suggestions.length === 0 ? (
+            <p className="header-search-empty">Cerco…</p>
+          ) : suggestions.length === 0 ? (
+            <p className="header-search-empty">Nessun risultato in IPA per &ldquo;{query.trim()}&rdquo;</p>
+          ) : (
+            suggestions.map((suggestion, index) => (
+              <Link
+                key={suggestion.codiceIpa}
+                href={`/enti/${encodeURIComponent(suggestion.codiceIpa)}`}
+                id={`${listboxId}-${index}`}
+                role="option"
+                aria-selected={index === activeIndex}
+                className="header-search-option"
+                data-active={index === activeIndex ? "true" : undefined}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => setOpen(false)}
+              >
+                <span className="header-search-option-name">{suggestion.denominazione}</span>
+                {suggestion.tipologia ? (
+                  <span className="header-search-option-type">{suggestion.tipologia}</span>
+                ) : null}
+              </Link>
+            ))
+          )}
+          <Link
+            href={`/enti?q=${encodeURIComponent(query.trim())}`}
+            className="header-search-all"
+            onClick={() => setOpen(false)}
+          >
+            Vedi tutti i risultati per &ldquo;{query.trim()}&rdquo;
+          </Link>
+        </div>
+      ) : null}
+    </form>
+  );
+}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -4,8 +4,9 @@ import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
+import { HeaderSearch } from "@/components/header-search";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { GithubIcon, Search01Icon } from "@hugeicons/core-free-icons";
+import { GithubIcon } from "@hugeicons/core-free-icons";
 import { REPO_URL } from "@/lib/site";
 
 const primary = [
@@ -55,20 +56,7 @@ export function Navigation() {
 
         <span className="header-spacer" />
 
-        <form className="header-search" action="/enti" method="get" role="search">
-          <label htmlFor="global-entity-search">Cerca nel registro degli enti</label>
-          <input
-            className="input"
-            id="global-entity-search"
-            name="q"
-            type="search"
-            placeholder="Cerca un Comune, un ente o un ministero"
-            autoComplete="off"
-          />
-          <button type="submit" aria-label="Cerca">
-            <HugeiconsIcon icon={Search01Icon} size={18} strokeWidth={1.7} aria-hidden="true" />
-          </button>
-        </form>
+        <HeaderSearch />
 
         <div className="header-actions">
           <Link className="header-action" href="/consulenza">

--- a/src/lib/italy-regions.ts
+++ b/src/lib/italy-regions.ts
@@ -39,6 +39,15 @@ export function istatCodeOfRegion(regionName: string): string | null {
   return ISTAT_CODE_BY_REGION_NAME[regionName] ?? null;
 }
 
+/**
+ * CPT publishes Trento and Bolzano separately, so the single SIOPE row for
+ * Trentino-Alto Adige cannot point to one unambiguous CPT territory.
+ */
+export function cptRegionAnchorOf(regionName: string): string | null {
+  const code = istatCodeOfRegion(regionName);
+  return code && code !== "04" ? `regione-${code}` : null;
+}
+
 export const ITALY_MACRO_AREAS = ["Nord", "Centro", "Sud e Isole"] as const;
 
 export type ItalyMacroArea = (typeof ITALY_MACRO_AREAS)[number];
@@ -86,6 +95,7 @@ export function macroAreaOf(regionName: string): ItalyMacroArea | null {
 export type ItalyMacroAreaSummary = {
   area: ItalyMacroArea;
   value: number;
+  perCapitaValue: number;
   population: number | null;
   perCapita: number | null;
   municipalities: number;
@@ -98,11 +108,15 @@ function summarizeRegionGroup(
   regions: SiopeRegionPoint[],
 ): ItalyMacroAreaSummary {
   const value = regions.reduce((total, region) => total + region.value, 0);
-  const population = regions.reduce<number | null>(
-    (total, region) =>
-      region.population === null ? total : (total ?? 0) + region.population,
-    null,
+  const perCapitaValue = regions.reduce(
+    (total, region) => total + region.perCapitaValue,
+    0,
   );
+  const coveredPopulation = regions.reduce(
+    (total, region) => total + (region.population ?? 0),
+    0,
+  );
+  const population = coveredPopulation > 0 ? coveredPopulation : null;
   const municipalities = regions.reduce((total, region) => total + region.municipalities, 0);
   const municipalitiesWithPopulation = regions.reduce(
     (total, region) => total + region.municipalitiesWithPopulation,
@@ -111,8 +125,9 @@ function summarizeRegionGroup(
   return {
     area,
     value,
+    perCapitaValue,
     population,
-    perCapita: population ? value / population : null,
+    perCapita: population ? perCapitaValue / population : null,
     municipalities,
     municipalitiesWithPopulation,
   };
@@ -124,7 +139,8 @@ export function groupRegionsByMacroArea<T extends SiopeRegionPoint>(
   const byArea = new Map<ItalyMacroArea, T[]>(ITALY_MACRO_AREAS.map((area) => [area, []]));
   for (const region of regions) {
     const area = macroAreaOf(region.region);
-    if (area) byArea.get(area)!.push(region);
+    if (!area) throw new Error(`Regione non associata a una macro-area: ${region.region}`);
+    byArea.get(area)!.push(region);
   }
   return ITALY_MACRO_AREAS.map((area) => {
     const areaRegions = byArea.get(area)!;

--- a/src/lib/italy-regions.ts
+++ b/src/lib/italy-regions.ts
@@ -137,11 +137,16 @@ export function groupRegionsByMacroArea<T extends SiopeRegionPoint>(
   regions: T[],
 ): Array<{ area: ItalyMacroArea; regions: T[]; summary: ItalyMacroAreaSummary }> {
   const byArea = new Map<ItalyMacroArea, T[]>(ITALY_MACRO_AREAS.map((area) => [area, []]));
+  const seen = new Set<string>();
   for (const region of regions) {
     const area = macroAreaOf(region.region);
     if (!area) throw new Error(`Regione non associata a una macro-area: ${region.region}`);
+    if (seen.has(region.region)) throw new Error(`Regione duplicata: ${region.region}`);
+    seen.add(region.region);
     byArea.get(area)!.push(region);
   }
+  const missing = Object.values(REGION_NAME_BY_ISTAT_CODE).filter((region) => !seen.has(region));
+  if (missing.length > 0) throw new Error(`Regioni mancanti: ${missing.join(", ")}`);
   return ITALY_MACRO_AREAS.map((area) => {
     const areaRegions = byArea.get(area)!;
     return { area, regions: areaRegions, summary: summarizeRegionGroup(area, areaRegions) };

--- a/src/lib/italy-regions.ts
+++ b/src/lib/italy-regions.ts
@@ -30,32 +30,53 @@ export function regionDataByIstatCode(regions: SiopeRegionPoint[]) {
   );
 }
 
+/** Reverse of REGION_NAME_BY_ISTAT_CODE, for linking from a region name back to its ISTAT code. */
+export const ISTAT_CODE_BY_REGION_NAME: Record<string, string> = Object.fromEntries(
+  Object.entries(REGION_NAME_BY_ISTAT_CODE).map(([code, name]) => [name, code]),
+);
+
+export function istatCodeOfRegion(regionName: string): string | null {
+  return ISTAT_CODE_BY_REGION_NAME[regionName] ?? null;
+}
+
 export const ITALY_MACRO_AREAS = ["Nord", "Centro", "Sud e Isole"] as const;
 
 export type ItalyMacroArea = (typeof ITALY_MACRO_AREAS)[number];
 
-const MACRO_AREA_BY_REGION_NAME: Record<string, ItalyMacroArea> = {
-  Piemonte: "Nord",
-  "Valle d'Aosta/Vallée d'Aoste": "Nord",
-  Lombardia: "Nord",
-  "Trentino-Alto Adige/Südtirol": "Nord",
-  Veneto: "Nord",
-  "Friuli-Venezia Giulia": "Nord",
-  Liguria: "Nord",
-  "Emilia-Romagna": "Nord",
-  Toscana: "Centro",
-  Umbria: "Centro",
-  Marche: "Centro",
-  Lazio: "Centro",
-  Abruzzo: "Sud e Isole",
-  Molise: "Sud e Isole",
-  Campania: "Sud e Isole",
-  Puglia: "Sud e Isole",
-  Basilicata: "Sud e Isole",
-  Calabria: "Sud e Isole",
-  Sicilia: "Sud e Isole",
-  Sardegna: "Sud e Isole",
+/**
+ * ISTAT ripartizione geografica per region code; Nord merges nord-ovest and
+ * nord-est. Keyed on the same ISTAT codes as REGION_NAME_BY_ISTAT_CODE so the
+ * two maps cannot drift apart on region naming.
+ */
+const MACRO_AREA_BY_ISTAT_CODE: Record<keyof typeof REGION_NAME_BY_ISTAT_CODE, ItalyMacroArea> = {
+  "01": "Nord",
+  "02": "Nord",
+  "03": "Nord",
+  "04": "Nord",
+  "05": "Nord",
+  "06": "Nord",
+  "07": "Nord",
+  "08": "Nord",
+  "09": "Centro",
+  "10": "Centro",
+  "11": "Centro",
+  "12": "Centro",
+  "13": "Sud e Isole",
+  "14": "Sud e Isole",
+  "15": "Sud e Isole",
+  "16": "Sud e Isole",
+  "17": "Sud e Isole",
+  "18": "Sud e Isole",
+  "19": "Sud e Isole",
+  "20": "Sud e Isole",
 };
+
+const MACRO_AREA_BY_REGION_NAME: Record<string, ItalyMacroArea> = Object.fromEntries(
+  Object.entries(REGION_NAME_BY_ISTAT_CODE).map(([code, name]) => [
+    name,
+    MACRO_AREA_BY_ISTAT_CODE[code as keyof typeof REGION_NAME_BY_ISTAT_CODE],
+  ]),
+);
 
 /** ISTAT ripartizione geografica for a region name; Nord merges nord-ovest and nord-est. */
 export function macroAreaOf(regionName: string): ItalyMacroArea | null {

--- a/src/lib/italy-regions.ts
+++ b/src/lib/italy-regions.ts
@@ -29,3 +29,84 @@ export function regionDataByIstatCode(regions: SiopeRegionPoint[]) {
     Object.entries(REGION_NAME_BY_ISTAT_CODE).map(([code, name]) => [code, byName.get(name)]),
   );
 }
+
+export const ITALY_MACRO_AREAS = ["Nord", "Centro", "Sud e Isole"] as const;
+
+export type ItalyMacroArea = (typeof ITALY_MACRO_AREAS)[number];
+
+const MACRO_AREA_BY_REGION_NAME: Record<string, ItalyMacroArea> = {
+  Piemonte: "Nord",
+  "Valle d'Aosta/Vallée d'Aoste": "Nord",
+  Lombardia: "Nord",
+  "Trentino-Alto Adige/Südtirol": "Nord",
+  Veneto: "Nord",
+  "Friuli-Venezia Giulia": "Nord",
+  Liguria: "Nord",
+  "Emilia-Romagna": "Nord",
+  Toscana: "Centro",
+  Umbria: "Centro",
+  Marche: "Centro",
+  Lazio: "Centro",
+  Abruzzo: "Sud e Isole",
+  Molise: "Sud e Isole",
+  Campania: "Sud e Isole",
+  Puglia: "Sud e Isole",
+  Basilicata: "Sud e Isole",
+  Calabria: "Sud e Isole",
+  Sicilia: "Sud e Isole",
+  Sardegna: "Sud e Isole",
+};
+
+/** ISTAT ripartizione geografica for a region name; Nord merges nord-ovest and nord-est. */
+export function macroAreaOf(regionName: string): ItalyMacroArea | null {
+  return MACRO_AREA_BY_REGION_NAME[regionName] ?? null;
+}
+
+export type ItalyMacroAreaSummary = {
+  area: ItalyMacroArea;
+  value: number;
+  population: number | null;
+  perCapita: number | null;
+  municipalities: number;
+  municipalitiesWithPopulation: number;
+};
+
+/** Sums the granular per-region figures into one totale for the area. */
+function summarizeRegionGroup(
+  area: ItalyMacroArea,
+  regions: SiopeRegionPoint[],
+): ItalyMacroAreaSummary {
+  const value = regions.reduce((total, region) => total + region.value, 0);
+  const population = regions.reduce<number | null>(
+    (total, region) =>
+      region.population === null ? total : (total ?? 0) + region.population,
+    null,
+  );
+  const municipalities = regions.reduce((total, region) => total + region.municipalities, 0);
+  const municipalitiesWithPopulation = regions.reduce(
+    (total, region) => total + region.municipalitiesWithPopulation,
+    0,
+  );
+  return {
+    area,
+    value,
+    population,
+    perCapita: population ? value / population : null,
+    municipalities,
+    municipalitiesWithPopulation,
+  };
+}
+
+export function groupRegionsByMacroArea<T extends SiopeRegionPoint>(
+  regions: T[],
+): Array<{ area: ItalyMacroArea; regions: T[]; summary: ItalyMacroAreaSummary }> {
+  const byArea = new Map<ItalyMacroArea, T[]>(ITALY_MACRO_AREAS.map((area) => [area, []]));
+  for (const region of regions) {
+    const area = macroAreaOf(region.region);
+    if (area) byArea.get(area)!.push(region);
+  }
+  return ITALY_MACRO_AREAS.map((area) => {
+    const areaRegions = byArea.get(area)!;
+    return { area, regions: areaRegions, summary: summarizeRegionGroup(area, areaRegions) };
+  });
+}

--- a/tests/italy-regions.test.mjs
+++ b/tests/italy-regions.test.mjs
@@ -69,6 +69,18 @@ test("macro-area grouping rejects an unmapped region", () => {
   );
 });
 
+test("macro-area grouping rejects missing and duplicate regions", async () => {
+  const snapshot = JSON.parse(await readFile(snapshotUrl, "utf8"));
+  assert.throws(
+    () => groupRegionsByMacroArea(snapshot.regions.slice(1)),
+    /Regioni mancanti/,
+  );
+  assert.throws(
+    () => groupRegionsByMacroArea([...snapshot.regions, snapshot.regions[0]]),
+    /Regione duplicata/,
+  );
+});
+
 test("macro-area totals reconcile for every committed SIOPE year", async () => {
   const cents = (value) => Math.round(value * 100);
 

--- a/tests/italy-regions.test.mjs
+++ b/tests/italy-regions.test.mjs
@@ -6,11 +6,18 @@ import {
   ISTAT_CODE_BY_REGION_NAME,
   ITALY_MACRO_AREAS,
   REGION_NAME_BY_ISTAT_CODE,
+  cptRegionAnchorOf,
+  groupRegionsByMacroArea,
   istatCodeOfRegion,
   macroAreaOf,
 } from "../src/lib/italy-regions.ts";
 
 const snapshotUrl = new URL("../src/data/generated/siope-municipal.json", import.meta.url);
+const annualSnapshotUrls = [
+  new URL("../src/data/generated/siope-municipal-2024.json", import.meta.url),
+  new URL("../src/data/generated/siope-municipal-2025.json", import.meta.url),
+  snapshotUrl,
+];
 
 test("ISTAT geometry and SIOPE data cover the same 20 regions", async () => {
   const snapshot = JSON.parse(await readFile(snapshotUrl, "utf8"));
@@ -47,4 +54,37 @@ test("ISTAT_CODE_BY_REGION_NAME is the exact reverse of REGION_NAME_BY_ISTAT_COD
     assert.equal(istatCodeOfRegion(name), code);
   }
   assert.equal(istatCodeOfRegion("Regione inesistente"), null);
+});
+
+test("CPT anchors fail closed for the one-to-many Trentino mapping", () => {
+  assert.equal(cptRegionAnchorOf("Piemonte"), "regione-01");
+  assert.equal(cptRegionAnchorOf("Trentino-Alto Adige/Südtirol"), null);
+  assert.equal(cptRegionAnchorOf("Regione inesistente"), null);
+});
+
+test("macro-area grouping rejects an unmapped region", () => {
+  assert.throws(
+    () => groupRegionsByMacroArea([{ region: "Regione inesistente" }]),
+    /Regione non associata a una macro-area/,
+  );
+});
+
+test("macro-area totals reconcile for every committed SIOPE year", async () => {
+  const cents = (value) => Math.round(value * 100);
+
+  for (const url of annualSnapshotUrls) {
+    const snapshot = JSON.parse(await readFile(url, "utf8"));
+    const groups = groupRegionsByMacroArea(snapshot.regions);
+
+    assert.equal(
+      cents(groups.reduce((total, group) => total + group.summary.value, 0)),
+      cents(snapshot.regions.reduce((total, region) => total + region.value, 0)),
+      `all payments for ${snapshot.year}`,
+    );
+    assert.equal(
+      cents(groups.reduce((total, group) => total + group.summary.perCapitaValue, 0)),
+      cents(snapshot.regions.reduce((total, region) => total + region.perCapitaValue, 0)),
+      `payments with a population denominator for ${snapshot.year}`,
+    );
+  }
 });

--- a/tests/italy-regions.test.mjs
+++ b/tests/italy-regions.test.mjs
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { italyRegionGeometry } from "../src/data/generated/italy-regions.ts";
-import { REGION_NAME_BY_ISTAT_CODE } from "../src/lib/italy-regions.ts";
+import {
+  ISTAT_CODE_BY_REGION_NAME,
+  ITALY_MACRO_AREAS,
+  REGION_NAME_BY_ISTAT_CODE,
+  istatCodeOfRegion,
+  macroAreaOf,
+} from "../src/lib/italy-regions.ts";
 
 const snapshotUrl = new URL("../src/data/generated/siope-municipal.json", import.meta.url);
 
@@ -22,4 +28,23 @@ test("ISTAT geometry and SIOPE data cover the same 20 regions", async () => {
     ),
   );
   assert.ok(italyRegionGeometry.every((region) => region.path.startsWith("M") && region.path.endsWith("Z")));
+});
+
+test("every region resolves to exactly one macro area, with no silent drops", () => {
+  const names = Object.values(REGION_NAME_BY_ISTAT_CODE);
+
+  for (const name of names) {
+    const area = macroAreaOf(name);
+    assert.ok(ITALY_MACRO_AREAS.includes(area), `${name} did not resolve to a known macro area`);
+  }
+
+  assert.equal(macroAreaOf("Regione inesistente"), null);
+});
+
+test("ISTAT_CODE_BY_REGION_NAME is the exact reverse of REGION_NAME_BY_ISTAT_CODE", () => {
+  for (const [code, name] of Object.entries(REGION_NAME_BY_ISTAT_CODE)) {
+    assert.equal(ISTAT_CODE_BY_REGION_NAME[name], code);
+    assert.equal(istatCodeOfRegion(name), code);
+  }
+  assert.equal(istatCodeOfRegion("Regione inesistente"), null);
 });


### PR DESCRIPTION
## Sintesi

Clean port della PR #14 sul `main` corrente, preservando le aggiunte successive e l'attribuzione dei commit originali a @marianimatteo-lexroom.

- raggruppa le 20 Regioni nelle ripartizioni ISTAT Nord, Centro, Sud e Isole;
- calcola il pro capite macro-area solo sul numeratore coperto da popolazione;
- fallisce esplicitamente se una Regione non è mappata, senza totali parziali silenziosi;
- collega le Regioni alla vista CPT, lasciando esplicito il caso uno-a-molti Trento/Bolzano;
- aggiunge autocomplete IPA accessibile in header, con debounce, abort, fallback e tastiera;
- preserva Consulenza, MCP, GitHub, geografia dei Comuni e fix responsive 901–980 px;
- aggiunge Browser E2E per macro-aree e ricerca a 390/1280 px, incluso Escape.

## Verifica locale

- `npm test`: 161/161
- `npm run typecheck`: PASS
- `npm run lint`: PASS
- `npm run design:check`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS
- Browser E2E completo: PASS (36 scenari; 320/390/768/901/1024/1280/1600 px)

## Provenienza

Sostituisce #14 perché il fork non può ricevere direttamente i fix/check del maintainer. I due commit funzionali originali restano con autore Matteo Mariani; il terzo commit contiene soltanto hardening e copertura di regressione.
