### PR TITLE
fix(mcp): normalize SIOPE region filter and reject unmatched values

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Per proporre una nuova fonte, apri una issue con:
 
 - [@fragiannicola](https://x.com/fragiannicola)
 - [@dom_gag_96](https://x.com/dom_gag_96)
+- [@OstinelliLuca](https://x.com/OstinelliLuca)
 
 ## Licenza
 

--- a/src/lib/mcp/datasets.ts
+++ b/src/lib/mcp/datasets.ts
@@ -48,6 +48,21 @@ function jsonSafe<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+/**
+ * Normalizes a Region name for comparison only (never for display or storage):
+ * folds case, unifies curly/straight apostrophes, and treats hyphens and
+ * spaces as the same separator so "Emilia Romagna" matches "Emilia-Romagna".
+ */
+function normalizeRegionFilterValue(value: string): string {
+  return value
+    .normalize("NFKC")
+    .trim()
+    .toLocaleLowerCase("it-IT")
+    .replace(/[‘’`´]/g, "'")
+    .replace(/[‐-―-]/g, " ")
+    .replace(/\s+/g, " ");
+}
+
 export async function queryPublicDataset(
   query: DatasetQuery,
   options: { signal?: AbortSignal } = {},
@@ -65,15 +80,22 @@ export async function queryPublicDataset(
         throw new Error(`Anno SIOPE non disponibile. Anni validi: ${availableSiopeYears.join(", ")}.`);
       }
       const snapshot = getSiopeMunicipalSnapshot(year);
-      const region = query.region?.trim().toLocaleLowerCase("it-IT");
-      if (!region) return jsonSafe(snapshot);
+      const rawRegion = query.region?.trim();
+      if (!rawRegion) return jsonSafe(snapshot);
+      const region = normalizeRegionFilterValue(rawRegion);
+      const matchingRegions = snapshot.regions.filter((item) => normalizeRegionFilterValue(item.region) === region);
+      if (matchingRegions.length === 0) {
+        throw new Error(
+          `Regione SIOPE non riconosciuta: "${rawRegion}". Regioni valide: ${snapshot.regions.map((item) => item.region).join(", ")}.`,
+        );
+      }
       const { distribution: nationalDistribution, ...snapshotWithoutDistribution } = snapshot;
       return jsonSafe({
         ...snapshotWithoutDistribution,
-        regions: snapshot.regions.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
-        topMunicipalities: snapshot.topMunicipalities.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
-        topMunicipalitiesByValue: snapshot.topMunicipalitiesByValue.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
-        topMunicipalitiesByPerCapita: snapshot.topMunicipalitiesByPerCapita.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
+        regions: matchingRegions,
+        topMunicipalities: snapshot.topMunicipalities.filter((item) => normalizeRegionFilterValue(item.region) === region),
+        topMunicipalitiesByValue: snapshot.topMunicipalitiesByValue.filter((item) => normalizeRegionFilterValue(item.region) === region),
+        topMunicipalitiesByPerCapita: snapshot.topMunicipalitiesByPerCapita.filter((item) => normalizeRegionFilterValue(item.region) === region),
         queryLimitations: {
           regionAggregateComplete: false,
           regionAggregateCompleteDeprecated:

--- a/tests/mcp-datasets.test.mjs
+++ b/tests/mcp-datasets.test.mjs
@@ -55,6 +55,23 @@ test("SIOPE query validates years and can filter a region", async () => {
   assert.match(result.queryLimitations.distribution, /non è pubblicata|risposta nazionale/i);
 });
 
+test("SIOPE region filter matches hyphen and space variants of the same name", async () => {
+  const withHyphen = await queryPublicDataset({ dataset: "siope_comuni", year: 2025, region: "Emilia-Romagna" });
+  const withSpace = await queryPublicDataset({ dataset: "siope_comuni", year: 2025, region: "Emilia Romagna" });
+  const mixedCase = await queryPublicDataset({ dataset: "siope_comuni", year: 2025, region: "  EMILIA   romagna " });
+  assert.equal(withHyphen.regions.length, 1);
+  assert.equal(withHyphen.regions[0].region, "Emilia-Romagna");
+  assert.deepEqual(withSpace.regions, withHyphen.regions);
+  assert.deepEqual(mixedCase.regions, withHyphen.regions);
+});
+
+test("SIOPE region filter rejects an unrecognized region instead of silently returning national totals", async () => {
+  await assert.rejects(
+    queryPublicDataset({ dataset: "siope_comuni", year: 2025, region: "Non Esiste" }),
+    /Regione SIOPE non riconosciuta.*Non Esiste/,
+  );
+});
+
 test("SIOPE national MCP query carries only compact full-population aggregates", async () => {
   const result = await queryPublicDataset({ dataset: "siope_comuni", year: 2026 });
   assert.equal(result.distribution.schemaVersion, 2);


### PR DESCRIPTION
## Cosa cambia

Il dataset MCP `siope_comuni` confrontava il filtro `region` con un match esatto case-insensitive: un valore come `"Emilia Romagna"` (spazio) non trovava `"Emilia-Romagna"` (trattino) nello snapshot, e la chiamata tornava comunque `ok: true` con `regions: []` e i totali nazionali, che un client può scambiare per il dato regionale.

- `normalizeRegionFilterValue()` uniforma maiuscole/minuscole, varianti di apostrofo e trattino/spazio come separatore prima del confronto, così `"Emilia Romagna"`, `"Emilia-Romagna"` e `"EMILIA-ROMAGNA"` combaciano.
- Se il filtro `region` è valorizzato e non trova corrispondenze, il dataset lancia ora un errore esplicito invece di restituire silenziosamente l'aggregato nazionale, coerentemente col contratto già usato dal filtro region di `inps_invalidita_civile` (vedi `src/lib/inps-invalidity-snapshot.ts`). Lo snapshot SIOPE valida sempre esattamente 20 Regioni in ingestione, quindi zero corrispondenze significa sempre un problema di testo, mai una Regione realmente assente.
- Aggiunti due test di regressione in `tests/mcp-datasets.test.mjs`: variante spazio/trattino/maiuscole che deve combaciare, e Regione inesistente che deve essere rifiutata.

Non ho toccato `inps-invalidity-snapshot.ts` per tenere la PR focalizzata sul bug segnalato: quel modulo normalizza già trattini/apostrofi unicode ma non unifica trattino↔spazio, quindi potrebbe avere un gap residuo simile; lo segnalo come possibile follow-up separato.

## Verifica locale

- `npm ci`
- `npm run lint`: PASS
- `npm test`: 259/259 (incluso i 2 nuovi test)
- `python3 -m unittest discover -s tests/etl -p 'test_*.py'`: 66/66
- `npm run typecheck`: PASS
- `npm run design:check`: PASS
- `npm run brand:check`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS

Non ho eseguito uno smoke test sul server MCP HTTP reale in locale (nessuna modifica ai trasporti/handler, solo alla logica del dataset già coperta dai test unitari).

Closes #49