### PR TITLE
feat: add verified regional spending page

### DIFF
--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -90,6 +90,7 @@ I file CIG, aggiudicazioni, aggiudicatari ed esecuzione restano dataset distinti
 **Titolare:** AgID.  
 **Uso:** anagrafe canonica degli enti, Codice IPA, codice fiscale, sito istituzionale, categoria.  
 **Freschezza:** dataset Enti con aggiornamento giornaliero.  
+
 **Ruolo:** base per scoprire i siti istituzionali e alimentare il crawler di Amministrazione Trasparente.
 
 Risorse integrate:
@@ -100,6 +101,19 @@ Risorse integrate:
 - amministrazioni centrali: categoria IPA `C1`; i ministeri vengono distinti dalla PCM con i codici natura, non dal testo della denominazione.
 
 Le UO non hanno un campo semantico che certifichi “dipartimento”, “direzione generale” o “ufficio”. Queste qualifiche richiedono un crosswalk ufficiale con regolamenti e sezioni Amministrazione Trasparente.
+
+### Bilanci consuntivi Istat delle Regioni 2024
+
+**Titolare:** Istat.
+
+**Periodo:** consuntivo definitivo 2024, pubblicato il 5 maggio 2026.
+
+**Perimetro:** 22 amministrazioni individuali: 15 Regioni ordinarie, 5 Regioni speciali e 2 Province autonome. I tre fogli aggregati Italia/ordinario/speciale servono solo come contesto e non vengono sommati alle amministrazioni.
+
+**Misura pubblicata:** impegni per Titolo. Pagamenti di competenza e sui residui restano fuori da questa vista.
+**Licenza:** non dichiarata sulla pagina o nell'archivio verificato; non ne viene attribuita una.
+
+L'ETL `scripts/etl/istat_regions_account.py` blocca archivio ZIP, workbook spese, 25 fogli, coordinate e totali ufficiali. Per ogni amministrazione i sei Titoli devono riconciliarsi con il `TOTALE GENERALE DELLE SPESE`. La pagina non usa una mappa perché 22 amministrazioni non corrispondono alle 20 geometrie regionali e non calcola valori pro capite finché popolazione e mapping non sono bloccati sullo stesso periodo.
 
 ## Tier 2: trasparenza distribuita
 

--- a/docs/INSTITUTIONAL_SPENDING_ARCHITECTURE.md
+++ b/docs/INSTITUTIONAL_SPENDING_ARCHITECTURE.md
@@ -21,7 +21,7 @@ Le pagine importano un solo modulo di dominio:
 /parlamento     -> dossier Parlamento
 /palazzo-chigi  -> dossier Presidenza del Consiglio
 /ministeri      -> rendiconto RGS dei Ministeri; dettaglio pagamenti separato già esistente
-/regioni        -> conti propri regionali omogenei, quando verificati
+/regioni        -> consuntivi Istat 2024 di 22 amministrazioni, impegni per Titolo
 ```
 
 Un eventuale `/istituzioni` orienta tra le route e mostra la copertura. Non somma valori.
@@ -56,7 +56,7 @@ La base è il candidato “quattro dossier, un confine contabile comune”. È s
 
 ## Rischi e domande aperte
 
-- Quale release nazionale omogenea contiene i conti propri di tutte le Regioni e Province autonome con denominatori compatibili?
+- Quale release Istat della popolazione può essere bloccata sul 2024 per abilitare confronti pro capite senza forzare il rapporto 22 amministrazioni/20 geografie?
 - Quali sezioni PCM possono essere pubblicate come dati strutturati oltre al rendiconto, senza mescolare incarichi, contratti e bilancio?
 - I dati ANAC e Consulenti Pubblici offrono chiavi stabili per ogni istituzione o soltanto filtri di scoperta?
 

--- a/scripts/etl/istat_regions_account.py
+++ b/scripts/etl/istat_regions_account.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Build the compact 2024 regional-accounts snapshot from official Istat tables."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA_PATH = ROOT / "src/data/generated/istat-regions-2024.data.json"
+META_PATH = ROOT / "src/data/generated/istat-regions-2024.meta.json"
+LANDING_URL = "https://www.istat.it/tavole-di-dati/i-bilanci-consuntivi-delle-regioni-e-province-autonome-anno-2024/"
+RESOURCE_URL = "https://www.istat.it/wp-content/uploads/2026/05/Tavole.zip"
+SOURCE_RECORD_ID = "istat:125266"
+EXPECTED_ZIP_BYTES = 280_471
+EXPECTED_ZIP_SHA256 = "ba98c16063bf2bb8b62cd29fbd1dae23eded549faaac2ba06707ac7206ccbb7f"
+SPENDING_FILE = "Tavole/Regioni_definitivi_2024_Tavola 2 - Spese anno 2024.xlsx"
+REVENUE_FILE = "Tavole/Regioni_definitivi_2024_Tavola 1 - Entrate anno 2024.xlsx"
+EXPECTED_SPENDING_BYTES = 200_402
+EXPECTED_SPENDING_SHA256 = "a2b6f7d0de90e7fa8c15fb6d325535cb747f3b5a19b49bcb33dc16d61bc16682"
+EXPECTED_SHEETS = (
+    "ITALIA", "REGIONI A STATUTO ORDINARIO", "PIEMONTE", "LIGURIA", "LOMBARDIA", "VENETO",
+    "EMILIA-ROMAGNA", "TOSCANA", "UMBRIA", "MARCHE", "LAZIO", "ABRUZZO", "MOLISE",
+    "CAMPANIA", "PUGLIA", "BASILICATA", "CALABRIA", "REGIONI A STATUTO SPECIALE",
+    "VALLE D'AOSTA - Vallée d'Aoste", "TRENTINO-ALTO ADIGE - Südtirol", "BOLZANO - Bozen",
+    "TRENTO", "FRIULI-VENEZIA GIULIA", "SICILIA", "SARDEGNA",
+)
+ENTITY_STATUS = {
+    **{name: "ordinary" for name in EXPECTED_SHEETS[2:17]},
+    **{name: "special" for name in (EXPECTED_SHEETS[18], EXPECTED_SHEETS[19], EXPECTED_SHEETS[22], EXPECTED_SHEETS[23], EXPECTED_SHEETS[24])},
+    EXPECTED_SHEETS[20]: "autonomous-province",
+    EXPECTED_SHEETS[21]: "autonomous-province",
+}
+ENTITY_IDS = {
+    "PIEMONTE": "piemonte", "LIGURIA": "liguria", "LOMBARDIA": "lombardia", "VENETO": "veneto",
+    "EMILIA-ROMAGNA": "emilia-romagna", "TOSCANA": "toscana", "UMBRIA": "umbria", "MARCHE": "marche",
+    "LAZIO": "lazio", "ABRUZZO": "abruzzo", "MOLISE": "molise", "CAMPANIA": "campania",
+    "PUGLIA": "puglia", "BASILICATA": "basilicata", "CALABRIA": "calabria",
+    "VALLE D'AOSTA - Vallée d'Aoste": "valle-aosta", "TRENTINO-ALTO ADIGE - Südtirol": "trentino-alto-adige",
+    "BOLZANO - Bozen": "bolzano", "TRENTO": "trento", "FRIULI-VENEZIA GIULIA": "friuli-venezia-giulia",
+    "SICILIA": "sicilia", "SARDEGNA": "sardegna",
+}
+ENTITY_LABELS = {
+    "PIEMONTE": "Piemonte", "LIGURIA": "Liguria", "LOMBARDIA": "Lombardia", "VENETO": "Veneto",
+    "EMILIA-ROMAGNA": "Emilia-Romagna", "TOSCANA": "Toscana", "UMBRIA": "Umbria", "MARCHE": "Marche",
+    "LAZIO": "Lazio", "ABRUZZO": "Abruzzo", "MOLISE": "Molise", "CAMPANIA": "Campania",
+    "PUGLIA": "Puglia", "BASILICATA": "Basilicata", "CALABRIA": "Calabria",
+    "VALLE D'AOSTA - Vallée d'Aoste": "Valle d'Aosta/Vallée d'Aoste",
+    "TRENTINO-ALTO ADIGE - Südtirol": "Trentino-Alto Adige/Südtirol",
+    "BOLZANO - Bozen": "Provincia autonoma di Bolzano/Bozen",
+    "TRENTO": "Provincia autonoma di Trento",
+    "FRIULI-VENEZIA GIULIA": "Friuli-Venezia Giulia", "SICILIA": "Sicilia", "SARDEGNA": "Sardegna",
+}
+TITLE_ROWS = (9, 58, 79, 98, 104, 105)
+NS = {"x": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+REL_NS = {"r": "http://schemas.openxmlformats.org/package/2006/relationships"}
+OFFICE_REL = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"
+
+
+def fetch() -> bytes:
+    request = urllib.request.Request(RESOURCE_URL, headers={"User-Agent": "DoveVannoINostriSoldi/0.2 source-verifier"})
+    with urllib.request.urlopen(request, timeout=90) as response:
+        if response.status != 200:
+            raise ValueError(f"HTTP inatteso {response.status}")
+        return response.read()
+
+
+def canonical_bytes(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def cents(value: Decimal) -> int:
+    return int((value * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def shared_strings(archive: zipfile.ZipFile) -> list[str]:
+    root = ET.fromstring(archive.read("xl/sharedStrings.xml"))
+    return ["".join(item.itertext()) for item in root.findall("x:si", NS)]
+
+
+def cell_value(cell: ET.Element, strings: list[str]) -> str | Decimal | None:
+    cell_type = cell.attrib.get("t")
+    value = cell.find("x:v", NS)
+    if cell_type == "inlineStr":
+        inline = cell.find("x:is", NS)
+        return "".join(inline.itertext()) if inline is not None else None
+    if value is None or value.text is None:
+        return None
+    if cell_type == "s":
+        return strings[int(value.text)]
+    if cell_type in {"str", "e"}:
+        return value.text
+    return Decimal(value.text)
+
+
+def worksheet_cells(payload: bytes) -> tuple[list[str], dict[str, dict[str, str | Decimal | None]]]:
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        strings = shared_strings(archive)
+        workbook = ET.fromstring(archive.read("xl/workbook.xml"))
+        relationships = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+        targets = {item.attrib["Id"]: item.attrib["Target"] for item in relationships.findall("r:Relationship", REL_NS)}
+        sheets = workbook.findall("x:sheets/x:sheet", NS)
+        names = [sheet.attrib["name"] for sheet in sheets]
+        cells_by_sheet: dict[str, dict[str, str | Decimal | None]] = {}
+        for sheet in sheets:
+            name = sheet.attrib["name"]
+            target = targets[sheet.attrib[OFFICE_REL]]
+            worksheet = ET.fromstring(archive.read(f"xl/{target}"))
+            dimension = worksheet.find("x:dimension", NS)
+            if dimension is None or dimension.attrib.get("ref") != "A1:D109":
+                raise ValueError(f"Dimensione inattesa nel foglio {name}")
+            cells_by_sheet[name] = {
+                cell.attrib["r"]: cell_value(cell, strings)
+                for cell in worksheet.findall(".//x:sheetData/x:row/x:c", NS)
+            }
+    return names, cells_by_sheet
+
+
+def text_cell(cells: dict[str, str | Decimal | None], coordinate: str) -> str:
+    value = cells.get(coordinate)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Testo Istat mancante in {coordinate}")
+    return " ".join(value.split())
+
+
+def money_cell(cells: dict[str, str | Decimal | None], coordinate: str) -> Decimal:
+    value = cells.get(coordinate)
+    if not isinstance(value, Decimal):
+        raise ValueError(f"Importo Istat mancante in {coordinate}")
+    return value
+
+
+def build_snapshot(payload: bytes, acquired_at: str) -> tuple[dict, dict]:
+    if len(payload) != EXPECTED_ZIP_BYTES or hashlib.sha256(payload).hexdigest() != EXPECTED_ZIP_SHA256:
+        raise ValueError("Archivio Istat diverso dal file validato")
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        if set(archive.namelist()) != {"Tavole/", REVENUE_FILE, SPENDING_FILE}:
+            raise ValueError("Contenuto archivio Istat inatteso")
+        spending = archive.read(SPENDING_FILE)
+    if len(spending) != EXPECTED_SPENDING_BYTES or hashlib.sha256(spending).hexdigest() != EXPECTED_SPENDING_SHA256:
+        raise ValueError("Tavola spese Istat diversa dal file validato")
+    sheet_names, sheets = worksheet_cells(spending)
+    if tuple(sheet_names) != EXPECTED_SHEETS:
+        raise ValueError("Elenco o ordine dei fogli Istat inatteso")
+
+    entities = []
+    for sheet_name, status in ENTITY_STATUS.items():
+        cells = sheets[sheet_name]
+        if text_cell(cells, "B4").casefold() != "impegni":
+            raise ValueError(f"Fase contabile inattesa nel foglio {sheet_name}")
+        source_label = text_cell(cells, "A7")
+        titles = []
+        for row in TITLE_ROWS:
+            label = text_cell(cells, f"A{row}")
+            match = re.search(r"TITOLO\s+([IVX0-9]+)", label, flags=re.IGNORECASE)
+            if not match:
+                raise ValueError(f"Titolo inatteso nel foglio {sheet_name}, riga {row}")
+            titles.append({"code": match.group(1).upper(), "label": label, "commitmentsCents": cents(money_cell(cells, f"B{row}"))})
+        if text_cell(cells, "A108").casefold() != "totale generale delle spese":
+            raise ValueError(f"Totale ufficiale mancante nel foglio {sheet_name}")
+        total = cents(money_cell(cells, "B108"))
+        if sum(item["commitmentsCents"] for item in titles) != total:
+            raise ValueError(f"Titoli non riconciliati nel foglio {sheet_name}")
+        entities.append({
+            "id": ENTITY_IDS[sheet_name],
+            "label": ENTITY_LABELS[sheet_name],
+            "sourceLabel": source_label,
+            "sourceSheet": sheet_name,
+            "status": status,
+            "commitmentsCents": total,
+            "titles": titles,
+        })
+    if len(entities) != 22 or len({item["id"] for item in entities}) != 22:
+        raise ValueError("Copertura delle amministrazioni regionali inattesa")
+
+    data = {
+        "schemaVersion": 1,
+        "referenceYear": 2024,
+        "unit": "euro_cents",
+        "accountingFrame": "commitments",
+        "entities": entities,
+        "coverage": {
+            "workbookSheets": len(sheet_names), "individualAdministrations": len(entities),
+            "ordinaryRegions": sum(item["status"] == "ordinary" for item in entities),
+            "specialRegions": sum(item["status"] == "special" for item in entities),
+            "autonomousProvinces": sum(item["status"] == "autonomous-province" for item in entities),
+            "entitiesReconciled": len(entities),
+        },
+        "definitions": {
+            "scope": "Bilanci consuntivi delle singole amministrazioni regionali e Province autonome.",
+            "measure": "Impegni 2024, tenuti separati dai pagamenti di competenza e sui residui.",
+            "comparisonLimit": "Valori assoluti: nessun confronto pro capite senza una popolazione Istat bloccata sullo stesso periodo.",
+            "geographyLimit": "Ventidue amministrazioni non corrispondono alle venti geometrie regionali; la mappa non viene usata.",
+        },
+    }
+    data_bytes = canonical_bytes(data)
+    meta = {
+        "schemaVersion": 1,
+        "source": {
+            "owner": "Istat", "landingUrl": LANDING_URL, "resourceUrl": RESOURCE_URL,
+            "sourceRecordId": SOURCE_RECORD_ID, "referencePeriod": "2024", "publishedAt": "2026-05-05",
+            "acquiredAt": acquired_at, "format": "zip+xlsx", "licenseStatus": "not-declared",
+        },
+        "asset": {"bytes": len(payload), "sha256": hashlib.sha256(payload).hexdigest()},
+        "spendingWorkbook": {"path": SPENDING_FILE, "bytes": len(spending), "sha256": hashlib.sha256(spending).hexdigest()},
+        "transformation": {"version": 1, "description": "Esclusi i tre fogli aggregati; letti solo gli impegni dei sei Titoli e riconciliati con il totale ufficiale per 22 amministrazioni."},
+        "dataArtifact": {"path": str(DATA_PATH.relative_to(ROOT)), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
+    }
+    return data, meta
+
+
+def validate_committed() -> None:
+    data_bytes = DATA_PATH.read_bytes()
+    data = json.loads(data_bytes)
+    meta = json.loads(META_PATH.read_text())
+    artifact = meta["dataArtifact"]
+    if len(data_bytes) != artifact["bytes"] or hashlib.sha256(data_bytes).hexdigest() != artifact["sha256"]:
+        raise ValueError("Artefatto Regioni non legato al manifesto")
+    if meta["asset"] != {"bytes": EXPECTED_ZIP_BYTES, "sha256": EXPECTED_ZIP_SHA256}:
+        raise ValueError("Archivio Regioni non legato alla fonte validata")
+    if meta["spendingWorkbook"] != {
+        "path": SPENDING_FILE, "bytes": EXPECTED_SPENDING_BYTES, "sha256": EXPECTED_SPENDING_SHA256,
+    }:
+        raise ValueError("Workbook Regioni non legato alla tavola validata")
+    if meta["source"]["sourceRecordId"] != SOURCE_RECORD_ID or meta["source"]["resourceUrl"] != RESOURCE_URL:
+        raise ValueError("Identità della fonte Regioni inattesa")
+    if data["coverage"] != {"workbookSheets": 25, "individualAdministrations": 22, "ordinaryRegions": 15, "specialRegions": 5, "autonomousProvinces": 2, "entitiesReconciled": 22}:
+        raise ValueError("Copertura Regioni inattesa")
+    if {
+        item["sourceSheet"]: (item["id"], item["status"])
+        for item in data["entities"]
+    } != {
+        sheet: (ENTITY_IDS[sheet], status)
+        for sheet, status in ENTITY_STATUS.items()
+    }:
+        raise ValueError("Identità delle amministrazioni regionali inattesa")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--acquired-at")
+    parser.add_argument("--validate-committed", action="store_true")
+    args = parser.parse_args()
+    if args.validate_committed:
+        validate_committed()
+        return
+    payload = args.input.read_bytes() if args.input else fetch()
+    acquired_at = args.acquired_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    data, meta = build_snapshot(payload, acquired_at)
+    DATA_PATH.write_bytes(canonical_bytes(data))
+    META_PATH.write_bytes(canonical_bytes(meta))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-institutional-ui.mjs
+++ b/scripts/verify-institutional-ui.mjs
@@ -118,6 +118,43 @@ async function inspect(page, route, viewport) {
     if (viewport.width <= 620) {
       assert.equal(evidence.scrollable, true, `${route}: tabella mobile non scorre`);
     }
+  } else if (route === "/regioni") {
+    assert.equal(shell.stats, 3, `${route}: la prima vista deve avere tre fatti`);
+    await page.waitForSelector('figure [role="img"] svg');
+    const evidence = await page.evaluate(() => {
+      const chart = document.querySelector('figure [role="img"]');
+      const titleTable = document.querySelector(
+        '[role="region"][aria-label^="Valori esatti degli impegni 2024"]',
+      );
+      const coverageTable = document.querySelector(
+        '[role="region"][aria-label="Impegni esatti delle 22 amministrazioni regionali"]',
+      );
+      titleTable?.focus();
+      const initialScrollLeft = titleTable?.scrollLeft ?? 0;
+      if (titleTable) titleTable.scrollLeft = titleTable.scrollWidth;
+      const result = {
+        activeTable: document.activeElement === titleTable,
+        coverageRows: coverageTable?.querySelectorAll("tbody tr").length ?? 0,
+        rectangles: chart?.querySelectorAll("svg rect").length ?? 0,
+        scrollable: Boolean(
+          titleTable &&
+          titleTable.scrollWidth > titleTable.clientWidth &&
+          titleTable.scrollLeft > initialScrollLeft,
+        ),
+        titleRows: titleTable?.querySelectorAll("tbody tr").length ?? 0,
+        total: titleTable?.querySelector("tfoot")?.textContent?.replace(/\s+/g, " ").trim(),
+      };
+      if (titleTable) titleTable.scrollLeft = initialScrollLeft;
+      return result;
+    });
+    assert.equal(evidence.activeTable, true, `${route}: tabella Titoli non focalizzabile`);
+    assert.equal(evidence.titleRows, 6, `${route}: Titoli incompleti`);
+    assert.equal(evidence.coverageRows, 22, `${route}: copertura amministrazioni incompleta`);
+    assert.ok(evidence.rectangles >= 5, `${route}: treemap incompleto`);
+    assert.match(evidence.total ?? "", /Totale ufficiale.+100,0\s?%/);
+    if (viewport.width <= 620) {
+      assert.equal(evidence.scrollable, true, `${route}: tabella Titoli mobile non scorre`);
+    }
   } else {
     const evidence = await page.evaluate(() => ({
       metadataRows: document.querySelectorAll(
@@ -155,6 +192,8 @@ try {
     ["/parlamento", { width: 390, height: 844, deviceScaleFactor: 1 }],
     ["/ministeri", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
     ["/ministeri", { width: 390, height: 844, deviceScaleFactor: 1 }],
+    ["/regioni", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
+    ["/regioni", { width: 390, height: 844, deviceScaleFactor: 1 }],
   ];
   for (const [route, viewport] of scenarios) {
     const page = await browser.newPage();

--- a/src/app/regioni/page.tsx
+++ b/src/app/regioni/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { compactEuro, exactEuro, longDate } from "@/lib/format";
+import { istatRegionsMetadata, istatRegionsSnapshot } from "@/lib/istat-regions-snapshot";
+import { RegionTitleTreemap } from "./region-title-treemap";
+import styles from "./regioni.module.css";
+
+export const metadata: Metadata = {
+  title: "Spese delle Regioni, consuntivi 2024",
+  description:
+    "Impegni 2024 dei bilanci consuntivi Istat per 22 amministrazioni regionali e Province autonome, con Titoli esatti e perimetri distinti.",
+};
+
+const percentage = new Intl.NumberFormat("it-IT", {
+  style: "percent",
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+const euro = (cents: number) => cents / 100;
+const statusLabel = {
+  ordinary: "Regione a statuto ordinario",
+  special: "Regione a statuto speciale",
+  "autonomous-province": "Provincia autonoma",
+} as const;
+
+export default async function RegionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ente?: string | string[] }>;
+}) {
+  const params = await searchParams;
+  const selectedId = typeof params.ente === "string" ? params.ente : "piemonte";
+  const selected = istatRegionsSnapshot.entities.find((entity) => entity.id === selectedId);
+  if (!selected) notFound();
+  const source = istatRegionsMetadata.source;
+
+  return (
+    <main className="shell page">
+      <div className="page-intro">
+        <h1>Spese delle Regioni</h1>
+        <p>
+          Leggiamo i consuntivi 2024 di 22 amministrazioni: 15 Regioni ordinarie, 5 speciali e
+          2 Province autonome. Qui mostriamo impegni, non pagamenti, e non li mescoliamo con
+          Comuni, sanità, CPT o residuo fiscale.
+        </p>
+      </div>
+
+      <form className={styles.selector} action="/regioni" method="get">
+        <label htmlFor="ente-regionale">
+          Scegli un&apos;amministrazione
+          <select id="ente-regionale" name="ente" defaultValue={selected.id}>
+            {istatRegionsSnapshot.entities.map((entity) => (
+              <option key={entity.id} value={entity.id}>{entity.label}</option>
+            ))}
+          </select>
+        </label>
+        <button type="submit">Mostra il consuntivo</button>
+      </form>
+
+      <dl className="stat-strip">
+        <div>
+          <dt>Impegni 2024</dt>
+          <dd>{compactEuro(euro(selected.commitmentsCents))}</dd>
+          <span className="stat-note">{exactEuro(euro(selected.commitmentsCents))} esatti</span>
+        </div>
+        <div>
+          <dt>Composizione</dt>
+          <dd>{selected.titles.length}</dd>
+          <span className="stat-note">Titoli riconciliati al totale</span>
+        </div>
+        <div>
+          <dt>Tipo</dt>
+          <dd>{selected.status === "ordinary" ? "Ordinaria" : selected.status === "special" ? "Speciale" : "Provincia"}</dd>
+          <span className="stat-note">{statusLabel[selected.status]}</span>
+        </div>
+      </dl>
+
+      <div className="notice">
+        <strong>Non è una classifica tra territori</strong>
+        <p>
+          Gli importi sono valori assoluti del bilancio di {selected.label}. Senza una popolazione
+          Istat bloccata sullo stesso periodo non calcoliamo valori pro capite. Le 22 amministrazioni
+          non coincidono con le 20 geometrie regionali, quindi in questa vista non usiamo la mappa.
+        </p>
+      </div>
+
+      <section className="panel" aria-labelledby="composizione-regionale">
+        <div className={styles.sectionHeader}>
+          <div>
+            <h2 id="composizione-regionale">Per cosa sono stati impegnati</h2>
+            <p>
+              Composizione per Titolo di {selected.label}. Il denominatore è il totale ufficiale
+              degli impegni 2024 della stessa amministrazione.
+            </p>
+          </div>
+          <span>Consuntivo definitivo</span>
+        </div>
+        <RegionTitleTreemap entity={selected} />
+        <p className={styles.scrollHint}>Scorri la tabella verso destra per vedere importi e quote.</p>
+        <div
+          className={`table-scroll ${styles.titleTable}`}
+          role="region"
+          aria-label={`Valori esatti degli impegni 2024 di ${selected.label} per Titolo`}
+          tabIndex={0}
+        >
+          <table className="table">
+            <thead><tr><th scope="col">Titolo</th><th scope="col">Impegni 2024</th><th scope="col">Quota</th></tr></thead>
+            <tbody>
+              {selected.titles.map((title) => (
+                <tr key={title.code}>
+                  <th scope="row">{title.label}</th>
+                  <td>{exactEuro(euro(title.commitmentsCents))}</td>
+                  <td>{percentage.format(title.commitmentsCents / selected.commitmentsCents)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr><th scope="row">Totale ufficiale</th><td>{exactEuro(euro(selected.commitmentsCents))}</td><td>{percentage.format(1)}</td></tr>
+            </tfoot>
+          </table>
+        </div>
+      </section>
+
+      <section className="panel" aria-labelledby="copertura-regioni">
+        <div className={styles.sectionHeader}>
+          <div>
+            <h2 id="copertura-regioni">Tutte le amministrazioni nel file</h2>
+            <p>Valori esatti per consultazione. L&apos;ordine non è una graduatoria.</p>
+          </div>
+          <span>22 su 22</span>
+        </div>
+        <p className={styles.statusNote}>
+          Statuto ordinario, statuto speciale e Province autonome restano visibili perché competenze
+          e assetti non sono equivalenti. Non calcoliamo una media comune.
+        </p>
+        <p className={styles.scrollHint}>Scorri la tabella verso destra per vedere gli importi.</p>
+        <div className={`table-scroll ${styles.allEntitiesTable}`} role="region" aria-label="Impegni esatti delle 22 amministrazioni regionali" tabIndex={0}>
+          <table className="table">
+            <thead><tr><th scope="col">Amministrazione</th><th scope="col">Tipo</th><th scope="col">Impegni 2024</th></tr></thead>
+            <tbody>
+              {istatRegionsSnapshot.entities.map((entity) => (
+                <tr key={entity.id}>
+                  <th scope="row">{entity.label}</th>
+                  <td>{statusLabel[entity.status]}</td>
+                  <td>{exactEuro(euro(entity.commitmentsCents))}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="panel" aria-labelledby="fonte-regioni">
+        <h2 className="panel-title" id="fonte-regioni">Fonte, periodo e controlli</h2>
+        <div className={styles.provenance}>
+          <div><span>Titolare</span><strong>{source.owner}</strong></div>
+          <div><span>Pubblicato</span><strong>{longDate(source.publishedAt)}</strong></div>
+          <div><span>Controllato da noi</span><strong>{longDate(source.acquiredAt)}</strong></div>
+          <div><span>Copertura</span><strong>22 amministrazioni · 22 totali riconciliati</strong></div>
+        </div>
+        <p className={styles.statusNote}>
+          Fonte {source.sourceRecordId}, foglio “{selected.sourceSheet}”. Abbiamo escluso i tre
+          fogli aggregati Italia, Regioni ordinarie e Regioni speciali; per ogni amministrazione
+          la somma dei sei Titoli coincide con il totale ufficiale. La pagina Istat non dichiara
+          una licenza per l&apos;archivio: non ne attribuiamo una.
+        </p>
+        <div className={styles.sourceLinks}>
+          <a href={source.landingUrl} target="_blank" rel="noreferrer">Apri la pagina Istat ↗</a>
+          <a href={source.resourceUrl} target="_blank" rel="noreferrer">Scarica le tavole ufficiali ↗</a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/regioni/region-title-treemap.module.css
+++ b/src/app/regioni/region-title-treemap.module.css
@@ -1,0 +1,69 @@
+.figure {
+  margin: 0;
+}
+
+.chart {
+  width: 100%;
+  height: 420px;
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-100);
+}
+
+.tileLabel,
+.tileShare,
+.tileAmount {
+  fill: var(--color-raised);
+  pointer-events: none;
+}
+
+.tileLabel,
+.tileShare {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.tileAmount {
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.tooltip {
+  max-width: 310px;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-raised);
+  background: var(--color-text);
+}
+
+.tooltip span,
+.tooltip strong,
+.tooltip small {
+  display: block;
+}
+
+.tooltip span,
+.tooltip small {
+  color: var(--color-neutral-300);
+}
+
+.tooltip strong {
+  margin-block: var(--space-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.figure figcaption {
+  max-width: 72ch;
+  margin-block-start: var(--space-3);
+  color: var(--color-neutral-600);
+  font-size: 0.78rem;
+}
+
+@media (max-width: 620px) {
+  .chart {
+    height: 340px;
+  }
+
+  .tileAmount {
+    display: none;
+  }
+}

--- a/src/app/regioni/region-title-treemap.tsx
+++ b/src/app/regioni/region-title-treemap.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
+import type { TreemapNode } from "recharts";
+import type { IstatRegionalAdministration } from "@/lib/data/istat-regions-contract";
+import styles from "./region-title-treemap.module.css";
+
+const compactEuro = new Intl.NumberFormat("it-IT", {
+  style: "currency",
+  currency: "EUR",
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const exactEuro = new Intl.NumberFormat("it-IT", {
+  style: "currency",
+  currency: "EUR",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+const percentage = new Intl.NumberFormat("it-IT", {
+  style: "percent",
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+type TitleNode = TreemapNode & {
+  shortLabel?: string;
+  fullLabel?: string;
+  commitmentsCents?: number;
+  share?: number;
+};
+
+function tile(props: TreemapNode) {
+  const node = props as TitleNode;
+  const showLabel = node.width >= 118 && node.height >= 58;
+  const showAmount = node.width >= 145 && node.height >= 88;
+  return (
+    <g>
+      <rect
+        x={node.x}
+        y={node.y}
+        width={node.width}
+        height={node.height}
+        fill="var(--color-accent)"
+        fillOpacity={0.96 - (node.index % 4) * 0.1}
+        stroke="var(--color-raised)"
+        strokeWidth={2}
+      />
+      {showLabel ? (
+        <>
+          <text x={node.x + 12} y={node.y + 25} className={styles.tileLabel}>{node.shortLabel}</text>
+          <text x={node.x + 12} y={node.y + 45} className={styles.tileShare}>{percentage.format(node.share ?? 0)}</text>
+          {showAmount ? (
+            <text x={node.x + 12} y={node.y + 66} className={styles.tileAmount}>
+              {compactEuro.format((node.commitmentsCents ?? 0) / 100)}
+            </text>
+          ) : null}
+        </>
+      ) : null}
+    </g>
+  );
+}
+
+function shortLabel(code: string) {
+  return `Titolo ${code}`;
+}
+
+export function RegionTitleTreemap({ entity }: { entity: IstatRegionalAdministration }) {
+  const data = entity.titles
+    .filter((title) => title.commitmentsCents > 0)
+    .map((title) => ({
+      name: title.code,
+      shortLabel: shortLabel(title.code),
+      fullLabel: title.label,
+      commitmentsCents: title.commitmentsCents,
+      share: title.commitmentsCents / entity.commitmentsCents,
+    }));
+
+  return (
+    <figure className={styles.figure}>
+      <div
+        className={styles.chart}
+        role="img"
+        aria-label={`Composizione degli impegni 2024 di ${entity.label} per Titolo`}
+        aria-describedby="regioni-treemap-caption"
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <Treemap
+            data={data}
+            dataKey="commitmentsCents"
+            nameKey="fullLabel"
+            nodeGap={1}
+            content={tile}
+            isAnimationActive={false}
+          >
+            <Tooltip
+              content={({ active, payload }) => {
+                const point = payload?.[0]?.payload as TitleNode | undefined;
+                if (!active || !point) return null;
+                return (
+                  <div className={styles.tooltip}>
+                    <span>{point.fullLabel}</span>
+                    <strong>{exactEuro.format((point.commitmentsCents ?? 0) / 100)}</strong>
+                    <small>{percentage.format(point.share ?? 0)} degli impegni</small>
+                  </div>
+                );
+              }}
+            />
+          </Treemap>
+        </ResponsiveContainer>
+      </div>
+      <figcaption id="regioni-treemap-caption">
+        Le aree sono additive: un solo consuntivo, una sola amministrazione, impegni 2024 in euro.
+        Il Titolo a zero resta nella tabella esatta ma non occupa spazio nel grafico.
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/app/regioni/regioni.module.css
+++ b/src/app/regioni/regioni.module.css
@@ -1,0 +1,146 @@
+.selector {
+  display: flex;
+  align-items: end;
+  gap: var(--space-3);
+  margin-block-end: var(--space-8);
+}
+
+.selector label {
+  display: grid;
+  gap: var(--space-2);
+  min-width: min(100%, 430px);
+  font-weight: 750;
+}
+
+.selector select {
+  min-height: 44px;
+  padding-inline: var(--space-3);
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-text);
+  background: var(--color-raised);
+}
+
+.selector button {
+  min-height: 44px;
+  padding-inline: var(--space-5);
+  border: 1px solid var(--color-accent);
+  color: var(--color-raised);
+  background: var(--color-accent);
+  font-weight: 800;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--space-6);
+  margin-block-end: var(--space-6);
+}
+
+.sectionHeader h2 {
+  margin: 0;
+}
+
+.sectionHeader p {
+  max-width: 72ch;
+  margin: var(--space-2) 0 0;
+  color: var(--color-neutral-700);
+}
+
+.sectionHeader > span,
+.provenance span {
+  color: var(--color-neutral-700);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.titleTable,
+.allEntitiesTable {
+  margin-block-start: var(--space-6);
+}
+
+.titleTable table {
+  min-width: 680px;
+}
+
+.allEntitiesTable table {
+  min-width: 760px;
+}
+
+.titleTable td,
+.allEntitiesTable td {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.titleTable tfoot {
+  font-weight: 800;
+}
+
+.statusNote {
+  max-width: 76ch;
+  color: var(--color-neutral-700);
+}
+
+.scrollHint {
+  display: none;
+  margin: var(--space-4) 0 0;
+  color: var(--color-neutral-700);
+  font-size: 0.85rem;
+}
+
+.provenance {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-6);
+  margin-block: var(--space-6);
+}
+
+.provenance div {
+  padding-block-start: var(--space-3);
+  border-block-start: 1px solid var(--color-neutral-300);
+}
+
+.provenance strong {
+  display: block;
+  margin-block-start: var(--space-2);
+  overflow-wrap: anywhere;
+}
+
+.sourceLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-block-start: var(--space-5);
+}
+
+.sourceLinks a {
+  font-weight: 750;
+}
+
+@media (max-width: 900px) {
+  .provenance {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .selector,
+  .sectionHeader {
+    display: grid;
+  }
+
+  .selector button {
+    width: 100%;
+  }
+
+  .provenance {
+    grid-template-columns: 1fr;
+  }
+
+  .scrollHint {
+    display: block;
+  }
+}

--- a/src/data/generated/istat-regions-2024.data.json
+++ b/src/data/generated/istat-regions-2024.data.json
@@ -1,0 +1,902 @@
+{
+  "accountingFrame": "commitments",
+  "coverage": {
+    "autonomousProvinces": 2,
+    "entitiesReconciled": 22,
+    "individualAdministrations": 22,
+    "ordinaryRegions": 15,
+    "specialRegions": 5,
+    "workbookSheets": 25
+  },
+  "definitions": {
+    "comparisonLimit": "Valori assoluti: nessun confronto pro capite senza una popolazione Istat bloccata sullo stesso periodo.",
+    "geographyLimit": "Ventidue amministrazioni non corrispondono alle venti geometrie regionali; la mappa non viene usata.",
+    "measure": "Impegni 2024, tenuti separati dai pagamenti di competenza e sui residui.",
+    "scope": "Bilanci consuntivi delle singole amministrazioni regionali e Province autonome."
+  },
+  "entities": [
+    {
+      "commitmentsCents": 1633987543655,
+      "id": "piemonte",
+      "label": "Piemonte",
+      "sourceLabel": "PIEMONTE",
+      "sourceSheet": "PIEMONTE",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1237626260301,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 101424628552,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 34482163059,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 33297154722,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 227157337021,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 586779836114,
+      "id": "liguria",
+      "label": "Liguria",
+      "sourceLabel": "LIGURIA",
+      "sourceSheet": "LIGURIA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 458532844610,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 41634666128,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 7523072642,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 14121324301,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 64967928433,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 3732831543979,
+      "id": "lombardia",
+      "label": "Lombardia",
+      "sourceLabel": "LOMBARDIA",
+      "sourceSheet": "LOMBARDIA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 2862841665603,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 262744563785,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 26291769815,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 8961757323,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 571991787453,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 1721397502020,
+      "id": "veneto",
+      "label": "Veneto",
+      "sourceLabel": "VENETO",
+      "sourceSheet": "VENETO",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1371360589878,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 107296103935,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 26403542896,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 11803927109,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 204533338202,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 1614350703954,
+      "id": "emilia-romagna",
+      "label": "Emilia-Romagna",
+      "sourceLabel": "EMILIA-ROMAGNA",
+      "sourceSheet": "EMILIA-ROMAGNA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1297548942930,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 92563103494,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 12406599894,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 5227674462,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 206604383174,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 1348194938143,
+      "id": "toscana",
+      "label": "Toscana",
+      "sourceLabel": "TOSCANA",
+      "sourceSheet": "TOSCANA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1063559626889,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 77608373234,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 2912647565,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 10650600904,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 193463689551,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 322829042667,
+      "id": "umbria",
+      "label": "Umbria",
+      "sourceLabel": "UMBRIA",
+      "sourceSheet": "UMBRIA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 258527538233,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 24026839224,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 3817772974,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 1368291925,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 35088600311,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 534993571223,
+      "id": "marche",
+      "label": "Marche",
+      "sourceLabel": "MARCHE",
+      "sourceSheet": "MARCHE",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 415142188904,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 41421257415,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 13252353189,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 2137393418,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 63040378297,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 1978917981233,
+      "id": "lazio",
+      "label": "Lazio",
+      "sourceLabel": "LAZIO",
+      "sourceSheet": "LAZIO",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1699082673759,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 125979189562,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 878693315,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 45883412439,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 107094012158,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 470327599430,
+      "id": "abruzzo",
+      "label": "Abruzzo",
+      "sourceLabel": "ABRUZZO",
+      "sourceSheet": "ABRUZZO",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 370893953123,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 50574399934,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 2617379668,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 1988720144,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 44253146561,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 135390395691,
+      "id": "molise",
+      "label": "Molise",
+      "sourceLabel": "MOLISE",
+      "sourceSheet": "MOLISE",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 99438851812,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 13743636092,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 397477696,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 2387380249,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 19423049842,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 3142029859766,
+      "id": "campania",
+      "label": "Campania",
+      "sourceLabel": "CAMPANIA",
+      "sourceSheet": "CAMPANIA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1547382383230,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 359561448089,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 1001399038185,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 70280955933,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 163406034329,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 1537700431438,
+      "id": "puglia",
+      "label": "Puglia",
+      "sourceLabel": "PUGLIA",
+      "sourceSheet": "PUGLIA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1122956433872,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 138132075091,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 27531236253,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 5721982245,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 243358703977,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 258817380704,
+      "id": "basilicata",
+      "label": "Basilicata",
+      "sourceLabel": "BASILICATA",
+      "sourceSheet": "BASILICATA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 183883374049,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 45124296569,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 3836999581,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 2044919333,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 23927791172,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 776031158500,
+      "id": "calabria",
+      "label": "Calabria",
+      "sourceLabel": "CALABRIA",
+      "sourceSheet": "CALABRIA",
+      "status": "ordinary",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 535524500500,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 127140198534,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 37686796725,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 6322949065,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 69356713676,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 170977926349,
+      "id": "valle-aosta",
+      "label": "Valle d'Aosta/Vallée d'Aoste",
+      "sourceLabel": "VALLE D'AOSTA/Vallée d'Aoste",
+      "sourceSheet": "VALLE D'AOSTA - Vallée d'Aoste",
+      "status": "special",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 126616515382,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 26553464109,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 3436488660,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 5148683495,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 9222774703,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 40533198147,
+      "id": "trentino-alto-adige",
+      "label": "Trentino-Alto Adige/Südtirol",
+      "sourceLabel": "TRENTINO-ALTO ADIGE/Südtirol",
+      "sourceSheet": "TRENTINO-ALTO ADIGE - Südtirol",
+      "status": "special",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 36795634845,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 2586596432,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 0,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 0,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 1150966870,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 847890310656,
+      "id": "friuli-venezia-giulia",
+      "label": "Friuli-Venezia Giulia",
+      "sourceLabel": "FRIULI-VENEZIA GIULIA",
+      "sourceSheet": "FRIULI-VENEZIA GIULIA",
+      "status": "special",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 616472328864,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 195227089621,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 16267987304,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 3763806727,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 16159098140,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 3015984340872,
+      "id": "sicilia",
+      "label": "Sicilia",
+      "sourceLabel": "SICILIA",
+      "sourceSheet": "SICILIA",
+      "status": "special",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 1765019384691,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 201570141672,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 13289398025,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 23674514752,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 1012430901732,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 1046510567383,
+      "id": "sardegna",
+      "label": "Sardegna",
+      "sourceLabel": "SARDEGNA",
+      "sourceSheet": "SARDEGNA",
+      "status": "special",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 879692526630,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 124031737837,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 10601041323,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 7658735714,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 24526525879,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 761701251959,
+      "id": "bolzano",
+      "label": "Provincia autonoma di Bolzano/Bozen",
+      "sourceLabel": "BOLZANO/Bozen",
+      "sourceSheet": "BOLZANO - Bozen",
+      "status": "autonomous-province",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 547093575815,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 147554376363,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 13088791817,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 2839159922,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 51125348042,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    },
+    {
+      "commitmentsCents": 598782073005,
+      "id": "trento",
+      "label": "Provincia autonoma di Trento",
+      "sourceLabel": "TRENTO",
+      "sourceSheet": "TRENTO",
+      "status": "autonomous-province",
+      "titles": [
+        {
+          "code": "1",
+          "commitmentsCents": 431465257160,
+          "label": "Titolo 1 - Spese correnti"
+        },
+        {
+          "code": "2",
+          "commitmentsCents": 134535267944,
+          "label": "Titolo 2 - Spese in conto capitale"
+        },
+        {
+          "code": "3",
+          "commitmentsCents": 209296777,
+          "label": "Titolo 3 - Spese per incremento attività finanziarie"
+        },
+        {
+          "code": "4",
+          "commitmentsCents": 838935703,
+          "label": "Titolo 4 - Rimborso di Prestiti"
+        },
+        {
+          "code": "5",
+          "commitmentsCents": 0,
+          "label": "Titolo 5 - Chiusura Anticipazioni ricevute da istituto tesoriere/cassiere"
+        },
+        {
+          "code": "7",
+          "commitmentsCents": 31733315421,
+          "label": "Titolo 7 - Uscite per conto terzi e partite di giro"
+        }
+      ]
+    }
+  ],
+  "referenceYear": 2024,
+  "schemaVersion": 1,
+  "unit": "euro_cents"
+}

--- a/src/data/generated/istat-regions-2024.meta.json
+++ b/src/data/generated/istat-regions-2024.meta.json
@@ -1,0 +1,32 @@
+{
+  "asset": {
+    "bytes": 280471,
+    "sha256": "ba98c16063bf2bb8b62cd29fbd1dae23eded549faaac2ba06707ac7206ccbb7f"
+  },
+  "dataArtifact": {
+    "bytes": 25984,
+    "path": "src/data/generated/istat-regions-2024.data.json",
+    "sha256": "03c4b4424167207938558bbc32467678e6cefe295a4d4dd81e777b8a831e7f28"
+  },
+  "schemaVersion": 1,
+  "source": {
+    "acquiredAt": "2026-08-22T00:00:00Z",
+    "format": "zip+xlsx",
+    "landingUrl": "https://www.istat.it/tavole-di-dati/i-bilanci-consuntivi-delle-regioni-e-province-autonome-anno-2024/",
+    "licenseStatus": "not-declared",
+    "owner": "Istat",
+    "publishedAt": "2026-05-05",
+    "referencePeriod": "2024",
+    "resourceUrl": "https://www.istat.it/wp-content/uploads/2026/05/Tavole.zip",
+    "sourceRecordId": "istat:125266"
+  },
+  "spendingWorkbook": {
+    "bytes": 200402,
+    "path": "Tavole/Regioni_definitivi_2024_Tavola 2 - Spese anno 2024.xlsx",
+    "sha256": "a2b6f7d0de90e7fa8c15fb6d325535cb747f3b5a19b49bcb33dc16d61bc16682"
+  },
+  "transformation": {
+    "description": "Esclusi i tre fogli aggregati; letti solo gli impegni dei sei Titoli e riconciliati con il totale ufficiale per 22 amministrazioni.",
+    "version": 1
+  }
+}

--- a/src/lib/data/institutional-source-registry.ts
+++ b/src/lib/data/institutional-source-registry.ts
@@ -14,7 +14,7 @@ export type InstitutionalSourceRegistryEntry = {
   sourceUrl: string;
   downloadUrl: string | null;
   assetId: string | null;
-  format: "html" | "pdf" | "csv" | "xlsx";
+  format: "html" | "pdf" | "csv" | "xlsx" | "zip";
   expectedSchema: { fieldCount: number; rowCount: number } | null;
   createdAt: string | null;
   updatedAt: string | null;
@@ -137,5 +137,26 @@ export const INSTITUTIONAL_SOURCE_REGISTRY = [
     readiness: "pending-download-validation",
     accountingScope: "Rendiconto dello Stato per 15 amministrazioni, distinto da previsioni e pagamenti mensili.",
     safeUse: "Valori solo dopo download, checksum, controllo delle 41 colonne e mappatura esatta delle amministrazioni.",
+  },
+  {
+    id: "istat-regional-accounts-2024",
+    domain: "region",
+    subjectId: "regional-administrations",
+    owner: "Istat",
+    title: "Bilanci consuntivi delle Regioni e Province autonome 2024",
+    sourceRecordId: "istat:125266",
+    referencePeriod: "2024",
+    sourceUrl: "https://www.istat.it/tavole-di-dati/i-bilanci-consuntivi-delle-regioni-e-province-autonome-anno-2024/",
+    downloadUrl: "https://www.istat.it/wp-content/uploads/2026/05/Tavole.zip",
+    assetId: "sha256:ba98c16063bf2bb8b62cd29fbd1dae23eded549faaac2ba06707ac7206ccbb7f",
+    format: "zip",
+    expectedSchema: { fieldCount: 4, rowCount: 22 },
+    createdAt: null,
+    updatedAt: null,
+    licenseStatus: "not-declared",
+    licenseName: null,
+    readiness: "verified-data",
+    accountingScope: "Consuntivi armonizzati di 22 amministrazioni regionali e Province autonome.",
+    safeUse: "Impegni 2024 per Titolo dentro una singola amministrazione; nessun pro capite o mappa senza mapping aggiuntivi.",
   },
 ] as const satisfies readonly InstitutionalSourceRegistryEntry[];

--- a/src/lib/data/istat-regions-contract.ts
+++ b/src/lib/data/istat-regions-contract.ts
@@ -98,8 +98,10 @@ export function validateIstatRegionsSnapshot(data: IstatRegionsData, metadata: I
     data.entities.every((entity) =>
       EXPECTED_ENTITIES.get(entity.id)?.sourceSheet === entity.sourceSheet &&
       EXPECTED_ENTITIES.get(entity.id)?.status === entity.status &&
-      entity.label.trim() && entity.sourceLabel.trim() && entity.sourceSheet.trim() && money(entity.commitmentsCents) &&
-      entity.titles.length === 6 && entity.titles.every((title) => title.code && title.label && money(title.commitmentsCents)) &&
+      entity.label.trim() && entity.sourceLabel.trim() && entity.sourceSheet.trim() &&
+      money(entity.commitmentsCents) && entity.commitmentsCents > 0 &&
+      entity.titles.length === 6 && entity.titles.map((title) => title.code).join(",") === "1,2,3,4,5,7" &&
+      entity.titles.every((title) => title.label && money(title.commitmentsCents)) &&
       entity.titles.reduce((sum, title) => sum + title.commitmentsCents, 0) === entity.commitmentsCents),
     "identità o Titoli non riconciliati",
   );

--- a/src/lib/data/istat-regions-contract.ts
+++ b/src/lib/data/istat-regions-contract.ts
@@ -1,0 +1,128 @@
+export type RegionalAdministrationStatus = "ordinary" | "special" | "autonomous-province";
+
+export type IstatRegionalAdministration = {
+  id: string;
+  label: string;
+  sourceLabel: string;
+  sourceSheet: string;
+  status: RegionalAdministrationStatus;
+  commitmentsCents: number;
+  titles: Array<{ code: string; label: string; commitmentsCents: number }>;
+};
+
+export type IstatRegionsData = {
+  schemaVersion: 1;
+  referenceYear: 2024;
+  unit: "euro_cents";
+  accountingFrame: "commitments";
+  entities: IstatRegionalAdministration[];
+  coverage: {
+    workbookSheets: 25;
+    individualAdministrations: 22;
+    ordinaryRegions: 15;
+    specialRegions: 5;
+    autonomousProvinces: 2;
+    entitiesReconciled: 22;
+  };
+  definitions: Record<string, string>;
+};
+
+export type IstatRegionsMetadata = {
+  schemaVersion: 1;
+  source: {
+    owner: "Istat";
+    landingUrl: string;
+    resourceUrl: string;
+    sourceRecordId: "istat:125266";
+    referencePeriod: "2024";
+    publishedAt: string;
+    acquiredAt: string;
+    format: "zip+xlsx";
+    licenseStatus: "not-declared";
+  };
+  asset: { bytes: 280471; sha256: string };
+  spendingWorkbook: { path: string; bytes: 200402; sha256: string };
+  transformation: { version: 1; description: string };
+  dataArtifact: { path: string; bytes: number; sha256: string };
+};
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Snapshot Regioni non valido: ${message}`);
+}
+
+function money(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+const EXPECTED_ASSET_SHA256 = "ba98c16063bf2bb8b62cd29fbd1dae23eded549faaac2ba06707ac7206ccbb7f";
+const EXPECTED_WORKBOOK_SHA256 = "a2b6f7d0de90e7fa8c15fb6d325535cb747f3b5a19b49bcb33dc16d61bc16682";
+const EXPECTED_DATA_SHA256 = "03c4b4424167207938558bbc32467678e6cefe295a4d4dd81e777b8a831e7f28";
+
+const EXPECTED_ENTITIES: ReadonlyMap<string, { sourceSheet: string; status: RegionalAdministrationStatus }> = new Map([
+  ["piemonte", { sourceSheet: "PIEMONTE", status: "ordinary" }],
+  ["liguria", { sourceSheet: "LIGURIA", status: "ordinary" }],
+  ["lombardia", { sourceSheet: "LOMBARDIA", status: "ordinary" }],
+  ["veneto", { sourceSheet: "VENETO", status: "ordinary" }],
+  ["emilia-romagna", { sourceSheet: "EMILIA-ROMAGNA", status: "ordinary" }],
+  ["toscana", { sourceSheet: "TOSCANA", status: "ordinary" }],
+  ["umbria", { sourceSheet: "UMBRIA", status: "ordinary" }],
+  ["marche", { sourceSheet: "MARCHE", status: "ordinary" }],
+  ["lazio", { sourceSheet: "LAZIO", status: "ordinary" }],
+  ["abruzzo", { sourceSheet: "ABRUZZO", status: "ordinary" }],
+  ["molise", { sourceSheet: "MOLISE", status: "ordinary" }],
+  ["campania", { sourceSheet: "CAMPANIA", status: "ordinary" }],
+  ["puglia", { sourceSheet: "PUGLIA", status: "ordinary" }],
+  ["basilicata", { sourceSheet: "BASILICATA", status: "ordinary" }],
+  ["calabria", { sourceSheet: "CALABRIA", status: "ordinary" }],
+  ["valle-aosta", { sourceSheet: "VALLE D'AOSTA - Vallée d'Aoste", status: "special" }],
+  ["trentino-alto-adige", { sourceSheet: "TRENTINO-ALTO ADIGE - Südtirol", status: "special" }],
+  ["bolzano", { sourceSheet: "BOLZANO - Bozen", status: "autonomous-province" }],
+  ["trento", { sourceSheet: "TRENTO", status: "autonomous-province" }],
+  ["friuli-venezia-giulia", { sourceSheet: "FRIULI-VENEZIA GIULIA", status: "special" }],
+  ["sicilia", { sourceSheet: "SICILIA", status: "special" }],
+  ["sardegna", { sourceSheet: "SARDEGNA", status: "special" }],
+]);
+
+export function validateIstatRegionsSnapshot(data: IstatRegionsData, metadata: IstatRegionsMetadata) {
+  invariant(data.schemaVersion === 1 && metadata.schemaVersion === 1, "versione inattesa");
+  invariant(data.referenceYear === 2024 && data.unit === "euro_cents", "periodo o unità inattesi");
+  invariant(data.accountingFrame === "commitments", "fase contabile inattesa");
+  invariant(data.entities.length === 22 && new Set(data.entities.map((entity) => entity.id)).size === 22, "copertura amministrazioni inattesa");
+  invariant(
+    data.coverage.workbookSheets === 25 && data.coverage.individualAdministrations === 22 &&
+      data.coverage.ordinaryRegions === 15 && data.coverage.specialRegions === 5 &&
+      data.coverage.autonomousProvinces === 2 && data.coverage.entitiesReconciled === 22,
+    "copertura workbook inattesa",
+  );
+  invariant(
+    data.entities.every((entity) =>
+      EXPECTED_ENTITIES.get(entity.id)?.sourceSheet === entity.sourceSheet &&
+      EXPECTED_ENTITIES.get(entity.id)?.status === entity.status &&
+      entity.label.trim() && entity.sourceLabel.trim() && entity.sourceSheet.trim() && money(entity.commitmentsCents) &&
+      entity.titles.length === 6 && entity.titles.every((title) => title.code && title.label && money(title.commitmentsCents)) &&
+      entity.titles.reduce((sum, title) => sum + title.commitmentsCents, 0) === entity.commitmentsCents),
+    "identità o Titoli non riconciliati",
+  );
+  invariant(
+    data.entities.filter((entity) => entity.status === "ordinary").length === 15 &&
+      data.entities.filter((entity) => entity.status === "special").length === 5 &&
+      data.entities.filter((entity) => entity.status === "autonomous-province").length === 2,
+    "classificazione statutaria inattesa",
+  );
+  invariant(metadata.source.owner === "Istat" && metadata.source.sourceRecordId === "istat:125266", "fonte inattesa");
+  invariant(metadata.source.landingUrl.startsWith("https://www.istat.it/"), "landing non ufficiale");
+  invariant(metadata.source.resourceUrl.startsWith("https://www.istat.it/"), "risorsa non ufficiale");
+  invariant(metadata.source.licenseStatus === "not-declared", "licenza non verificata attribuita");
+  invariant(metadata.asset.bytes === 280471 && metadata.asset.sha256 === EXPECTED_ASSET_SHA256, "archivio non valido");
+  invariant(
+    metadata.spendingWorkbook.bytes === 200402 && metadata.spendingWorkbook.sha256 === EXPECTED_WORKBOOK_SHA256,
+    "workbook non valido",
+  );
+  invariant(
+    metadata.dataArtifact.path === "src/data/generated/istat-regions-2024.data.json" &&
+      metadata.dataArtifact.bytes === 25984 && metadata.dataArtifact.sha256 === EXPECTED_DATA_SHA256,
+    "artefatto dati inatteso",
+  );
+  invariant(metadata.transformation.version === 1 && metadata.transformation.description.trim(), "trasformazione assente");
+  return { data, metadata };
+}

--- a/src/lib/istat-regions-snapshot.ts
+++ b/src/lib/istat-regions-snapshot.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import dataJson from "@/data/generated/istat-regions-2024.data.json";
+import metadataJson from "@/data/generated/istat-regions-2024.meta.json";
+import {
+  validateIstatRegionsSnapshot,
+  type IstatRegionsData,
+  type IstatRegionsMetadata,
+} from "@/lib/data/istat-regions-contract";
+
+const validated = validateIstatRegionsSnapshot(
+  dataJson as IstatRegionsData,
+  metadataJson as IstatRegionsMetadata,
+);
+
+export const istatRegionsSnapshot = validated.data;
+export const istatRegionsMetadata = validated.metadata;

--- a/tests/etl/test_istat_regions_account.py
+++ b/tests/etl/test_istat_regions_account.py
@@ -1,0 +1,23 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/etl/istat_regions_account.py"
+SPEC = importlib.util.spec_from_file_location("istat_regions_account", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class IstatRegionsAccountTests(unittest.TestCase):
+    def test_import_rejects_an_unlocked_archive(self):
+        with self.assertRaisesRegex(ValueError, "diverso dal file validato"):
+            MODULE.build_snapshot(b"not-the-official-archive", "2026-08-22T00:00:00Z")
+
+    def test_committed_snapshot_is_byte_bound(self):
+        MODULE.validate_committed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/institutional-source-registry.test.mjs
+++ b/tests/institutional-source-registry.test.mjs
@@ -25,4 +25,10 @@ test("institutional source registry keeps stable IDs, dates and publication read
   const ministries2025 = ministries.find((source) => source.referencePeriod === "2025");
   assert.equal(ministries2025?.readiness, "verified-data");
   assert.equal(ministries2025?.licenseName, "CC BY 3.0");
+  const regions = INSTITUTIONAL_SOURCE_REGISTRY.find((source) => source.domain === "region");
+  assert.equal(regions?.sourceRecordId, "istat:125266");
+  assert.equal(regions?.readiness, "verified-data");
+  assert.deepEqual(regions?.expectedSchema, { fieldCount: 4, rowCount: 22 });
+  assert.equal(regions?.createdAt, null);
+  assert.equal(regions?.updatedAt, null);
 });

--- a/tests/istat-regions-account.test.mjs
+++ b/tests/istat-regions-account.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import data from "../src/data/generated/istat-regions-2024.data.json" with { type: "json" };
+import metadata from "../src/data/generated/istat-regions-2024.meta.json" with { type: "json" };
+import { validateIstatRegionsSnapshot } from "../src/lib/data/istat-regions-contract.ts";
+
+test("Istat regional accounts preserve the 22-administration scope", () => {
+  const snapshot = validateIstatRegionsSnapshot(data, metadata);
+  assert.equal(snapshot.data.referenceYear, 2024);
+  assert.equal(snapshot.data.entities.length, 22);
+  assert.equal(snapshot.data.coverage.ordinaryRegions, 15);
+  assert.equal(snapshot.data.coverage.specialRegions, 5);
+  assert.equal(snapshot.data.coverage.autonomousProvinces, 2);
+  assert.equal(snapshot.metadata.source.licenseStatus, "not-declared");
+});
+
+test("Istat regional accounts fail closed on identity, title or source drift", () => {
+  const first = data.entities[0];
+  assert.throws(
+    () => validateIstatRegionsSnapshot({
+      ...data,
+      entities: [{ ...first, commitmentsCents: first.commitmentsCents + 1 }, ...data.entities.slice(1)],
+    }, metadata),
+    /identità o Titoli non riconciliati/,
+  );
+  assert.throws(
+    () => validateIstatRegionsSnapshot({
+      ...data,
+      entities: [{ ...first, status: "special" }, ...data.entities.slice(1)],
+    }, metadata),
+    /identità o Titoli non riconciliati/,
+  );
+  assert.throws(
+    () => validateIstatRegionsSnapshot(data, {
+      ...metadata,
+      source: { ...metadata.source, licenseStatus: "declared" },
+    }),
+    /licenza non verificata attribuita/,
+  );
+  assert.throws(
+    () => validateIstatRegionsSnapshot(data, {
+      ...metadata,
+      asset: { ...metadata.asset, sha256: "0".repeat(64) },
+    }),
+    /archivio non valido/,
+  );
+});

--- a/tests/regions-ui.test.mjs
+++ b/tests/regions-ui.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const page = fs.readFileSync(new URL("../src/app/regioni/page.tsx", import.meta.url), "utf8");
+const css = fs.readFileSync(new URL("../src/app/regioni/regioni.module.css", import.meta.url), "utf8");
+const treemap = fs.readFileSync(new URL("../src/app/regioni/region-title-treemap.tsx", import.meta.url), "utf8");
+
+test("Regions page uses only the verified Istat regional account", () => {
+  assert.match(page, /istatRegionsSnapshot/);
+  assert.match(page, /22 amministrazioni/);
+  assert.match(page, /impegni, non pagamenti/);
+  assert.match(page, /non li mescoliamo con\s*\n?\s*Comuni, sanità, CPT o residuo fiscale/);
+  assert.doesNotMatch(page, /getRegionalFiscal|SIOPE|OpenCivitas/);
+});
+
+test("Regions page exposes a URL filter, exact table and honest comparison limits", () => {
+  assert.match(page, /searchParams: Promise/);
+  assert.match(page, /name="ente"/);
+  assert.match(page, /Non è una classifica tra territori/);
+  assert.match(page, /non calcoliamo valori pro capite/);
+  assert.match(page, /in questa vista non usiamo la mappa/);
+  assert.match(page, /Valori esatti degli impegni 2024/);
+  assert.match(page, /Scorri la tabella verso destra/);
+  assert.doesNotMatch(page, /spreco|corruzione|illecito/i);
+});
+
+test("Regional treemap is additive and exact tables remain internally scrollable", () => {
+  assert.match(treemap, /commitmentsCents \/ entity\.commitmentsCents/);
+  assert.match(treemap, /aria-describedby="regioni-treemap-caption"/);
+  assert.match(treemap, /un solo consuntivo, una sola amministrazione, impegni 2024/);
+  assert.match(css, /min-width: 680px/);
+  assert.match(css, /min-width: 760px/);
+  assert.match(css, /@media \(max-width: 620px\)/);
+  assert.doesNotMatch(`${css}\n${treemap}`, /border-radius|box-shadow|linear-gradient|transition:\s*all/);
+});


### PR DESCRIPTION
Base: codex/institutional-ministries
Head: codex/institutional-regions

## Scope
- imports the official Istat 2024 regional accounts into a compact, checksum-bound snapshot
- adds the separate /regioni route with URL-addressable administration selection
- shows one homogeneous measure: 2024 commitments by Title inside one administration
- adds an additive treemap, exact tables, provenance, coverage and comparison limits

## Dependency
Stacked on PR #61. Merge or retarget only after the Ministries stack is integrated.

## Official source
Istat, Bilanci consuntivi delle Regioni e Province autonome 2024, record istat:125266. The ETL locks archive and workbook bytes and hashes, all 25 sheets, 22 individual administrations and 22 exact Title reconciliations. The source page does not declare a license for the archive, so none is attributed.

## Verification
PASS: 281/281 Node tests; 79/79 Python ETL tests; lint; typecheck; Next production build.
PASS: desktop 1440x1000 and mobile 390x844 browser smoke, keyboard-focusable tables, internal horizontal scrolling, no runtime errors or global overflow. Screenshots are local proof and are not committed.
PASS: contextual privacy scan on commit messages, changed filenames and diff.

## Risks and limits
- values are absolute commitments, not payments or per-capita measures
- 22 administrations do not map one-to-one to 20 regional geometries, so this page intentionally has no map
- no ranking, average or fiscal-balance calculation is published
- the final navigation link is deliberately excluded and will be a small stacked PR with the Consulting regression gate

## Not verified
No hosted preview smoke at the final PR head yet. No merge or deployment performed.