### PR TITLE
feat: prepare MCP distribution surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ LEAD_INBOX_EMAIL=
 # Mittente sul dominio verificato in Resend. Obbligatorio.
 # RESEND_FROM_EMAIL=Consulenza <consulenza@dovevannoinostrisoldi.com>
 RESEND_FROM_EMAIL=
+
+# Token fornito da OpenAI durante la verifica del dominio per la directory Apps.
+# Se assente o non valido, la route challenge risponde 404.
+OPENAI_APPS_CHALLENGE_TOKEN=

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ In locale è `http://localhost:3000/api/mcp`. La pagina `/mcp` mostra l'indirizz
 Il server espone:
 
 - `list_datasets`, per elencare dataset, filtri, freschezza e cautele interpretative;
-- `query_dataset`, per interrogare snapshot verificati e fonti ufficiali live con filtri e paginazione;
+- `query_dataset`, per interrogare snapshot verificati e fonti ufficiali live; filtri e paginazione
+  sono disponibili soltanto quando dichiarati dal dataset;
 - la risorsa `dvns://datasets`, che contiene il catalogo machine-readable.
 - la risorsa `dvns://related-mcp-services`, che segnala servizi pubblici complementari senza
   confonderli con gli adapter gestiti dal portale.
@@ -96,13 +97,17 @@ curl -X POST http://localhost:3000/api/mcp \
   --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
-L'accesso anonimo è intenzionale perché il server espone esclusivamente dati pubblici e operazioni read-only. Le richieste hanno input limitati, paginazione massima e controlli sugli header `Origin` e `Host`; eventuali origini browser aggiuntive si configurano con `MCP_ALLOWED_ORIGINS`, mentre i domini pubblici ammessi si dichiarano in `MCP_ALLOWED_HOSTS`. I filtri estranei al dataset vengono rifiutati esplicitamente, senza produrre risultati che sembrino filtrati ma non lo siano. Non vengono esposte credenziali di ingestione.
+L'accesso senza account o autenticazione è intenzionale perché il server espone esclusivamente dati pubblici e operazioni read-only. Le richieste hanno input limitati, paginazione massima dove prevista e controlli sugli header `Origin` e `Host`; eventuali origini browser aggiuntive si configurano con `MCP_ALLOWED_ORIGINS`, mentre i domini pubblici ammessi si dichiarano in `MCP_ALLOWED_HOSTS`. I filtri estranei al dataset vengono rifiutati esplicitamente, senza produrre risultati che sembrino filtrati ma non lo siano. Non vengono esposte credenziali di ingestione.
 
 Il repository non simula un rate limit distribuito con memoria locale: sul deployment la regola edge
 per `/api/mcp` va attivata e verificata separatamente. Finché non è attiva, questa protezione non va
 considerata presente; la configurazione proposta è documentata in [docs/MCP.md](docs/MCP.md).
 
 Per aggiungere una fonte all'MCP si registra la descrizione in `src/lib/mcp/catalog.ts` e l'adapter in `src/lib/mcp/datasets.ts`. Gli strumenti restano gli stessi, quindi i client non devono essere riconfigurati quando il catalogo cresce. Dettagli e checklist sono in [docs/MCP.md](docs/MCP.md).
+
+Per Manufact, ChatGPT e Claude si collega lo stesso endpoint pubblico: non si effettua un secondo
+deploy del server. Challenge di dominio, pagine pubbliche, starter prompt e test di submission sono
+documentati in [docs/MCP_DISTRIBUTION.md](docs/MCP_DISTRIBUTION.md).
 
 Il form di consulenza usa configurazione email fail-closed, richieste same-origin limitate e invii
 idempotenti. Honeypot e validazione non vengono presentati come rate limit: la regola WAF e la

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -6,10 +6,15 @@ Il server MCP espone i dati pubblici già disponibili nel portale attraverso un 
 
 L'endpoint Streamable HTTP è `/api/mcp`. L'implementazione usa l'SDK TypeScript ufficiale e mantiene compatibilità stateless con i client MCP della generazione precedente.
 
+Le procedure per collegare l'endpoint esistente a Manufact, ChatGPT e Claude, insieme a starter
+prompt e casi di review, sono in [MCP_DISTRIBUTION.md](MCP_DISTRIBUTION.md). L'endpoint canonico non
+va duplicato su un secondo runtime.
+
 ## Superficie pubblica
 
 - Tool `list_datasets`: catalogo completo con identificativo stabile, filtri, freschezza e caveat.
-- Tool `query_dataset`: query tipizzata con limite massimo di 100 record per pagina.
+- Tool `query_dataset`: query tipizzata; `limit` e `offset` sono accettati soltanto dagli adapter
+  che li dichiarano nel catalogo, con limite massimo di 100 record per pagina.
 - Resource `dvns://datasets`: copia JSON del catalogo.
 - Resource `dvns://related-mcp-services`: endpoint pubblici complementari, separati dagli adapter
   DVNS e mai inoltrati automaticamente.

--- a/docs/MCP_DISTRIBUTION.md
+++ b/docs/MCP_DISTRIBUTION.md
@@ -1,0 +1,89 @@
+# Distribuzione MCP
+
+L'endpoint canonico resta:
+
+```text
+https://www.dovevannoinostrisoldi.com/api/mcp
+```
+
+Non creare una seconda copia del server per un client o una directory. Una copia separata
+renderebbe più difficile mantenere allineati dataset, provenienza, annotazioni e correzioni.
+
+## Manufact
+
+In Manufact Cloud scegliere `Servers → New Server → Connect an existing server` e incollare
+l'endpoint canonico. Questa modalità usa il server già pubblicato per chat, test e publish checks;
+non richiede una migrazione a `mcp-use` né un secondo deployment.
+
+Prima di abilitare analytics o cattura dei payload, verificare impostazioni, retention e informativa
+privacy. Non includere prompt o dati personali nei test: i tool DVNS interrogano fonti pubbliche.
+
+Riferimenti ufficiali:
+
+- [Manufact: creare o collegare un server](https://docs.manufact.com/dashboard/servers)
+- [Manufact Cloud](https://docs.manufact.com/dashboard)
+
+## ChatGPT
+
+La verifica del dominio usa `/.well-known/openai-apps-challenge`. Configurare
+`OPENAI_APPS_CHALLENGE_TOKEN` soltanto con il token fornito durante la submission. La route risponde
+in testo semplice, senza cache; senza un token valido risponde `404`.
+
+Materiale da verificare prima dell'invio:
+
+- nome: `DoveVannoINostriSoldi`;
+- categoria: dati pubblici e civic tech;
+- endpoint MCP, sito, supporto, privacy e termini tutti raggiungibili in produzione;
+- logo ufficiale del progetto, senza marchi di enti fonte o piattaforme AI;
+- tool dichiarati read-only, senza autenticazione e senza effetti collaterali;
+- almeno cinque casi positivi e tre negativi eseguiti sul deployment di produzione;
+- release notes coerenti con ciò che è già online;
+- piano Vercel attivo e relativa retention dei log registrati nella scheda di review;
+
+Riferimenti ufficiali:
+
+- [OpenAI: costruire un server MCP](https://developers.openai.com/plugins/build/mcp-server)
+- [OpenAI: submission pubblica](https://developers.openai.com/plugins/deploy/submission)
+- [OpenAI: linee guida per le app](https://developers.openai.com/plugins/app-guidelines)
+
+## Claude
+
+Il server si collega come custom remote connector usando lo stesso endpoint. La directory Anthropic
+ha una candidatura separata: un test riuscito nel client non equivale all'accettazione pubblica.
+
+- [Claude: custom remote MCP connector](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
+- [Claude: submission di un remote MCP server](https://support.claude.com/it/articles/12922490-guida-all-invio-di-remote-mcp-server)
+
+## Starter prompt
+
+- `Confronta i pagamenti pro capite dei Comuni disponibili e mostrami fonte, anno e limiti.`
+- `Quali dataset territoriali posso interrogare? Non eseguire ancora una query.`
+- `Mostrami l'imposta netta dichiarata 2024 per le Regioni, distinguendola dal gettito totale.`
+- `Riassumi i pagamenti statali per missione usando l'ultimo consuntivo disponibile.`
+- `Cerca i dati disponibili per la Calabria e dimmi che cosa non è confrontabile.`
+
+## Casi di review minimi
+
+Positivi:
+
+1. discovery del server e `tools/list`;
+2. `list_datasets` con catalogo non vuoto;
+3. query regionale MEF IRPEF con provenance;
+4. query SIOPE con anno e Regione supportati, senza inventare una paginazione non dichiarata;
+5. query OpenBDAP annuale che preferisce il consuntivo;
+6. risposta con valori soppressi mantenuti espliciti;
+7. accesso alla risorsa `dvns://datasets`.
+
+Negativi:
+
+1. dataset inesistente rifiutato senza fallback;
+2. filtro non supportato rifiutato invece di essere ignorato;
+3. paginazione fuori limite rifiutata su un dataset che dichiara `limit` e `offset`;
+4. richiesta malformata restituita come errore applicativo;
+5. nessun tool mutativo o distruttivo esposto.
+
+## Evidenza, non promessa
+
+Registrare separatamente data, client, endpoint, prompt, tool chiamato ed esito di ogni prova. Un
+publish check Manufact non dimostra l'inclusione nelle directory ChatGPT o Claude; una candidatura
+inviata non dimostra approvazione; un endpoint raggiungibile non dimostra qualità delle risposte.

--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -641,6 +641,58 @@ try {
     completed.push(label);
   }
 
+  for (const [pathname, heading] of [
+    ["/supporto", /Supporto/i],
+    ["/termini", /Termini di utilizzo/i],
+  ]) {
+    for (const width of [320, 390, 1280]) {
+      const label = `${pathname.slice(1)} ${width}px`;
+      await runScenario(browser, {
+        label,
+        pathname,
+        width,
+        validate: async (page) => {
+          assertTextMatches(await bodyText(page), heading, label);
+        },
+      });
+      completed.push(label);
+    }
+  }
+
+  for (const width of [320, 1280]) {
+    const label = `Prompt MCP ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/mcp",
+      width,
+      validate: async (page) => {
+        const text = await bodyText(page);
+        assertTextMatches(text, /Prompt pronto per un agente AI/i, label);
+        assertTextMatches(text, /Copia prompt per agenti/i, label);
+        assertTextMatches(text, /list_datasets/i, label);
+        await page.evaluate(() => {
+          Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: {
+              writeText: async (value) => {
+                globalThis.__dvnsCopiedPrompt = value;
+              },
+            },
+          });
+          const button = [...document.querySelectorAll("button")].find(
+            (candidate) => candidate.textContent?.trim() === "Copia prompt per agenti",
+          );
+          button?.click();
+        });
+        await page.waitForFunction(() => document.body.innerText.includes("Prompt copiato"));
+        const copiedPrompt = await page.evaluate(() => globalThis.__dvnsCopiedPrompt ?? "");
+        assertTextMatches(copiedPrompt, /https:\/\/www\.dovevannoinostrisoldi\.com\/api\/mcp/, label);
+        assertTextMatches(copiedPrompt, /list_datasets/, label);
+      },
+    });
+    completed.push(label);
+  }
+
   for (const width of [390, 1280]) {
     const label = `Parlamento previdenza ${width}px`;
     await runScenario(browser, {

--- a/src/app/.well-known/openai-apps-challenge/route.ts
+++ b/src/app/.well-known/openai-apps-challenge/route.ts
@@ -1,0 +1,20 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NO_STORE_HEADERS = {
+  "cache-control": "no-store",
+  "content-type": "text/plain; charset=utf-8",
+  "x-content-type-options": "nosniff",
+};
+
+function challengeToken(): string | null {
+  const token = process.env.OPENAI_APPS_CHALLENGE_TOKEN?.trim();
+  if (!token || token.length > 1_024 || /[\u0000-\u001f\u007f]/.test(token)) return null;
+  return token;
+}
+
+export function GET() {
+  const token = challengeToken();
+  if (!token) return new Response("Not found", { status: 404, headers: NO_STORE_HEADERS });
+  return new Response(token, { status: 200, headers: NO_STORE_HEADERS });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -69,6 +69,9 @@ export default function RootLayout({
             <a href="https://x.com/fragiannicola" target="_blank" rel="noreferrer">@fragiannicola</a>
             <span aria-hidden="true">·</span>
             <a href="https://x.com/dom_gag_96" target="_blank" rel="noreferrer">@dom_gag_96</a>
+            <span className="footer-spacer" />
+            <a href="/supporto">Supporto</a>
+            <a href="/termini">Termini</a>
           </div>
         </footer>
       </body>

--- a/src/app/legal-page.module.css
+++ b/src/app/legal-page.module.css
@@ -1,0 +1,28 @@
+.page :global(.panel) p,
+.page :global(.panel) li {
+  font-size: 13px;
+  color: var(--color-neutral-800);
+  max-width: 78ch;
+}
+
+.page :global(.panel) p {
+  margin: 0;
+}
+
+.page :global(.panel) ul {
+  margin: var(--space-3) 0 0;
+  padding-left: 20px;
+}
+
+.page :global(.panel) li + li {
+  margin-top: var(--space-2);
+}
+
+.page :global(.panel) a {
+  overflow-wrap: anywhere;
+}
+
+.page :global(.panel) code {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}

--- a/src/app/mcp/mcp.module.css
+++ b/src/app/mcp/mcp.module.css
@@ -1,8 +1,11 @@
-.endpointPanel { margin-bottom: var(--space-4); }
+.endpointPanel,
+.promptPanel { margin-bottom: var(--space-4); }
 
 .endpointPanel h2,
+.promptPanel h2,
 .columns h2 { margin: 0 0 var(--space-3); font-size: 18px; }
 .endpointPanel p,
+.promptPanel p,
 .columns p { margin: var(--space-3) 0 0; max-width: 80ch; color: var(--color-neutral-700); }
 
 .endpointRow {
@@ -27,6 +30,20 @@
   clip-path: inset(50%);
   white-space: nowrap;
 }
+
+.promptBlock { margin-top: var(--space-3); }
+.agentPrompt {
+  max-height: 340px;
+  margin: 0;
+  padding: 14px;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-100);
+}
+.agentPrompt code { white-space: inherit; }
+.promptBlock button { margin-top: var(--space-3); }
 
 .columns {
   display: grid;
@@ -109,6 +126,7 @@
   .columns { grid-template-columns: 1fr; }
   .endpointRow { align-items: stretch; flex-direction: column; }
   .endpointRow button { width: 100%; }
+  .promptBlock button { width: 100%; }
   .serviceFacts { grid-template-columns: minmax(0, 1fr); }
   .serviceFacts > div:nth-child(odd),
   .serviceFacts > div:nth-child(even) { padding-inline: 0; border-left: 0; }

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { McpEndpoint } from "@/components/mcp-endpoint";
+import { AgentMcpPrompt, McpEndpoint } from "@/components/mcp-endpoint";
 import { datasetCatalog } from "@/lib/mcp/catalog";
 import { relatedMcpServices } from "@/lib/mcp/related-services";
 import styles from "./mcp.module.css";
@@ -44,6 +44,29 @@ export default function McpPage() {
             qualità, spreco o responsabilità. Ogni risposta conserva provenienza e metodologia.
           </p>
         </article>
+      </section>
+
+      <section className="panel" aria-labelledby="clients-title">
+        <h2 id="clients-title">Collegalo ai client compatibili</h2>
+        <p>
+          Usa sempre l&apos;endpoint canonico qui sopra: Claude può aggiungerlo come connettore MCP
+          remoto e Manufact può collegarlo come server esistente. L&apos;inclusione nelle directory
+          pubbliche di ChatGPT o Claude richiede una candidatura e una review separate; non è
+          implicita nel collegamento tecnico.
+        </p>
+        <p>
+          Prima di inviare contesto tramite un servizio esterno, consulta <a href="/privacy">privacy</a>,{" "}
+          <a href="/termini">termini</a> e <a href="/supporto">supporto</a>.
+        </p>
+      </section>
+
+      <section className={`panel ${styles.promptPanel}`} aria-labelledby="agent-prompt-title">
+        <h2 id="agent-prompt-title">Prompt pronto per un agente AI</h2>
+        <p>
+          Copialo in un agente che supporta server MCP remoti. Include la sequenza di discovery e
+          i limiti necessari per non confondere fonti o significato dei dati.
+        </p>
+        <AgentMcpPrompt />
       </section>
 
       <section className="panel" aria-labelledby="datasets-title">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import { CONTACT_EMAIL } from "@/lib/site";
-import styles from "./privacy.module.css";
+import styles from "../legal-page.module.css";
 
 export const metadata: Metadata = {
   title: "Privacy",
-  description: "Come trattiamo i dati delle richieste di consulenza.",
+  description: "Come trattiamo i dati tecnici e le richieste di consulenza.",
 };
 
 export default function PrivacyPage() {
@@ -60,11 +60,41 @@ export default function PrivacyPage() {
       <section className="panel">
         <h2 className="panel-title">Dati tecnici</h2>
         <p>
-          Il provider di hosting può trattare log tecnici, come indirizzo IP, user agent,
-          orario e percorso richiesto, per consegnare e proteggere il servizio. La home può
+          Vercel, il provider di hosting, può trattare log tecnici, come indirizzo IP, user
+          agent, orario e percorso richiesto, per consegnare, proteggere e diagnosticare il
+          servizio. L&apos;applicazione non aggiunge ai log il contenuto delle richieste MCP. I log
+          runtime restano disponibili secondo il piano Vercel attivo: un&apos;ora su Hobby, un
+          giorno su Pro, tre giorni su Enterprise oppure fino a 30 giorni con Observability
+          Plus. Consulta i limiti aggiornati dei{" "}
+          <a href="https://vercel.com/docs/logs/runtime" target="_blank" rel="noreferrer">
+            log runtime di Vercel
+          </a>{" "}
+          e il relativo{" "}
+          <a href="https://vercel.com/legal/dpa" target="_blank" rel="noreferrer">
+            accordo sul trattamento dei dati
+          </a>. La home può
           ricavare dal provider una Regione approssimativa per proporre la mappa iniziale:
           l&apos;applicazione non mostra né salva l&apos;indirizzo IP e puoi cambiare Regione in ogni
           momento.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Server MCP e assistenti esterni</h2>
+        <p>
+          L&apos;endpoint MCP è pubblico, senza account o autenticazione e in sola lettura. Riceve
+          richieste tecniche, filtri e parametri necessari a interrogare i dataset;
+          l&apos;applicazione non crea un profilo utente né un archivio delle conversazioni. Restano
+          possibili i log tecnici Vercel descritti sopra. Se colleghi l&apos;endpoint tramite un
+          client o un gateway esterno, per esempio ChatGPT, Claude o Manufact, quel servizio
+          tratta la richiesta secondo la propria informativa, conservazione e impostazioni:
+          controllale prima di inviare testo o contesto. I tool DVNS espongono soltanto dati
+          pubblici e non hanno bisogno di dati personali. Collegando direttamente il server,
+          Manufact inoltra le richieste all&apos;endpoint DVNS; attivando proxy, analytics o cattura
+          dei payload può trattare anche metadati e contenuto delle richieste secondo la sua{" "}
+          <a href="https://manufact.com/privacy" target="_blank" rel="noreferrer">
+            informativa privacy
+          </a>.
         </p>
       </section>
 

--- a/src/app/privacy/privacy.module.css
+++ b/src/app/privacy/privacy.module.css
@@ -1,6 +1,0 @@
-.page :global(.panel) p {
-  margin: 0;
-  font-size: 13px;
-  color: var(--color-neutral-800);
-  max-width: 78ch;
-}

--- a/src/app/supporto/page.tsx
+++ b/src/app/supporto/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { CONTACT_EMAIL, PUBLIC_MCP_ENDPOINT, REPO_URL } from "@/lib/site";
+import styles from "../legal-page.module.css";
+
+export const metadata: Metadata = {
+  title: "Supporto",
+  description: "Assistenza per il sito e per il server MCP di DoveVannoINostriSoldi.",
+};
+
+export default function SupportPage() {
+  return (
+    <main className={`shell page ${styles.page}`}>
+      <div className="page-intro">
+        <h1>Supporto</h1>
+        <p>Per problemi riproducibili del sito, dei dati pubblicati o del collegamento MCP.</p>
+      </div>
+
+      <section className="panel">
+        <h2 className="panel-title">Problemi e richieste tecniche</h2>
+        <p>
+          Apri una <a href={`${REPO_URL}/issues`}>issue pubblica su GitHub</a> indicando pagina o
+          endpoint, risultato atteso, risultato osservato, data e passaggi per riprodurlo. Non
+          inserire dati personali, credenziali o informazioni riservate.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Privacy e segnalazioni riservate</h2>
+        <p>
+          Per esercitare i diritti privacy o segnalare un problema che non deve essere pubblico,
+          scrivi a <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Non inviare segreti o
+          dataset personali non richiesti; descrivi prima il problema e concorda un canale adatto.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Collegare il server MCP</h2>
+        <p>
+          Usa l&apos;endpoint <code>{PUBLIC_MCP_ENDPOINT}</code> come server
+          Streamable HTTP remoto. Non richiede autenticazione e offre soltanto tool read-only.
+          Consulta la <a href="/mcp">pagina MCP</a> per catalogo e limiti prima di aprire una
+          segnalazione.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/termini/page.tsx
+++ b/src/app/termini/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import { REPO_URL } from "@/lib/site";
+import styles from "../legal-page.module.css";
+
+export const metadata: Metadata = {
+  title: "Termini di utilizzo",
+  description: "Condizioni essenziali per usare il sito e il server MCP pubblico.",
+};
+
+export default function TermsPage() {
+  return (
+    <main className={`shell page ${styles.page}`}>
+      <div className="page-intro">
+        <h1>Termini di utilizzo</h1>
+        <p>Condizioni essenziali per il sito e per l&apos;endpoint MCP pubblico. Aggiornate il 21 agosto 2026.</p>
+      </div>
+
+      <section className="panel">
+        <h2 className="panel-title">Che cosa offre il servizio</h2>
+        <p>
+          DoveVannoINostriSoldi rende più leggibili dati pubblici italiani e li espone anche
+          tramite strumenti MCP in sola lettura. Le pagine indicano fonte, periodo, perimetro e
+          limiti interpretativi. Il servizio non sostituisce le fonti ufficiali e non fornisce
+          consulenza legale, fiscale, contabile o finanziaria.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Uso corretto</h2>
+        <ul>
+          <li>Non tentare di aggirare limiti, compromettere il servizio o sovraccaricare gli endpoint.</li>
+          <li>Non presentare segnali, costi o scostamenti come prova automatica di illecito, spreco o responsabilità individuale.</li>
+          <li>Verifica sulla fonte ufficiale qualsiasi decisione importante o dato che può essere cambiato.</li>
+          <li>Non inviare dati personali o riservati ai tool MCP: non sono necessari per interrogarli.</li>
+        </ul>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Disponibilità e responsabilità</h2>
+        <p>
+          Il progetto è offerto senza garanzia di continuità, completezza o assenza di errori.
+          Fonti e schemi pubblici possono cambiare o diventare temporaneamente indisponibili.
+          Correggiamo gli errori verificabili, ma chi riusa i risultati resta responsabile di
+          controllarne adeguatezza, data e contesto.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-title">Licenze e modifiche</h2>
+        <p>
+          Il <a href={REPO_URL}>codice del progetto</a> è distribuito con licenza MIT. I dataset
+          e gli elementi di terze parti conservano le licenze e attribuzioni indicate nelle
+          rispettive fonti. Questi termini possono essere aggiornati quando cambiano servizio o
+          requisiti; la data in apertura identifica la versione pubblicata.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/components/mcp-endpoint.tsx
+++ b/src/components/mcp-endpoint.tsx
@@ -2,26 +2,35 @@
 
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import styles from "@/app/mcp/mcp.module.css";
+import { PUBLIC_MCP_ENDPOINT } from "@/lib/site";
 
-export function McpEndpoint() {
+const AGENT_PROMPT = `Collega questo server MCP remoto:
+${PUBLIC_MCP_ENDPOINT}
+
+Procedura:
+1. Scopri i tool disponibili e usa list_datasets prima di interrogare i dati.
+2. Scegli il dataset coerente con la domanda e usa solo filtri dichiarati dal catalogo.
+3. Usa limit e offset soltanto quando il catalogo li dichiara; mantieni sempre i filtri più stretti necessari.
+4. Nella risposta indica dataset, periodo, territorio, fonte ufficiale e limiti interpretativi.
+5. Distingui pagamenti, costi, imposte dichiarate e stime: l'imposta netta dichiarata MEF non è il gettito totale e non va sottratta al saldo CPT; il saldo CPT non è un residuo fiscale.
+6. Non chiamare un valore spreco, frode o qualità del servizio senza una fonte che lo dimostri.
+7. Se il dato non esiste, è soppresso o i perimetri non sono confrontabili, dichiaralo senza imputazioni o stime inventate.
+
+Inizia elencando i dataset utili alla mia domanda; esegui la query soltanto dopo aver scelto quello corretto.`;
+
+function useClipboardFeedback(value: string, enabled = true) {
   const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
   const resetTimer = useRef<number | null>(null);
-  const origin = useSyncExternalStore(
-    () => () => undefined,
-    () => window.location.origin,
-    () => "",
-  );
-  const endpoint = `${origin}/api/mcp`;
 
   useEffect(() => () => {
     if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
   }, []);
 
-  async function copyEndpoint() {
-    if (!origin) return;
+  async function copy() {
+    if (!enabled) return;
     if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
     try {
-      await navigator.clipboard.writeText(endpoint);
+      await navigator.clipboard.writeText(value);
       setStatus("copied");
     } catch {
       setStatus("error");
@@ -29,14 +38,49 @@ export function McpEndpoint() {
     resetTimer.current = window.setTimeout(() => setStatus("idle"), 2400);
   }
 
+  return { copy, status };
+}
+
+export function McpEndpoint() {
+  const origin = useSyncExternalStore(
+    () => () => undefined,
+    () => window.location.origin,
+    () => "",
+  );
+  const endpoint = `${origin}/api/mcp`;
+  const { copy, status } = useClipboardFeedback(endpoint, Boolean(origin));
+
   return (
     <div className={styles.endpointRow}>
       <code>{endpoint}</code>
-      <button className="btn" type="button" onClick={copyEndpoint} disabled={!origin}>
+      <button className="btn" type="button" onClick={copy} disabled={!origin}>
         {status === "copied" ? "Copiato" : status === "error" ? "Copia non riuscita" : "Copia endpoint"}
       </button>
       <span className={styles.srStatus} role="status" aria-live="polite">
         {status === "copied" ? "Endpoint MCP copiato negli appunti." : status === "error" ? "Copia non riuscita. Seleziona e copia manualmente l’indirizzo." : ""}
+      </span>
+    </div>
+  );
+}
+
+export function AgentMcpPrompt() {
+  const { copy, status } = useClipboardFeedback(AGENT_PROMPT);
+
+  return (
+    <div className={styles.promptBlock}>
+      <pre
+        className={styles.agentPrompt}
+        role="region"
+        aria-label="Prompt MCP per agenti AI"
+        tabIndex={0}
+      >
+        <code>{AGENT_PROMPT}</code>
+      </pre>
+      <button className="btn" type="button" onClick={copy}>
+        {status === "copied" ? "Prompt copiato" : status === "error" ? "Copia non riuscita" : "Copia prompt per agenti"}
+      </button>
+      <span className={styles.srStatus} role="status" aria-live="polite">
+        {status === "copied" ? "Prompt MCP copiato negli appunti." : status === "error" ? "Copia non riuscita. Seleziona e copia manualmente il prompt." : ""}
       </span>
     </div>
   );

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -5,6 +5,8 @@
  */
 
 export const REPO_URL = "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi";
+export const PUBLIC_SITE_URL = "https://www.dovevannoinostrisoldi.com";
+export const PUBLIC_MCP_ENDPOINT = `${PUBLIC_SITE_URL}/api/mcp`;
 
 /** Public contact shown in the privacy notice; delivery is configured separately. */
 export const CONTACT_EMAIL = "gagliardidomenico46@gmail.com";

--- a/tests/mcp_distribution.test.mjs
+++ b/tests/mcp_distribution.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { GET } = await import("../src/app/.well-known/openai-apps-challenge/route.ts");
+
+test("OpenAI domain challenge fails closed and returns only a configured token", async () => {
+  const previous = process.env.OPENAI_APPS_CHALLENGE_TOKEN;
+  try {
+    delete process.env.OPENAI_APPS_CHALLENGE_TOKEN;
+    const missing = GET();
+    assert.equal(missing.status, 404);
+    assert.equal(missing.headers.get("cache-control"), "no-store");
+
+    process.env.OPENAI_APPS_CHALLENGE_TOKEN = "  dvns-verification-token  ";
+    const configured = GET();
+    assert.equal(configured.status, 200);
+    assert.equal(configured.headers.get("content-type"), "text/plain; charset=utf-8");
+    assert.equal(await configured.text(), "dvns-verification-token");
+
+    process.env.OPENAI_APPS_CHALLENGE_TOKEN = "bad\ntoken";
+    assert.equal(GET().status, 404);
+  } finally {
+    if (previous === undefined) delete process.env.OPENAI_APPS_CHALLENGE_TOKEN;
+    else process.env.OPENAI_APPS_CHALLENGE_TOKEN = previous;
+  }
+});
+
+test("distribution pages and docs keep one canonical MCP endpoint", async () => {
+  const files = await Promise.all([
+    readFile(new URL("../src/app/mcp/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/supporto/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/termini/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/privacy/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/components/mcp-endpoint.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../docs/MCP_DISTRIBUTION.md", import.meta.url), "utf8"),
+  ]);
+  const combined = files.join("\n");
+  assert.match(combined, /https:\/\/www\.dovevannoinostrisoldi\.com\/api\/mcp/);
+  assert.match(combined, /Manufact/);
+  assert.match(combined, /ChatGPT/);
+  assert.match(combined, /Claude/);
+  assert.match(combined, /soltanto dati pubblici|dati pubblici/i);
+  assert.match(combined, /Copia prompt per agenti/);
+  assert.match(combined, /list_datasets/);
+  assert.match(combined, /imposta netta dichiarata MEF non è il gettito totale/i);
+  assert.match(combined, /saldo CPT non è un residuo fiscale/i);
+  assert.match(combined, /spreco, frode o qualità del servizio/i);
+  assert.doesNotMatch(combined, /già (?:pubblicat[oa]|disponibile) (?:su|in) (?:ChatGPT|Claude|Manufact)/i);
+});


### PR DESCRIPTION
## Outcome

Prepares the existing public MCP server for Manufact connection and future ChatGPT/Claude distribution without creating a second data runtime.

## What changes

- adds a copyable, source-safe agent prompt and client guidance to `/mcp`;
- adds support, terms, and expanded privacy surfaces;
- adds the fail-closed OpenAI Apps domain challenge route;
- adds an official-source distribution runbook for Manufact, ChatGPT, and Claude;
- adds automated contract and responsive Browser coverage;
- centralizes the canonical public MCP endpoint.

## Manufact decision

Manufact officially supports **Connect an existing server** for Chat, testing, and publish checks. Managed hosting via `mcp-use deploy` or GitHub import is a separate decision. This PR does not migrate the working server or claim store publication.

## Verification

- `npm test` — 163/163
- `npm run typecheck`
- `npm run lint`
- `npm run design:check`
- `npm run build`
- `git diff --check`
- Browser production build — 45/45 scenarios, 320–1600 px
- independent read-only review — no code blockers

## Why draft / dependency

This PR is intentionally stacked on #39. Do not merge it before #39 is either approved and merged or the stack is rebased onto a safe replacement.

Operational work still required before claiming Manufact/store readiness:

- connect the live endpoint in the provisioned Manufact organization and run publish checks;
- confirm whether the founder invitation means existing-server connection or managed hosting;
- record the active Vercel plan and effective log retention;
- verify production WAF/rate limits and the lead-deletion procedure from #39;
- configure and verify the OpenAI challenge token only during submission;
- allow only exact client/proxy origins if Manufact sends an `Origin` header.
