### PR TITLE
feat(data): add public spending evidence contract

### DIFF
--- a/src/lib/data/public-spending-benchmark.ts
+++ b/src/lib/data/public-spending-benchmark.ts
@@ -1,0 +1,80 @@
+import type { Benchmark, EvidenceAmount, EvidencePeriod } from "./public-spending-evidence-contract";
+
+export type BenchmarkMember = {
+  observationId: string;
+  valueCents: number;
+  category: string;
+  period: EvidencePeriod;
+  taxBasis: EvidenceAmount["taxBasis"];
+  unit: EvidenceAmount["unit"];
+  denominator: Benchmark["denominator"];
+};
+
+export type BenchmarkInput = {
+  cohortId: string;
+  cohortLabel: string;
+  targetObservationId: string;
+  members: BenchmarkMember[];
+};
+
+function quantileR7(sortedValues: readonly number[], probability: number): number {
+  const position = probability * (sortedValues.length - 1);
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sortedValues[lower];
+  return sortedValues[lower] * (upper - position) + sortedValues[upper] * (position - lower);
+}
+
+function samePeriod(left: EvidencePeriod, right: EvidencePeriod): boolean {
+  return left.start === right.start && left.end === right.end && left.precision === right.precision;
+}
+
+function sameDenominator(left: Benchmark["denominator"], right: Benchmark["denominator"]): boolean {
+  return left.name === right.name && left.value === right.value && left.unit === right.unit;
+}
+
+export function computePublicSpendingBenchmark(input: BenchmarkInput): Benchmark {
+  if (input.members.length < 3) throw new Error("benchmark: almeno tre osservazioni richieste");
+  const target = input.members.find((member) => member.observationId === input.targetObservationId);
+  if (!target) throw new Error("benchmark: osservazione target assente dalla coorte");
+  if (new Set(input.members.map((member) => member.observationId)).size !== input.members.length) {
+    throw new Error("benchmark: observationId duplicato");
+  }
+
+  for (const member of input.members) {
+    if (
+      member.category !== target.category ||
+      !samePeriod(member.period, target.period) ||
+      member.taxBasis !== target.taxBasis ||
+      member.unit !== target.unit ||
+      !sameDenominator(member.denominator, target.denominator)
+    ) {
+      throw new Error("benchmark: coorte non like-for-like");
+    }
+    if (!Number.isSafeInteger(member.valueCents) || member.valueCents < 0) {
+      throw new Error("benchmark: importo in centesimi non valido");
+    }
+  }
+
+  const sortedValues = input.members.map((member) => member.valueCents).sort((a, b) => a - b);
+  const medianCents = quantileR7(sortedValues, 0.5);
+  const targetDeltaCents = target.valueCents - medianCents;
+
+  return {
+    cohortId: input.cohortId,
+    cohortLabel: input.cohortLabel,
+    category: target.category,
+    period: target.period,
+    taxBasis: target.taxBasis,
+    unit: target.unit,
+    denominator: target.denominator,
+    method: "linear_interpolation_r7",
+    cohortSize: input.members.length,
+    medianCents,
+    p25Cents: quantileR7(sortedValues, 0.25),
+    p75Cents: quantileR7(sortedValues, 0.75),
+    targetDeltaCents,
+    targetDeltaPercent: medianCents === 0 ? null : (targetDeltaCents / medianCents) * 100,
+    observationIds: input.members.map((member) => member.observationId),
+  };
+}

--- a/src/lib/data/public-spending-evidence-contract.ts
+++ b/src/lib/data/public-spending-evidence-contract.ts
@@ -1,0 +1,377 @@
+import { z } from "zod";
+import { computePublicSpendingBenchmark } from "@/lib/data/public-spending-benchmark";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "data ISO YYYY-MM-DD attesa").refine((value) => {
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().startsWith(value);
+}, "data di calendario non valida");
+const httpUrl = z.url().refine((value) => {
+  const protocol = new URL(value).protocol;
+  return protocol === "https:" || protocol === "http:";
+}, "URL HTTP(S) atteso");
+
+export const sourceSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  publisher: z.string().min(1),
+  kind: z.enum(["official_record", "official_dataset", "official_finding", "legal_basis"]),
+  url: httpUrl,
+  identifier: z.string().min(1).optional(),
+  publishedAt: isoDate.optional(),
+  retrievedAt: isoDate,
+  scope: z.string().min(1),
+  reuseStatus: z.enum(["verified", "restricted", "unknown"]),
+});
+
+export const subjectSchema = z.object({
+  spendingEntity: z.object({
+    name: z.string().min(1),
+    identifier: z.string().min(1).optional(),
+  }),
+  counterparty: z.object({
+    name: z.string().min(1),
+    identifier: z.string().min(1).optional(),
+  }).optional(),
+});
+
+export const amountSchema = z.object({
+  valueCents: z.number().int().nonnegative().safe(),
+  currency: z.literal("EUR"),
+  taxBasis: z.enum(["net", "gross", "not_stated"]),
+  unit: z.enum(["award_total", "paid_total", "annual_total", "per_capita"]),
+});
+
+export const periodSchema = z.object({
+  start: isoDate,
+  end: isoDate,
+  precision: z.enum(["day", "month", "year"]),
+}).superRefine((period, context) => {
+  if (period.end < period.start) {
+    context.addIssue({ code: "custom", message: "period.end precede period.start", path: ["end"] });
+  }
+});
+
+export const procurementMethodSchema = z.object({
+  value: z.enum(["direct_award", "open_procedure", "restricted_procedure", "other", "unknown"]),
+  provenance: z.enum(["source_explicit", "text_derived", "not_available"]),
+  ruleVersion: z.string().min(1).optional(),
+  confidence: z.enum(["high", "medium", "low"]).optional(),
+}).superRefine((method, context) => {
+  if (method.provenance === "text_derived" && (!method.ruleVersion || !method.confidence)) {
+    context.addIssue({
+      code: "custom",
+      message: "una classificazione derivata richiede regola versionata e confidenza",
+    });
+  }
+  if (method.provenance === "not_available" && method.value !== "unknown") {
+    context.addIssue({ code: "custom", message: "metodo non disponibile deve avere valore unknown" });
+  }
+});
+
+export const denominatorSchema = z.object({
+  name: z.string().min(1),
+  value: z.number().positive().finite(),
+  unit: z.string().min(1),
+});
+
+export const sourcedDenominatorSchema = denominatorSchema.extend({
+  sourceId: z.string().min(1),
+});
+
+export const benchmarkSchema = z.object({
+  cohortId: z.string().min(1),
+  cohortLabel: z.string().min(1),
+  category: z.string().min(1),
+  period: periodSchema,
+  taxBasis: amountSchema.shape.taxBasis,
+  unit: amountSchema.shape.unit,
+  denominator: denominatorSchema,
+  method: z.literal("linear_interpolation_r7"),
+  cohortSize: z.number().int().min(3),
+  medianCents: z.number().nonnegative().finite(),
+  p25Cents: z.number().nonnegative().finite(),
+  p75Cents: z.number().nonnegative().finite(),
+  targetDeltaCents: z.number().finite(),
+  targetDeltaPercent: z.number().finite().nullable(),
+  observationIds: z.array(z.string().min(1)).min(3),
+}).superRefine((benchmark, context) => {
+  if (benchmark.observationIds.length !== benchmark.cohortSize) {
+    context.addIssue({ code: "custom", message: "cohortSize non coincide con observationIds" });
+  }
+  if (new Set(benchmark.observationIds).size !== benchmark.observationIds.length) {
+    context.addIssue({ code: "custom", message: "observationIds contiene duplicati" });
+  }
+  if (benchmark.p25Cents > benchmark.medianCents || benchmark.medianCents > benchmark.p75Cents) {
+    context.addIssue({ code: "custom", message: "quantili benchmark non ordinati" });
+  }
+});
+
+export const observationSchema = z.object({
+  id: z.string().min(1),
+  observedAt: isoDate,
+  title: z.string().min(1),
+  category: z.string().min(1),
+  subject: subjectSchema,
+  amount: amountSchema.nullable(),
+  denominator: sourcedDenominatorSchema,
+  period: periodSchema,
+  procurementMethod: procurementMethodSchema,
+  sourceIds: z.array(z.string().min(1)).min(1),
+  classification: z.enum([
+    "documented_irregularity",
+    "anomaly",
+    "missing_transparency",
+    "incomplete_or_not_comparable",
+  ]),
+  evidenceStrength: z.enum([
+    "official_finding",
+    "verified_official_record",
+    "computed_from_verified_sources",
+    "unverified",
+  ]),
+  publicationStatus: z.enum(["draft", "publishable", "blocked"]),
+  caveats: z.array(z.string().min(1)).min(1),
+  benchmark: benchmarkSchema.optional(),
+  transparencyGap: z.object({
+    missingItem: z.string().min(1),
+    legalBasisSourceId: z.string().min(1),
+    checkedOfficialSourceId: z.string().min(1),
+    checkedAt: isoDate,
+  }).optional(),
+}).superRefine((observation, context) => {
+  if (new Set(observation.sourceIds).size !== observation.sourceIds.length) {
+    context.addIssue({ code: "custom", message: "sourceIds contiene duplicati", path: ["sourceIds"] });
+  }
+});
+
+export const publicSpendingEvidenceSnapshotSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: isoDate,
+  sources: z.array(sourceSchema).min(1),
+  observations: z.array(observationSchema).min(1),
+}).superRefine((snapshot, context) => {
+  const sources = new Map(snapshot.sources.map((source) => [source.id, source]));
+  if (sources.size !== snapshot.sources.length) {
+    context.addIssue({ code: "custom", message: "source.id duplicato", path: ["sources"] });
+  }
+
+  const observationIds = new Set(snapshot.observations.map((observation) => observation.id));
+  if (observationIds.size !== snapshot.observations.length) {
+    context.addIssue({ code: "custom", message: "observation.id duplicato", path: ["observations"] });
+  }
+
+  snapshot.observations.forEach((observation, index) => {
+    const path = ["observations", index];
+    const linkedSources = observation.sourceIds.map((sourceId) => sources.get(sourceId));
+    if (linkedSources.some((source) => !source)) {
+      context.addIssue({ code: "custom", message: "sourceId non risolto", path: [...path, "sourceIds"] });
+    }
+
+    const denominatorSource = sources.get(observation.denominator.sourceId);
+    const denominatorSourceIsOfficial =
+      denominatorSource?.kind === "official_record" ||
+      denominatorSource?.kind === "official_dataset";
+    if (
+      !observation.sourceIds.includes(observation.denominator.sourceId) ||
+      !denominatorSourceIsOfficial
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "fonte ufficiale del denominatore richiesta",
+        path: [...path, "denominator", "sourceId"],
+      });
+    }
+
+    const hasPublishableOfficialSource = linkedSources.some((source) =>
+      source?.kind === "official_record" ||
+      source?.kind === "official_dataset" ||
+      source?.kind === "official_finding");
+    if (observation.publicationStatus === "publishable" && !hasPublishableOfficialSource) {
+      context.addIssue({ code: "custom", message: "fonte ufficiale richiesta per pubblicare", path });
+    }
+
+    if (observation.classification === "documented_irregularity") {
+      const hasFinding = linkedSources.some((source) => source?.kind === "official_finding");
+      if (observation.evidenceStrength !== "official_finding" || !hasFinding) {
+        context.addIssue({ code: "custom", message: "accertamento ufficiale richiesto", path });
+      }
+    }
+
+    if (observation.classification === "anomaly") {
+      if (!observation.benchmark) {
+        context.addIssue({ code: "custom", message: "benchmark riproducibile richiesto", path });
+      }
+      if (observation.evidenceStrength !== "computed_from_verified_sources") {
+        context.addIssue({ code: "custom", message: "evidenza calcolata e verificata richiesta", path });
+      }
+    }
+    if (
+      (observation.classification === "anomaly" ||
+        observation.evidenceStrength === "computed_from_verified_sources") &&
+      !linkedSources.some((source) =>
+        source?.kind === "official_record" || source?.kind === "official_dataset")
+    ) {
+      context.addIssue({ code: "custom", message: "fonte ufficiale del dato richiesta", path });
+    }
+    if (observation.benchmark) {
+      const members = observation.benchmark.observationIds.map((observationId) =>
+        snapshot.observations.find((candidate) => candidate.id === observationId));
+      if (members.some((member) => !member?.amount)) {
+        context.addIssue({ code: "custom", message: "membro benchmark non risolto", path });
+      } else {
+        const membersHaveOfficialDataSource = members.every((member) =>
+          member!.sourceIds.some((sourceId) => {
+            const source = sources.get(sourceId);
+            return source?.kind === "official_record" || source?.kind === "official_dataset";
+          }));
+        if (!membersHaveOfficialDataSource) {
+          context.addIssue({ code: "custom", message: "fonte ufficiale richiesta per ogni membro", path });
+        }
+        try {
+          const computed = computePublicSpendingBenchmark({
+            cohortId: observation.benchmark.cohortId,
+            cohortLabel: observation.benchmark.cohortLabel,
+            targetObservationId: observation.id,
+            members: members.map((member) => ({
+              observationId: member!.id,
+              valueCents: member!.amount!.valueCents,
+              category: member!.category,
+              period: member!.period,
+              taxBasis: member!.amount!.taxBasis,
+              unit: member!.amount!.unit,
+              denominator: {
+                name: member!.denominator.name,
+                value: member!.denominator.value,
+                unit: member!.denominator.unit,
+              },
+            })),
+          });
+          const metrics = [
+            "medianCents",
+            "p25Cents",
+            "p75Cents",
+            "targetDeltaCents",
+            "targetDeltaPercent",
+          ] as const;
+          const declared = observation.benchmark;
+          const dimensionsMatch =
+            computed.category === declared.category &&
+            computed.taxBasis === declared.taxBasis &&
+            computed.unit === declared.unit &&
+            computed.period.start === declared.period.start &&
+            computed.period.end === declared.period.end &&
+            computed.period.precision === declared.period.precision &&
+            computed.denominator.name === declared.denominator.name &&
+            computed.denominator.value === declared.denominator.value &&
+            computed.denominator.unit === declared.denominator.unit;
+          if (
+            !dimensionsMatch ||
+            metrics.some((metric) => computed[metric] !== declared[metric])
+          ) {
+            context.addIssue({ code: "custom", message: "metriche benchmark non riconciliate", path });
+          }
+        } catch {
+          context.addIssue({ code: "custom", message: "coorte benchmark non like-for-like", path });
+        }
+      }
+    }
+
+    if (observation.classification === "missing_transparency") {
+      const gap = observation.transparencyGap;
+      const legalSource = gap ? sources.get(gap.legalBasisSourceId) : undefined;
+      const checkedOfficialSource = gap ? sources.get(gap.checkedOfficialSourceId) : undefined;
+      if (
+        !gap ||
+        legalSource?.kind !== "legal_basis" ||
+        !observation.sourceIds.includes(gap.legalBasisSourceId) ||
+        checkedOfficialSource?.kind !== "official_record" ||
+        !observation.sourceIds.includes(gap.checkedOfficialSourceId)
+      ) {
+        context.addIssue({
+          code: "custom",
+          message: "base normativa e pagina o record ufficiale verificato richiesti",
+          path,
+        });
+      }
+    }
+
+    if (observation.publicationStatus === "publishable" && observation.evidenceStrength === "unverified") {
+      context.addIssue({ code: "custom", message: "evidenza non verificata non pubblicabile", path });
+    }
+
+    if (
+      observation.classification === "incomplete_or_not_comparable" &&
+      observation.publicationStatus === "publishable"
+    ) {
+      context.addIssue({ code: "custom", message: "dato incompleto non pubblicabile come evidenza", path });
+    }
+  });
+});
+
+export type EvidenceSource = z.infer<typeof sourceSchema>;
+export type EvidenceSubject = z.infer<typeof subjectSchema>;
+export type EvidenceAmount = z.infer<typeof amountSchema>;
+export type EvidencePeriod = z.infer<typeof periodSchema>;
+export type SourcedDenominator = z.infer<typeof sourcedDenominatorSchema>;
+export type ProcurementMethod = z.infer<typeof procurementMethodSchema>;
+export type Benchmark = z.infer<typeof benchmarkSchema>;
+export type EvidenceObservation = z.infer<typeof observationSchema>;
+export type PublicSpendingEvidenceSnapshot = z.infer<typeof publicSpendingEvidenceSnapshotSchema>;
+
+export function assertPublicSpendingEvidenceSnapshot(value: unknown): PublicSpendingEvidenceSnapshot {
+  return publicSpendingEvidenceSnapshotSchema.parse(value);
+}
+
+export function assessSocialCardReadiness(
+  snapshot: PublicSpendingEvidenceSnapshot,
+  observation: EvidenceObservation,
+): string[] {
+  const reasons: string[] = [];
+  if (observation.publicationStatus !== "publishable") reasons.push("stato non pubblicabile");
+  if (!observation.amount) reasons.push("importo non disponibile");
+  if (!observation.benchmark) reasons.push("benchmark non disponibile");
+  if (observation.evidenceStrength === "unverified") reasons.push("evidenza non verificata");
+  const sources = new Map(snapshot.sources.map((source) => [source.id, source]));
+  const linkedSources = observation.sourceIds.map((sourceId) => sources.get(sourceId));
+  if (linkedSources.some((source) => !source)) {
+    reasons.push("fonte non risolta");
+  }
+  const denominatorSource = sources.get(observation.denominator.sourceId);
+  if (
+    !observation.sourceIds.includes(observation.denominator.sourceId) ||
+    (denominatorSource?.kind !== "official_record" && denominatorSource?.kind !== "official_dataset")
+  ) {
+    reasons.push("fonte ufficiale del denominatore non disponibile");
+  }
+  if (
+    observation.publicationStatus === "publishable" &&
+    !linkedSources.some((source) =>
+      source?.kind === "official_record" ||
+      source?.kind === "official_dataset" ||
+      source?.kind === "official_finding")
+  ) {
+    reasons.push("fonte ufficiale per la pubblicazione non disponibile");
+  }
+  if (
+    observation.classification === "anomaly" &&
+    !linkedSources.some((source) =>
+      source?.kind === "official_record" || source?.kind === "official_dataset")
+  ) {
+    reasons.push("fonte ufficiale del dato non disponibile");
+  }
+  if (observation.classification === "missing_transparency") {
+    const gap = observation.transparencyGap;
+    const legalSource = gap ? sources.get(gap.legalBasisSourceId) : undefined;
+    const checkedOfficialSource = gap ? sources.get(gap.checkedOfficialSourceId) : undefined;
+    if (
+      !gap ||
+      legalSource?.kind !== "legal_basis" ||
+      !observation.sourceIds.includes(gap.legalBasisSourceId) ||
+      checkedOfficialSource?.kind !== "official_record" ||
+      !observation.sourceIds.includes(gap.checkedOfficialSourceId)
+    ) {
+      reasons.push("verifica della trasparenza incompleta");
+    }
+  }
+  return reasons;
+}

--- a/tests/fixtures/public-spending-evidence/synthetic-snapshot.json
+++ b/tests/fixtures/public-spending-evidence/synthetic-snapshot.json
@@ -1,0 +1,93 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-01-31",
+  "sources": [
+    {
+      "id": "synthetic-record-source",
+      "title": "Fonte ufficiale sintetica",
+      "publisher": "Ente dimostrativo",
+      "kind": "official_record",
+      "url": "https://example.test/atti/1",
+      "identifier": "ATTO-SINTETICO-1",
+      "publishedAt": "2026-01-15",
+      "retrievedAt": "2026-01-31",
+      "scope": "Fixture sintetica per test del contratto",
+      "reuseStatus": "unknown"
+    }
+  ],
+  "observations": [
+    {
+      "id": "synthetic-observation-1",
+      "observedAt": "2026-01-31",
+      "title": "Servizio dimostrativo",
+      "category": "servizio-sintetico",
+      "subject": {
+        "spendingEntity": { "name": "Ente dimostrativo" },
+        "counterparty": { "name": "Fornitore dimostrativo" }
+      },
+      "amount": {
+        "valueCents": 120000,
+        "currency": "EUR",
+        "taxBasis": "net",
+        "unit": "award_total"
+      },
+      "denominator": { "name": "affidamento", "value": 1, "unit": "affidamento", "sourceId": "synthetic-record-source" },
+      "period": { "start": "2026-01-01", "end": "2026-01-31", "precision": "month" },
+      "procurementMethod": { "value": "direct_award", "provenance": "source_explicit" },
+      "sourceIds": ["synthetic-record-source"],
+      "classification": "anomaly",
+      "evidenceStrength": "computed_from_verified_sources",
+      "publicationStatus": "publishable",
+      "caveats": ["Fixture sintetica: non descrive una spesa reale."],
+      "benchmark": {
+        "cohortId": "synthetic-cohort",
+        "cohortLabel": "Tre servizi sintetici omogenei",
+        "category": "servizio-sintetico",
+        "period": { "start": "2026-01-01", "end": "2026-01-31", "precision": "month" },
+        "taxBasis": "net",
+        "unit": "award_total",
+        "denominator": { "name": "affidamento", "value": 1, "unit": "affidamento" },
+        "method": "linear_interpolation_r7",
+        "cohortSize": 3,
+        "medianCents": 100000,
+        "p25Cents": 90000,
+        "p75Cents": 110000,
+        "targetDeltaCents": 20000,
+        "targetDeltaPercent": 20,
+        "observationIds": ["synthetic-observation-1", "synthetic-observation-2", "synthetic-observation-3"]
+      }
+    },
+    {
+      "id": "synthetic-observation-2",
+      "observedAt": "2026-01-31",
+      "title": "Secondo servizio dimostrativo",
+      "category": "servizio-sintetico",
+      "subject": { "spendingEntity": { "name": "Ente dimostrativo" } },
+      "amount": { "valueCents": 80000, "currency": "EUR", "taxBasis": "net", "unit": "award_total" },
+      "denominator": { "name": "affidamento", "value": 1, "unit": "affidamento", "sourceId": "synthetic-record-source" },
+      "period": { "start": "2026-01-01", "end": "2026-01-31", "precision": "month" },
+      "procurementMethod": { "value": "unknown", "provenance": "not_available" },
+      "sourceIds": ["synthetic-record-source"],
+      "classification": "incomplete_or_not_comparable",
+      "evidenceStrength": "verified_official_record",
+      "publicationStatus": "blocked",
+      "caveats": ["Fixture sintetica: non descrive una spesa reale."]
+    },
+    {
+      "id": "synthetic-observation-3",
+      "observedAt": "2026-01-31",
+      "title": "Terzo servizio dimostrativo",
+      "category": "servizio-sintetico",
+      "subject": { "spendingEntity": { "name": "Ente dimostrativo" } },
+      "amount": { "valueCents": 100000, "currency": "EUR", "taxBasis": "net", "unit": "award_total" },
+      "denominator": { "name": "affidamento", "value": 1, "unit": "affidamento", "sourceId": "synthetic-record-source" },
+      "period": { "start": "2026-01-01", "end": "2026-01-31", "precision": "month" },
+      "procurementMethod": { "value": "unknown", "provenance": "not_available" },
+      "sourceIds": ["synthetic-record-source"],
+      "classification": "incomplete_or_not_comparable",
+      "evidenceStrength": "verified_official_record",
+      "publicationStatus": "blocked",
+      "caveats": ["Fixture sintetica: non descrive una spesa reale."]
+    }
+  ]
+}

--- a/tests/public-spending-evidence-contract.test.mjs
+++ b/tests/public-spending-evidence-contract.test.mjs
@@ -1,0 +1,280 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const {
+  assessSocialCardReadiness,
+  assertPublicSpendingEvidenceSnapshot,
+} = await import("../src/lib/data/public-spending-evidence-contract.ts");
+const { computePublicSpendingBenchmark } = await import(
+  "../src/lib/data/public-spending-benchmark.ts"
+);
+
+const fixturePath = new URL(
+  "./fixtures/public-spending-evidence/synthetic-snapshot.json",
+  import.meta.url,
+);
+
+function fixture() {
+  return JSON.parse(readFileSync(fixturePath, "utf8"));
+}
+
+function benchmarkMembers() {
+  return [80_000, 100_000, 120_000, 140_000].map((valueCents, index) => ({
+    observationId: `synthetic-${index + 1}`,
+    valueCents,
+    category: "servizio-sintetico",
+    period: { start: "2026-01-01", end: "2026-12-31", precision: "year" },
+    taxBasis: "net",
+    unit: "award_total",
+    denominator: { name: "affidamento", value: 1, unit: "affidamento" },
+  }));
+}
+
+test("accepts a fully synthetic evidence snapshot", () => {
+  const snapshot = assertPublicSpendingEvidenceSnapshot(fixture());
+  assert.equal(snapshot.observations.length, 3);
+  assert.deepEqual(assessSocialCardReadiness(snapshot, snapshot.observations[0]), []);
+});
+
+test("fails closed on unsupported evidence classifications", () => {
+  const documented = fixture();
+  documented.observations[0].classification = "documented_irregularity";
+  documented.observations[0].evidenceStrength = "verified_official_record";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(documented), /accertamento ufficiale/);
+
+  const noBenchmark = fixture();
+  delete noBenchmark.observations[0].benchmark;
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(noBenchmark), /benchmark riproducibile/);
+
+  const incomplete = fixture();
+  incomplete.observations[0].classification = "incomplete_or_not_comparable";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(incomplete), /non pubblicabile/);
+
+  const unresolvedCohort = fixture();
+  unresolvedCohort.observations[0].benchmark.observationIds[2] = "missing-observation";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(unresolvedCohort), /non risolto/);
+
+  const falseMedian = fixture();
+  falseMedian.observations[0].benchmark.medianCents += 1;
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(falseMedian), /non riconciliate/);
+
+  const wrongDimension = fixture();
+  wrongDimension.observations[0].benchmark.category = "categoria-diversa";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(wrongDimension), /non riconciliate/);
+
+  const memberDenominator = fixture();
+  memberDenominator.observations[1].denominator.value = 2;
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(memberDenominator), /non like-for-like/);
+
+  const declaredDenominator = fixture();
+  declaredDenominator.observations[0].benchmark.denominator.name = "unità arbitraria";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(declaredDenominator), /non riconciliate/);
+});
+
+test("requires a verified legal basis for missing-transparency claims", () => {
+  const snapshot = fixture();
+  snapshot.observations[0].classification = "missing_transparency";
+  delete snapshot.observations[0].transparencyGap;
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(snapshot),
+    /base normativa e pagina o record ufficiale verificato/,
+  );
+
+  const missingControlSource = fixture();
+  missingControlSource.sources.push({
+    id: "synthetic-legal-source",
+    title: "Base normativa sintetica",
+    publisher: "Ente dimostrativo",
+    kind: "legal_basis",
+    url: "https://example.test/norme/1",
+    retrievedAt: "2026-01-31",
+    scope: "Fixture sintetica",
+    reuseStatus: "unknown",
+  });
+  missingControlSource.observations[0].classification = "missing_transparency";
+  missingControlSource.observations[0].evidenceStrength = "verified_official_record";
+  missingControlSource.observations[0].sourceIds = ["synthetic-legal-source"];
+  missingControlSource.observations[0].transparencyGap = {
+    missingItem: "Documento sintetico",
+    legalBasisSourceId: "synthetic-legal-source",
+    checkedOfficialSourceId: "synthetic-legal-source",
+    checkedAt: "2026-01-31",
+  };
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(missingControlSource),
+    /pagina o record ufficiale verificato/,
+  );
+
+  const datasetIsNotCheckedPage = fixture();
+  datasetIsNotCheckedPage.sources[0].kind = "official_dataset";
+  datasetIsNotCheckedPage.sources.push({
+    id: "synthetic-legal-source",
+    title: "Base normativa sintetica",
+    publisher: "Ente dimostrativo",
+    kind: "legal_basis",
+    url: "https://example.test/norme/1",
+    retrievedAt: "2026-01-31",
+    scope: "Fixture sintetica",
+    reuseStatus: "unknown",
+  });
+  datasetIsNotCheckedPage.observations[0].classification = "missing_transparency";
+  datasetIsNotCheckedPage.observations[0].evidenceStrength = "verified_official_record";
+  datasetIsNotCheckedPage.observations[0].sourceIds.push("synthetic-legal-source");
+  datasetIsNotCheckedPage.observations[0].transparencyGap = {
+    missingItem: "Documento sintetico",
+    legalBasisSourceId: "synthetic-legal-source",
+    checkedOfficialSourceId: "synthetic-record-source",
+    checkedAt: "2026-01-31",
+  };
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(datasetIsNotCheckedPage),
+    /pagina o record ufficiale verificato/,
+  );
+});
+
+test("requires an official source for every denominator", () => {
+  const unresolved = fixture();
+  unresolved.observations[1].denominator.sourceId = "missing-source";
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(unresolved),
+    /fonte ufficiale del denominatore/,
+  );
+
+  const notLinked = fixture();
+  notLinked.sources.push({
+    id: "other-official-record",
+    title: "Altro record ufficiale sintetico",
+    publisher: "Ente dimostrativo",
+    kind: "official_record",
+    url: "https://example.test/atti/2",
+    retrievedAt: "2026-01-31",
+    scope: "Fixture sintetica",
+    reuseStatus: "unknown",
+  });
+  notLinked.observations[1].denominator.sourceId = "other-official-record";
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(notLinked),
+    /fonte ufficiale del denominatore/,
+  );
+
+  const wrongRole = fixture();
+  wrongRole.sources[0].kind = "legal_basis";
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(wrongRole),
+    /fonte ufficiale del denominatore/,
+  );
+});
+
+test("blocks publication backed only by a legal basis", () => {
+  const snapshot = fixture();
+  snapshot.sources[0].kind = "legal_basis";
+  snapshot.observations[0].classification = "documented_irregularity";
+  snapshot.observations[0].evidenceStrength = "official_finding";
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(snapshot),
+    /fonte ufficiale richiesta per pubblicare/,
+  );
+
+  const parsed = structuredClone(snapshot.observations[0]);
+  assert.ok(
+    assessSocialCardReadiness(snapshot, parsed).includes(
+      "fonte ufficiale per la pubblicazione non disponibile",
+    ),
+  );
+});
+
+test("requires distinct and role-appropriate sources at runtime", () => {
+  const wrongRole = fixture();
+  wrongRole.sources[0].kind = "legal_basis";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(wrongRole), /fonte ufficiale del dato/);
+
+  const duplicateSource = fixture();
+  duplicateSource.observations[0].sourceIds.push("synthetic-record-source");
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(duplicateSource), /contiene duplicati/);
+
+  const memberWithoutDataSource = fixture();
+  memberWithoutDataSource.sources.push({
+    id: "synthetic-legal-source",
+    title: "Base normativa sintetica",
+    publisher: "Ente dimostrativo",
+    kind: "legal_basis",
+    url: "https://example.test/norme/1",
+    retrievedAt: "2026-01-31",
+    scope: "Fixture sintetica",
+    reuseStatus: "unknown",
+  });
+  memberWithoutDataSource.observations[1].sourceIds = ["synthetic-legal-source"];
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(memberWithoutDataSource),
+    /fonte ufficiale richiesta per ogni membro/,
+  );
+
+  assert.deepEqual(assessSocialCardReadiness(wrongRole, wrongRole.observations[0]), [
+    "fonte ufficiale del denominatore non disponibile",
+    "fonte ufficiale per la pubblicazione non disponibile",
+    "fonte ufficiale del dato non disponibile",
+  ]);
+});
+
+test("requires explicit provenance for text-derived procurement methods", () => {
+  const snapshot = fixture();
+  snapshot.observations[0].procurementMethod = {
+    value: "direct_award",
+    provenance: "text_derived",
+  };
+  assert.throws(
+    () => assertPublicSpendingEvidenceSnapshot(snapshot),
+    /regola versionata e confidenza/,
+  );
+
+  const invalidDate = fixture();
+  invalidDate.observations[0].period.start = "2026-02-31";
+  assert.throws(() => assertPublicSpendingEvidenceSnapshot(invalidDate), /calendario non valida/);
+});
+
+test("computes transparent R7 quantiles and target delta", () => {
+  const benchmark = computePublicSpendingBenchmark({
+    cohortId: "synthetic-cohort",
+    cohortLabel: "Quattro record sintetici omogenei",
+    targetObservationId: "synthetic-4",
+    members: benchmarkMembers(),
+  });
+
+  assert.equal(benchmark.medianCents, 110_000);
+  assert.equal(benchmark.p25Cents, 95_000);
+  assert.equal(benchmark.p75Cents, 125_000);
+  assert.equal(benchmark.targetDeltaCents, 30_000);
+  assert.equal(benchmark.targetDeltaPercent, (30_000 / 110_000) * 100);
+});
+
+test("rejects cohorts that are not like-for-like", () => {
+  const members = benchmarkMembers();
+  members[3].taxBasis = "gross";
+  assert.throws(
+    () => computePublicSpendingBenchmark({
+      cohortId: "synthetic-cohort",
+      cohortLabel: "Coorte incoerente",
+      targetObservationId: "synthetic-4",
+      members,
+    }),
+    /non like-for-like/,
+  );
+});
+
+test("social cards stay blocked when material fields are missing", () => {
+  const snapshot = assertPublicSpendingEvidenceSnapshot(fixture());
+  const observation = structuredClone(snapshot.observations[0]);
+  observation.amount = null;
+  observation.publicationStatus = "draft";
+  observation.evidenceStrength = "unverified";
+  delete observation.benchmark;
+
+  assert.deepEqual(assessSocialCardReadiness(snapshot, observation), [
+    "stato non pubblicabile",
+    "importo non disponibile",
+    "benchmark non disponibile",
+    "evidenza non verificata",
+  ]);
+});


### PR DESCRIPTION
## Base / head

- Base: `main` at `acbc271`
- Head: `codex/public-spending-evidence-contract` at `d344234`
- One atomic commit; no merge or deployment requested.

## Scope

- Adds a source-agnostic evidence contract for public-spending observations.
- Requires each observation denominator to cite a linked official record or dataset.
- Requires every publishable observation to carry an official source with an allowed evidence role.
- Requires missing-transparency claims to link both their legal basis and the checked official page or record.
- Keeps `sourceIds` unique and mirrors publication blockers in social-card readiness.
- Computes median, quartiles, and target delta only for exact like-for-like cohorts using linear interpolation R7.
- Includes only synthetic test data; it does not add a production dataset or UI.

## Sources and privacy

No external dataset is included. The committed fixture uses reserved `example.test` URLs and invented entities, values, and identifiers. The diff contains no private archive name, path, hash, checksum, relationship reference, private-person name, or statistic derived from private material.

## Verification

- `node --test tests/public-spending-evidence-contract.test.mjs` — PASS (10/10)
- `npm test` — PASS (267/267)
- `npm run typecheck` — PASS
- `npm run lint` — PASS
- `git diff --check origin/main` — PASS
- Privacy and neutral-naming scan of the four-file diff — PASS
- Hosted CI on `d344234` — IN PROGRESS; lint, tests, ETL contracts, typecheck, design detector, brand assets, and build have passed; production/browser/Lighthouse gate pending at last update.

## Risks and limits

- Schema version 1 keeps a positive numeric denominator and has no migration layer because it has no production consumer yet.
- A cohort needs at least three records, but minimum size alone does not make a comparison meaningful.
- Local checks are not hosted-CI or production proof; the current-head CI line above remains pending until GitHub completes it.
