### PR TITLE
Make institutional evidence easier to scan

### DIFF
--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -92,6 +92,15 @@
   --chart-quinary: var(--color-accent-300);
   --chart-negative: var(--color-accent-700);
 
+  /* Categorie additive: famiglie distinte, non semaforiche. Il rosso resta
+     riservato ad azioni e avvisi; etichette e tabelle rendono il colore ridondante. */
+  --chart-category-blue: #2855a5;
+  --chart-category-teal: #087c74;
+  --chart-category-purple: #6b46a3;
+  --chart-category-amber: #9a5b00;
+  --chart-category-green: #2f6f44;
+  --chart-category-slate: #405b70;
+
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
   --focus-ring: var(--color-accent);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -306,6 +306,14 @@ main { display: block; }
   font-size: 14px;
   color: var(--color-neutral-700);
 }
+.page-intro .scope-line {
+  margin-top: var(--space-3);
+  color: var(--color-neutral-800);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: .035em;
+  text-transform: uppercase;
+}
 
 /* ── footer ─────────────────────────────────────────────────────────────── */
 

--- a/src/app/istituzioni/page.tsx
+++ b/src/app/istituzioni/page.tsx
@@ -48,9 +48,12 @@ export default function InstitutionsPage() {
           Parlamento, Palazzo Chigi, Ministeri e Regioni hanno conti e regole diverse.
           Scegli il percorso che ti interessa: non li sommiamo in un totale unico.
         </p>
+        <p className="scope-line" data-evidence-stage="scope">
+          Orientamento · periodi e unità cambiano per fonte · nessun totale comune
+        </p>
       </div>
 
-      <section aria-labelledby="percorsi-istituzionali">
+      <section aria-labelledby="percorsi-istituzionali" data-evidence-stage="visual">
         <div className={styles.sectionHeader}>
           <h2 id="percorsi-istituzionali">Quattro conti, quattro perimetri</h2>
           <p>In ogni pagina trovi importi esatti o limiti di copertura, periodo e fonte ufficiale.</p>
@@ -69,11 +72,12 @@ export default function InstitutionsPage() {
         </div>
       </section>
 
-      <div className="notice">
-        <strong>Perché non c&apos;è un totale delle istituzioni</strong>
+      <div className="notice" data-evidence-stage="source">
+        <strong>Fonti e limiti dell&apos;hub</strong>
         <p>
           Periodi, perimetri e fasi contabili non coincidono. Sommarli produrrebbe un numero
-          fuorviante. I confronti restano dentro ogni fonte e solo tra grandezze compatibili.
+          fuorviante. I confronti restano dentro ogni fonte e solo tra grandezze compatibili;
+          metodo, licenza, copertura e limiti completi sono in fondo a ciascun percorso.
         </p>
       </div>
     </main>

--- a/src/app/ministeri/ministeri.module.css
+++ b/src/app/ministeri/ministeri.module.css
@@ -51,7 +51,7 @@
 }
 
 .ministryTable table {
-  min-width: 820px;
+  min-width: 940px;
 }
 
 .ministryTable td {

--- a/src/app/ministeri/ministry-commitment-treemap.module.css
+++ b/src/app/ministeri/ministry-commitment-treemap.module.css
@@ -21,7 +21,7 @@
 }
 
 .tileShare {
-  font-size: 13px;
+  font-size: 11px;
 }
 
 .tooltip {

--- a/src/app/ministeri/ministry-commitment-treemap.tsx
+++ b/src/app/ministeri/ministry-commitment-treemap.tsx
@@ -3,7 +3,15 @@
 import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
 import type { TreemapNode } from "recharts";
 import type { RgsMinistry } from "@/lib/data/rgs-ministries-contract";
+import { institutionalCategoryColor } from "@/lib/chart-category-colors";
 import styles from "./ministry-commitment-treemap.module.css";
+
+const compactEuro = new Intl.NumberFormat("it-IT", {
+  style: "currency",
+  currency: "EUR",
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
 
 const exactEuro = new Intl.NumberFormat("it-IT", {
   style: "currency",
@@ -60,8 +68,7 @@ function tile(props: TreemapNode) {
         y={node.y}
         width={node.width}
         height={node.height}
-        fill="var(--color-accent)"
-        fillOpacity={0.96 - (node.index % 4) * 0.1}
+        fill={institutionalCategoryColor(node.index)}
         stroke="var(--color-raised)"
         strokeWidth={2}
       />
@@ -72,7 +79,7 @@ function tile(props: TreemapNode) {
           </text>
           {showShare ? (
             <text x={node.x + 12} y={node.y + 47} className={styles.tileShare}>
-              {percentage.format(node.share ?? 0)}
+              {compactEuro.format((node.totalCpCents ?? 0) / 100)} · {percentage.format(node.share ?? 0)}
             </text>
           ) : null}
         </>

--- a/src/app/ministeri/page.tsx
+++ b/src/app/ministeri/page.tsx
@@ -26,9 +26,12 @@ export default function MinistriesPage() {
           competenza dell&apos;anno: separiamo Pagato CP da Rimasto da pagare CP e mostriamo
           come insieme formano il Totale CP. Non includiamo Palazzo Chigi, Camera, Senato o Regioni.
         </p>
+        <p className="scope-line" data-evidence-stage="scope">
+          Consuntivo RGS 2025 · 15 Ministeri · competenza · euro
+        </p>
       </div>
 
-      <section className={styles.frameSection} aria-labelledby="quadro-cp" data-institutional-section>
+      <section className={styles.frameSection} aria-labelledby="quadro-cp" data-institutional-section data-evidence-stage="kpi">
         <div className={styles.sectionHeader}>
           <div>
             <h2 id="quadro-cp">Due componenti del Totale CP</h2>
@@ -40,11 +43,6 @@ export default function MinistriesPage() {
           </div>
           <span>Consuntivo · EUR</span>
         </div>
-        <p className={styles.definitionNote}>
-          <strong>Economie-Maggiori spese CP</strong>
-          Nella fonte indica l&apos;importo di competenza rimasto inutilizzato rispetto alle
-          previsioni o utilizzato oltre i limiti. È una voce diversa da Rimasto da pagare CP.
-        </p>
         <dl className="stat-strip">
           <div>
             <dt>Totale CP</dt>
@@ -62,9 +60,14 @@ export default function MinistriesPage() {
             <span className="stat-note">{exactEuro(euro(totals.remainingCpCents))} esatti</span>
           </div>
         </dl>
+        <p className={styles.definitionNote}>
+          <strong>Economie-Maggiori spese CP</strong>
+          Nella fonte indica l&apos;importo di competenza rimasto inutilizzato rispetto alle
+          previsioni o utilizzato oltre i limiti. È una voce diversa da Rimasto da pagare CP.
+        </p>
       </section>
 
-      <section className="panel" aria-labelledby="composizione-cp" data-institutional-section>
+      <section className="panel" aria-labelledby="composizione-cp" data-institutional-section data-evidence-stage="visual">
         <div className={styles.sectionHeader}>
           <div>
             <h2 id="composizione-cp">Come si distribuisce il Totale CP</h2>
@@ -78,7 +81,7 @@ export default function MinistriesPage() {
         <MinistryCommitmentTreemap ministries={ministries} />
       </section>
 
-      <section className="panel" aria-labelledby="elenco-ministeri" data-institutional-section>
+      <section className="panel" aria-labelledby="elenco-ministeri" data-institutional-section data-evidence-stage="detail">
         <div className={styles.sectionHeader}>
           <div>
             <h2 id="elenco-ministeri">Valori esatti per Ministero</h2>
@@ -134,8 +137,8 @@ export default function MinistriesPage() {
         </div>
       </section>
 
-      <section className="panel" aria-labelledby="fonte-ministeri" data-institutional-section>
-        <h2 className="panel-title" id="fonte-ministeri">Fonte, perimetro e controlli</h2>
+      <section className="panel" aria-labelledby="fonte-ministeri" data-institutional-section data-evidence-stage="source">
+        <h2 className="panel-title" id="fonte-ministeri">Fonte, metodo, licenza, copertura e limiti</h2>
         <div className={styles.provenance}>
           <div><span>Titolare</span><strong>{source.owner}</strong></div>
           <div><span>Rilascio aggiornato</span><strong>{longDate(source.updatedAt)}</strong></div>

--- a/src/app/ministeri/page.tsx
+++ b/src/app/ministeri/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
 };
 
 const euro = (cents: number) => cents / 100;
+const percentage = new Intl.NumberFormat("it-IT", {
+  style: "percent",
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
 
 export default function MinistriesPage() {
   const { ministries, totals, coverage } = rgsMinistriesSnapshot;
@@ -105,6 +110,7 @@ export default function MinistriesPage() {
               <tr>
                 <th scope="col">Ministero</th>
                 <th scope="col">Totale CP</th>
+                <th scope="col">Quota del Totale CP</th>
                 <th scope="col">Pagato CP</th>
                 <th scope="col">Rimasto da pagare CP</th>
               </tr>
@@ -119,6 +125,7 @@ export default function MinistriesPage() {
                       <small>Codice RGS {ministry.code} · IPA {identity?.ipaCode ?? "non collegato"}</small>
                     </th>
                     <td>{exactEuro(euro(ministry.commitmentsCpCents))}</td>
+                    <td>{percentage.format(ministry.commitmentsCpCents / totals.commitmentsCpCents)}</td>
                     <td>{exactEuro(euro(ministry.paymentsCompetenceCpCents))}</td>
                     <td>{exactEuro(euro(ministry.remainingCpCents))}</td>
                   </tr>
@@ -129,6 +136,7 @@ export default function MinistriesPage() {
               <tr>
                 <th scope="row">Totale dei 15 Ministeri</th>
                 <td>{exactEuro(euro(totals.commitmentsCpCents))}</td>
+                <td>{percentage.format(1)}</td>
                 <td>{exactEuro(euro(totals.paymentsCompetenceCpCents))}</td>
                 <td>{exactEuro(euro(totals.remainingCpCents))}</td>
               </tr>

--- a/src/app/palazzo-chigi/page.tsx
+++ b/src/app/palazzo-chigi/page.tsx
@@ -40,9 +40,12 @@ export default function PalazzoChigiPage() {
           Mostriamo separatamente ciò che è stato impegnato e ciò che è stato pagato, senza
           sommarlo ai Ministeri o al Parlamento.
         </p>
+        <p className="scope-line" data-evidence-stage="scope">
+          Rendiconto PCM 2024 · sola Presidenza del Consiglio · euro
+        </p>
       </div>
 
-      <dl className="stat-strip">
+      <dl className="stat-strip" data-evidence-stage="kpi">
         <div>
           <dt>Pagato nel 2024</dt>
           <dd>{compactEuro(euro(data.totals.paymentsTotalCents))}</dd>
@@ -75,7 +78,7 @@ export default function PalazzoChigiPage() {
         </p>
       </div>
 
-      <section className={styles.phaseGrid} aria-labelledby="fasi-contabili">
+      <section className={styles.phaseGrid} aria-labelledby="fasi-contabili" data-evidence-stage="visual">
         <div className={styles.phaseHeading}>
           <h2 id="fasi-contabili">Come si compone il pagato</h2>
           <p>
@@ -102,7 +105,7 @@ export default function PalazzoChigiPage() {
         </dl>
       </section>
 
-      <section className="panel" aria-labelledby="missioni-pcm">
+      <section className="panel" aria-labelledby="missioni-pcm" data-evidence-stage="visual">
         <div className={styles.sectionHeader}>
           <div>
             <h2 id="missioni-pcm">Pagamenti per missione</h2>
@@ -120,6 +123,7 @@ export default function PalazzoChigiPage() {
           role="region"
           aria-label="Valori esatti dei pagamenti PCM per missione"
           tabIndex={0}
+          data-evidence-stage="detail"
         >
           <table className="table">
             <thead>
@@ -152,8 +156,8 @@ export default function PalazzoChigiPage() {
         </div>
       </section>
 
-      <section className="panel" aria-labelledby="fonte-pcm">
-        <h2 className="panel-title" id="fonte-pcm">Fonte e controlli</h2>
+      <section className="panel" aria-labelledby="fonte-pcm" data-evidence-stage="source">
+        <h2 className="panel-title" id="fonte-pcm">Fonte, metodo, licenza, copertura e limiti</h2>
         <div className={styles.provenance}>
           <div>
             <span>Titolare</span>

--- a/src/app/palazzo-chigi/pcm-mission-treemap.module.css
+++ b/src/app/palazzo-chigi/pcm-mission-treemap.module.css
@@ -66,8 +66,4 @@
   .chart {
     height: 360px;
   }
-
-  .tileAmount {
-    display: none;
-  }
 }

--- a/src/app/palazzo-chigi/pcm-mission-treemap.tsx
+++ b/src/app/palazzo-chigi/pcm-mission-treemap.tsx
@@ -3,6 +3,7 @@
 import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
 import type { TreemapNode } from "recharts";
 import type { PcmFinancialMission } from "@/lib/data/pcm-financial-contract";
+import { institutionalCategoryColor } from "@/lib/chart-category-colors";
 import styles from "./pcm-mission-treemap.module.css";
 
 const compactEuro = new Intl.NumberFormat("it-IT", {
@@ -44,8 +45,7 @@ function tile(props: TreemapNode) {
         y={node.y}
         width={node.width}
         height={node.height}
-        fill="var(--color-accent)"
-        fillOpacity={0.96 - (node.index % 4) * 0.1}
+        fill={institutionalCategoryColor(node.index)}
         stroke="var(--color-raised)"
         strokeWidth={2}
       />
@@ -54,14 +54,15 @@ function tile(props: TreemapNode) {
           <text x={node.x + 12} y={node.y + 25} className={styles.tileLabel}>
             {node.shortLabel}
           </text>
-          <text x={node.x + 12} y={node.y + 45} className={styles.tileShare}>
-            {percentage.format(node.share ?? 0)}
-          </text>
           {showAmount ? (
-            <text x={node.x + 12} y={node.y + 66} className={styles.tileAmount}>
-              {compactEuro.format((node.paymentsCents ?? 0) / 100)}
+            <text x={node.x + 12} y={node.y + 47} className={styles.tileAmount}>
+              {compactEuro.format((node.paymentsCents ?? 0) / 100)} · {percentage.format(node.share ?? 0)}
             </text>
-          ) : null}
+          ) : (
+            <text x={node.x + 12} y={node.y + 45} className={styles.tileShare}>
+              {percentage.format(node.share ?? 0)}
+            </text>
+          )}
         </>
       ) : null}
     </g>

--- a/src/app/parlamento/page.tsx
+++ b/src/app/parlamento/page.tsx
@@ -192,7 +192,7 @@ export default function ParliamentPage() {
       <section className="panel" aria-labelledby="fonti-parlamento" data-evidence-stage="source">
         <div className={styles.coverageHeader}>
           <div>
-            <h2 id="fonti-parlamento">Fonti, metodo, copertura e limiti</h2>
+            <h2 id="fonti-parlamento">Fonti, metodo, licenza, copertura e limiti</h2>
             <p>Un documento censito non diventa automaticamente un dato numerico.</p>
           </div>
           <span>Documenti 2024 · fonti ufficiali</span>

--- a/src/app/parlamento/page.tsx
+++ b/src/app/parlamento/page.tsx
@@ -60,9 +60,12 @@ export default function ParliamentPage() {
           estratto e riconciliato; per i documenti 2024 dei due rami mostriamo per ora soltanto
           metadati e procedure. Non li sommiamo e non stimiamo i numeri che non abbiamo verificato.
         </p>
+        <p className="scope-line" data-evidence-stage="scope">
+          Camera · consuntivi e bilanci verificati · milioni di euro · documenti 2024 censiti separatamente
+        </p>
       </div>
 
-      <dl className="stat-strip">
+      <dl className="stat-strip" data-evidence-stage="kpi">
         <div>
           <dt>Rami con numeri verificati</dt>
           <dd>{chambers.length}</dd>
@@ -93,54 +96,8 @@ export default function ParliamentPage() {
         </p>
       </div>
 
-      <section className="panel" aria-labelledby="copertura-parlamento">
-        <div className={styles.coverageHeader}>
-          <div>
-            <h2 id="copertura-parlamento">Copertura dei due rami</h2>
-            <p>Un documento censito non diventa automaticamente un dato numerico.</p>
-          </div>
-          <span>Documenti 2024 · fonti ufficiali</span>
-        </div>
-        <p className={styles.scrollHint}>Scorri la tabella verso destra per vedere approvazione, copertura e fonti.</p>
-        <div className={`table-scroll ${styles.coverageTable}`} role="region" aria-label="Copertura dei documenti contabili di Camera e Senato" tabIndex={0}>
-          <table className="table">
-            <thead>
-              <tr>
-                <th scope="col">Ramo</th>
-                <th scope="col">Documento</th>
-                <th scope="col">Approvato</th>
-                <th scope="col">Copertura</th>
-                <th scope="col">Fonte</th>
-              </tr>
-            </thead>
-            <tbody>
-              {documentCoverage.map((source) => (
-                <tr key={source.id}>
-                  <th scope="row">{source.subjectId === "camera" ? "Camera" : "Senato"}</th>
-                  <td>
-                    {source.title}
-                    <small>ID fonte: {source.sourceRecordId}</small>
-                  </td>
-                  <td>{longDate(source.updatedAt)}</td>
-                  <td>
-                    <span className={styles.metadataStatus}>Solo metadati</span>
-                    <small>Numeri del PDF non verificati</small>
-                  </td>
-                  <td>
-                    <a href={source.sourceUrl} target="_blank" rel="noreferrer">Procedura ↗</a>
-                    {source.downloadUrl ? (
-                      <small><a href={source.downloadUrl} target="_blank" rel="noreferrer">PDF ufficiale ↗</a></small>
-                    ) : null}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
       {chambers.map((chamber) => (
-        <section className={styles.chamber} key={chamber.id}>
+        <section className={styles.chamber} key={chamber.id} data-evidence-stage="detail">
           <header className={styles.chamberHeader}>
             <div>
               <span>Dati ufficiali</span>
@@ -232,8 +189,59 @@ export default function ParliamentPage() {
         </section>
       ))}
 
-      <section className="panel">
-        <h2 className="panel-title">Cosa non pubblichiamo ancora</h2>
+      <section className="panel" aria-labelledby="fonti-parlamento" data-evidence-stage="source">
+        <div className={styles.coverageHeader}>
+          <div>
+            <h2 id="fonti-parlamento">Fonti, metodo, copertura e limiti</h2>
+            <p>Un documento censito non diventa automaticamente un dato numerico.</p>
+          </div>
+          <span>Documenti 2024 · fonti ufficiali</span>
+        </div>
+        <p className={styles.plainText}>{parliamentSnapshot.methodology.publicationCheck}</p>
+        <p className={styles.scrollHint}>Scorri la tabella verso destra per vedere approvazione, copertura e fonti.</p>
+        <div
+          className={`table-scroll ${styles.coverageTable}`}
+          role="region"
+          aria-label="Copertura dei documenti contabili di Camera e Senato"
+          tabIndex={0}
+        >
+          <table className="table">
+            <thead>
+              <tr>
+                <th scope="col">Ramo</th>
+                <th scope="col">Documento</th>
+                <th scope="col">Approvato</th>
+                <th scope="col">Copertura</th>
+                <th scope="col">Licenza</th>
+                <th scope="col">Fonte</th>
+              </tr>
+            </thead>
+            <tbody>
+              {documentCoverage.map((source) => (
+                <tr key={source.id}>
+                  <th scope="row">{source.subjectId === "camera" ? "Camera" : "Senato"}</th>
+                  <td>
+                    {source.title}
+                    <small>ID fonte: {source.sourceRecordId}</small>
+                  </td>
+                  <td>{longDate(source.updatedAt)}</td>
+                  <td>
+                    <span className={styles.metadataStatus}>Solo metadati</span>
+                    <small>Numeri del PDF non verificati</small>
+                  </td>
+                  <td>Non dichiarata sulla pagina ufficiale</td>
+                  <td>
+                    <a href={source.sourceUrl} target="_blank" rel="noreferrer">Procedura ↗</a>
+                    {source.downloadUrl ? (
+                      <small><a href={source.downloadUrl} target="_blank" rel="noreferrer">PDF ufficiale ↗</a></small>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <h3 className={styles.limitsHeading}>Limiti di pubblicazione e confronto</h3>
         <p className={styles.plainText}>{parliamentSnapshot.methodology.missingData}</p>
         <p className={styles.plainText}>{parliamentSnapshot.methodology.comparability}</p>
         <div className={styles.relatedLinks}>

--- a/src/app/parlamento/parlamento.module.css
+++ b/src/app/parlamento/parlamento.module.css
@@ -237,7 +237,7 @@
 }
 
 .coverageTable table {
-  min-width: 760px;
+  min-width: 900px;
 }
 
 .coverageTable td > small {
@@ -251,6 +251,11 @@
   margin: 0 0 var(--space-3);
   color: var(--color-neutral-700);
   font-size: 0.85rem;
+}
+
+.limitsHeading {
+  margin: var(--space-6) 0 var(--space-2);
+  font-size: 1rem;
 }
 
 @media (max-width: 620px) {

--- a/src/app/regioni/page.tsx
+++ b/src/app/regioni/page.tsx
@@ -43,6 +43,9 @@ export default async function RegionsPage({
           2 Province autonome. Qui mostriamo impegni, non pagamenti, e non li mescoliamo con
           Comuni, sanità, CPT o residuo fiscale.
         </p>
+        <p className="scope-line" data-evidence-stage="scope">
+          Consuntivi Istat 2024 · 22 amministrazioni · impegni · euro
+        </p>
       </div>
 
       <form className={styles.selector} action="/regioni" method="get">
@@ -57,7 +60,7 @@ export default async function RegionsPage({
         <button type="submit">Mostra il consuntivo</button>
       </form>
 
-      <dl className="stat-strip">
+      <dl className="stat-strip" data-evidence-stage="kpi">
         <div>
           <dt>Impegni 2024</dt>
           <dd>{compactEuro(euro(selected.commitmentsCents))}</dd>
@@ -84,7 +87,7 @@ export default async function RegionsPage({
         </p>
       </div>
 
-      <section className="panel" aria-labelledby="composizione-regionale">
+      <section className="panel" aria-labelledby="composizione-regionale" data-evidence-stage="visual">
         <div className={styles.sectionHeader}>
           <div>
             <h2 id="composizione-regionale">Per cosa sono stati impegnati</h2>
@@ -102,6 +105,7 @@ export default async function RegionsPage({
           role="region"
           aria-label={`Valori esatti degli impegni 2024 di ${selected.label} per Titolo`}
           tabIndex={0}
+          data-evidence-stage="detail"
         >
           <table className="table">
             <thead><tr><th scope="col">Titolo</th><th scope="col">Impegni 2024</th><th scope="col">Quota</th></tr></thead>
@@ -121,7 +125,7 @@ export default async function RegionsPage({
         </div>
       </section>
 
-      <section className="panel" aria-labelledby="copertura-regioni">
+      <section className="panel" aria-labelledby="copertura-regioni" data-evidence-stage="detail">
         <div className={styles.sectionHeader}>
           <div>
             <h2 id="copertura-regioni">Tutte le amministrazioni nel file</h2>
@@ -150,8 +154,8 @@ export default async function RegionsPage({
         </div>
       </section>
 
-      <section className="panel" aria-labelledby="fonte-regioni">
-        <h2 className="panel-title" id="fonte-regioni">Fonte, periodo e controlli</h2>
+      <section className="panel" aria-labelledby="fonte-regioni" data-evidence-stage="source">
+        <h2 className="panel-title" id="fonte-regioni">Fonte, metodo, licenza, copertura e limiti</h2>
         <div className={styles.provenance}>
           <div><span>Titolare</span><strong>{source.owner}</strong></div>
           <div><span>Pubblicato</span><strong>{longDate(source.publishedAt)}</strong></div>

--- a/src/app/regioni/region-title-treemap.module.css
+++ b/src/app/regioni/region-title-treemap.module.css
@@ -62,8 +62,4 @@
   .chart {
     height: 340px;
   }
-
-  .tileAmount {
-    display: none;
-  }
 }

--- a/src/app/regioni/region-title-treemap.tsx
+++ b/src/app/regioni/region-title-treemap.tsx
@@ -3,6 +3,7 @@
 import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
 import type { TreemapNode } from "recharts";
 import type { IstatRegionalAdministration } from "@/lib/data/istat-regions-contract";
+import { institutionalCategoryColor } from "@/lib/chart-category-colors";
 import styles from "./region-title-treemap.module.css";
 
 const compactEuro = new Intl.NumberFormat("it-IT", {
@@ -41,20 +42,20 @@ function tile(props: TreemapNode) {
         y={node.y}
         width={node.width}
         height={node.height}
-        fill="var(--color-accent)"
-        fillOpacity={0.96 - (node.index % 4) * 0.1}
+        fill={institutionalCategoryColor(node.index)}
         stroke="var(--color-raised)"
         strokeWidth={2}
       />
       {showLabel ? (
         <>
           <text x={node.x + 12} y={node.y + 25} className={styles.tileLabel}>{node.shortLabel}</text>
-          <text x={node.x + 12} y={node.y + 45} className={styles.tileShare}>{percentage.format(node.share ?? 0)}</text>
           {showAmount ? (
-            <text x={node.x + 12} y={node.y + 66} className={styles.tileAmount}>
-              {compactEuro.format((node.commitmentsCents ?? 0) / 100)}
+            <text x={node.x + 12} y={node.y + 47} className={styles.tileAmount}>
+              {compactEuro.format((node.commitmentsCents ?? 0) / 100)} · {percentage.format(node.share ?? 0)}
             </text>
-          ) : null}
+          ) : (
+            <text x={node.x + 12} y={node.y + 45} className={styles.tileShare}>{percentage.format(node.share ?? 0)}</text>
+          )}
         </>
       ) : null}
     </g>

--- a/src/lib/chart-category-colors.ts
+++ b/src/lib/chart-category-colors.ts
@@ -1,0 +1,12 @@
+export const INSTITUTIONAL_CATEGORY_COLORS = [
+  "var(--chart-category-blue)",
+  "var(--chart-category-teal)",
+  "var(--chart-category-purple)",
+  "var(--chart-category-amber)",
+  "var(--chart-category-green)",
+  "var(--chart-category-slate)",
+] as const;
+
+export function institutionalCategoryColor(index: number): string {
+  return INSTITUTIONAL_CATEGORY_COLORS[index % INSTITUTIONAL_CATEGORY_COLORS.length];
+}

--- a/tests/institutional-chart-palette.test.mjs
+++ b/tests/institutional-chart-palette.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const designSystem = fs.readFileSync(new URL("../src/app/design-system.css", import.meta.url), "utf8");
+const palette = fs.readFileSync(new URL("../src/lib/chart-category-colors.ts", import.meta.url), "utf8");
+const pcm = fs.readFileSync(new URL("../src/app/palazzo-chigi/pcm-mission-treemap.tsx", import.meta.url), "utf8");
+const ministries = fs.readFileSync(new URL("../src/app/ministeri/ministry-commitment-treemap.tsx", import.meta.url), "utf8");
+const ministryPage = fs.readFileSync(new URL("../src/app/ministeri/page.tsx", import.meta.url), "utf8");
+const regions = fs.readFileSync(new URL("../src/app/regioni/region-title-treemap.tsx", import.meta.url), "utf8");
+const regionPage = fs.readFileSync(new URL("../src/app/regioni/page.tsx", import.meta.url), "utf8");
+const pcmPage = fs.readFileSync(new URL("../src/app/palazzo-chigi/page.tsx", import.meta.url), "utf8");
+
+const tokenNames = ["blue", "teal", "purple", "amber", "green", "slate"];
+
+function channel(value) {
+  const normalized = value / 255;
+  return normalized <= 0.04045
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+function contrastWithWhite(hex) {
+  const rgb = [1, 3, 5].map((offset) => Number.parseInt(hex.slice(offset, offset + 2), 16));
+  const luminance = 0.2126 * channel(rgb[0]) + 0.7152 * channel(rgb[1]) + 0.0722 * channel(rgb[2]);
+  return 1.05 / (luminance + 0.05);
+}
+
+test("institutional categorical tokens provide six non-red AA families", () => {
+  for (const name of tokenNames) {
+    const match = designSystem.match(new RegExp(`--chart-category-${name}:\\s*(#[0-9a-f]{6})`, "i"));
+    assert.ok(match, `${name}: token missing`);
+    assert.ok(contrastWithWhite(match[1]) >= 4.5, `${name}: white text must meet WCAG AA`);
+    assert.match(palette, new RegExp(`var\\(--chart-category-${name}\\)`));
+  }
+  assert.doesNotMatch(palette, /accent|red/i);
+});
+
+test("additive treemaps use the categorical palette and keep value plus share in text", () => {
+  for (const [name, component] of [["PCM", pcm], ["Ministeri", ministries], ["Regioni", regions]]) {
+    assert.match(component, /institutionalCategoryColor\(node\.index\)/, `${name}: categorical fill missing`);
+    assert.doesNotMatch(component, /fill="var\(--color-accent\)"|fillOpacity/, `${name}: old red fill remains`);
+    assert.match(component, /compactEuro\.format[\s\S]*·[\s\S]*percentage\.format/, `${name}: value and share are not paired`);
+  }
+});
+
+test("each additive view states its denominator and exposes an exact table equivalent", () => {
+  assert.match(pcm, /del pagato PCM/);
+  assert.match(pcmPage, /Quota del pagato PCM/);
+  assert.match(ministries, /del Totale CP dei 15 Ministeri/);
+  assert.match(ministryPage, /Quota del Totale CP/);
+  assert.match(ministryPage, /percentage\.format\(ministry\.commitmentsCpCents \/ totals\.commitmentsCpCents\)/);
+  assert.match(regions, /degli impegni/);
+  assert.match(regionPage, /denominatore è il totale ufficiale/);
+  assert.match(regionPage, /<th scope="col">Quota<\/th>/);
+});

--- a/tests/institutional-evidence-flow.test.mjs
+++ b/tests/institutional-evidence-flow.test.mjs
@@ -43,7 +43,7 @@ test("data routes expose period, perimeter, unit and a complete final provenance
     assert.match(pages[route], pattern, `${route}: incomplete visible scope`);
     assert.match(
       pages[route],
-      /Fonte, metodo, licenza, copertura e limiti|Fonti, metodo, copertura e limiti/,
+      /Font[ei], metodo, licenza, copertura e limiti/,
       `${route}: incomplete final provenance heading`,
     );
   }

--- a/tests/institutional-evidence-flow.test.mjs
+++ b/tests/institutional-evidence-flow.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const routes = ["istituzioni", "parlamento", "palazzo-chigi", "ministeri", "regioni"];
+const pages = Object.fromEntries(
+  routes.map((route) => [
+    route,
+    fs.readFileSync(new URL(`../src/app/${route}/page.tsx`, import.meta.url), "utf8"),
+  ]),
+);
+
+function stageIndex(page, stage) {
+  return page.indexOf(`data-evidence-stage="${stage}"`);
+}
+
+test("institutional routes lead with scope and leave source panels last", () => {
+  for (const [route, page] of Object.entries(pages)) {
+    const scope = stageIndex(page, "scope");
+    const source = stageIndex(page, "source");
+    assert.ok(scope >= 0, `${route}: scope marker missing`);
+    assert.ok(source > scope, `${route}: source panel must follow scope`);
+
+    for (const stage of ["kpi", "visual", "detail"]) {
+      const index = stageIndex(page, stage);
+      if (index >= 0) {
+        assert.ok(index > scope, `${route}: ${stage} must follow scope`);
+        assert.ok(index < source, `${route}: ${stage} must precede sources`);
+      }
+    }
+  }
+});
+
+test("data routes expose period, perimeter, unit and a complete final provenance panel", () => {
+  const expectedScope = {
+    parlamento: /Camera · consuntivi e bilanci verificati · milioni di euro/,
+    "palazzo-chigi": /Rendiconto PCM 2024 · sola Presidenza del Consiglio · euro/,
+    ministeri: /Consuntivo RGS 2025 · 15 Ministeri · competenza · euro/,
+    regioni: /Consuntivi Istat 2024 · 22 amministrazioni · impegni · euro/,
+  };
+
+  for (const [route, pattern] of Object.entries(expectedScope)) {
+    assert.match(pages[route], pattern, `${route}: incomplete visible scope`);
+    assert.match(
+      pages[route],
+      /Fonte, metodo, licenza, copertura e limiti|Fonti, metodo, copertura e limiti/,
+      `${route}: incomplete final provenance heading`,
+    );
+  }
+});
+
+test("Parliament remains metadata-only where numbers are unverified", () => {
+  assert.match(pages.parlamento, /Solo metadati/);
+  assert.match(pages.parlamento, /Numeri del PDF non verificati/);
+  assert.doesNotMatch(pages.parlamento, /Quota del totale|style: "percent"/);
+});

--- a/tests/ministries-ui.test.mjs
+++ b/tests/ministries-ui.test.mjs
@@ -41,7 +41,7 @@ test("Totale CP has a treemap and an exact accessible table fallback", () => {
 });
 
 test("Ministries exact table remains internally scrollable", () => {
-  assert.match(css, /min-width: 820px/);
+  assert.match(css, /min-width: 940px/);
   assert.match(css, /@media \(max-width: 900px\)/);
   assert.match(css, /@media \(max-width: 620px\)/);
   assert.doesNotMatch(css, /border-radius|box-shadow|linear-gradient|transition:\s*all/);


### PR DESCRIPTION
## Stack

- Base: `codex/institutional-mobile-hardening` / #68
- This PR adds only source-order and additive-chart presentation changes.
- No merge or deploy performed.

## What changes

- Makes the reading order explicit on `/istituzioni`, `/parlamento`, `/palazzo-chigi`, `/ministeri`, and `/regioni`: scope first, then KPIs/visuals, exact detail, and the complete source/method/license/coverage/limits panel last.
- Moves Parliament's metadata-only coverage table below the verified Camera cards. Camera and Senato remain separate; no unverified percentage or amount is added.
- Replaces the uniform red additive treemaps with six accessible categorical tokens: blue, teal, purple, amber, green, and slate. Red remains an action/warning accent, not a category or judgment.
- Shows amount and percentage together where a tile has room, with the exact value and the explicit denominator always available in the table. Ministries gains a `Quota del Totale CP` column.

## Atomic commits

- `55f1826` `refactor(ui): order institutional evidence`
- `2d05158` `feat(ui): add institutional category palettes`
- `effbf25` `test(ui): lock complete source headings`

## Verification

- `npm test`: PASS, 290/290
- `npm run lint`: PASS
- `npx tsc --noEmit --incremental false`: PASS
- `npm run build`: PASS, 41/41 static pages generated
- Impeccable detector on changed institutional surfaces: PASS, `[]`
- Palette contrast test: PASS; all six token backgrounds meet WCAG AA with white text
- Browser production build: PASS at 1440×1000 and 390×844 for the five institutional routes plus `/consulenza`
  - 12 results, 54 primary PNGs, full-page + S1-S4 for every institutional route
  - CLS max 0; no global overflow; no long-label overflow; no page, console, HTTP, or genuine request failures
  - 10 focusable exact-table regions; all 5 mobile tables keyboard-scrollable
  - PCM: 6 category families, 0 red tiles; Ministries: 6/0; Regions: 5/0
  - 94 cancelled Next RSC prefetches classified separately as `net::ERR_ABORTED`
  - Consulenza intercepted exactly one local synthetic POST per viewport with consent `true`; no external send
- Maintainer Consulenza fix `acbc271` remains an ancestor of the head.

## Browser artifacts

- Primary manifest: `/private/tmp/dvns-effbf25-proof-round1/manifest.json`
- Primary results: `/private/tmp/dvns-effbf25-proof-round1/results.json`
- Handoff summary: `/private/tmp/dvns-effbf25-proof-handoff.json`
- Corrected Regions desktop stitching proof: `/private/tmp/dvns-effbf25-proof-corrections-final/manifest.json`

The corrected Regions files replace only a full-page screenshot stitching artifact where the normally off-screen skip link appeared at the top. Metrics remain those of the complete primary run; no repository code was changed for the correction.
