### PR TITLE
fix: clarify mobile institutional evidence

### DIFF
--- a/scripts/verify-institutional-ui.mjs
+++ b/scripts/verify-institutional-ui.mjs
@@ -85,7 +85,9 @@ async function inspect(page, route, viewport) {
         '[role="region"][aria-label="Valori esatti dei pagamenti PCM per missione"]',
       );
       tableRegion?.focus();
-      return {
+      const initialScrollLeft = tableRegion?.scrollLeft ?? 0;
+      if (tableRegion) tableRegion.scrollLeft = tableRegion.scrollWidth;
+      const result = {
         activeTable: document.activeElement === tableRegion,
         rectangles: chart?.querySelectorAll("svg rect").length ?? 0,
         labels: chart
@@ -94,8 +96,15 @@ async function inspect(page, route, viewport) {
             ).length
           : 0,
         rows: tableRegion?.querySelectorAll("tbody tr").length ?? 0,
+        scrollable: Boolean(
+          tableRegion &&
+          tableRegion.scrollWidth > tableRegion.clientWidth &&
+          tableRegion.scrollLeft > initialScrollLeft,
+        ),
         total: tableRegion?.querySelector("tfoot")?.textContent?.replace(/\s+/g, " ").trim(),
       };
+      if (tableRegion) tableRegion.scrollLeft = initialScrollLeft;
+      return result;
     });
     assert.equal(evidence.activeTable, true, `${route}: tabella non focalizzabile`);
     assert.ok(evidence.rectangles >= 11, `${route}: treemap incompleto`);
@@ -103,6 +112,7 @@ async function inspect(page, route, viewport) {
     assert.match(evidence.total ?? "", /Totale PCM.+100,0\s?%/, `${route}: totale tabella assente`);
     if (viewport.width <= 620) {
       assert.ok(evidence.labels <= 12, `${route}: troppe micro-label nel treemap mobile`);
+      assert.equal(evidence.scrollable, true, `${route}: tabella mobile non scorre`);
     }
   } else if (route === "/ministeri") {
     assert.equal(shell.stats, 3, `${route}: Totale CP, Pagato CP e Rimasto CP devono restare verificabili`);
@@ -178,16 +188,34 @@ async function inspect(page, route, viewport) {
       assert.equal(evidence.scrollable, true, `${route}: tabella Titoli mobile non scorre`);
     }
   } else {
-    const evidence = await page.evaluate(() => ({
-      metadataRows: document.querySelectorAll(
-        '[aria-label="Copertura dei documenti contabili di Camera e Senato"] tbody tr',
-      ).length,
-      metadataStatuses: [...document.querySelectorAll("td")].filter((node) =>
-        node.textContent?.includes("Solo metadati"),
-      ).length,
-    }));
+    const evidence = await page.evaluate(() => {
+      const tableRegion = document.querySelector(
+        '[role="region"][aria-label="Copertura dei documenti contabili di Camera e Senato"]',
+      );
+      tableRegion?.focus();
+      const initialScrollLeft = tableRegion?.scrollLeft ?? 0;
+      if (tableRegion) tableRegion.scrollLeft = tableRegion.scrollWidth;
+      const result = {
+        activeTable: document.activeElement === tableRegion,
+        metadataRows: tableRegion?.querySelectorAll("tbody tr").length ?? 0,
+        metadataStatuses: [...(tableRegion?.querySelectorAll("td") ?? [])].filter((node) =>
+          node.textContent?.includes("Solo metadati"),
+        ).length,
+        scrollable: Boolean(
+          tableRegion &&
+          tableRegion.scrollWidth > tableRegion.clientWidth &&
+          tableRegion.scrollLeft > initialScrollLeft,
+        ),
+      };
+      if (tableRegion) tableRegion.scrollLeft = initialScrollLeft;
+      return result;
+    });
+    assert.equal(evidence.activeTable, true, `${route}: tabella copertura non focalizzabile`);
     assert.equal(evidence.metadataRows, 2, `${route}: copertura Camera/Senato incompleta`);
     assert.equal(evidence.metadataStatuses, 2, `${route}: stato PDF non verificato assente`);
+    if (viewport.width <= 620) {
+      assert.equal(evidence.scrollable, true, `${route}: tabella copertura mobile non scorre`);
+    }
   }
 
   mkdirSync(outputDir, { recursive: true });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -282,6 +282,8 @@ main td a:not(.btn) {
   white-space: nowrap;
 }
 
+.nav-scroll-hint { display: none; }
+
 /* ── page shells ────────────────────────────────────────────────────────── */
 
 main { display: block; }
@@ -532,6 +534,14 @@ main { display: block; }
   .primary-nav { scrollbar-width: thin; }
   .primary-nav::-webkit-scrollbar { display: block; height: 3px; }
   .primary-nav::-webkit-scrollbar-thumb { background: var(--color-neutral-400); }
+  .nav-scroll-hint {
+    display: block;
+    flex: none;
+    color: var(--color-neutral-600);
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+  }
   .page-intro h1 { font-size: 24px; }
   .stat-strip { grid-template-columns: 1fr; }
   .stat-strip > div { border-right: 0; border-bottom: 1px solid var(--color-neutral-200); }

--- a/src/app/palazzo-chigi/page.tsx
+++ b/src/app/palazzo-chigi/page.tsx
@@ -114,6 +114,7 @@ export default function PalazzoChigiPage() {
           missions={data.missions}
           totalCents={data.totals.paymentsTotalCents}
         />
+        <p className={styles.scrollHint}>Scorri la tabella verso destra per vedere importi e quote.</p>
         <div
           className={`table-scroll ${styles.exactTable}`}
           role="region"

--- a/src/app/palazzo-chigi/palazzo-chigi.module.css
+++ b/src/app/palazzo-chigi/palazzo-chigi.module.css
@@ -78,6 +78,13 @@
   margin-block-start: var(--space-8);
 }
 
+.scrollHint {
+  display: none;
+  margin: var(--space-5) 0 0;
+  color: var(--color-neutral-700);
+  font-size: 0.85rem;
+}
+
 .exactTable table {
   min-width: 680px;
 }
@@ -165,5 +172,9 @@
   .sectionHeader > span {
     display: block;
     margin-block-start: var(--space-2);
+  }
+
+  .scrollHint {
+    display: block;
   }
 }

--- a/src/app/parlamento/page.tsx
+++ b/src/app/parlamento/page.tsx
@@ -69,12 +69,12 @@ export default function ParliamentPage() {
           <span className="stat-note">su documenti ufficiali verificati</span>
         </div>
         <div>
-          <dt>Ultimo consuntivo</dt>
+          <dt>Ultimo consuntivo Camera</dt>
           <dd>{latestAccount?.year ?? "Non disponibile"}</dd>
           <span className="stat-note">spese già registrate</span>
         </div>
         <div>
-          <dt>Ultimo bilancio</dt>
+          <dt>Ultimo bilancio Camera</dt>
           <dd>{latestBudget?.year ?? "Non disponibile"}</dd>
           <span className="stat-note">spese previste</span>
         </div>
@@ -101,6 +101,7 @@ export default function ParliamentPage() {
           </div>
           <span>Documenti 2024 · fonti ufficiali</span>
         </div>
+        <p className={styles.scrollHint}>Scorri la tabella verso destra per vedere approvazione, copertura e fonti.</p>
         <div className={`table-scroll ${styles.coverageTable}`} role="region" aria-label="Copertura dei documenti contabili di Camera e Senato" tabIndex={0}>
           <table className="table">
             <thead>
@@ -118,7 +119,7 @@ export default function ParliamentPage() {
                   <th scope="row">{source.subjectId === "camera" ? "Camera" : "Senato"}</th>
                   <td>
                     {source.title}
-                    <small>{source.sourceRecordId}</small>
+                    <small>ID fonte: {source.sourceRecordId}</small>
                   </td>
                   <td>{longDate(source.updatedAt)}</td>
                   <td>

--- a/src/app/parlamento/parlamento.module.css
+++ b/src/app/parlamento/parlamento.module.css
@@ -240,6 +240,19 @@
   min-width: 760px;
 }
 
+.coverageTable td > small {
+  display: block;
+  margin-block-start: var(--space-1);
+  color: var(--color-neutral-600);
+}
+
+.scrollHint {
+  display: none;
+  margin: 0 0 var(--space-3);
+  color: var(--color-neutral-700);
+  font-size: 0.85rem;
+}
+
 @media (max-width: 620px) {
   .coverageHeader {
     display: block;
@@ -248,5 +261,9 @@
   .coverageHeader > span {
     display: block;
     margin-block-start: var(--space-3);
+  }
+
+  .scrollHint {
+    display: block;
   }
 }

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -104,6 +104,7 @@ export function Navigation() {
             );
           })}
         </nav>
+        <span className="nav-scroll-hint" aria-hidden="true">Scorri →</span>
         <span className="nav-note">Fonte e data sempre visibili</span>
       </div>
     </header>

--- a/tests/pcm-financial-ui.test.mjs
+++ b/tests/pcm-financial-ui.test.mjs
@@ -6,6 +6,7 @@ const page = fs.readFileSync(new URL("../src/app/palazzo-chigi/page.tsx", import
 const css = fs.readFileSync(new URL("../src/app/palazzo-chigi/palazzo-chigi.module.css", import.meta.url), "utf8");
 const treemap = fs.readFileSync(new URL("../src/app/palazzo-chigi/pcm-mission-treemap.tsx", import.meta.url), "utf8");
 const parliament = fs.readFileSync(new URL("../src/app/parlamento/page.tsx", import.meta.url), "utf8");
+const parliamentCss = fs.readFileSync(new URL("../src/app/parlamento/parlamento.module.css", import.meta.url), "utf8");
 
 test("Palazzo Chigi keeps scope, accounting phases and source visible", () => {
   assert.match(page, /soltanto la Presidenza del Consiglio/);
@@ -25,6 +26,14 @@ test("institutional pages keep Parliament and Palazzo Chigi separate", () => {
   assert.match(parliament, /Solo metadati/);
   assert.doesNotMatch(parliament, /pcmFinancial|Palazzo Chigi/);
   assert.doesNotMatch(page, /parliamentSnapshot|Camera dei deputati|Senato della Repubblica/);
+});
+
+test("institutional tables explain horizontal access on mobile", () => {
+  assert.match(parliament, /Scorri la tabella verso destra per vedere approvazione, copertura e fonti/);
+  assert.match(parliament, /ID fonte:/);
+  assert.match(page, /Scorri la tabella verso destra per vedere importi e quote/);
+  assert.match(parliamentCss, /\.scrollHint/);
+  assert.match(css, /\.scrollHint/);
 });
 
 test("Palazzo Chigi layout has bounded responsive collapses", () => {


### PR DESCRIPTION
Base: `codex/institutional-navigation`
Head: `codex/institutional-mobile-hardening`

## Scope
- adds an explicit mobile affordance for the horizontally scrollable primary menu
- adds mobile scroll instructions to Parliament and PCM exact tables
- separates Parliament document titles from stable source IDs
- labels the Camera-only account and budget facts explicitly
- extends browser assertions for keyboard focus and horizontal access on PCM and Parliament tables

## Dependency
Stacked on PR #67. No data values or totals change in this PR.

## Reason
Two independent blind screenshot reviews agreed that the hub and scope separation work, but both flagged unclear mobile scroll affordances and raw Parliament source IDs. This PR addresses those shared findings without combining accounting perimeters.

## Verification
- PASS: 284/284 Node tests; 81/81 Python tests; lint; typecheck; clean production build
- PASS: Consulting API/default-inbox regression in the full suite
- PASS: contextual privacy scan on commit messages, changed filenames and diff
- PASS on exact head `05b3b51`: 12 route/viewport results covering `/istituzioni`, `/parlamento`, `/palazzo-chigi`, `/ministeri`, `/regioni` and `/consulenza` at 1440×1000 and 390×844
- proof manifest contains 54 PNGs: full page plus S1–S4 for each institutional route at both viewports, and initial/success Consulting states at both viewports
- every route returned a valid page with one H1, CLS 0, no global overflow, no detected long-label overflow, no page/console errors, no HTTP error and no genuine failed request
- 97 cancelled `?_rsc=` requests are recorded separately as Next.js prefetch `net::ERR_ABORTED`, not page/API failures
- all 10 exact-table regions were focusable; all 5 mobile table regions scrolled from the keyboard and were reset to their initial left edge for the final visual captures
- the mobile `Scorri →` navigation cue is visible on all six mobile routes
- current-head DOM gates confirm `Due componenti del Totale CP`, the cash caveat and absence of the old Ministry copy; Parliament exposes Camera-scoped labels and separate `ID fonte:` lines
- Consulting native validity changes from invalid to valid only after the required fields and consent; the privacy link is present; one synthetic local POST per viewport was intercepted with `consent=true`; the success notice receives focus. No external message was sent
- final visual manifest records `visualScrollReset: true`; the success notice is stable and the fixed skip link is not focus-visible and remains offscreen

## S1–S4 visual judgment
- `/istituzioni`: orientation, four separate perimeters, route cards and the no-combined-total warning remain clear on desktop and mobile
- `/parlamento`: Camera-only periods are explicit; document titles and source IDs are visually separate; metadata-only coverage remains honest; no percentage is invented
- `/palazzo-chigi`: scope, three accounting facts, additive payment composition, exact table and source panel remain ordered and readable
- `/ministeri`: the current Totale/Pagato/Rimasto CP explanation, additive composition, exact 15-Ministry table and source/coverage panel are visible without stale copy
- `/regioni`: selected administration, non-ranking warning, additive Title composition, both exact tables and source limits remain distinct
- no P0/P1 visual defect found. Remaining accepted risks are the horizontally scrollable narrow tables and very small treemap tiles, both backed by visible instructions and exact tables

## Limits
- dark, loading, empty and error visual states are N/A for these static snapshot surfaces
- proof files are local review artifacts and are not committed
- no merge or deployment is performed
