### PR TITLE
feat: index institutional spending pages

### DIFF
--- a/scripts/verify-institutional-ui.mjs
+++ b/scripts/verify-institutional-ui.mjs
@@ -54,7 +54,29 @@ async function inspect(page, route, viewport) {
   assert.ok(shell.bodyWidth <= shell.clientWidth + 1, `${route}: overflow orizzontale globale`);
   assert.deepEqual(errors, [], `${route}: errori runtime o HTTP`);
 
-  if (route === "/palazzo-chigi") {
+  if (route === "/istituzioni") {
+    const evidence = await page.evaluate(() => ({
+      activeHub: document.querySelector('a[href="/istituzioni"][aria-current="page"]')?.textContent?.trim(),
+      links: [...document.querySelectorAll("[data-institution-link]")].map((link) => link.getAttribute("href")),
+    }));
+    assert.equal(evidence.activeHub, "Istituzioni", `${route}: voce menu non attiva`);
+    assert.deepEqual(evidence.links, ["/parlamento", "/palazzo-chigi", "/ministeri", "/regioni"]);
+  } else if (route === "/consulenza") {
+    const evidence = await page.evaluate(() => {
+      const form = document.querySelector("form[aria-busy]");
+      const required = form?.querySelectorAll("[required]").length ?? 0;
+      return {
+        form: Boolean(form),
+        invalidBeforeInput: form instanceof HTMLFormElement ? !form.checkValidity() : false,
+        required,
+        submit: form?.querySelector('button[type="submit"]')?.textContent?.trim(),
+      };
+    });
+    assert.equal(evidence.form, true, `${route}: form assente`);
+    assert.equal(evidence.invalidBeforeInput, true, `${route}: validazione required non attiva`);
+    assert.ok(evidence.required >= 8, `${route}: campi obbligatori mancanti`);
+    assert.equal(evidence.submit, "Invia la richiesta", `${route}: submit non disponibile`);
+  } else if (route === "/palazzo-chigi") {
     assert.equal(shell.stats, 3, `${route}: la prima vista deve avere tre fatti`);
     await page.waitForSelector('figure [role="img"] svg');
     const evidence = await page.evaluate(() => {
@@ -186,6 +208,8 @@ const browser = await puppeteer.launch({
 
 try {
   const scenarios = [
+    ["/istituzioni", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
+    ["/istituzioni", { width: 390, height: 844, deviceScaleFactor: 1 }],
     ["/palazzo-chigi", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
     ["/palazzo-chigi", { width: 390, height: 844, deviceScaleFactor: 1 }],
     ["/parlamento", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
@@ -194,6 +218,8 @@ try {
     ["/ministeri", { width: 390, height: 844, deviceScaleFactor: 1 }],
     ["/regioni", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
     ["/regioni", { width: 390, height: 844, deviceScaleFactor: 1 }],
+    ["/consulenza", { width: 1440, height: 1000, deviceScaleFactor: 1 }],
+    ["/consulenza", { width: 390, height: 844, deviceScaleFactor: 1 }],
   ];
   for (const [route, viewport] of scenarios) {
     const page = await browser.newPage();

--- a/src/app/istituzioni/istituzioni.module.css
+++ b/src/app/istituzioni/istituzioni.module.css
@@ -1,0 +1,68 @@
+.sectionHeader {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-6);
+  margin-block-end: var(--space-6);
+}
+
+.sectionHeader h2,
+.sectionHeader p {
+  margin: 0;
+}
+
+.sectionHeader p {
+  max-width: 58ch;
+  color: var(--color-neutral-700);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-5);
+  margin-block-end: var(--space-8);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: var(--space-6);
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-raised);
+}
+
+.card > span {
+  color: var(--color-neutral-700);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.card h3 {
+  margin: var(--space-3) 0 0;
+  font-size: 1.55rem;
+}
+
+.card p {
+  max-width: 62ch;
+  margin: var(--space-3) 0 var(--space-6);
+  color: var(--color-neutral-700);
+}
+
+.card a {
+  width: fit-content;
+  min-height: 44px;
+  margin-block-start: auto;
+  padding-block: var(--space-3);
+  font-weight: 800;
+}
+
+@media (max-width: 760px) {
+  .sectionHeader,
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/istituzioni/page.tsx
+++ b/src/app/istituzioni/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import styles from "./istituzioni.module.css";
+
+export const metadata: Metadata = {
+  title: "Spese delle istituzioni",
+  description:
+    "Quattro percorsi separati per Parlamento, Palazzo Chigi, Ministeri e Regioni, con periodo, perimetro e fonte visibili.",
+};
+
+const dossiers = [
+  {
+    href: "/parlamento",
+    title: "Parlamento",
+    period: "Camera: dati 2025 · documenti 2024 per Camera e Senato",
+    description:
+      "Camera e Senato restano distinti. I numeri sono pubblicati solo dove il dato ufficiale è verificato; per gli altri documenti mostriamo la copertura mancante.",
+  },
+  {
+    href: "/palazzo-chigi",
+    title: "Palazzo Chigi",
+    period: "Rendiconto PCM 2024",
+    description:
+      "Impegni e pagamenti della sola Presidenza del Consiglio, con fasi contabili separate e fonte ufficiale scaricabile.",
+  },
+  {
+    href: "/ministeri",
+    title: "Ministeri",
+    period: "Rendiconto dello Stato 2025",
+    description:
+      "Totale CP, Pagato CP e Rimasto CP per 15 Ministeri. Palazzo Chigi e Parlamento non sono inclusi.",
+  },
+  {
+    href: "/regioni",
+    title: "Regioni",
+    period: "Consuntivi Istat 2024",
+    description:
+      "Impegni per Titolo di 22 amministrazioni regionali e Province autonome, senza classifiche o confronti pro capite improvvisati.",
+  },
+] as const;
+
+export default function InstitutionsPage() {
+  return (
+    <main className="shell page">
+      <div className="page-intro">
+        <h1>Spese delle istituzioni</h1>
+        <p>
+          Parlamento, Palazzo Chigi, Ministeri e Regioni hanno conti e regole diverse.
+          Scegli il percorso che ti interessa: non li sommiamo in un totale unico.
+        </p>
+      </div>
+
+      <section aria-labelledby="percorsi-istituzionali">
+        <div className={styles.sectionHeader}>
+          <h2 id="percorsi-istituzionali">Quattro conti, quattro perimetri</h2>
+          <p>In ogni pagina trovi importi esatti o limiti di copertura, periodo e fonte ufficiale.</p>
+        </div>
+        <div className={styles.grid}>
+          {dossiers.map((dossier) => (
+            <article className={styles.card} key={dossier.href}>
+              <span>{dossier.period}</span>
+              <h3>{dossier.title}</h3>
+              <p>{dossier.description}</p>
+              <Link href={dossier.href} data-institution-link>
+                Apri {dossier.title} <span aria-hidden="true">→</span>
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <div className="notice">
+        <strong>Perché non c&apos;è un totale delle istituzioni</strong>
+        <p>
+          Periodi, perimetri e fasi contabili non coincidono. Sommarli produrrebbe un numero
+          fuorviante. I confronti restano dentro ogni fonte e solo tra grandezze compatibili.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -11,9 +11,14 @@ import { REPO_URL } from "@/lib/site";
 
 const primary = [
   { href: "/", label: "Home" },
-  { href: "/spese", label: "Soldi", aliases: ["/stato", "/parlamento"] },
+  { href: "/spese", label: "Soldi", aliases: ["/stato"] },
   { href: "/territori", label: "Territori" },
   { href: "/coesione", label: "Fondi e progetti" },
+  {
+    href: "/istituzioni",
+    label: "Istituzioni",
+    aliases: ["/parlamento", "/palazzo-chigi", "/ministeri", "/regioni"],
+  },
   { href: "/enti", label: "Enti e società", aliases: ["/partecipazioni"] },
   { href: "/controlli", label: "Cosa controllare" },
   { href: "/assistente", label: "Assistente" },

--- a/tests/institutions-hub.test.mjs
+++ b/tests/institutions-hub.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const page = fs.readFileSync(new URL("../src/app/istituzioni/page.tsx", import.meta.url), "utf8");
+const css = fs.readFileSync(new URL("../src/app/istituzioni/istituzioni.module.css", import.meta.url), "utf8");
+const navigation = fs.readFileSync(new URL("../src/components/navigation.tsx", import.meta.url), "utf8");
+
+test("Institutions hub indexes four separate routes without a combined total", () => {
+  for (const route of ["/parlamento", "/palazzo-chigi", "/ministeri", "/regioni"]) {
+    assert.match(page, new RegExp(`href: "${route}"`));
+    assert.match(navigation, new RegExp(`"${route}"`));
+  }
+  assert.match(navigation, /href: "\/istituzioni",\s*\n\s*label: "Istituzioni"/);
+  assert.match(page, /non li sommiamo in un totale unico/);
+  assert.match(page, /Sommarli produrrebbe un numero\s*\n?\s*fuorviante/);
+  assert.doesNotMatch(page, /compactEuro|exactEuro|treemap/i);
+});
+
+test("Institutions hub keeps cards readable on narrow screens", () => {
+  assert.match(css, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+  assert.match(css, /@media \(max-width: 760px\)/);
+  assert.match(css, /min-height: 44px/);
+  assert.doesNotMatch(css, /border-radius|box-shadow|linear-gradient|transition:\s*all/);
+});


### PR DESCRIPTION
Base: codex/institutional-regions
Head: codex/institutional-navigation

## Scope
- adds one Istituzioni item to the primary menu
- adds /istituzioni as an orientation hub for four separate routes
- keeps Parliament, Palazzo Chigi, Ministries and Regions as distinct accounting surfaces
- publishes no combined institutional total

## Dependency
Stacked on PR #63.

## Verification
PASS: 284/284 Node tests, including the Consulting API/default inbox regression; 81/81 Python tests; lint; typecheck; production build.
PASS: 12 browser scenarios at 1440x1000 and 390x844, including /istituzioni and /consulenza; no runtime errors or global overflow. The Consulting smoke checks the required form and native validity without submitting data.
PASS: contextual privacy scan on commit messages, changed filenames and diff.

## UI evidence
Two independent blind reviews agree that the hub clearly separates the four scopes and that Consulting remains understandable. Both identified mobile navigation/table affordance issues; those are isolated in the next stacked hardening PR.

## Risks and limits
The horizontal primary menu remains scrollable on mobile. This PR does not change global tokens, the Consulting form or any institutional numbers.

## Not verified
No hosted preview smoke at the final head yet. No merge or deployment performed.