### PR TITLE
feat(state): expose the definitive 2025 accounts

### DIFF
--- a/src/app/stato/page.tsx
+++ b/src/app/stato/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { SpendingBarChart } from "@/components/charts/spending-bar-chart";
 import {
@@ -11,6 +12,10 @@ import {
   type BdapDataset,
   type StateSpendingSnapshot,
 } from "@/lib/bdap-payments";
+import {
+  parseStateOverviewSelection,
+  STATE_CONSUNTIVO_YEAR,
+} from "@/lib/data/state-overview-period";
 import styles from "./stato.module.css";
 
 export const dynamic = "force-dynamic";
@@ -95,11 +100,34 @@ function SourceRow({ dataset }: { dataset: BdapDataset }) {
   );
 }
 
+function StatePeriodSelector({ isConsuntivo }: { isConsuntivo: boolean }) {
+  return (
+    <nav className={styles.periodSelector} aria-label="Seleziona il rilascio della spesa dello Stato">
+      <span>Vista del periodo</span>
+      <div>
+        <Link
+          href="/stato"
+          aria-current={!isConsuntivo ? "page" : undefined}
+        >
+          Ultimo rilascio mensile disponibile
+        </Link>
+        <Link
+          href={`/stato?anno=${STATE_CONSUNTIVO_YEAR}`}
+          aria-current={isConsuntivo ? "page" : undefined}
+        >
+          Consuntivo {STATE_CONSUNTIVO_YEAR} · definitivo
+        </Link>
+      </div>
+    </nav>
+  );
+}
+
 function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
   const maxPaymentMethod = snapshot.paymentMethods[0]?.value ?? 0;
   const sourceUpdatedAt = snapshot.sources.mission.metadataModified;
   const isConsuntivo = snapshot.period.releaseKind === "consuntivo";
   const totalPaidField = isConsuntivo ? "Totale pagato" : "Totale Pagato";
+  const chartValueLabel = isConsuntivo ? "totale pagato del consuntivo" : "totale pagato cumulato";
   const administrationQuery = snapshot.period.month === null
     ? `anno=${snapshot.period.year}`
     : `anno=${snapshot.period.year}&mese=${snapshot.period.month}`;
@@ -119,7 +147,11 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
         <aside className={styles.sourceSummary} aria-label="Metadati della fonte">
           <div className={styles.sourceSummaryRow}>
             <span>Periodo</span>
-            <strong>{snapshot.period.label}</strong>
+            <strong>
+              {isConsuntivo
+                ? `Consuntivo ${snapshot.period.year} · definitivo`
+                : `${snapshot.period.monthName} ${snapshot.period.year} · rilascio mensile cumulativo`}
+            </strong>
           </div>
           <div className={styles.sourceSummaryRow}>
             <span>Fonte</span>
@@ -144,7 +176,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
         <div className={styles.primaryMetric}>
           <div className={styles.metricLabel}>
             <i aria-hidden="true" />
-            {isConsuntivo ? "Pagamenti del consuntivo" : "Pagamenti da inizio anno"}
+            {isConsuntivo ? "Consuntivo annuale definitivo" : "Rilascio mensile cumulativo"}
           </div>
           <strong>{compactEuro(snapshot.totalPaid)}</strong>
           <span>
@@ -183,9 +215,28 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
         </div>
       </section>
 
-      <Suspense fallback={<StateSpendingHistoryFallback />}>
-        <StateSpendingHistorySection />
-      </Suspense>
+      {isConsuntivo ? (
+        <section className={styles.section} aria-labelledby="monthly-history-title">
+          <div className={styles.sectionHeader}>
+            <div>
+              <span className={styles.kicker}>SERIE SEPARATA</span>
+              <h2 id="monthly-history-title">La serie mese per mese resta mensile</h2>
+            </div>
+            <p>
+              Il grafico storico usa solo i rilasci mensili cumulativi. Non scompone il consuntivo
+              {` ${snapshot.period.year}`}. La serie mensile non viene mostrata in questa vista per non
+              confrontare livelli diversi.
+            </p>
+          </div>
+          <Link className={styles.separationLink} href="/stato">
+            Apri l&apos;ultimo rilascio mensile cumulativo →
+          </Link>
+        </section>
+      ) : (
+        <Suspense fallback={<StateSpendingHistoryFallback />}>
+          <StateSpendingHistorySection />
+        </Suspense>
+      )}
 
       <section className={styles.section}>
         <div className={styles.sectionHeader}>
@@ -206,7 +257,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           </div>
           <SpendingBarChart
             data={snapshot.missions}
-            ariaLabel={`Prime missioni del Bilancio dello Stato per totale pagato cumulato, ${snapshot.period.label}`}
+            ariaLabel={`Prime missioni del Bilancio dello Stato per ${chartValueLabel}, ${snapshot.period.label}`}
             maxItems={12}
             height={500}
           />
@@ -240,7 +291,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             </div>
             <SpendingBarChart
               data={snapshot.administrations}
-              ariaLabel={`Amministrazioni centrali per totale pagato cumulato, ${snapshot.period.label}`}
+              ariaLabel={`Amministrazioni centrali per ${chartValueLabel}, ${snapshot.period.label}`}
               maxItems={10}
               height={430}
             />
@@ -291,7 +342,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
             </div>
             <SpendingBarChart
               data={snapshot.economicCategories}
-              ariaLabel={`Categorie economiche per totale pagato cumulato, ${snapshot.period.label}`}
+              ariaLabel={`Categorie economiche per ${chartValueLabel}, ${snapshot.period.label}`}
               maxItems={10}
               height={430}
             />
@@ -378,12 +429,21 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
   );
 }
 
-export default async function StateSpendingPage() {
+type PageProps = {
+  searchParams: Promise<{ anno?: string | string[] }>;
+};
+
+export default async function StateSpendingPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const selection = parseStateOverviewSelection(params.anno);
+  if (selection.kind === "invalid") notFound();
+
   let snapshot: StateSpendingSnapshot | null = null;
   let errorMessage: string | null = null;
 
   try {
     snapshot = await getStateSpendingSnapshot({
+      ...(selection.kind === "year" ? { year: selection.year } : {}),
       signal: AbortSignal.timeout(PAGE_DATA_BUDGET_MS),
     });
   } catch (error) {
@@ -397,6 +457,12 @@ export default async function StateSpendingPage() {
         <span>→</span>
         <span>Spese dello Stato</span>
       </nav>
+
+      <StatePeriodSelector
+        isConsuntivo={snapshot
+          ? snapshot.period.releaseKind === "consuntivo"
+          : selection.kind === "year" && selection.year === STATE_CONSUNTIVO_YEAR}
+      />
 
       {snapshot ? (
         <SpendingDashboard snapshot={snapshot} />

--- a/src/app/stato/stato.module.css
+++ b/src/app/stato/stato.module.css
@@ -15,6 +15,65 @@
   color: var(--color-accent-700);
 }
 
+.periodSelector {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 30px;
+  padding: 10px 0;
+  border-block: 1px solid var(--color-neutral-200);
+}
+
+.periodSelector > span {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.periodSelector > div {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.periodSelector a,
+.separationLink {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  padding: 0 13px;
+  border: 1px solid var(--color-neutral-300);
+  color: var(--color-text);
+  font-size: 11px;
+  line-height: 1.35;
+  transition: background-color 130ms ease, border-color 130ms ease, transform 130ms var(--ease-out);
+}
+
+.periodSelector a:hover,
+.separationLink:hover {
+  background: var(--color-neutral-100);
+  border-color: var(--color-accent-700);
+}
+
+.periodSelector a[aria-current="page"] {
+  background: var(--color-neutral-100);
+  border-color: var(--color-accent-700);
+  font-weight: 680;
+}
+
+.periodSelector a:active,
+.separationLink:active {
+  transform: scale(.98);
+}
+
+.separationLink {
+  font-weight: 650;
+}
+
 .header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(280px, .38fr);
@@ -492,6 +551,15 @@
     text-align: left;
   }
 
+  .periodSelector {
+    display: block;
+  }
+
+  .periodSelector > div {
+    justify-content: flex-start;
+    margin-top: 9px;
+  }
+
   .chartBlock {
     padding: 18px 12px;
   }
@@ -528,7 +596,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .provenanceActions a {
+  .periodSelector a,
+  .provenanceActions a,
+  .separationLink {
     transition: none;
   }
 }

--- a/src/lib/data/state-overview-period.ts
+++ b/src/lib/data/state-overview-period.ts
@@ -1,0 +1,32 @@
+export const STATE_CONSUNTIVO_YEAR = 2025;
+export const STATE_SUPPORTED_YEARS = [STATE_CONSUNTIVO_YEAR] as const;
+
+export type StateOverviewYear = (typeof STATE_SUPPORTED_YEARS)[number];
+
+export type StateOverviewSelection =
+  | { kind: "latest" }
+  | { kind: "year"; year: StateOverviewYear }
+  | { kind: "invalid"; value: string };
+
+function isStateOverviewYear(value: number): value is StateOverviewYear {
+  return STATE_SUPPORTED_YEARS.some((year) => year === value);
+}
+
+export function parseStateOverviewSelection(
+  value: string | string[] | undefined,
+): StateOverviewSelection {
+  if (value === undefined) return { kind: "latest" };
+
+  const values = Array.isArray(value) ? value : [value];
+  if (values.length !== 1) {
+    return { kind: "invalid", value: values.join(",") };
+  }
+
+  const raw = values[0] ?? "";
+  if (!/^20\d{2}$/.test(raw)) return { kind: "invalid", value: raw };
+
+  const year = Number.parseInt(raw, 10);
+  if (!isStateOverviewYear(year)) return { kind: "invalid", value: raw };
+
+  return { kind: "year", year };
+}

--- a/tests/state-overview-period.test.mjs
+++ b/tests/state-overview-period.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  STATE_SUPPORTED_YEARS,
+  parseStateOverviewSelection,
+} from "../src/lib/data/state-overview-period.ts";
+
+test("state overview defaults to the latest supported release", () => {
+  assert.deepEqual(parseStateOverviewSelection(undefined), { kind: "latest" });
+});
+
+test("state overview accepts the verified annual year and keeps monthly latest implicit", () => {
+  assert.deepEqual(parseStateOverviewSelection("2025"), { kind: "year", year: 2025 });
+  assert.deepEqual(parseStateOverviewSelection(["2025"]), { kind: "year", year: 2025 });
+  assert.equal(parseStateOverviewSelection("2026").kind, "invalid");
+  assert.deepEqual(STATE_SUPPORTED_YEARS, [2025]);
+});
+
+test("state overview rejects unsupported, malformed and repeated years", () => {
+  for (const value of ["2024", "2025x", "20", ["2025", "2026"]]) {
+    assert.equal(parseStateOverviewSelection(value).kind, "invalid");
+  }
+});

--- a/tests/state-page-ui.test.mjs
+++ b/tests/state-page-ui.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const page = await readFile(new URL("../src/app/stato/page.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../src/app/stato/stato.module.css", import.meta.url), "utf8");
+
+test("state page reads the Next 16 searchParams promise and fails closed", () => {
+  assert.match(page, /searchParams: Promise<\{ anno\?: string \| string\[\] \}>/);
+  assert.match(page, /const params = await searchParams;/);
+  assert.match(page, /parseStateOverviewSelection\(params\.anno\)/);
+  assert.match(page, /if \(selection\.kind === "invalid"\) notFound\(\);/);
+});
+
+test("state page exposes distinct monthly and definitive annual releases", () => {
+  assert.match(page, /Ultimo rilascio mensile disponibile/);
+  assert.match(page, /Consuntivo \{STATE_CONSUNTIVO_YEAR\} · definitivo/);
+  assert.match(page, /Consuntivo \$\{snapshot\.period\.year\} · definitivo/);
+  assert.match(page, /Rilascio mensile cumulativo/);
+  assert.match(page, /serie mensile non viene mostrata/i);
+});
+
+test("state page never renders monthly history alongside the annual consuntivo", () => {
+  assert.equal(page.match(/<StateSpendingHistorySection \/>/g)?.length, 1);
+  assert.match(
+    page,
+    /\{isConsuntivo \? \([\s\S]*?La serie mese per mese resta mensile[\s\S]*?\) : \([\s\S]*?<StateSpendingHistorySection \/>/,
+  );
+});
+
+test("state period controls preserve keyboard-sized targets on narrow screens", () => {
+  assert.match(css, /\.periodSelector a,\s*\.separationLink \{[\s\S]*?min-height: 44px;/);
+  assert.match(css, /@media \(max-width: 720px\)[\s\S]*?\.periodSelector \{\s*display: block;/);
+  assert.match(css, /\.periodSelector a\[aria-current="page"\]/);
+});


### PR DESCRIPTION
## Cosa cambia
- rende selezionabile il consuntivo OpenBDAP 2025 dalla pagina Stato
- mantiene l’ultimo rilascio mensile come vista predefinita
- separa esplicitamente il consuntivo definitivo dalla serie mensile cumulativa
- aggiunge parser fail-closed e regressioni UI/accessibilità

## Verifica
- npm test: 245/245
- typecheck, lint, design check, build e diff-check
- MCP HTTP smoke reale
- Browser 320/390/768/1280 su vista mensile e consuntivo

Il consuntivo annuale e i rilasci mensili non vengono sommati o confrontati come se fossero la stessa serie.