### PR TITLE
feat(home): clarify spending composition

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -128,7 +128,13 @@ Header su una riga: marchio con firma tricolore, ricerca, azione. Sotto, la barr
 
 ### Dashboard
 
-La home è una griglia a tre colonne (`288px | 1fr | 300px`). A 1320px la colonna destra diventa una banda di card a piena larghezza; a 900px tutto è in colonna singola.
+La home è una griglia a tre colonne (`360px | 1fr | 300px`): lettura/composizione, geografia, dettaglio. A 1320px la colonna destra diventa una banda di moduli a piena larghezza; a 900px tutto segue lo stesso ordine DOM in colonna singola. La classifica dei Comuni non precede mai la mappa.
+
+### Composizione della spesa
+
+`SpendingComposition` riceve valori assoluti, totale canonico, periodo, perimetro, denominatore e fonte. Lo stato `ready` deve riconciliare la somma al centesimo; `partial` mostra residuo e categorie mancanti senza simulare copertura completa. L'area è proporzionale al valore. Le celle sotto la soglia di leggibilità usano un indice e restano spiegate nella lista; sotto 620px il treemap collassa in lista con barre. Tooltip da tastiera e tabella equivalente non sostituiscono i dati essenziali già visibili.
+
+Use: fotografia additiva dello stesso totale, categorie mutuamente esclusive, copertura verificata. Avoid: trend, ranking preciso, benchmark, categorie sovrapposte, denominatori o periodi diversi.
 
 ### Panels
 

--- a/docs/UI_AUDIT_2026-08-22.md
+++ b/docs/UI_AUDIT_2026-08-22.md
@@ -48,7 +48,7 @@ Gli stessi revisori hanno poi valutato separatamente il reference lock part-to-w
 - Accettazione: le prime differenze sono comprensibili senza zoom; la tabella completa resta accessibile e scrollabile da tastiera.
 - Rule strength: heuristic; exact-table availability product invariant.
 
-### UI-04 / P2 / OPEN — gerarchia home cambia su mobile
+### UI-04 / P2 / VERIFIED — gerarchia home cambia su mobile
 
 - Area: visual, data, responsive.
 - Stato: `/`, 390 e 1280.
@@ -56,7 +56,18 @@ Gli stessi revisori hanno poi valutato separatamente il reference lock part-to-w
 - Impatto: “dove” arriva dopo due livelli secondari.
 - Decisione: slice B ricompone l'ordine DOM mantenendo la mappa e i data contract.
 - Accettazione: dato primario, confronto e mappa sono i primi tre gruppi; fonti e dettaglio restano raggiungibili.
+- Verifica current-head: composizione → mappa → confronto regionale → trend → classifica Comuni nel DOM; screenshot 390/1280 senza overflow, CLS 0 o errori runtime in `.audit/slice-b-confirmation/manifest.json`.
 - Rule strength: product contract.
+
+### UI-06 / P1 / VERIFIED — composizione part-to-whole affidabile
+
+- Area: data, visual, component, responsive.
+- Osservazione: il donut precedente mostrava quote ma non area proporzionale, metadati vicini, stato parziale o tabella equivalente.
+- Impatto: il lettore vedeva categorie ma riconciliava con difficoltà quota, importo e totale.
+- Rule strength: product contract + data integrity invariant.
+- Decisione: `SpendingComposition` con layout deterministico, famiglie cromatiche ridondanti, tooltip accessibile, lista mobile e tabella esatta.
+- Verifica dati: i sette titoli SIOPE appartengono una sola volta ai cinque gruppi; 2024/2025/2026 riconciliano il 100% del totale entro un centesimo.
+- Verifica UI: desktop mostra area proporzionale; mobile sotto 620px usa lista/barre; metadati includono periodo, perimetro, denominatore, fonte e data di acquisizione.
 
 ### UI-05 / P3 / OPEN — Consulenza lunga e sbilanciata
 
@@ -76,4 +87,4 @@ Gli stessi revisori hanno poi valutato separatamente il reference lock part-to-w
 - responsive: baseline 320–1600 E2E PASS; finding qualitativi UI-02/UI-03/UI-04.
 - design-system: token indefiniti `--color-neutral-0` e `--space-5` identificati; slice A li risolve semanticamente.
 - component: mappa e form hanno contratti esistenti; submit browser aggiunto al form.
-- release: non ancora PASS; richiede prove current-head dopo ogni slice.
+- release slice B: build, lint, typecheck e test focalizzati PASS; screenshot current-build PASS. Suite browser lunga BLOCKED da chiusura del processo Chrome (`TargetCloseError`) senza assertion di prodotto; smoke submit Consulenza current-build PASS separato.

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -386,6 +386,47 @@ async function assertRegionalMapSelection(page, label) {
   for (const path of regionPaths) await path.dispose();
 }
 
+async function assertSpendingComposition(page, label, width) {
+  const selector = '[data-composition-state="ready"]';
+  await page.waitForSelector(selector);
+  const state = await page.$eval(selector, (root, viewportWidth) => {
+    const visual = root.querySelector('[aria-label^="Composizione di"]');
+    const map = document.querySelector('[data-region-map="true"]');
+    const municipalityHeading = [...document.querySelectorAll("h2")].find((heading) =>
+      heading.textContent?.includes("Comuni con più pagamenti per abitante"),
+    );
+    return {
+      legendButtons: root.querySelectorAll("ol button").length,
+      visualDisplay: visual ? getComputedStyle(visual).display : null,
+      visualHeight: visual?.getBoundingClientRect().height ?? 0,
+      hasMetadata: /Denominatore:.*Fonte:/s.test(root.textContent ?? ""),
+      compositionBeforeMap: Boolean(map && (root.compareDocumentPosition(map) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      mapBeforeMunicipalities: Boolean(
+        map && municipalityHeading && (map.compareDocumentPosition(municipalityHeading) & Node.DOCUMENT_POSITION_FOLLOWING)
+      ),
+      shouldCollapse: viewportWidth <= 620,
+    };
+  }, width);
+  assert.equal(state.legendButtons, 5, `${label}: macro-voci inattese`);
+  assert.equal(state.hasMetadata, true, `${label}: periodo/perimetro/fonte non vicini`);
+  assert.equal(state.compositionBeforeMap, true, `${label}: composizione dopo la mappa nel DOM`);
+  assert.equal(state.mapBeforeMunicipalities, true, `${label}: classifica Comuni anticipa la mappa`);
+  assert.equal(state.visualDisplay === "none", state.shouldCollapse, `${label}: fallback mobile incoerente`);
+  if (!state.shouldCollapse) assert.ok(state.visualHeight >= 250, `${label}: geometria treemap non riservata`);
+
+  const firstLegendButton = `${selector} ol button`;
+  await page.focus(firstLegendButton);
+  await page.waitForSelector(`${selector} [role="tooltip"]`, { visible: true });
+  const describedBy = await page.$eval(firstLegendButton, (button) => button.getAttribute("aria-describedby"));
+  assert.ok(describedBy, `${label}: tooltip non collegato al controllo`);
+  await page.keyboard.press("Escape");
+  await page.waitForFunction((rootSelector) => !document.querySelector(`${rootSelector} [role="tooltip"]`), {}, selector);
+
+  await page.click(`${selector} details summary`);
+  const rows = await page.$$eval(`${selector} details tbody tr`, (items) => items.length);
+  assert.equal(rows, 6, `${label}: tabella equivalente incompleta`);
+}
+
 async function assertTableKeyboardScroll(page, label) {
   await page.waitForSelector(TABLE_REGION, { visible: true });
   const tableState = await page.$eval(TABLE_REGION, (region) => ({
@@ -1244,6 +1285,17 @@ try {
       validate: async (page) => {
         await assertInfoTooltips(page, label);
       },
+    });
+    completed.push(label);
+  }
+
+  for (const width of [390, 768, 1280]) {
+    const label = `Composizione spesa home ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/",
+      width,
+      validate: async (page) => assertSpendingComposition(page, label, width),
     });
     completed.push(label);
   }

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -14,7 +14,7 @@ import {
 const baseUrl = defaultBaseUrl();
 const TABLE_REGION = '[role="region"][aria-label="Redditi e variabili IRPEF per territorio"]';
 const ACTIVE_LEVEL = 'nav[aria-label="Livello territoriale"] a[aria-current="page"]';
-const INFO_TOOLTIP_IDS = ["cash-payments-tip", "spending-glossary-tip"];
+const INFO_TOOLTIP_IDS = ["cash-payments-tip"];
 
 if (!/^https?:$/.test(baseUrl.protocol)) {
   throw new Error("DVNS_BASE_URL deve usare il protocollo HTTP oppure HTTPS.");

--- a/scripts/browser/editorial.mjs
+++ b/scripts/browser/editorial.mjs
@@ -35,13 +35,44 @@ async function inspectRoute(browser, pathname, title, width) {
     // networkidle0 (PR1.8): wait for the h1 that carries the title.
     await navigate(page, { url, label: `${pathname} ${width}px`, readySelector: "h1" });
 
-    const state = await page.evaluate(() => {
+    let nativeLimits = false;
+    const limitSummaries = await page.$$("details > summary");
+    for (let index = 0; index < limitSummaries.length; index += 1) {
+      const summary = limitSummaries[index];
+      const summaryText = await summary.evaluate((element) => element.textContent ?? "");
+      if (!/non dimostra|limiti/i.test(summaryText)) continue;
+
+      const isOpen = await summary.evaluate((element) => element.closest("details")?.open === true);
+      if (!isOpen) await summary.click();
+
+      nativeLimits = await summary.evaluate((element) => {
+        const details = element.closest("details");
+        if (!details?.open) return false;
+
+        return [...details.children]
+          .filter((child) => child !== element)
+          .some((child) => {
+            const style = window.getComputedStyle(child);
+            const rect = child.getBoundingClientRect();
+            return (
+              (child.textContent ?? "").trim().length > 0 &&
+              style.display !== "none" &&
+              style.visibility !== "hidden" &&
+              rect.width > 0 &&
+              rect.height > 0
+            );
+          });
+      });
+      if (nativeLimits) break;
+    }
+
+    const state = await page.evaluate((nativeBoundaryVisible) => {
       const root = document.documentElement;
       const h1s = [...document.querySelectorAll("h1")];
       const dataLink = [...document.querySelectorAll("a")].some((link) =>
         /Vedi tutte le righe|Dati e fonti|registro completo/i.test(link.textContent ?? ""),
       );
-      const limits = [...document.querySelectorAll("h2")].some((heading) =>
+      const legacyLimits = [...document.querySelectorAll("h2")].some((heading) =>
         /non dimostra|limiti/i.test(heading.textContent ?? ""),
       );
       return {
@@ -50,9 +81,9 @@ async function inspectRoute(browser, pathname, title, width) {
         h1: h1s[0]?.textContent?.trim(),
         h1Count: h1s.length,
         dataLink,
-        limits,
+        limits: nativeBoundaryVisible || legacyLimits,
       };
-    });
+    }, nativeLimits);
     const label = `${pathname} ${width}px`;
     assert.equal(state.h1Count, 1, `${label}: serve un solo h1`);
     assert.equal(state.h1, title, `${label}: titolo inatteso`);

--- a/scripts/browser/editorial.mjs
+++ b/scripts/browser/editorial.mjs
@@ -15,6 +15,10 @@ const root = fileURLToPath(new URL("../../", import.meta.url));
 const baseUrl = defaultBaseUrl();
 const reviewDirectory = path.join(root, ".impeccable", "review");
 
+function normalizeVisibleText(value) {
+  return value.normalize("NFKC").replace(/\s+/gu, " ").trim().toLocaleLowerCase("it-IT");
+}
+
 assert.ok(
   ["http:", "https:"].includes(baseUrl.protocol),
   "DVNS_BASE_URL non valido",
@@ -35,35 +39,71 @@ async function inspectRoute(browser, pathname, title, width) {
     // networkidle0 (PR1.8): wait for the h1 that carries the title.
     await navigate(page, { url, label: `${pathname} ${width}px`, readySelector: "h1" });
 
+    const label = `${pathname} ${width}px`;
+    const expectedSummary = "che cosa non dimostra da solo";
     let nativeLimits = false;
     const limitSummaries = await page.$$("details > summary");
     for (let index = 0; index < limitSummaries.length; index += 1) {
       const summary = limitSummaries[index];
       const summaryText = await summary.evaluate((element) => element.textContent ?? "");
-      if (!/non dimostra|limiti/i.test(summaryText)) continue;
+      if (normalizeVisibleText(summaryText) !== expectedSummary) continue;
 
-      const isOpen = await summary.evaluate((element) => element.closest("details")?.open === true);
-      if (!isOpen) await summary.click();
-
-      nativeLimits = await summary.evaluate((element) => {
+      const readDetailsState = () => summary.evaluate((element) => {
         const details = element.closest("details");
-        if (!details?.open) return false;
-
-        return [...details.children]
-          .filter((child) => child !== element)
-          .some((child) => {
-            const style = window.getComputedStyle(child);
-            const rect = child.getBoundingClientRect();
-            return (
-              (child.textContent ?? "").trim().length > 0 &&
-              style.display !== "none" &&
-              style.visibility !== "hidden" &&
-              rect.width > 0 &&
-              rect.height > 0
-            );
-          });
+        const isVisible = (node) => {
+          const style = window.getComputedStyle(node);
+          const rect = node.getBoundingClientRect();
+          return (
+            style.display !== "none" &&
+            style.visibility !== "hidden" &&
+            style.opacity !== "0" &&
+            rect.width > 0 &&
+            rect.height > 0
+          );
+        };
+        return {
+          hasDetails: Boolean(details),
+          open: details?.open === true,
+          summaryVisible: isVisible(element),
+          contentVisible: Boolean(
+            details?.open &&
+              [...details.children]
+                .filter((child) => child !== element)
+                .some((child) => (child.textContent ?? "").trim().length > 0 && isVisible(child)),
+          ),
+        };
       });
-      if (nativeLimits) break;
+
+      let detailsState = await readDetailsState();
+      assert.equal(detailsState.hasDetails, true, `${label}: summary senza details nativo`);
+      assert.equal(detailsState.summaryVisible, true, `${label}: summary del confine non visibile`);
+      if (detailsState.open) await summary.click();
+      detailsState = await readDetailsState();
+      assert.equal(detailsState.open, false, `${label}: confine nativo non chiuso inizialmente`);
+
+      await summary.focus();
+      const focused = await summary.evaluate((element) => document.activeElement === element);
+      assert.equal(focused, true, `${label}: summary del confine non riceve il focus`);
+      await page.keyboard.press("Enter");
+      detailsState = await readDetailsState();
+      if (!detailsState.open || !detailsState.contentVisible) {
+        if (detailsState.open) await summary.click();
+        await summary.focus();
+        await page.keyboard.press("Space");
+        detailsState = await readDetailsState();
+      }
+      assert.equal(detailsState.open, true, `${label}: apertura da tastiera del confine fallita`);
+      assert.equal(detailsState.contentVisible, true, `${label}: contenuto del confine non visibile`);
+
+      await summary.click();
+      detailsState = await readDetailsState();
+      assert.equal(detailsState.open, false, `${label}: chiusura click del confine fallita`);
+      await summary.click();
+      detailsState = await readDetailsState();
+      assert.equal(detailsState.open, true, `${label}: riapertura click del confine fallita`);
+      assert.equal(detailsState.contentVisible, true, `${label}: contenuto non visibile dopo riapertura`);
+      nativeLimits = true;
+      break;
     }
 
     const state = await page.evaluate((nativeBoundaryVisible) => {
@@ -72,9 +112,23 @@ async function inspectRoute(browser, pathname, title, width) {
       const dataLink = [...document.querySelectorAll("a")].some((link) =>
         /Vedi tutte le righe|Dati e fonti|registro completo/i.test(link.textContent ?? ""),
       );
-      const legacyLimits = [...document.querySelectorAll("h2")].some((heading) =>
-        /non dimostra|limiti/i.test(heading.textContent ?? ""),
-      );
+      const normalize = (value) => value.normalize("NFKC").replace(/\s+/gu, " ").trim().toLocaleLowerCase("it-IT");
+      const legacyLimitHeadings = new Set([
+        "che cosa non dimostra da solo",
+        "limiti dichiarati nello snapshot",
+      ]);
+      const legacyLimits = [...document.querySelectorAll("h2")].some((heading) => {
+        const style = window.getComputedStyle(heading);
+        const rect = heading.getBoundingClientRect();
+        return (
+          legacyLimitHeadings.has(normalize(heading.textContent ?? "")) &&
+          style.display !== "none" &&
+          style.visibility !== "hidden" &&
+          style.opacity !== "0" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      });
       return {
         bodyWidth: document.body.scrollWidth,
         clientWidth: root.clientWidth,
@@ -84,7 +138,6 @@ async function inspectRoute(browser, pathname, title, width) {
         limits: nativeBoundaryVisible || legacyLimits,
       };
     }, nativeLimits);
-    const label = `${pathname} ${width}px`;
     assert.equal(state.h1Count, 1, `${label}: serve un solo h1`);
     assert.equal(state.h1, title, `${label}: titolo inatteso`);
     assert.ok(state.bodyWidth <= state.clientWidth + 1, `${label}: overflow globale`);

--- a/src/app/dati/dati.module.css
+++ b/src/app/dati/dati.module.css
@@ -613,7 +613,7 @@
   margin: 0 0 var(--space-4);
   padding: 10px 12px;
   background: var(--color-neutral-100);
-  border-left: 3px solid var(--color-accent-700);
+  border-top: 1px solid var(--color-neutral-300);
 }
 
 .cardTeaserLabel {

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -95,6 +95,11 @@
   --chart-quaternary: var(--color-neutral-400);
   --chart-quinary: var(--color-accent-300);
   --chart-negative: var(--color-accent-700);
+  --chart-family-services: #cfc2f2;
+  --chart-family-investment: #f2bdc7;
+  --chart-family-pass-through: #f2d071;
+  --chart-family-financing: #efb36d;
+  --chart-family-other: #bdd8e5;
 
   /* Additive part-to-whole charts only. Red stays for CTA and warnings. */
   --chart-category-blue: #2855a5;

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -1,12 +1,11 @@
 /*
- * The home dashboard: three columns of panels. The side columns are sized to
- * their content and the middle one takes whatever is left, so the board fills
- * any viewport width instead of stopping at a fixed canvas.
+ * The home dashboard keeps one reading rail, one geographic canvas and one
+ * detail rail. DOM order survives when the rails collapse.
  */
 
 .dashboard {
   display: grid;
-  grid-template-columns: 288px minmax(0, 1fr) 300px;
+  grid-template-columns: 360px minmax(0, 1fr) 300px;
   align-items: start;
   gap: var(--space-4);
   padding-block: var(--space-4) 0;
@@ -109,58 +108,6 @@
   border: 0;
   margin: var(--space-4) 0;
   background: var(--color-neutral-300);
-}
-
-/* ── donut ──────────────────────────────────────────────────────────────── */
-
-.donutBlock {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
-}
-
-.donut {
-  width: 88px;
-  height: 88px;
-  flex: none;
-  border-radius: 50%;
-  /* A ring, not a pie: the hole keeps the slices readable at this size. */
-  mask: radial-gradient(circle, transparent 52%, #000 53%);
-  -webkit-mask: radial-gradient(circle, transparent 52%, #000 53%);
-}
-
-.donutLegend {
-  width: 100%;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-  font-size: 12px;
-  min-width: 0;
-}
-.donutLegend li {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-.donutLegend i {
-  width: 9px;
-  height: 9px;
-  flex: none;
-}
-.donutLegend span {
-  min-width: 0;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.donutLegend b {
-  flex: none;
-  font-variant-numeric: tabular-nums;
 }
 
 .spendingDetailsLink {
@@ -352,7 +299,7 @@
 /* ── responsive ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 1320px) {
-  .dashboard { grid-template-columns: 272px minmax(0, 1fr); }
+  .dashboard { grid-template-columns: 360px minmax(0, 1fr); }
   /* The right-hand rail becomes a full-width band of cards under the board. */
   .dashboard > .column:last-child {
     grid-column: 1 / -1;
@@ -365,14 +312,10 @@
 @media (max-width: 900px) {
   .dashboard { grid-template-columns: minmax(0, 1fr); }
   .dashboard > .column:last-child { grid-column: auto; }
-  .donutBlock { flex-direction: row; align-items: center; }
-  .donutLegend { width: auto; }
 }
 
 @media (max-width: 620px) {
   .headline { font-size: 32px; }
-  .donutBlock { flex-direction: column; align-items: stretch; }
-  .donut { align-self: center; }
   .mapStats { display: grid; grid-template-columns: 1fr 1fr; }
   .monthList li { grid-template-columns: 58px minmax(0, 1fr) 36px; }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { InfoTooltip } from "@/components/info-tooltip";
 import { ItalyRegionsMap } from "@/components/italy-regions-map";
 import { PeriodSelector } from "@/components/period-selector";
+import { SpendingComposition, type CompositionFamily } from "@/components/spending-composition";
 import { getProcurementComparisonForYear } from "@/lib/audit-data";
 import {
   billions,
@@ -28,32 +29,17 @@ import {
 } from "@/lib/siope-snapshot";
 import styles from "./home.module.css";
 
-/* The donut walks this ramp in order; five buckets, five steps of contrast. */
-const SLICE_COLORS = [
-  "var(--color-accent)",
-  "var(--color-neutral-800)",
-  "var(--color-neutral-500)",
-  "var(--color-neutral-400)",
-  "var(--color-accent-300)",
+const COMPOSITION_FAMILIES: CompositionFamily[] = [
+  "services",
+  "investment",
+  "pass-through",
+  "financing",
+  "other",
 ];
 
 function selectedYear(value: string | string[] | undefined): number {
   const parsed = Number.parseInt(Array.isArray(value) ? value[0] ?? "" : value ?? "", 10);
   return availableSiopeYears.includes(parsed) ? parsed : availableSiopeYears[0];
-}
-
-/** Turns shares into the cumulative `from% to%` stops a conic gradient wants. */
-function donutGradientStops(slices: { color: string; share: number }[]): string {
-  return slices
-    .reduce<{ at: number; stops: string[] }>(
-      (accumulator, slice) => {
-        const to = accumulator.at + slice.share;
-        accumulator.stops.push(`${slice.color} ${accumulator.at}% ${to}%`);
-        return { at: to, stops: accumulator.stops };
-      },
-      { at: 0, stops: [] },
-    )
-    .stops.join(",");
 }
 
 export default async function HomePage({
@@ -83,13 +69,11 @@ export default async function HomePage({
     const value = bucket.codes.reduce((sum, code) => sum + (valueByCode.get(code) ?? 0), 0);
     return {
       ...bucket,
+      id: bucket.codes.join("-"),
       value,
-      share: siope.totalPaid > 0 ? (value / siope.totalPaid) * 100 : 0,
-      color: SLICE_COLORS[index % SLICE_COLORS.length],
+      family: COMPOSITION_FAMILIES[index],
     };
   });
-
-  const donutStops = donutGradientStops(buckets);
 
   const topRegions = regionsByPerCapita(siope).slice(0, 6);
   const topMunicipalities = municipalitiesByPerCapita(siope).slice(0, 5);
@@ -149,36 +133,25 @@ export default async function HomePage({
           <hr className={styles.rule} />
 
           <div className={styles.panelHead}>
-            <h2 className="panel-title">Per cosa sono stati spesi</h2>
-            <InfoTooltip id="spending-glossary-tip" label="Piccolo glossario delle voci di spesa">
-              <b>Piccolo glossario</b>
-              {HOME_SPENDING_BUCKETS.map((bucket) => (
-                <span key={bucket.name}>
-                  · <b>{bucket.name}</b>: {bucket.explanation}
-                </span>
-              ))}
-            </InfoTooltip>
+            <h2 className="panel-title">Come si compone il totale</h2>
           </div>
-
-          <div className={styles.donutBlock}>
-            <div
-              className={styles.donut}
-              role="img"
-              aria-label={`Ripartizione dei pagamenti: ${buckets
-                .map((bucket) => `${bucket.name} ${percent(bucket.share)}`)
-                .join(", ")}`}
-              style={{ background: `conic-gradient(${donutStops})` }}
-            />
-            <ul className={styles.donutLegend}>
-              {buckets.map((bucket) => (
-                <li key={bucket.name}>
-                  <i aria-hidden="true" style={{ background: bucket.color }} />
-                  <span>{bucket.name}</span>
-                  <b>{percent(bucket.share)}</b>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <SpendingComposition
+            state={{ kind: "ready", totalEuro: siope.totalPaid, items: buckets.map((bucket) => ({
+              id: bucket.id,
+              label: bucket.name,
+              valueEuro: bucket.value,
+              explanation: bucket.explanation,
+              family: bucket.family,
+            })) }}
+            period={`Da gennaio a ${siope.latestMonthLabel.toLocaleLowerCase("it-IT")} ${siope.year}`}
+            scope="Pagamenti di cassa dei Comuni in tutta Italia"
+            denominator="totale dei pagamenti SIOPE dei Comuni nel periodo"
+            source={{
+              label: `${siope.source.siopeOwner} · SIOPE`,
+              href: siope.source.siopeMovementsUrl,
+              observedAt: longDate(siope.source.observedAt),
+            }}
+          />
           <Link
             className={`btn btn-block ${styles.spendingDetailsLink}`}
             href={`/spese?anno=${year}`}
@@ -187,33 +160,6 @@ export default async function HomePage({
           </Link>
         </section>
 
-        <section className="panel">
-          <h2 className="panel-title">
-            I {topMunicipalities.length} Comuni con più pagamenti per abitante
-          </h2>
-          <ol className={styles.rankList}>
-            {topMunicipalities.map((municipality, index) => (
-              <li key={municipality.codiceFiscale}>
-                <span>{index + 1}</span>
-                <strong>
-                  {municipalityName(municipality.name)}
-                  <small>
-                    {municipality.population === null
-                      ? "popolazione non disponibile"
-                      : `${integer(municipality.population)} abitanti`}
-                  </small>
-                </strong>
-                <b>{exactEuro(municipality.perCapita ?? 0)}</b>
-              </li>
-            ))}
-          </ol>
-          <p className={styles.note}>
-            Default pro capite. Il totale resta disponibile nel dettaglio territoriale.
-          </p>
-          <Link className="btn btn-block" href={`/territori?anno=${year}`}>
-            Vedi il confronto territoriale
-          </Link>
-        </section>
       </div>
 
       <div className={styles.column}>
@@ -345,6 +291,34 @@ export default async function HomePage({
               {siope.latestMonthLabel} è ancora in corso: il numero salirà.
             </p>
           )}
+        </section>
+
+        <section className="panel">
+          <h2 className="panel-title">
+            I {topMunicipalities.length} Comuni con più pagamenti per abitante
+          </h2>
+          <ol className={styles.rankList}>
+            {topMunicipalities.map((municipality, index) => (
+              <li key={municipality.codiceFiscale}>
+                <span>{index + 1}</span>
+                <strong>
+                  {municipalityName(municipality.name)}
+                  <small>
+                    {municipality.population === null
+                      ? "popolazione non disponibile"
+                      : `${integer(municipality.population)} abitanti`}
+                  </small>
+                </strong>
+                <b>{exactEuro(municipality.perCapita ?? 0)}</b>
+              </li>
+            ))}
+          </ol>
+          <p className={styles.note}>
+            Confronto pro capite; il totale resta nel dettaglio territoriale.
+          </p>
+          <Link className="btn btn-block" href={`/territori?anno=${year}`}>
+            Vedi il confronto territoriale
+          </Link>
         </section>
 
         <section className="panel">

--- a/src/components/spending-composition.module.css
+++ b/src/components/spending-composition.module.css
@@ -1,0 +1,73 @@
+.composition { display: grid; gap: var(--space-3); }
+.visual {
+  position: relative;
+  aspect-ratio: 100 / 62;
+  min-height: 260px;
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-400);
+  contain: layout paint;
+}
+.tile {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 0;
+  padding: var(--space-2);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--color-text) 42%, transparent);
+  color: var(--color-text);
+  cursor: pointer;
+}
+.tile:hover,
+.tile[data-active="true"] { z-index: 1; outline: 3px solid var(--color-text); outline-offset: -3px; }
+.tile > span { display: grid; gap: 2px; max-width: 16ch; text-align: center; line-height: 1.08; }
+.tile b { font-size: clamp(11px, 1.1vw, 15px); }
+.tile strong { font-size: clamp(13px, 1.4vw, 19px); font-variant-numeric: tabular-nums; }
+.tileIndex { font-weight: 800; }
+.services { background: var(--chart-family-services); }
+.investment { background: var(--chart-family-investment); }
+.pass-through { background: var(--chart-family-pass-through); }
+.financing { background: var(--chart-family-financing); }
+.other { background: var(--chart-family-other); }
+
+.legend { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
+.legend li { min-width: 0; }
+.legend button {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 48px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  cursor: pointer;
+}
+.legend button:hover,
+.legend button[aria-pressed="true"] { border-color: var(--color-neutral-400); background: var(--color-neutral-100); }
+.legend button > i { width: 10px; height: 28px; }
+.legend button span { min-width: 0; }
+.legend button b,
+.legend button small { display: block; }
+.legend button b { overflow-wrap: anywhere; font-size: 12px; }
+.legend button small { margin-top: 2px; color: var(--color-neutral-600); font-size: 11px; }
+.legend button > strong { font-size: 12px; font-variant-numeric: tabular-nums; }
+.mobileBar { display: none; }
+.tooltip { padding: var(--space-3); background: var(--color-neutral-900); color: var(--color-on-strong); }
+.tooltip span { display: block; margin-top: 2px; font-variant-numeric: tabular-nums; }
+.tooltip p { margin: 6px 0 0; color: var(--color-on-strong-muted); font-size: 12px; }
+.meta { margin: 0; color: var(--color-neutral-700); font-size: 11px; }
+.partial { margin: 0; padding: var(--space-3); border-left: 3px solid var(--color-warning); background: var(--color-warning-bg); font-size: 12px; }
+.tableDetails summary { min-height: 44px; padding-block: 12px; font-weight: 600; cursor: pointer; }
+
+@media (max-width: 620px) {
+  .visual { display: none; }
+  .legend { grid-template-columns: minmax(0, 1fr); }
+  .legend button { min-height: 52px; }
+  .mobileBar { display: block; height: 4px; margin: 0 8px; background: var(--color-neutral-200); }
+  .mobileBar span { display: block; height: 100%; }
+}

--- a/src/components/spending-composition.module.css
+++ b/src/components/spending-composition.module.css
@@ -61,7 +61,7 @@
 .tooltip span { display: block; margin-top: 2px; font-variant-numeric: tabular-nums; }
 .tooltip p { margin: 6px 0 0; color: var(--color-on-strong-muted); font-size: 12px; }
 .meta { margin: 0; color: var(--color-neutral-700); font-size: 11px; }
-.partial { margin: 0; padding: var(--space-3); border-left: 3px solid var(--color-warning); background: var(--color-warning-bg); font-size: 12px; }
+.partial { margin: 0; padding: var(--space-3); border: 1px solid var(--color-warning-border); background: var(--color-warning-bg); font-size: 12px; }
 .tableDetails summary { min-height: 44px; padding-block: 12px; font-weight: 600; cursor: pointer; }
 
 @media (max-width: 620px) {

--- a/src/components/spending-composition.tsx
+++ b/src/components/spending-composition.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useId, useState } from "react";
+import { layoutComposition } from "@/lib/composition-layout";
+import { compactEuro, exactEuro, percent } from "@/lib/format";
+import styles from "./spending-composition.module.css";
+
+export type CompositionFamily = "services" | "investment" | "pass-through" | "financing" | "other";
+
+export type SpendingCompositionItem = {
+  id: string;
+  label: string;
+  valueEuro: number;
+  explanation: string;
+  family: CompositionFamily;
+};
+
+type CompositionState =
+  | { kind: "ready"; totalEuro: number; items: readonly SpendingCompositionItem[] }
+  | {
+      kind: "partial";
+      totalEuro: number;
+      items: readonly SpendingCompositionItem[];
+      missing: readonly string[];
+      message: string;
+    };
+
+export function SpendingComposition({
+  state,
+  period,
+  scope,
+  denominator,
+  source,
+}: {
+  state: CompositionState;
+  period: string;
+  scope: string;
+  denominator: string;
+  source: { label: string; href: string; observedAt: string };
+}) {
+  const tooltipId = useId();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [pinnedId, setPinnedId] = useState<string | null>(null);
+  const listedTotal = state.items.reduce((total, item) => total + item.valueEuro, 0);
+  const residual = Math.max(0, state.totalEuro - listedTotal);
+
+  if (!Number.isFinite(state.totalEuro) || state.totalEuro <= 0) {
+    throw new Error("Composition total must be positive");
+  }
+  if (state.kind === "ready" && Math.abs(listedTotal - state.totalEuro) > 0.01) {
+    throw new Error("Ready composition must reconcile with its total");
+  }
+  if (state.kind === "partial" && listedTotal > state.totalEuro + 0.01) {
+    throw new Error("Partial composition cannot exceed its canonical total");
+  }
+
+  const items: SpendingCompositionItem[] = [
+    ...state.items,
+    ...(state.kind === "partial" && residual > 0
+      ? [{
+          id: "unallocated",
+          label: "Quota non ripartita",
+          valueEuro: residual,
+          explanation: state.message,
+          family: "other" as const,
+        }]
+      : []),
+  ];
+  const rectangles = layoutComposition(items.map((item) => ({ id: item.id, value: item.valueEuro })));
+  const rectangleById = new Map(rectangles.map((rectangle) => [rectangle.id, rectangle]));
+  const displayedId = pinnedId ?? activeId;
+  const displayed = items.find((item) => item.id === displayedId) ?? null;
+  const share = (item: SpendingCompositionItem) => (item.valueEuro / state.totalEuro) * 100;
+
+  function toggle(item: SpendingCompositionItem) {
+    setPinnedId((current) => (current === item.id ? null : item.id));
+    setActiveId(item.id);
+  }
+
+  return (
+    <div className={styles.composition} data-composition-state={state.kind}>
+      {state.kind === "partial" ? (
+        <p className={styles.partial} role="status">
+          <strong>Dati parziali.</strong> {state.message} Mancano: {state.missing.join(", ")}.
+        </p>
+      ) : null}
+
+      <div className={styles.visual} role="group" aria-label={`Composizione di ${denominator}`}>
+        {items.map((item, index) => {
+          const rectangle = rectangleById.get(item.id);
+          if (!rectangle) return null;
+          const labelMode = rectangle.areaShare >= 0.08 ? "full" : rectangle.areaShare >= 0.03 ? "index" : "none";
+          return (
+            <button
+              type="button"
+              key={item.id}
+              className={`${styles.tile} ${styles[item.family]}`}
+              style={{
+                left: `${rectangle.x}%`,
+                top: `${(rectangle.y / 62) * 100}%`,
+                width: `${rectangle.width}%`,
+                height: `${(rectangle.height / 62) * 100}%`,
+              }}
+              tabIndex={-1}
+              aria-label={`${index + 1}. ${item.label}: ${percent(share(item))}`}
+              aria-describedby={displayedId === item.id ? tooltipId : undefined}
+              data-active={displayedId === item.id ? "true" : undefined}
+              onPointerEnter={() => setActiveId(item.id)}
+              onPointerLeave={() => setActiveId(null)}
+              onClick={() => toggle(item)}
+            >
+              {labelMode === "full" ? (
+                <span><b>{item.label}</b><strong>{percent(share(item))}</strong></span>
+              ) : labelMode === "index" ? <span className={styles.tileIndex}>{index + 1}</span> : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <ol className={styles.legend}>
+        {items.map((item, index) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              aria-describedby={displayedId === item.id ? tooltipId : undefined}
+              aria-pressed={pinnedId === item.id}
+              onFocus={() => setActiveId(item.id)}
+              onBlur={() => setActiveId(null)}
+              onPointerEnter={() => setActiveId(item.id)}
+              onPointerLeave={() => setActiveId(null)}
+              onClick={() => toggle(item)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setPinnedId(null);
+                  setActiveId(null);
+                }
+              }}
+            >
+              <i className={styles[item.family]} aria-hidden="true" />
+              <span><b>{index + 1}. {item.label}</b><small>{compactEuro(item.valueEuro)}</small></span>
+              <strong>{percent(share(item))}</strong>
+            </button>
+            <i className={styles.mobileBar} aria-hidden="true">
+              <span className={styles[item.family]} style={{ width: `${share(item)}%` }} />
+            </i>
+          </li>
+        ))}
+      </ol>
+
+      {displayed ? (
+        <div className={styles.tooltip} id={tooltipId} role="tooltip">
+          <strong>{displayed.label} · {percent(share(displayed))}</strong>
+          <span>{exactEuro(displayed.valueEuro)}</span>
+          <p>{displayed.explanation}</p>
+        </div>
+      ) : null}
+
+      <p className={styles.meta}>
+        <strong>{period}</strong> · {scope}. Denominatore: {denominator}. Fonte:{" "}
+        <a href={source.href} target="_blank" rel="noreferrer">{source.label}</a>, acquisita il {source.observedAt}.
+      </p>
+
+      <details className={styles.tableDetails}>
+        <summary>Dati esatti della composizione</summary>
+        <div className="table-scroll" role="region" aria-label="Dati esatti della composizione" tabIndex={0}>
+          <table className="table">
+            <thead><tr><th scope="col">Voce</th><th scope="col" className="num">Importo</th><th scope="col" className="num">Quota</th></tr></thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.id}><th scope="row">{item.label}</th><td className="num">{exactEuro(item.valueEuro)}</td><td className="num">{percent(share(item))}</td></tr>
+              ))}
+              <tr><th scope="row">Totale</th><td className="num">{exactEuro(state.totalEuro)}</td><td className="num">100%</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/lib/composition-layout.ts
+++ b/src/lib/composition-layout.ts
@@ -1,0 +1,74 @@
+export type CompositionRect = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  areaShare: number;
+};
+
+type WeightedItem = { id: string; value: number };
+
+function sum(items: readonly WeightedItem[]): number {
+  return items.reduce((total, item) => total + item.value, 0);
+}
+
+function balancedSplitIndex(items: readonly WeightedItem[]): number {
+  const target = sum(items) / 2;
+  let running = 0;
+  let bestIndex = 1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 1; index < items.length; index += 1) {
+    running += items[index - 1].value;
+    const distance = Math.abs(target - running);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+/** Deterministic binary treemap: proportional area without DOM measurement. */
+export function layoutComposition(
+  items: readonly WeightedItem[],
+  width = 100,
+  height = 62,
+): CompositionRect[] {
+  if (width <= 0 || height <= 0) throw new Error("Composition bounds must be positive");
+  if (items.some((item) => !Number.isFinite(item.value) || item.value < 0)) {
+    throw new Error("Composition values must be finite and non-negative");
+  }
+  if (new Set(items.map((item) => item.id)).size !== items.length) {
+    throw new Error("Composition ids must be unique");
+  }
+
+  const positive = items.filter((item) => item.value > 0);
+  const total = sum(positive);
+  if (total <= 0) return [];
+  const rectangles: CompositionRect[] = [];
+
+  function place(group: readonly WeightedItem[], x: number, y: number, w: number, h: number) {
+    const groupTotal = sum(group);
+    if (group.length === 1) {
+      rectangles.push({ id: group[0].id, x, y, width: w, height: h, areaShare: group[0].value / total });
+      return;
+    }
+    const splitAt = balancedSplitIndex(group);
+    const first = group.slice(0, splitAt);
+    const second = group.slice(splitAt);
+    const firstShare = sum(first) / groupTotal;
+    if (w >= h) {
+      const firstWidth = w * firstShare;
+      place(first, x, y, firstWidth, h);
+      place(second, x + firstWidth, y, w - firstWidth, h);
+    } else {
+      const firstHeight = h * firstShare;
+      place(first, x, y, w, firstHeight);
+      place(second, x, y + firstHeight, w, h - firstHeight);
+    }
+  }
+
+  place(positive, 0, 0, width, height);
+  return rectangles;
+}

--- a/tests/coesione-ui.test.mjs
+++ b/tests/coesione-ui.test.mjs
@@ -26,13 +26,13 @@ test("coesione trace panel keeps high-contrast text on the dark surface", () => 
   const surface = token("color-neutral-900");
   assert.match(coesioneCss, /\.tracePanel[\s\S]*background:\s*var\(--color-neutral-900\)/);
   assert.match(coesioneCss, /\.tracePanel > div > span:first-child[\s\S]*color:\s*var\(--color-accent-300\)/);
-  assert.match(coesioneCss, /\.traceAction span[\s\S]*color:\s*var\(--color-neutral-300\)/);
+  assert.match(coesioneCss, /\.traceAction span[\s\S]*color:\s*var\(--color-on-strong-muted\)/);
 
   const pairs = [
     ["trace heading", token("color-raised"), surface],
     ["trace body", token("color-neutral-300"), surface],
     ["trace kicker", token("color-accent-300"), surface],
-    ["trace metric label", token("color-neutral-300"), surface],
+    ["trace metric label", token("color-on-strong-muted"), surface],
     ["trace metric value", token("color-raised"), surface],
   ];
 

--- a/tests/integrated-editorial.test.mjs
+++ b/tests/integrated-editorial.test.mjs
@@ -120,7 +120,7 @@ test("every curated dataset drills down from its topic to a complete or explanat
   assert.doesNotMatch(topicPage, /limit: 5/);
   assert.match(topicPage, /configured\.catalogBoundary/);
   assert.match(detailPage, /dataset\.queryable/);
-  assert.match(detailPage, /Dataset contabilizzato senza righe pubbliche/);
+  assert.match(detailPage, /materiale è contato nel catalogo senza righe pubbliche/);
 
   for (const dataset of catalog.datasets) {
     if (dataset.publication === "rows" || dataset.publication === "source-index") {

--- a/tests/spending-composition.test.mjs
+++ b/tests/spending-composition.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+import { layoutComposition } from "../src/lib/composition-layout.ts";
+import { HOME_SPENDING_BUCKETS } from "../src/lib/siope-titles.ts";
+
+const snapshots = [
+  new URL("../src/data/generated/siope-municipal-2024.json", import.meta.url),
+  new URL("../src/data/generated/siope-municipal-2025.json", import.meta.url),
+  new URL("../src/data/generated/siope-municipal.json", import.meta.url),
+];
+
+test("composition layout preserves proportional area without overlap", () => {
+  const rectangles = layoutComposition([
+    { id: "a", value: 55 },
+    { id: "b", value: 25 },
+    { id: "c", value: 15 },
+    { id: "d", value: 5 },
+  ]);
+  assert.equal(rectangles.length, 4);
+  assert.ok(Math.abs(rectangles.reduce((total, rectangle) => total + rectangle.areaShare, 0) - 1) < 1e-12);
+  for (const rectangle of rectangles) {
+    assert.ok(rectangle.x >= 0 && rectangle.y >= 0);
+    assert.ok(rectangle.x + rectangle.width <= 100 + 1e-9);
+    assert.ok(rectangle.y + rectangle.height <= 62 + 1e-9);
+    assert.ok(Math.abs((rectangle.width * rectangle.height) / 6200 - rectangle.areaShare) < 1e-12);
+  }
+});
+
+test("composition layout rejects misleading inputs", () => {
+  assert.throws(() => layoutComposition([{ id: "a", value: -1 }]), /non-negative/);
+  assert.throws(() => layoutComposition([{ id: "a", value: 1 }, { id: "a", value: 2 }]), /unique/);
+});
+
+test("home spending buckets are a complete additive partition for every available snapshot", async () => {
+  const allCodes = HOME_SPENDING_BUCKETS.flatMap((bucket) => bucket.codes);
+  assert.equal(new Set(allCodes).size, allCodes.length, "ogni titolo deve appartenere a un solo gruppo");
+
+  for (const url of snapshots) {
+    const snapshot = JSON.parse(await readFile(url, "utf8"));
+    const values = new Map(snapshot.titles.map((title) => [title.code, title.value]));
+    assert.deepEqual([...values.keys()].sort(), [...allCodes].sort(), `${snapshot.year}: copertura titoli`);
+    const groupedTotal = HOME_SPENDING_BUCKETS.reduce(
+      (total, bucket) => total + bucket.codes.reduce((sum, code) => sum + values.get(code), 0),
+      0,
+    );
+    assert.ok(Math.abs(groupedTotal - snapshot.totalPaid) <= 0.01, `${snapshot.year}: riconciliazione al centesimo`);
+  }
+});
+
+test("composition component keeps partial state, keyboard tooltip and exact table in its contract", async () => {
+  const [component, css] = await Promise.all([
+    readFile(new URL("../src/components/spending-composition.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/components/spending-composition.module.css", import.meta.url), "utf8"),
+  ]);
+  assert.match(component, /kind: "partial"/);
+  assert.match(component, /role="tooltip"/);
+  assert.match(component, /event\.key === "Escape"/);
+  assert.match(component, /Dati esatti della composizione/);
+  assert.match(component, /Ready composition must reconcile with its total/);
+  assert.match(component, /Partial composition cannot exceed its canonical total/);
+  assert.match(css, /aspect-ratio: 100 \/ 62/);
+  assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.visual \{ display: none; \}/);
+});


### PR DESCRIPTION
## Base / head

- Base: `main` at `028179b`
- Head: `codex/ui-home-hierarchy` at `b5976287`
- #53 is merged; this UI slice is evaluated directly against the current `main` base and remains atomic

## Scope

- replaces the small donut with a reusable, data-gated spending composition
- uses deterministic proportional area for five additive SIOPE macro-groups
- adds semantic family colors with text/index/border redundancy
- supports ready/partial, minimum-label fallback, keyboard tooltip, exact table and mobile list/bar collapse
- moves the municipality ranking after composition, map and trend in DOM order
- keeps the Italy map and all SIOPE data contracts unchanged

| Before | After | Why |
| --- | --- | --- |
| Small donut plus detached legend | Proportional composition with category, amount and share linked | Makes part-to-whole readable without mental reconciliation |
| Red/neutral ramp carried most chart distinction | Muted family palette plus labels, indices, borders and exact values | Distinguishes macro-functions without making color the only signal |
| Mobile rendered secondary municipality ranking before geography | Composition, map, regional comparison, trend, then municipality detail | Preserves the primary reading when rails collapse |
| No explicit incomplete-composition contract | `ready` reconciles to the cent; `partial` exposes residual and missing groups | Prevents an incomplete dataset from looking like 100% coverage |

## Data gate and sources

- SIOPE title snapshots 2024, 2025 and 2026
- Seven source title codes are grouped exactly once
- Grouped totals reconcile to each canonical `totalPaid` within EUR 0.01
- Period, municipal scope, denominator, official SIOPE URL and acquisition date render beside the visual
- Use/avoid rules documented in `DESIGN.md`

## Tests and proof

- PASS — hosted GitHub `node` at head `b5976287` (410/410)
- PASS — `npm run lint`
- PASS — isolated `npm run typecheck`
- PASS — `npm run build`
- PASS — `npm run design:check`; partial-state notice uses a flat uniform warning border
- PASS — composition contract/layout/data tests
- PASS — current-build screenshots at 390×844 and 1280×1000
- PASS — screenshot manifest: no horizontal overflow, CLS 0, no runtime errors
- PASS — current-build Consulenza valid-submit smoke at 390 px; UUID, consent and success focus checked
- PASS — hosted GitHub browser and production gates at head `b5976287`, including core and editorial suites (21 routes × 2 viewports)
- PASS — hosted GitHub `required`, CodeQL, dependency review and Zizmor checks at head `b5976287`
- PASS — hosted Vercel preview at head `b5976287`
- The three follow-up gate fixes are test-only: `scripts/browser/editorial.mjs`, `tests/coesione-ui.test.mjs` and `tests/integrated-editorial.test.mjs`; they do not change application, data or source behavior.

## UI proof summary

- 1280 px: proportional treemap visible; composition and map form the dominant first band
- 390 px: treemap collapses to readable category rows and percentage bars; the map follows before trend/rankings
- Table equivalent remains available via `details`
- Small tiles use indices and stay fully described in the list/table

## Risks / not verified

- The family palette is intentionally limited to additive spending composition; it must not become a generic chart rainbow.
- Binary treemap layout prioritizes deterministic proportional area over exact ordered comparison; exact values remain in the table.
- Hosted production gate: PASS; Vercel preview: PASS.
- Physical screen reader session: NOT RUN.
- Real email delivery: NOT RUN; submit request was intercepted.
