### PR TITLE
fix(territori): disclose wide table navigation

### DIFF
--- a/docs/UI_VERIFICATION_BATCH_3_2026-08-22.md
+++ b/docs/UI_VERIFICATION_BATCH_3_2026-08-22.md
@@ -1,0 +1,67 @@
+# Verifica UI batch 3 — Fisco territoriale
+
+Base iniziale: HEAD `7d95812`, build locale, 390×844 e 1280×1000, tema light e italiano. Dark N/A: il prodotto non offre un tema scuro. Ogni full-page è divisa matematicamente in S1–S4 contigue e copre il 100% dell’altezza. Prove iniziali: `.audit/batch-3-initial/`; conferma di Fisco e Confronto: `.audit/batch-3-confirmation/`; ricattura IRPEF sull’HEAD finale: `.audit/batch-3-final-head/`.
+
+Due revisori Luna xhigh, ciechi rispetto alla soluzione e indipendenti, hanno valutato le 24 fasce. Accordo: le tre viste desktop sono leggibili; IRPEF spiega già la tabella larga; Fisco e Confronto su mobile mostravano solo le prime colonne senza un segnale visibile. Disaccordo: un revisore ha segnalato il taglio della navigazione mobile; la misura e il comportamento già verificato mostrano invece una barra intenzionalmente scorrevole con “SCORRI →”, quindi non è stato riaperto in questa slice. Le misure oggettive di overflow, focus e scorrimento prevalgono sui giudizi soggettivi.
+
+Ogni Observation considera comprensione in 5 secondi, priorità del dato, linguaggio, gerarchia in scala di grigi, densità/keyline, colore ridondante, leggibilità, periodo/perimetro/denominatore, reflow e overflow. Focus e tastiera sono provati dal browser E2E, non dedotti dalle immagini.
+
+## `/territori/fisco`
+
+| Vista | Fascia | Observation | Impact | Rule strength | Decision | Acceptance criteria | Proof dopo fix | Stato |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Mobile | S1 | Titolo semplice, anno, fonte e tre KPI precedono il contesto; unità e natura pro capite sono esplicite. | Prima lettura comprensibile senza colore. | MUST perimetro; SHOULD gerarchia. | Nessun fix. | Fonte, periodo, unità e perimetro nel primo tratto. | `fisco-mobile-s1.png`; manifest 390 px, CLS 0. | PASS |
+| Mobile | S2 | Barre e tabella distinguono entrate, spese e saldo; inizialmente mancava un invito visibile alle colonne laterali, ora presente. | Evita di scambiare la prima colonna per il record completo. | MUST accesso dati/reflow. | Aggiungere istruzione mobile, conservando i valori esatti. | Hint visibile; regione focalizzabile; ArrowRight, Fine e Inizio funzionanti. | `fisco-mobile-s2.png`; E2E. | PASS |
+| Mobile | S3 | La tabella prosegue con righe regolari e valori raggiungibili nello scroll locale; nessun overflow pagina. | Lookup completo su schermo stretto. | MUST overflow; SHOULD densità. | Nessun ulteriore fix. | Root entro 390 px e colonne raggiungibili. | `fisco-mobile-s3.png`; manifest. | PASS |
+| Mobile | S4 | Caveat sul consolidato CPT, fonte ufficiale, download e footer chiudono la pagina. | Limita interpretazioni improprie del saldo. | MUST fonte/limiti. | Nessun fix. | Fonte, periodo e perimetro restano raggiungibili. | `fisco-mobile-s4.png`. | PASS |
+| Desktop | S1 | Titolo, metadati e KPI guidano subito alla lettura per residente; gerarchia stabile in grigio. | Comprensione in 5 secondi. | MUST/SHOULD. | Nessun fix. | Nessuna dipendenza dal colore o collisione. | `fisco-desktop-s1.png`. | PASS |
+| Desktop | S2 | Grafico e tabella offrono confronto visivo e valori esatti con intestazioni allineate. | Scansione e verifica rapide. | MUST equivalente testuale. | Nessun fix. | Barre ridondanti con testo; tabella completa. | `fisco-desktop-s2.png`; E2E focus. | PASS |
+| Desktop | S3 | Le righe territoriali mantengono ritmo e numeri tabulari; l’istruzione mobile resta nascosta. | Densità adatta al lookup. | SHOULD densità. | Nessun fix. | Nessun overflow desktop inatteso. | `fisco-desktop-s3.png`; E2E. | PASS |
+| Desktop | S4 | Limiti, fonte e footer sono separati dal dettaglio tramite keyline e spazio. | Provenienza verificabile. | MUST fonte. | Nessun fix. | Link ufficiali e caveat visibili. | `fisco-desktop-s4.png`. | PASS |
+
+Stati: snapshot filled PASS. Loading/empty/error non esposti dalla pagina statica: N/A.
+
+## `/territori/irpef`
+
+| Vista | Fascia | Observation | Impact | Rule strength | Decision | Acceptance criteria | Proof | Stato |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Mobile | S1 | Titolo, anno d’imposta, dichiarazioni, pubblicazione, snapshot e caveat precedono sei totali. | Periodi e natura del dato sono immediati. | MUST freschezza/perimetro. | Nessun fix. | Metadati e limite “non gettito” nella prima fascia. | `irpef-mobile-s1.png`; manifest 390 px, CLS 0. | PASS |
+| Mobile | S2 | Controlli territoriali raggruppati; la tabella dichiara scroll e comandi da tastiera prima delle righe. | Interazione prevedibile e dato esatto preservato. | MUST affordance/focus. | Nessun fix. | Istruzioni visibili e regione focalizzabile. | `irpef-mobile-s2.png`; E2E. | PASS |
+| Mobile | S3 | Le venti Regioni restano in ordine, con valori laterali nello scroller locale e senza overflow globale. | Lookup completo, pur con densità elevata. | MUST integrità; SHOULD densità. | Nessun fix. | Root entro 390 px; Fine/Inizio raggiungono gli estremi. | `irpef-mobile-s3.png`; E2E. | PASS |
+| Mobile | S4 | Definizioni, soppressioni, fonte MEF, copertura e impronta dello snapshot chiudono la prova. | Denominatori e limiti non restano impliciti. | MUST fonte/denominatore. | Nessun fix. | Fonte, periodo, copertura e trasformazioni visibili. | `irpef-mobile-s4.png`. | PASS |
+| Desktop | S1 | Titolo, metadati, caveat e sei totali formano una gerarchia netta anche in scala di grigi. | Lettura primaria forte. | MUST/SHOULD. | Nessun fix. | Nessuna collisione; unità adiacenti ai valori. | `irpef-desktop-s1.png`. | PASS |
+| Desktop | S2 | Filtri e inizio tabella separano scelta e risultato; intestazioni e numeri sono allineati. | Confronto rapido e controllabile. | SHOULD affordance. | Nessun fix. | Controlli etichettati e tabella focalizzabile. | `irpef-desktop-s2.png`; E2E. | PASS |
+| Desktop | S3 | La tabella lunga mantiene schema e keyline costanti; lo scroll è confinato alla regione. | Nessuna perdita informativa. | MUST overflow. | Nessun fix. | Pagina senza overflow orizzontale globale. | `irpef-desktop-s3.png`; manifest. | PASS |
+| Desktop | S4 | Ultime righe, glossario e fonti seguono il dettaglio senza sovrapposizioni. | Auditabilità completa. | MUST fonte/metodo. | Nessun fix. | Link ufficiali, copertura e limite dell’impronta presenti. | `irpef-desktop-s4.png`. | PASS |
+
+Stati: Regioni filled PASS. Lo stato preparatorio dei Comuni e i controlli filtro/ricerca sono coperti dal browser E2E. Error state: NOT VERIFIED. Dark N/A.
+
+## `/territori/confronto`
+
+| Vista | Fascia | Observation | Impact | Rule strength | Decision | Acceptance criteria | Proof dopo fix | Stato |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Mobile | S1 | Titolo, periodo, fonte e spiegazione distinguono spesa storica e fabbisogno standard prima dei filtri. | Riduce la lettura del confronto come giudizio di qualità. | MUST evidence boundary. | Nessun fix. | Definizione e periodo prima dei risultati. | `confronto-mobile-s1.png`; manifest 390 px. | PASS |
+| Mobile | S2 | Risultati, ordinamento e tabella erano corretti ma senza cue visibile; ora un testo elenca colonne e tasti. | Le metriche laterali non sembrano assenti. | MUST accesso dati/reflow. | Istruzione mobile e componente scroll condiviso. | Hint visibile, regione focalizzabile e scroll da tastiera. | `confronto-mobile-s2.png`; E2E. | PASS |
+| Mobile | S3 | Le righe comunali restano entro lo scroller locale con nomi leggibili e valori esatti raggiungibili. | Lookup preservato senza comprimere le colonne. | MUST overflow. | Nessun ulteriore fix. | Nessun overflow globale; estremi raggiungibili. | `confronto-mobile-s3.png`; E2E. | PASS |
+| Mobile | S4 | Metodo, limiti OpenCivitas, fonte e footer completano il confronto. | Spiega perimetro e assenza di causalità. | MUST fonte/limiti. | Nessun fix. | Metodo e fonti raggiungibili. | `confronto-mobile-s4.png`. | PASS |
+| Desktop | S1 | Titolo, spiegazione e filtri precedono il riepilogo, con gruppi distinti e whitespace coerente. | Il compito è chiaro in 5 secondi. | SHOULD gerarchia. | Nessun fix. | Controlli e risultato non si confondono. | `confronto-desktop-s1.png`. | PASS |
+| Desktop | S2 | Tabella ampia espone spesa, fabbisogno, differenze e servizi con unità nelle intestazioni. | Confronto preciso senza dipendere dal colore. | MUST integrità. | Nessun fix. | Colonne allineate e numeri tabulari. | `confronto-desktop-s2.png`; E2E focus. | PASS |
+| Desktop | S3 | La lista mantiene densità uniforme e separatori leggeri; nessun contenuto è tagliato. | Scansione stabile. | SHOULD densità. | Nessun fix. | Nessun overflow desktop inatteso. | `confronto-desktop-s3.png`; E2E. | PASS |
+| Desktop | S4 | Paginazione, metodo, fonte e footer sono distinti dal corpo dati. | Chiusura verificabile. | MUST fonte/affordance. | Nessun fix. | Link e controlli raggiungibili da tastiera. | `confronto-desktop-s4.png`. | PASS |
+
+Stati: risultati filled PASS. Empty/error e combinazioni estreme dei filtri: NOT VERIFIED visualmente. Dark N/A.
+
+## Before | After | Why
+
+| Before | After | Why |
+| --- | --- | --- |
+| Fisco mobile mostrava le prime colonne senza cue visibile | Istruzione breve sopra la regione scrollabile, con tasti supportati | Rende evidente che spese, saldo e totali sono laterali |
+| Confronto mobile nascondeva metriche laterali dietro uno scroll non dichiarato | Cue responsive e componente condiviso con label e descrizione accessibili | Conserva la tabella esatta e riduce l’ambiguità |
+| Prova browser assumeva overflow anche quando la tabella entrava nel desktop | Il test distingue viewport con overflow da viewport senza overflow e verifica comunque il focus | L’assenza di scroll desktop non è un difetto; l’overflow mobile resta obbligatoriamente testato |
+
+## Prove eseguite
+
+- PASS: 60 immagini iniziali/finali tra full-page e S1–S4, viewport esatti, CLS 0 e nessun errore runtime.
+- PASS: browser E2E canonico contro build di produzione, incluse tabelle Fisco, IRPEF e Confronto, focus, Frecce, Inizio/Fine e form Consulenza.
+- PASS: 269/269 test Node, lint, typecheck e build Next.js 16.3.1 (37 pagine) prima della sola aggiunta documentale.
+- NOT VERIFIED: tema dark non supportato, audit assistivo completo e stati non raggiungibili elencati sopra.

--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -9,6 +9,8 @@ const SERVER_TIMEOUT_MS = 60_000;
 const NAVIGATION_TIMEOUT_MS = 45_000;
 const BROWSER_LAUNCH_TIMEOUT_MS = 60_000;
 const TABLE_REGION = '[role="region"][aria-label="Redditi e variabili IRPEF per territorio"]';
+const FISCAL_TABLE_REGION = '[role="region"][aria-label="Dettaglio entrate e spese per territorio"]';
+const COMPARISON_TABLE_REGION = '[role="region"][aria-label="Confronto tra spesa storica e fabbisogno standard dei Comuni"]';
 const ACTIVE_LEVEL = 'nav[aria-label="Livello territoriale"] a[aria-current="page"]';
 const INFO_TOOLTIP_IDS = ["cash-payments-tip"];
 
@@ -529,9 +531,9 @@ async function assertSpendingComposition(page, label, width) {
   assert.equal(rows, 6, `${label}: tabella equivalente incompleta`);
 }
 
-async function assertTableKeyboardScroll(page, label) {
-  await page.waitForSelector(TABLE_REGION, { visible: true });
-  const tableState = await page.$eval(TABLE_REGION, (region) => ({
+async function assertTableKeyboardScroll(page, label, selector = TABLE_REGION, expectOverflow = true) {
+  await page.waitForSelector(selector, { visible: true });
+  const tableState = await page.$eval(selector, (region) => ({
     clientWidth: region.clientWidth,
     hasTable: Boolean(region.querySelector("table")),
     scrollWidth: region.scrollWidth,
@@ -539,18 +541,25 @@ async function assertTableKeyboardScroll(page, label) {
   }));
   assert.equal(tableState.hasTable, true, `${label}: tabella assente`);
   assert.equal(tableState.tabIndex, 0, `${label}: regione tabella non raggiungibile da tastiera`);
-  assert.ok(
-    tableState.scrollWidth > tableState.clientWidth,
-    `${label}: la tabella non espone lo scroll orizzontale atteso`,
-  );
+  if (!expectOverflow) {
+    assert.ok(
+      tableState.scrollWidth <= tableState.clientWidth + 1,
+      `${label}: overflow desktop inatteso`,
+    );
+    await page.focus(selector);
+    assert.equal(await page.$eval(selector, (region) => document.activeElement === region), true);
+    return;
+  }
 
-  await page.$eval(TABLE_REGION, (region) => region.scrollTo({ left: 0, behavior: "auto" }));
-  await page.focus(TABLE_REGION);
+  assert.ok(tableState.scrollWidth > tableState.clientWidth, `${label}: scroll orizzontale assente`);
+
+  await page.$eval(selector, (region) => region.scrollTo({ left: 0, behavior: "auto" }));
+  await page.focus(selector);
   await page.keyboard.press("ArrowRight");
   await page.waitForFunction(
     (selector) => document.querySelector(selector)?.scrollLeft > 0,
     { timeout: 2_000 },
-    TABLE_REGION,
+    selector,
   );
 
   await page.keyboard.press("End");
@@ -560,15 +569,24 @@ async function assertTableKeyboardScroll(page, label) {
       return region && region.scrollLeft >= region.scrollWidth - region.clientWidth - 1;
     },
     { timeout: 2_000 },
-    TABLE_REGION,
+    selector,
   );
 
   await page.keyboard.press("Home");
   await page.waitForFunction(
     (selector) => document.querySelector(selector)?.scrollLeft === 0,
     { timeout: 2_000 },
-    TABLE_REGION,
+    selector,
   );
+}
+
+async function assertResponsiveScrollHint(page, label, selector, visible) {
+  const state = await page.$eval(selector, (hint) => ({
+    display: getComputedStyle(hint).display,
+    text: hint.textContent ?? "",
+  }));
+  assert.equal(state.display !== "none", visible, `${label}: visibilità dell'istruzione di scorrimento inattesa`);
+  assert.match(state.text, /Scorri lateralmente/i, `${label}: istruzione di scorrimento assente`);
 }
 
 async function assertHealthSpendingTables(page, label) {
@@ -713,6 +731,25 @@ try {
       },
     });
     completed.push(label);
+  }
+
+  for (const [pathname, routeLabel, tableSelector, hintSelector] of [
+    ["/territori/fisco", "Fisco", FISCAL_TABLE_REGION, "#fiscal-scroll-hint"],
+    ["/territori/confronto", "Confronto", COMPARISON_TABLE_REGION, "#comparison-scroll-hint"],
+  ]) {
+    for (const width of [390, 1280]) {
+      const label = `${routeLabel} tabella ${width}px`;
+      await runScenario(browser, {
+        label,
+        pathname,
+        width,
+        validate: async (page) => {
+          await assertTableKeyboardScroll(page, label, tableSelector, width <= 760);
+          await assertResponsiveScrollHint(page, label, hintSelector, width <= 760);
+        },
+      });
+      completed.push(label);
+    }
   }
 
   await runScenario(browser, {

--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -1281,7 +1281,7 @@ try {
     completed.push(label);
   }
 
-  for (const [pathname, routeLabel] of [["/stato", "Stato"], ["/stato/amministrazioni/2", "Amministrazione"]]) {
+  for (const [pathname, routeLabel] of [["/stato?anno=2025", "Stato"], ["/stato/amministrazioni/02?anno=2025", "Amministrazione"]]) {
     for (const width of [390, 1280]) {
       const label = `${routeLabel} canali ${width}px`;
       await runScenario(browser, {

--- a/src/app/stato/amministrazioni/[codice]/page.tsx
+++ b/src/app/stato/amministrazioni/[codice]/page.tsx
@@ -204,7 +204,7 @@ function AdministrationDashboard({ data }: { data: StateAdministrationSpending }
             <p>Le prime voci ordinate per totale pagato nel periodo selezionato.</p>
           </div>
           <p className={localStyles.tableHint}>Scorri lateralmente per codice e importo pagato.</p>
-          <div className={`table-scroll ${localStyles.detailTable}`} role="region" aria-label="Dettaglio economico" tabIndex={0}>
+          <div className={`table-scroll ${localStyles.detailTable}`} role="region" aria-label="Dettaglio economico per codice e importo pagato" tabIndex={0}>
             <table className="table">
               <thead>
                 <tr>

--- a/src/app/territori/confronto/confronto.module.css
+++ b/src/app/territori/confronto/confronto.module.css
@@ -64,6 +64,13 @@
   outline-offset: 3px;
 }
 
+.scrollHint {
+  display: none;
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 11px;
+}
+
 .table {
   min-width: 1140px;
 }
@@ -195,6 +202,7 @@
 }
 
 @media (max-width: 620px) {
+  .scrollHint { display: block; }
   .filters {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/src/app/territori/confronto/page.tsx
+++ b/src/app/territori/confronto/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Form from "next/form";
 import Link from "next/link";
+import { HorizontalScrollRegion } from "@/components/horizontal-scroll-region";
 import { exactEuro, integer, longDate } from "@/lib/format";
 import { municipalityName } from "@/lib/municipality-name";
 import { openCivitasSnapshot } from "@/lib/opencivitas-snapshot";
@@ -250,14 +251,17 @@ export default async function MunicipalComparisonPage({
         </div>
 
         {municipalities.length > 0 ? (
-          <div
-            aria-describedby="comparison-method results-summary"
-            aria-label="Tabella dei Comuni. Scorri orizzontalmente per vedere tutte le colonne."
-            className={`table-scroll ${styles.tableRegion}`}
-            role="region"
-            tabIndex={0}
-          >
-            <table className={`table ${styles.table}`}>
+          <>
+            <p className={styles.scrollHint} id="comparison-scroll-hint">
+              Scorri lateralmente per fabbisogno, differenze e servizi. Da tastiera usa Freccia
+              sinistra, Freccia destra, Inizio e Fine.
+            </p>
+            <HorizontalScrollRegion
+              ariaDescribedBy="comparison-method results-summary comparison-scroll-hint"
+              ariaLabel="Confronto tra spesa storica e fabbisogno standard dei Comuni"
+              className={`table-scroll ${styles.tableRegion}`}
+            >
+              <table className={`table ${styles.table}`}>
               <caption>
                 Spesa storica, fabbisogno standard e servizi dei Comuni nel
                 2022
@@ -311,8 +315,9 @@ export default async function MunicipalComparisonPage({
                   </tr>
                 ))}
               </tbody>
-            </table>
-          </div>
+              </table>
+            </HorizontalScrollRegion>
+          </>
         ) : (
           <div className={styles.emptyState}>
             <p>Prova a cambiare il nome del Comune o a scegliere un’altra Regione.</p>

--- a/src/app/territori/fisco/fisco.module.css
+++ b/src/app/territori/fisco/fisco.module.css
@@ -96,6 +96,17 @@
   font-size: 12px;
 }
 
+.scrollHint {
+  display: none;
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 11px;
+}
+
+.tableRegion:focus-visible {
+  outline-offset: 3px;
+}
+
 .methodology {
   max-width: 920px;
 }
@@ -126,6 +137,7 @@
 }
 
 @media (max-width: 760px) {
+  .scrollHint { display: block; }
   .sectionHeading { display: grid; }
   .balanceChart li { grid-template-columns: minmax(130px, 1fr) 96px; gap: 5px var(--space-3); }
   .regionName { grid-column: 1; }

--- a/src/app/territori/fisco/page.tsx
+++ b/src/app/territori/fisco/page.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { HorizontalScrollRegion } from "@/components/horizontal-scroll-region";
 import { queryCptRegionalFiscal } from "@/lib/cpt-regional-fiscal-snapshot";
 import { longDate } from "@/lib/format";
 import styles from "./fisco.module.css";
@@ -110,11 +111,14 @@ export default function RegionalFiscalPage() {
 
       <section className="panel" aria-labelledby="fiscal-table-title">
         <h2 className="panel-title" id="fiscal-table-title">Entrate, spese e saldo</h2>
-        <div
-          className="table-scroll"
-          role="region"
-          aria-label="Dettaglio entrate e spese per territorio; scorri orizzontalmente per vedere tutte le colonne"
-          tabIndex={0}
+        <p className={styles.scrollHint} id="fiscal-scroll-hint">
+          Scorri lateralmente per spese, saldo e totali. Da tastiera usa Freccia sinistra,
+          Freccia destra, Inizio e Fine.
+        </p>
+        <HorizontalScrollRegion
+          ariaDescribedBy="fiscal-table-title fiscal-scroll-hint"
+          ariaLabel="Dettaglio entrate e spese per territorio"
+          className={`table-scroll ${styles.tableRegion}`}
         >
           <table className="table">
             <caption className={styles.visuallyHidden}>Valori CPT PA consolidati {data.year}, ordinati per saldo pro capite</caption>
@@ -143,7 +147,7 @@ export default function RegionalFiscalPage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </HorizontalScrollRegion>
       </section>
 
       <div className="notice">

--- a/src/components/spending-composition.module.css
+++ b/src/components/spending-composition.module.css
@@ -61,7 +61,7 @@
 .tooltip span { display: block; margin-top: 2px; font-variant-numeric: tabular-nums; }
 .tooltip p { margin: 6px 0 0; color: var(--color-on-strong-muted); font-size: 12px; }
 .meta { margin: 0; color: var(--color-neutral-700); font-size: 11px; }
-.partial { margin: 0; padding: var(--space-3); border-left: 3px solid var(--color-warning); background: var(--color-warning-bg); font-size: 12px; }
+.partial { margin: 0; padding: var(--space-3); border: 1px solid var(--color-warning-border); background: var(--color-warning-bg); font-size: 12px; }
 .tableDetails summary { min-height: 44px; padding-block: 12px; font-weight: 600; cursor: pointer; }
 
 @media (max-width: 620px) {

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -288,3 +288,22 @@ test("state detail and health tables disclose mobile horizontal scrolling", asyn
   assert.match(stateCss, /\.title \{[\s\S]*?overflow-wrap: anywhere/);
   assert.match(stateCss, /\.sourceSummary \{ max-width: 100%; min-width: 0; \}/);
 });
+
+test("fiscal comparison tables share the keyboard scroll pattern", async () => {
+  const [fiscal, fiscalCss, comparison, comparisonCss] = await Promise.all([
+    source("../src/app/territori/fisco/page.tsx"),
+    source("../src/app/territori/fisco/fisco.module.css"),
+    source("../src/app/territori/confronto/page.tsx"),
+    source("../src/app/territori/confronto/confronto.module.css"),
+  ]);
+
+  for (const page of [fiscal, comparison]) {
+    assert.match(page, /HorizontalScrollRegion/);
+    assert.match(page, /Scorri lateralmente/);
+    assert.match(page, /Freccia\s+sinistra/);
+  }
+  assert.match(fiscal, /id="fiscal-scroll-hint"/);
+  assert.match(comparison, /id="comparison-scroll-hint"/);
+  assert.match(fiscalCss, /@media \(max-width: 760px\)[\s\S]*?\.scrollHint \{ display: block; \}/);
+  assert.match(comparisonCss, /@media \(max-width: 620px\)[\s\S]*?\.scrollHint \{ display: block; \}/);
+});

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -273,15 +273,19 @@ test("state payment bars scale against the true maximum", async () => {
 });
 
 test("state detail and health tables disclose mobile horizontal scrolling", async () => {
-  const [administration, administrationCss, health, healthCss, stateCss] = await Promise.all([
+  const [administration, administrationCss, health, healthCss, stateCss, browserE2e] = await Promise.all([
     source("../src/app/stato/amministrazioni/[codice]/page.tsx"),
     source("../src/app/stato/amministrazioni/[codice]/amministrazione.module.css"),
     source("../src/app/spese/sanita/page.tsx"),
     source("../src/app/spese/sanita/sanita.module.css"),
     source("../src/app/stato/stato.module.css"),
+    source("../scripts/browser_e2e.mjs"),
   ]);
 
   assert.match(administration, /Scorri lateralmente per codice e importo pagato/);
+  assert.match(administration, /aria-label="Dettaglio economico per codice e importo pagato"/);
+  assert.match(browserE2e, /\/stato\?anno=2025/);
+  assert.match(browserE2e, /\/stato\/amministrazioni\/02\?anno=2025/);
   assert.equal((health.match(/Scorri lateralmente/g) ?? []).length, 3);
   assert.match(administrationCss, /@media \(max-width: 720px\)[\s\S]*?\.tableHint \{[\s\S]*?display: block/);
   assert.match(healthCss, /@media \(max-width: 620px\)[\s\S]*?\.tableHint \{[\s\S]*?display: block/);


### PR DESCRIPTION
## Base / head

- Base: `codex/ui-audit-spending-pages` at `be458cc` (PR #64)
- Head: `codex/ui-audit-fiscal-pages` at `e70d03f`
- Dependency: stacked on PR #64; do not merge independently before its base

## Scope

- Makes horizontal data in `/territori/fisco` and `/territori/confronto` discoverable on mobile.
- Reuses the shared keyboard-aware scroll region without changing data contracts.
- Adds exact browser coverage for mobile overflow, desktop containment, focus, Arrow keys, Home and End.
- Audits `/territori/fisco`, `/territori/irpef` and `/territori/confronto` over full-page desktop/mobile captures split into S1–S4.
- Uses explicit 2025 consuntivo fixtures for the existing State payment-channel regression and an informative administration-detail region label.

## Sources and semantics

- No dataset or source changes.
- Existing CPT, MEF, OpenCivitas and RGS/OpenBDAP periods, perimeters and caveats remain unchanged.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| Mobile tables exposed only their first columns | A short responsive instruction names the hidden measures and keyboard controls | Users can discover the complete record without removing exact values |
| Browser assertion assumed every desktop table overflowed | It distinguishes contained desktop tables from overflowing mobile tables | Tests the required behavior instead of a layout assumption |
| State browser gate used the latest partial release | Explicit `/stato?anno=2025` and administration `02` consuntivo fixtures | Validates the complete seven-channel dataset deterministically |

## Verification

- PASS: 269/269 Node tests.
- PASS: lint, typecheck, full Impeccable detector and production build (Next.js 16.3.1, 37 pages).
- PASS: 60 current-build full-page/section captures, exact 390/1280 widths, CLS 0, no runtime errors.
- PASS: two independent blind reviews; agreement and disagreement recorded in `docs/UI_VERIFICATION_BATCH_3_2026-08-22.md`.
- PASS locally on a fresh head build at 390×844: `/stato?anno=2025` returns HTTP 200, preserves the query, has runtime errors `[]` and renders seven payment channels; the largest is 100%.
- PASS on PR #64: canonical full browser E2E, including State/administration 390/1280 and the protected Consulenza flow.
- PASS: Vercel preview and mergeability.
- BLOCKED in GitHub `quality`: run `32594603821` and its single authorized rerun both stop at `Stato canali 390px: canali di pagamento assenti`, although the exact head/fixture passes locally. No further retries or speculative code changes were made.

## Risks / not verified

- The repeated CI-only State failure remains unresolved and must be diagnosed from the CI merge-candidate/runtime before merge.
- Dark theme: N/A because the product does not support one.
- Full assistive-technology audit: NOT VERIFIED.
- Fisco loading/empty/error: N/A for the static snapshot.
- IRPEF error state and Confronto empty/error/extreme filter combinations: NOT VERIFIED visually.
- No merge or deployment performed.
