### PR TITLE
fix: describe MCP query parameters

### DIFF
--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -7,18 +7,42 @@ import { relatedMcpServices } from "@/lib/mcp/related-services";
 
 const querySchema = z.object({
   dataset: z.enum(DATASET_IDS).describe("Identificativo restituito da list_datasets."),
-  year: z.number().int().min(2000).max(2100).optional(),
-  month: z.number().int().min(1).max(12).optional(),
-  query: z.string().max(200).optional(),
-  region: z.string().max(100).optional(),
-  province: z.string().max(3).optional(),
-  level: z.enum(["region", "province", "municipality"]).optional(),
-  code: z.string().max(100).optional(),
-  cup: z.string().max(15).optional(),
-  area: z.string().max(100).optional(),
-  chamber: z.enum(["camera", "senato"]).optional(),
-  limit: z.number().int().min(1).max(100).optional(),
-  offset: z.number().int().min(0).max(100_000).optional(),
+  year: z.number().int().min(2000).max(2100)
+    .describe("Anno di riferimento a quattro cifre, solo se dichiarato tra i filtri del dataset.")
+    .optional(),
+  month: z.number().int().min(1).max(12)
+    .describe("Mese di riferimento da 1 a 12; richiede anche year e un dataset che supporti month.")
+    .optional(),
+  query: z.string().max(200)
+    .describe("Testo libero da cercare nel dataset, con significato e copertura indicati nel catalogo.")
+    .optional(),
+  region: z.string().max(100)
+    .describe("Nome o codice della Regione accettato dal dataset selezionato.")
+    .optional(),
+  province: z.string().max(3)
+    .describe("Sigla o codice provinciale accettato dal dataset selezionato, massimo 3 caratteri.")
+    .optional(),
+  level: z.enum(["region", "province", "municipality"])
+    .describe("Livello territoriale della risposta: region, province oppure municipality.")
+    .optional(),
+  code: z.string().max(100)
+    .describe("Codice identificativo richiesto dal dataset, per esempio codice IPA o ISTAT.")
+    .optional(),
+  cup: z.string().max(15)
+    .describe("Codice Unico di Progetto dell'opera pubblica da cercare, massimo 15 caratteri.")
+    .optional(),
+  area: z.string().max(100)
+    .describe("Area tematica usata dai dataset che espongono classificazioni o segnali di controllo.")
+    .optional(),
+  chamber: z.enum(["camera", "senato"])
+    .describe("Ramo del Parlamento: camera oppure senato.")
+    .optional(),
+  limit: z.number().int().min(1).max(100)
+    .describe("Numero massimo di record da restituire, da 1 a 100, solo per dataset che supportano limit.")
+    .optional(),
+  offset: z.number().int().min(0).max(100_000)
+    .describe("Numero di record da saltare, da 0 a 100000, solo per dataset che supportano offset.")
+    .optional(),
 }).strict();
 
 function toolResult(value: unknown) {

--- a/src/lib/mef-irpef-snapshot.ts
+++ b/src/lib/mef-irpef-snapshot.ts
@@ -126,9 +126,12 @@ type NormalizedQuery = Readonly<{
 }>;
 
 type InternalRecord = Readonly<{
-  publicRecord: MefIrpefTerritoryRecord;
+  territory: MefIrpefTerritoryRecord["territory"];
   aggregate: MefIrpefStoredAggregate;
-  sortName: string;
+  sortKey: string;
+  regionCode: string;
+  provinceCode?: string;
+  searchText?: string;
 }>;
 
 // The ETL writes canonical compact JSON plus one trailing newline. Keep this
@@ -149,10 +152,6 @@ const CAVEATS = Object.freeze([
   "La riga Mancante/errata resta separata dagli aggregati territoriali e compare soltanto nella riconciliazione nazionale.",
   "Questi aggregati non dimostrano evasione, frode, responsabilità individuali o qualità dei servizi.",
 ]);
-
-const municipalitiesByCode = new Map(snapshot.municipalities.map((row) => [row[0], row]));
-const provincesByCode = new Map(snapshot.provinces.map((row) => [row.code, row]));
-const regionsByCode = new Map(snapshot.regions.map((row) => [row.code, row]));
 
 function invalid(message: string): never {
   throw new MefIrpefQueryError("invalid_query", message);
@@ -252,13 +251,13 @@ function normalizedSearch(value: string): string {
 }
 
 function compareRecords(left: InternalRecord, right: InternalRecord): number {
-  const nameOrder = normalizedSearch(left.sortName).localeCompare(
-    normalizedSearch(right.sortName),
+  const nameOrder = left.sortKey.localeCompare(
+    right.sortKey,
     "it-IT",
     { sensitivity: "base" },
   );
   if (nameOrder !== 0) return nameOrder;
-  return left.publicRecord.territory.code.localeCompare(right.publicRecord.territory.code, "en");
+  return left.territory.code.localeCompare(right.territory.code, "en");
 }
 
 function toReportedMeasure(measure: MefIrpefAggregateMeasure): ReportedMeasure {
@@ -283,6 +282,13 @@ function toPublicAggregate(aggregate: MefIrpefStoredAggregate): MefIrpefPublicAg
   return { taxpayers: aggregate.taxpayers, measures: toMeasures(aggregate.measures) };
 }
 
+function toPublicRecord(record: InternalRecord): MefIrpefTerritoryRecord {
+  const territory = record.territory.level === "region"
+    ? { ...record.territory, sourceNames: [...record.territory.sourceNames] }
+    : { ...record.territory };
+  return { territory, ...toPublicAggregate(record.aggregate) };
+}
+
 function municipalityAggregate(row: MefIrpefPackedMunicipality): MefIrpefStoredAggregate {
   return {
     taxpayers: row[6],
@@ -299,15 +305,13 @@ function municipalityAggregate(row: MefIrpefPackedMunicipality): MefIrpefStoredA
 function regionRecord(region: MefIrpefStoredRegion): InternalRecord {
   return {
     aggregate: region,
-    sortName: region.name,
-    publicRecord: {
-      territory: {
-        level: "region",
-        code: region.code,
-        name: region.name,
-        sourceNames: region.sourceNames,
-      },
-      ...toPublicAggregate(region),
+    sortKey: normalizedSearch(region.name),
+    regionCode: region.code,
+    territory: {
+      level: "region",
+      code: region.code,
+      name: region.name,
+      sourceNames: region.sourceNames,
     },
   };
 }
@@ -315,15 +319,14 @@ function regionRecord(region: MefIrpefStoredRegion): InternalRecord {
 function provinceRecord(province: MefIrpefStoredProvince): InternalRecord {
   return {
     aggregate: province,
-    sortName: province.abbreviation,
-    publicRecord: {
-      territory: {
-        level: "province",
-        code: province.code,
-        abbreviation: province.abbreviation,
-        regionCode: province.regionCode,
-      },
-      ...toPublicAggregate(province),
+    sortKey: normalizedSearch(province.abbreviation),
+    regionCode: province.regionCode,
+    provinceCode: province.code,
+    territory: {
+      level: "province",
+      code: province.code,
+      abbreviation: province.abbreviation,
+      regionCode: province.regionCode,
     },
   };
 }
@@ -332,21 +335,31 @@ function municipalityRecord(row: MefIrpefPackedMunicipality): InternalRecord {
   const aggregate = municipalityAggregate(row);
   return {
     aggregate,
-    sortName: row[2],
-    publicRecord: {
-      territory: {
-        level: "municipality",
-        code: row[0],
-        cadastralCode: row[1],
-        name: row[2],
-        provinceCode: row[3],
-        provinceAbbreviation: row[4],
-        regionCode: row[5],
-      },
-      ...toPublicAggregate(aggregate),
+    sortKey: normalizedSearch(row[2]),
+    regionCode: row[5],
+    provinceCode: row[3],
+    searchText: [row[0], row[1], row[2]].map(normalizedSearch).join("\n"),
+    territory: {
+      level: "municipality",
+      code: row[0],
+      cadastralCode: row[1],
+      name: row[2],
+      provinceCode: row[3],
+      provinceAbbreviation: row[4],
+      regionCode: row[5],
     },
   };
 }
+
+const regionRecords = snapshot.regions.map(regionRecord).sort(compareRecords);
+const provinceRecords = snapshot.provinces.map(provinceRecord).sort(compareRecords);
+const municipalityRecords = snapshot.municipalities.map(municipalityRecord).sort(compareRecords);
+
+const regionsByCode = new Map(regionRecords.map((record) => [record.territory.code, record]));
+const provincesByCode = new Map(provinceRecords.map((record) => [record.territory.code, record]));
+const municipalitiesByCode = new Map(
+  municipalityRecords.map((record) => [record.territory.code, record]),
+);
 
 function emptyAggregate(): { taxpayers: number; measures: Array<[number, number, number]> } {
   return { taxpayers: 0, measures: MEF_IRPEF_MEASURE_ORDER.map(() => [0, 0, 0]) };
@@ -391,12 +404,9 @@ function selectRecords(query: NormalizedQuery): InternalRecord[] {
     if (query.code) {
       const match = regionsByCode.get(query.code);
       if (!match) notFound(`Regione non trovata: ${query.code}.`);
-      return [regionRecord(match)];
+      return [match];
     }
-    return snapshot.regions
-      .filter((region) => !regionCode || region.code === regionCode)
-      .map(regionRecord)
-      .sort(compareRecords);
+    return regionRecords.filter((record) => !regionCode || record.regionCode === regionCode);
   }
 
   if (query.level === "province") {
@@ -405,36 +415,30 @@ function selectRecords(query: NormalizedQuery): InternalRecord[] {
       if (!match || (regionCode && match.regionCode !== regionCode)) {
         notFound(`Provincia non trovata: ${query.code}.`);
       }
-      return [provinceRecord(match)];
+      return [match];
     }
-    return snapshot.provinces
-      .filter((province) =>
-        (!regionCode || province.regionCode === regionCode) &&
-        (!provinceCode || province.code === provinceCode))
-      .map(provinceRecord)
-      .sort(compareRecords);
+    return provinceRecords.filter((record) =>
+      (!regionCode || record.regionCode === regionCode) &&
+      (!provinceCode || record.provinceCode === provinceCode));
   }
 
   if (query.code) {
     const match = municipalitiesByCode.get(query.code);
     if (
       !match ||
-      (regionCode && match[5] !== regionCode) ||
-      (provinceCode && match[3] !== provinceCode)
+      (regionCode && match.regionCode !== regionCode) ||
+      (provinceCode && match.provinceCode !== provinceCode)
     ) {
       notFound(`Comune non trovato: ${query.code}.`);
     }
-    return [municipalityRecord(match)];
+    return [match];
   }
 
   const term = query.query ? normalizedSearch(query.query) : undefined;
-  return snapshot.municipalities
-    .filter((row) =>
-      (!regionCode || row[5] === regionCode) &&
-      (!provinceCode || row[3] === provinceCode) &&
-      (!term || [row[0], row[1], row[2]].some((value) => normalizedSearch(value).includes(term))))
-    .map(municipalityRecord)
-    .sort(compareRecords);
+  return municipalityRecords.filter((record) =>
+    (!regionCode || record.regionCode === regionCode) &&
+    (!provinceCode || record.provinceCode === provinceCode) &&
+    (!term || record.searchText?.includes(term)));
 }
 
 export function queryMefMunicipalIrpef(query?: MefIrpefQuery): MefIrpefQueryResult {
@@ -458,7 +462,7 @@ export function queryMefMunicipalIrpef(query?: MefIrpefQuery): MefIrpefQueryResu
       returned: page.length,
     },
     matchedTotals: toPublicAggregate(foldAggregates(matches)),
-    data: page.map((record) => record.publicRecord),
+    data: page.map(toPublicRecord),
     national: {
       assigned: toPublicAggregate(snapshot.national.assigned),
       unassigned: { label: "Mancante/errata", ...unassigned },

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -167,6 +167,37 @@ test("MCP endpoint exposes the read-only tools over Streamable HTTP", async () =
   assert.equal(response.headers.get("cache-control"), "private, no-store");
 });
 
+test("MCP query tool describes every input parameter for clients and directories", async () => {
+  const response = await POST(request({ Origin: "https://example.test" }));
+  const rpcEvent = parseRpcEvent(await response.text());
+  const queryTool = rpcEvent.result.tools.find((tool) => tool.name === "query_dataset");
+  assert.ok(queryTool, "query_dataset tool missing");
+  const properties = queryTool.inputSchema?.properties;
+  assert.ok(properties && Object.keys(properties).length > 0, "query_dataset properties missing");
+  assert.deepEqual(Object.keys(properties), [
+    "dataset",
+    "year",
+    "month",
+    "query",
+    "region",
+    "province",
+    "level",
+    "code",
+    "cup",
+    "area",
+    "chamber",
+    "limit",
+    "offset",
+  ]);
+  for (const [name, schema] of Object.entries(properties)) {
+    assert.equal(
+      typeof schema.description === "string" && schema.description.trim().length > 0,
+      true,
+      `${name} is missing a non-empty description`,
+    );
+  }
+});
+
 test("MCP endpoint exposes the machine-readable dataset catalog resource", async () => {
   const response = await POST(request({}, JSON.stringify({
     jsonrpc: "2.0",

--- a/tests/mef-irpef.test.mjs
+++ b/tests/mef-irpef.test.mjs
@@ -104,6 +104,14 @@ test("MEF IRPEF query keeps periods and semantic boundaries explicit", () => {
   assert.match(result.caveats.join(" "), /non è il gettito fiscale totale/i);
   assert.match(result.caveats.join(" "), /non vengono sottratti.*CPT/i);
   assert.doesNotMatch(JSON.stringify(result), /ABANO TERME/);
+
+  const originalName = result.data[0].territory.name;
+  const originalSourceName = result.data[0].territory.sourceNames[0];
+  result.data[0].territory.name = "MUTATED";
+  result.data[0].territory.sourceNames[0] = "MUTATED";
+  const freshResult = queryMefMunicipalIrpef();
+  assert.equal(freshResult.data[0].territory.name, originalName);
+  assert.equal(freshResult.data[0].territory.sourceNames[0], originalSourceName);
 });
 
 test("MEF IRPEF query is bounded, stable and preserves suppressed values", () => {
@@ -121,6 +129,17 @@ test("MEF IRPEF query is bounded, stable and preserves suppressed values", () =>
     knownFrequency: 0,
     knownAmountCents: 0,
     suppressedRows: 1,
+  });
+
+  const abanoByName = queryMefMunicipalIrpef({
+    level: "municipality",
+    query: "abano térme",
+  });
+  assert.equal(abanoByName.pagination.total, 1);
+  assert.equal(abanoByName.data[0].territory.code, abano.data[0].territory.code);
+  assert.deepEqual(abanoByName.matchedTotals, {
+    taxpayers: abano.data[0].taxpayers,
+    measures: abano.data[0].measures,
   });
 
   const firstPage = queryMefMunicipalIrpef({


### PR DESCRIPTION
## Outcome

Closes the only actionable warning from the first live Manufact submission-readiness run and removes the MEF municipal query bottleneck exposed by the release load gate.

## Changes

- describes all 13 advertised `query_dataset` parameters, including dataset-specific applicability and bounds;
- adds a route-level regression test for the exact property set and every non-empty description;
- precomputes immutable MEF territory indexes, normalized search keys and stable ordering once per snapshot import;
- materializes public measure objects only for the bounded page returned;
- defensively copies cached territory metadata so in-process callers cannot contaminate later queries;
- intentionally leaves `outputSchema` unspecified: query payloads are dataset-specific and success/error shapes differ, so a generic schema would overstate the contract.

## Evidence

- `npm test`: 163/163;
- focused MCP/MEF tests: 41/41;
- typecheck, lint, Impeccable and `git diff --check`: pass;
- production build: pass;
- real Streamable HTTP smoke: page, API, legacy tools/query, modern discovery/query;
- independent equivalence oracle: 27 query/search cases, 0 mismatches;
- load correctness on the final production build: 60/60 across five MEF scenarios.

## Performance

The original local gate reproduced a real failure: p95 8,401 ms with 3/60 timeouts at concurrency 6. On the final exact build, the same cold workload passes at p95 1,455 ms (budget 3,000 ms), 60/60 successful. A warm repeat reached p95 141 ms. The budget was not widened.
