### PR TITLE
feat(ui): chiarire spese e territori

### DIFF
--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -94,11 +94,11 @@
   --chart-quaternary: var(--color-neutral-400);
   --chart-quinary: var(--color-accent-300);
   --chart-negative: var(--color-accent-700);
-  --chart-family-services: #cfc2f2;
-  --chart-family-investment: #f2bdc7;
-  --chart-family-pass-through: #f2d071;
-  --chart-family-financing: #efb36d;
-  --chart-family-other: #bdd8e5;
+  --chart-family-services: #aac6e8;
+  --chart-family-investment: #9fd3cb;
+  --chart-family-pass-through: #c1afe1;
+  --chart-family-financing: #e8c47f;
+  --chart-family-other: #acd0ae;
 
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
   --focus-ring: var(--color-accent);

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -18,6 +18,16 @@ export const metadata: Metadata = {
     "Per cosa vengono spesi i soldi dei Comuni: le voci di uscita dei pagamenti di cassa SIOPE, mese per mese.",
 };
 
+const TITLE_FAMILY_BY_CODE: Record<string, string> = {
+  "1": "services",
+  "2": "investment",
+  "7": "pass-through",
+  "4": "financing",
+  "5": "financing",
+  "0": "other",
+  "3": "other",
+};
+
 function selectedYear(value: string | string[] | undefined): number {
   const raw = Array.isArray(value) ? value[0] ?? "" : value ?? "";
   const parsed = /^\d{4}$/.test(raw) ? Number(raw) : Number.NaN;
@@ -54,6 +64,7 @@ export default async function MoneyPage({
   const titles = data.titles.map((title) => ({
     ...title,
     copy: siopeTitleCopy(title.code),
+    family: TITLE_FAMILY_BY_CODE[title.code] ?? "other",
     share: data.totalPaid > 0 ? (title.value / data.totalPaid) * 100 : 0,
   }));
   const titleOneShare = siopeTitleShare(data, "1");
@@ -83,7 +94,7 @@ export default async function MoneyPage({
           <h1>Per cosa vengono spesi i soldi</h1>
           <p>
             Pagamenti dei Comuni nel periodo tra gennaio e {monthLabel} {data.year}, divisi per tipo di
-            uscita. Fonte SIOPE, file del {longDate(data.source.siopeMovementsLastModified)}.
+            uscita. Importi in euro e quote sul totale dei pagamenti nel periodo.
           </p>
           <Link className={styles.mobileDataJump} href="#voci-spesa">
             Vedi le {data.titles.length} voci di uscita ↓
@@ -118,7 +129,7 @@ export default async function MoneyPage({
       </div>
 
       <section
-        className="notice scope-notice"
+        className={`notice scope-notice ${styles.scopeNotice}`}
         aria-labelledby="spese-scope-title"
       >
         <h2 id="spese-scope-title">Quali spese vuoi vedere?</h2>
@@ -278,7 +289,7 @@ export default async function MoneyPage({
 
           <ol className={styles.titleList}>
             {titles.map((title) => (
-              <li key={title.code}>
+              <li key={title.code} data-family={title.family}>
                 <div className={styles.titleHead}>
                   <h3>
                     {title.copy.name}
@@ -359,8 +370,8 @@ export default async function MoneyPage({
         </div>
       </div>
 
-      <details className={styles.method}>
-        <summary>Come sono raccolti questi dati</summary>
+      <section className={`panel ${styles.method}`} aria-labelledby="spese-method-title">
+        <h2 className="panel-title" id="spese-method-title">Fonti e metodo</h2>
         <p>
           Misura: {data.methodology.measure}. {data.methodology.periodicity}. Righe lette:{" "}
           {integer(data.coverage.movementRows)} · incluse:{" "}
@@ -377,7 +388,7 @@ export default async function MoneyPage({
           · {data.source.siopeOwner} · scaricato il {longDate(data.source.observedAt)}.{" "}
           <Link href="/metodologia">Come leggiamo i dati →</Link>
         </p>
-      </details>
+      </section>
     </main>
   );
 }

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -82,7 +82,7 @@ export default async function MoneyPage({
         <div className="page-intro">
           <h1>Per cosa vengono spesi i soldi</h1>
           <p>
-            Pagamenti dei Comuni nel periodo gennaio–{monthLabel} {data.year}, divisi per tipo di
+            Pagamenti dei Comuni nel periodo tra gennaio e {monthLabel} {data.year}, divisi per tipo di
             uscita. Fonte SIOPE, file del {longDate(data.source.siopeMovementsLastModified)}.
           </p>
           <Link className={styles.mobileDataJump} href="#voci-spesa">

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -82,9 +82,12 @@ export default async function MoneyPage({
         <div className="page-intro">
           <h1>Per cosa vengono spesi i soldi</h1>
           <p>
-            Pagamenti dei Comuni da gennaio a {monthLabel} {data.year}, divisi per tipo di uscita.
-            Fonte SIOPE, file del {longDate(data.source.siopeMovementsLastModified)}.
+            Pagamenti dei Comuni nel periodo gennaio–{monthLabel} {data.year}, divisi per tipo di
+            uscita. Fonte SIOPE, file del {longDate(data.source.siopeMovementsLastModified)}.
           </p>
+          <Link className={styles.mobileDataJump} href="#voci-spesa">
+            Vedi le {data.titles.length} voci di uscita ↓
+          </Link>
         </div>
         <PeriodSelector activeYear={year} years={availableSiopeYears} pathname="/spese" />
       </div>
@@ -157,7 +160,7 @@ export default async function MoneyPage({
       </section>
 
       <div className={styles.split}>
-        <section className="panel">
+        <section className="panel" id="voci-spesa">
           <h2 className="panel-title">Le {data.titles.length} voci di uscita</h2>
 
           <section className={styles.analysis} aria-labelledby="spese-analysis-title">

--- a/src/app/spese/spese.module.css
+++ b/src/app/spese/spese.module.css
@@ -22,6 +22,11 @@
   min-width: 0;
 }
 
+.scopeNotice {
+  border-color: var(--color-neutral-300);
+  background: var(--color-raised);
+}
+
 /* ── the expenditure titles ─────────────────────────────────────────────── */
 
 .titleList {
@@ -68,8 +73,13 @@
 .titleTrack i {
   display: block;
   height: 100%;
-  background: var(--color-accent);
+  background: var(--chart-family-other);
 }
+.titleList li[data-family="services"] .titleTrack i { background: var(--chart-family-services); }
+.titleList li[data-family="investment"] .titleTrack i { background: var(--chart-family-investment); }
+.titleList li[data-family="pass-through"] .titleTrack i { background: var(--chart-family-pass-through); }
+.titleList li[data-family="financing"] .titleTrack i { background: var(--chart-family-financing); }
+.titleList li[data-family="other"] .titleTrack i { background: var(--chart-family-other); }
 
 .titleList p {
   margin: 0;
@@ -177,7 +187,7 @@
 .monthList li > i > b {
   display: block;
   height: 100%;
-  background: var(--color-accent);
+  background: var(--chart-family-services);
 }
 .monthList li > b {
   text-align: right;
@@ -195,22 +205,11 @@
 /* ── methodology ────────────────────────────────────────────────────────── */
 
 .method {
-  padding: 16px 18px;
-  background: var(--color-raised);
-  border: 1px solid var(--color-neutral-300);
+  display: grid;
+  gap: var(--space-3);
 }
-.method summary {
-  cursor: pointer;
-  font-family: var(--font-heading);
-  font-size: 11px;
-  font-weight: var(--font-heading-weight);
-  letter-spacing: .09em;
-  text-transform: uppercase;
-  color: var(--color-neutral-700);
-}
-.method summary:hover { color: var(--color-accent-700); }
 .method p {
-  margin: var(--space-3) 0 0;
+  margin: 0;
   font-size: 13px;
   color: var(--color-neutral-800);
   max-width: 100ch;

--- a/src/app/spese/spese.module.css
+++ b/src/app/spese/spese.module.css
@@ -6,6 +6,8 @@
   flex-wrap: wrap;
 }
 
+.mobileDataJump { display: none; }
+
 .split {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 340px;
@@ -220,6 +222,14 @@
 
 @media (max-width: 620px) {
   .intro { align-items: stretch; }
+  .mobileDataJump {
+    display: inline-block;
+    min-height: 24px;
+    margin-top: var(--space-2);
+    color: var(--color-accent-700);
+    font-weight: 600;
+    text-underline-offset: 3px;
+  }
   .titleHead { flex-direction: column; gap: 2px; }
   .monthList li { grid-template-columns: 62px minmax(0, 1fr) 42px; }
   .quantiles { grid-template-columns: 1fr 1fr; }

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -49,8 +49,8 @@ export default async function TerritoriesPage({
         <div className="page-intro">
           <h1>Pagamenti dei Comuni, territorio per territorio</h1>
           <p>
-            Pagamenti dei Comuni con sede nella regione, da gennaio a {monthLabel} {data.year}. Media
-            italiana:{" "}
+            Pagamenti dei Comuni con sede nella regione, nel periodo gennaio–{monthLabel} {data.year}.
+            Media italiana:{" "}
             {data.nationalPerCapita === null
               ? "non disponibile"
               : `${exactEuro(data.nationalPerCapita)} per abitante`}
@@ -64,6 +64,15 @@ export default async function TerritoriesPage({
       <div className={styles.split}>
         <section className="panel">
           <h2 className="panel-title">Tutte le {regions.length} regioni</h2>
+          <p className={styles.datasetMeta}>
+            Fonte SIOPE · {data.source.siopeOwner}. File del{" "}
+            {longDate(data.source.siopeMovementsLastModified)} · periodo gennaio–{monthLabel}{" "}
+            {data.year}. Pro capite: {data.methodology.populationSource},{" "}
+            {data.methodology.populationReference}.
+          </p>
+          <p className={styles.regionTableHint}>
+            Tabella completa: scorri orizzontalmente per abitanti e copertura dei Comuni →
+          </p>
           <div className="table-scroll" role="region" aria-label="Pagamenti di tutte le regioni; scorri orizzontalmente per vedere tutte le colonne" tabIndex={0}>
             <table className="table">
               <thead>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -49,7 +49,7 @@ export default async function TerritoriesPage({
         <div className="page-intro">
           <h1>Pagamenti dei Comuni, territorio per territorio</h1>
           <p>
-            Pagamenti dei Comuni con sede nella regione, nel periodo gennaio–{monthLabel} {data.year}.
+            Pagamenti dei Comuni con sede nella regione, nel periodo tra gennaio e {monthLabel} {data.year}.
             Media italiana:{" "}
             {data.nationalPerCapita === null
               ? "non disponibile"
@@ -66,7 +66,7 @@ export default async function TerritoriesPage({
           <h2 className="panel-title">Tutte le {regions.length} regioni</h2>
           <p className={styles.datasetMeta}>
             Fonte SIOPE · {data.source.siopeOwner}. File del{" "}
-            {longDate(data.source.siopeMovementsLastModified)} · periodo gennaio–{monthLabel}{" "}
+            {longDate(data.source.siopeMovementsLastModified)} · periodo tra gennaio e {monthLabel}{" "}
             {data.year}. Pro capite: {data.methodology.populationSource},{" "}
             {data.methodology.populationReference}.
           </p>

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -35,6 +35,10 @@ export default async function TerritoriesPage({
   const regions = regionsByPerCapita(data);
   const regionsByArea = groupRegionsByMacroArea(regions);
   const topByPerCapita = data.topMunicipalitiesByPerCapita.slice(0, 20);
+  const topByPerCapitaGroups = [
+    { label: "Posizioni 1-10", municipalities: topByPerCapita.slice(0, 10) },
+    { label: "Posizioni 11-20", municipalities: topByPerCapita.slice(10, 20) },
+  ];
   const topByVolume = data.topMunicipalitiesByValue.slice(0, 10);
   const regionScale = Math.max(
     ...regions.map((region) => region.value),
@@ -146,39 +150,51 @@ export default async function TerritoriesPage({
         <div className={styles.aside}>
           <section className="panel" data-municipality-ranking="per-capita">
             <h2 className="panel-title">I {topByPerCapita.length} Comuni con più pagamenti per abitante</h2>
-            <div className="table-scroll" role="region" aria-label="Comuni ordinati per pagamenti pro capite; scorri orizzontalmente per vedere tutte le colonne" tabIndex={0}>
-              <table className="table">
-                <thead>
-                  <tr>
-                    <th scope="col">Comune</th>
-                    <th scope="col" className="num">Per abitante</th>
-                    <th scope="col" className="num">Totale</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {topByPerCapita.map((municipality) => (
-                    <tr key={municipality.codiceFiscale}>
-                      <th scope="row">
-                        {municipalityName(municipality.name)}
-                        <small>
-                          {municipality.province} · {municipality.region}
-                        </small>
-                        <small>
-                          {municipality.population === null
-                            ? "abitanti non disponibili"
-                            : `${integer(municipality.population)} abitanti`}
-                        </small>
-                      </th>
-                      <td className="num">
-                        {municipality.perCapita === null
-                          ? "n.d."
-                          : exactEuro(municipality.perCapita)}
-                      </td>
-                      <td className="num">{compactEuro(municipality.value)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+            <div className={styles.rankingGrid}>
+              {topByPerCapitaGroups.map((group) => (
+                <div className={styles.rankingGroup} key={group.label}>
+                  <h3 className={styles.rankingGroupTitle}>{group.label}</h3>
+                  <div
+                    className="table-scroll"
+                    role="region"
+                    aria-label={`${group.label}: Comuni ordinati per pagamenti pro capite; scorri orizzontalmente per vedere tutte le colonne`}
+                    tabIndex={0}
+                  >
+                    <table className="table">
+                      <thead>
+                        <tr>
+                          <th scope="col">Comune</th>
+                          <th scope="col" className="num">Per abitante</th>
+                          <th scope="col" className="num">Totale</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {group.municipalities.map((municipality) => (
+                          <tr key={municipality.codiceFiscale}>
+                            <th scope="row">
+                              {municipalityName(municipality.name)}
+                              <small>
+                                {municipality.province} · {municipality.region}
+                              </small>
+                              <small>
+                                {municipality.population === null
+                                  ? "abitanti non disponibili"
+                                  : `${integer(municipality.population)} abitanti`}
+                              </small>
+                            </th>
+                            <td className="num">
+                              {municipality.perCapita === null
+                                ? "n.d."
+                                : exactEuro(municipality.perCapita)}
+                            </td>
+                            <td className="num">{compactEuro(municipality.value)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))}
             </div>
           </section>
 

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -68,17 +68,11 @@ export default async function TerritoriesPage({
       <div className={styles.split}>
         <section className="panel">
           <h2 className="panel-title">Tutte le {regions.length} regioni</h2>
-          <p className={styles.datasetMeta}>
-            Fonte SIOPE · {data.source.siopeOwner}. File del{" "}
-            {longDate(data.source.siopeMovementsLastModified)} · periodo tra gennaio e {monthLabel}{" "}
-            {data.year}. Pro capite: {data.methodology.populationSource},{" "}
-            {data.methodology.populationReference}.
-          </p>
           <p className={styles.regionTableHint}>
             Tabella completa: scorri orizzontalmente per abitanti e copertura dei Comuni →
           </p>
           <div className="table-scroll" role="region" aria-label="Pagamenti di tutte le regioni; scorri orizzontalmente per vedere tutte le colonne" tabIndex={0}>
-            <table className="table">
+            <table className={`table ${styles.regionTable}`}>
               <thead>
                 <tr>
                   <th scope="col">Regione</th>
@@ -138,13 +132,6 @@ export default async function TerritoriesPage({
               ))}
             </table>
           </div>
-          <p className={styles.note}>Nota di metodo: {data.methodology.warning}</p>
-          <p className={styles.note}>Copertura pro capite: {data.methodology.perCapitaCoverage}.</p>
-          <p className={styles.note}>
-            I link regionali aprono i dati CPT 2023, un perimetro distinto da SIOPE. Nei CPT,
-            Trento e Bolzano sono pubblicati come due Province autonome: il dato SIOPE aggregato
-            del Trentino-Alto Adige non viene collegato artificialmente a una sola voce.
-          </p>
         </section>
 
         <div className={styles.aside}>
@@ -242,7 +229,7 @@ export default async function TerritoriesPage({
         </div>
       </div>
 
-      <div className="notice">
+      <div className={`notice ${styles.relatedNotice}`}>
         <strong>Quanto entra e quanto viene speso sul territorio?</strong>
         <p>
           I Conti Pubblici Territoriali permettono di confrontare entrate e spese della Pubblica
@@ -251,7 +238,7 @@ export default async function TerritoriesPage({
         </p>
       </div>
 
-      <div className="notice">
+      <div className={`notice ${styles.relatedNotice}`}>
         <strong>Redditi e imposta netta dichiarata</strong>
         <p>
           Il MEF pubblica contribuenti, redditi, imposta netta dichiarata e addizionali per Comune.
@@ -260,7 +247,7 @@ export default async function TerritoriesPage({
         </p>
       </div>
 
-      <div className="notice">
+      <div className={`notice ${styles.relatedNotice}`}>
         <strong>Confronta spesa e fabbisogno standard</strong>
         <p>
           Per i Comuni delle Regioni a statuto ordinario puoi confrontare la spesa storica con il
@@ -299,20 +286,36 @@ export default async function TerritoriesPage({
               <dd>{integer(data.coverage.withoutPopulation)}</dd>
             </div>
           </dl>
-          <p>
-            I {exactEuro(data.coverage.paymentsWithoutRegion)} dei Comuni senza abbinamento IPA
-            restano nel totale nazionale ma fuori dai totali regionali: non assegniamo una regione
-            senza una corrispondenza ufficiale. Il denominatore è la{" "}
-            {data.methodology.populationSource}; {data.methodology.populationReference}; anagrafica
-            aggiornata il{" "}
-            {data.methodology.populationSourceLastModified
-              ? longDate(data.methodology.populationSourceLastModified)
-              : "data non disponibile"}. Fonte SIOPE · {data.source.siopeOwner},
-            scaricata il{" "}
-            {longDate(data.source.observedAt)}.{" "}
-            <Link href="/fonti/stato">Stato di tutte le fonti →</Link>
-          </p>
         </div>
+      </section>
+
+      <section className={`panel ${styles.method}`} aria-labelledby="territori-method-title">
+        <h2 className="panel-title" id="territori-method-title">Fonti e metodo</h2>
+        <p>Nota di metodo: {data.methodology.warning}</p>
+        <p>Copertura pro capite: {data.methodology.perCapitaCoverage}.</p>
+        <p>
+          I {exactEuro(data.coverage.paymentsWithoutRegion)} dei Comuni senza abbinamento IPA
+          restano nel totale nazionale ma fuori dai totali regionali: non assegniamo una regione
+          senza una corrispondenza ufficiale. Il denominatore è la{" "}
+          {data.methodology.populationSource}; {data.methodology.populationReference}; anagrafica
+          aggiornata il{" "}
+          {data.methodology.populationSourceLastModified
+            ? longDate(data.methodology.populationSourceLastModified)
+            : "data non disponibile"}.
+        </p>
+        <p>
+          I link regionali aprono i dati CPT 2023, un perimetro distinto da SIOPE. Nei CPT,
+          Trento e Bolzano sono pubblicati come due Province autonome: il dato SIOPE aggregato
+          del Trentino-Alto Adige non viene collegato artificialmente a una sola voce.
+        </p>
+        <p>
+          Fonte{" "}
+          <a href={data.source.siopeMovementsUrl} target="_blank" rel="noreferrer">SIOPE</a>
+          {" "}· {data.source.siopeOwner} · file del{" "}
+          {longDate(data.source.siopeMovementsLastModified)} · scaricato il{" "}
+          {longDate(data.source.observedAt)}.{" "}
+          <Link href="/fonti/stato">Stato di tutte le fonti →</Link>
+        </p>
       </section>
     </main>
   );

--- a/src/app/territori/territori.module.css
+++ b/src/app/territori/territori.module.css
@@ -35,6 +35,23 @@
   font-weight: 600;
 }
 
+.regionTable a {
+  color: var(--color-text);
+  text-decoration: underline;
+  text-decoration-color: var(--color-neutral-400);
+  text-underline-offset: 2px;
+}
+
+.regionTable a:hover,
+.regionTable a:focus-visible { color: var(--color-accent-700); }
+
+.relatedNotice {
+  border-color: var(--color-neutral-300);
+  background: var(--color-raised);
+}
+
+.relatedNotice :global(strong) { color: var(--color-neutral-700); }
+
 .areaRow th,
 .areaRow td {
   background: var(--color-neutral-100);
@@ -49,13 +66,6 @@
   letter-spacing: .08em;
   text-transform: uppercase;
   color: var(--color-neutral-600);
-}
-
-.datasetMeta {
-  max-width: 100ch;
-  margin: 0 0 var(--space-3);
-  color: var(--color-neutral-700);
-  font-size: 12px;
 }
 
 .regionTableHint { display: none; }
@@ -98,6 +108,18 @@
   margin: 0;
   font-size: 13px;
   color: var(--color-neutral-800);
+}
+
+.method {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.method p {
+  max-width: 100ch;
+  margin: 0;
+  color: var(--color-neutral-800);
+  font-size: 13px;
 }
 
 @media (max-width: 760px) {

--- a/src/app/territori/territori.module.css
+++ b/src/app/territori/territori.module.css
@@ -7,10 +7,9 @@
 }
 
 .split {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 400px;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-4);
-  align-items: start;
 }
 
 .aside {
@@ -35,6 +34,15 @@
   text-transform: uppercase;
   color: var(--color-neutral-600);
 }
+
+.datasetMeta {
+  max-width: 100ch;
+  margin: 0 0 var(--space-3);
+  color: var(--color-neutral-700);
+  font-size: 12px;
+}
+
+.regionTableHint { display: none; }
 
 .note {
   margin: var(--space-3) 0 0;
@@ -76,15 +84,18 @@
   color: var(--color-neutral-800);
 }
 
-@media (max-width: 1100px) {
-  .split { grid-template-columns: minmax(0, 1fr); }
-}
-
 @media (max-width: 760px) {
   .coverage { grid-template-columns: minmax(0, 1fr); gap: var(--space-4); }
 }
 
 @media (max-width: 620px) {
   .intro { align-items: stretch; }
+  .regionTableHint {
+    display: block;
+    margin: 0 0 var(--space-3);
+    color: var(--color-neutral-700);
+    font-size: 12px;
+    font-weight: 600;
+  }
   .coverageList dd { font-size: 18px; }
 }

--- a/src/app/territori/territori.module.css
+++ b/src/app/territori/territori.module.css
@@ -19,6 +19,22 @@
   min-width: 0;
 }
 
+.rankingGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.rankingGroup { min-width: 0; }
+
+.rankingGroupTitle {
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .areaRow th,
 .areaRow td {
   background: var(--color-neutral-100);
@@ -85,6 +101,7 @@
 }
 
 @media (max-width: 760px) {
+  .rankingGrid { grid-template-columns: minmax(0, 1fr); }
   .coverage { grid-template-columns: minmax(0, 1fr); gap: var(--space-4); }
 }
 

--- a/tests/ui-contracts.test.mjs
+++ b/tests/ui-contracts.test.mjs
@@ -71,7 +71,7 @@ test("municipal screening is marked derived, bounded and dimension-aware", () =>
 
 test("scope guidance is consolidated without losing its source boundaries", () => {
   assert.equal(
-    spendingPage.match(/className="notice scope-notice"/g)?.length,
+    spendingPage.match(/className=\{`notice scope-notice \$\{styles\.scopeNotice\}`\}/g)?.length,
     1,
   );
   assert.equal(

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -175,6 +175,11 @@ test("strong civic surfaces use defined foreground tokens", async () => {
   assert.match(cohesionCss, /color:\s*var\(--color-on-strong\);/);
   assert.match(cohesionCss, /color:\s*var\(--color-on-strong-muted\);/);
   assert.doesNotMatch(cohesionCss, /var\(--color-neutral-0\)/);
+  assert.match(tokens, /--chart-family-services:\s*#aac6e8;/);
+  assert.match(tokens, /--chart-family-investment:\s*#9fd3cb;/);
+  assert.match(tokens, /--chart-family-pass-through:\s*#c1afe1;/);
+  assert.match(tokens, /--chart-family-financing:\s*#e8c47f;/);
+  assert.match(tokens, /--chart-family-other:\s*#acd0ae;/);
 });
 
 test("the fiscal layout uses only defined spacing tokens", async () => {
@@ -254,18 +259,31 @@ test("spending exposes a mobile jump to the complete expenditure breakdown", asy
   assert.match(page, /id="voci-spesa"/);
   assert.match(page, /Vedi le \{data\.titles\.length\} voci di uscita/);
   assert.match(page, /periodo tra gennaio e \{monthLabel\}/);
+  assert.doesNotMatch(page.slice(page.indexOf("<h1>"), page.indexOf("<PeriodSelector")), /Fonte SIOPE/);
+  assert.ok(page.indexOf("Fonti e metodo") > page.indexOf("Flusso mensile e cumulato delle spese"));
+  assert.match(page, /data-family=\{title\.family\}/);
+  assert.match(css, /data-family="services"[\s\S]*?var\(--chart-family-services\)/);
+  assert.match(css, /data-family="investment"[\s\S]*?var\(--chart-family-investment\)/);
+  assert.match(css, /data-family="pass-through"[\s\S]*?var\(--chart-family-pass-through\)/);
+  assert.match(css, /\.scopeNotice \{[\s\S]*?border-color: var\(--color-neutral-300\);/);
+  assert.match(css, /\.monthList li > i > b \{[\s\S]*?background: var\(--chart-family-services\);/);
   assert.match(css, /\.mobileDataJump \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.mobileDataJump \{[\s\S]*?display: inline-block;/);
 });
 
-test("territories keeps provenance close and reflows without a short desktop column", async () => {
+test("territories puts complete provenance after the data and reflows without a short desktop column", async () => {
   const [page, css] = await Promise.all([
     source("../src/app/territori/page.tsx"),
     source("../src/app/territori/territori.module.css"),
   ]);
 
-  assert.match(page, /Fonte SIOPE · \{data\.source\.siopeOwner\}/);
-  assert.match(page, /Pro capite: \{data\.methodology\.populationSource\}/);
+  const firstDataset = page.indexOf("Pagamenti di tutte le regioni");
+  const method = page.indexOf("Fonti e metodo");
+  assert.ok(firstDataset >= 0);
+  assert.ok(method > firstDataset);
+  assert.ok(page.indexOf("Fonte{\" \"}", method) > method);
+  assert.doesNotMatch(page.slice(page.indexOf("<h1>"), firstDataset), /Fonte SIOPE/);
+  assert.match(page, /\{data\.methodology\.populationSource\}/);
   assert.match(page, /Tabella completa: scorri orizzontalmente per abitanti e copertura dei Comuni/);
   assert.match(page, /aria-label="Pagamenti di tutte le regioni; scorri orizzontalmente/);
   assert.match(page, /tabIndex=\{0\}/);
@@ -274,6 +292,9 @@ test("territories keeps provenance close and reflows without a short desktop col
   assert.match(page, /Posizioni 11-20/);
   assert.match(css, /\.split \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
   assert.match(css, /\.rankingGrid \{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);/);
+  assert.match(page, /className=\{`table \$\{styles\.regionTable\}`\}/);
+  assert.match(css, /\.regionTable a \{[\s\S]*?color: var\(--color-text\);[\s\S]*?text-decoration: underline;/);
+  assert.match(css, /\.relatedNotice \{[\s\S]*?border-color: var\(--color-neutral-300\);/);
   assert.match(css, /@media \(max-width: 760px\)[\s\S]*?\.rankingGrid \{ grid-template-columns: minmax\(0, 1fr\); \}/);
   assert.match(css, /\.regionTableHint \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.regionTableHint \{[\s\S]*?display: block;/);

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -257,3 +257,20 @@ test("spending exposes a mobile jump to the complete expenditure breakdown", asy
   assert.match(css, /\.mobileDataJump \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.mobileDataJump \{[\s\S]*?display: inline-block;/);
 });
+
+test("territories keeps provenance close and reflows without a short desktop column", async () => {
+  const [page, css] = await Promise.all([
+    source("../src/app/territori/page.tsx"),
+    source("../src/app/territori/territori.module.css"),
+  ]);
+
+  assert.match(page, /Fonte SIOPE · \{data\.source\.siopeOwner\}/);
+  assert.match(page, /Pro capite: \{data\.methodology\.populationSource\}/);
+  assert.match(page, /Tabella completa: scorri orizzontalmente per abitanti e copertura dei Comuni/);
+  assert.match(page, /aria-label="Pagamenti di tutte le regioni; scorri orizzontalmente/);
+  assert.match(page, /tabIndex=\{0\}/);
+  assert.match(page, /periodo gennaio–\{monthLabel\}/);
+  assert.match(css, /\.split \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
+  assert.match(css, /\.regionTableHint \{ display: none; \}/);
+  assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.regionTableHint \{[\s\S]*?display: block;/);
+});

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -270,7 +270,11 @@ test("territories keeps provenance close and reflows without a short desktop col
   assert.match(page, /aria-label="Pagamenti di tutte le regioni; scorri orizzontalmente/);
   assert.match(page, /tabIndex=\{0\}/);
   assert.match(page, /periodo tra gennaio e \{monthLabel\}/);
+  assert.match(page, /Posizioni 1-10/);
+  assert.match(page, /Posizioni 11-20/);
   assert.match(css, /\.split \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
+  assert.match(css, /\.rankingGrid \{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);/);
+  assert.match(css, /@media \(max-width: 760px\)[\s\S]*?\.rankingGrid \{ grid-template-columns: minmax\(0, 1fr\); \}/);
   assert.match(css, /\.regionTableHint \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.regionTableHint \{[\s\S]*?display: block;/);
 });

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -253,7 +253,7 @@ test("spending exposes a mobile jump to the complete expenditure breakdown", asy
   assert.match(page, /href="#voci-spesa"/);
   assert.match(page, /id="voci-spesa"/);
   assert.match(page, /Vedi le \{data\.titles\.length\} voci di uscita/);
-  assert.match(page, /periodo gennaio–\{monthLabel\}/);
+  assert.match(page, /periodo tra gennaio e \{monthLabel\}/);
   assert.match(css, /\.mobileDataJump \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.mobileDataJump \{[\s\S]*?display: inline-block;/);
 });
@@ -269,7 +269,7 @@ test("territories keeps provenance close and reflows without a short desktop col
   assert.match(page, /Tabella completa: scorri orizzontalmente per abitanti e copertura dei Comuni/);
   assert.match(page, /aria-label="Pagamenti di tutte le regioni; scorri orizzontalmente/);
   assert.match(page, /tabIndex=\{0\}/);
-  assert.match(page, /periodo gennaio–\{monthLabel\}/);
+  assert.match(page, /periodo tra gennaio e \{monthLabel\}/);
   assert.match(css, /\.split \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
   assert.match(css, /\.regionTableHint \{ display: none; \}/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.regionTableHint \{[\s\S]*?display: block;/);

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -243,3 +243,17 @@ test("cohesion adds a mobile summary without removing the exact table", async ()
   assert.match(page, /<table className="table">/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.dimensionSummary \{[\s\S]*?display: grid;/);
 });
+
+test("spending exposes a mobile jump to the complete expenditure breakdown", async () => {
+  const [page, css] = await Promise.all([
+    source("../src/app/spese/page.tsx"),
+    source("../src/app/spese/spese.module.css"),
+  ]);
+
+  assert.match(page, /href="#voci-spesa"/);
+  assert.match(page, /id="voci-spesa"/);
+  assert.match(page, /Vedi le \{data\.titles\.length\} voci di uscita/);
+  assert.match(page, /periodo gennaio–\{monthLabel\}/);
+  assert.match(css, /\.mobileDataJump \{ display: none; \}/);
+  assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.mobileDataJump \{[\s\S]*?display: inline-block;/);
+});


### PR DESCRIPTION
## Obiettivo

Prima slice dell'audit route-by-route: rendere `/spese` e `/territori` più comprensibili e scansionabili, senza cambiare dati, perimetri o semantica delle fonti.

PR stacked su `codex/ui-route-matrix`; nessun merge o deploy incluso.

## Osservazioni → decisioni

- `/spese` mobile: il totale era visibile subito, ma il dettaglio delle sette voci iniziava molto più in basso. Decisione: aggiungere nel primo viewport un salto minimo `Vedi le 7 voci di uscita`, preservando KPI, periodo, caveat e valori.
- `/territori` desktop: due colonne fortemente asimmetriche lasciavano oltre 300 px di spazio morto e allungavano la scansione. Decisione bounded A/B: mantenere la tabella regionale full-width e dividere il ranking esatto in due tabelle bilanciate 1–10 / 11–20.
- `/territori` mobile: la tabella a cinque colonne non dichiarava lo scorrimento. Decisione: hint visibile e regione scrollabile raggiungibile da touch e tastiera, senza nascondere colonne o righe.
- Le informazioni tecniche di provenienza interrompevano l'ingresso nei dati. Decisione: nel titolo lasciare solo periodo, perimetro e unità; spostare fonte, copertura, denominatore e metodo nel blocco finale `Fonti e metodo`.
- Le superfici dati ripetevano troppo il rosso. Decisione: usare famiglie categoriali blu, turchese, viola, ambra e verde per la composizione additiva; blu per i flussi mensili; superfici informative neutre. Il rosso resta per CTA, accento e warning reali. Percentuali, etichette e valori esatti restano sempre visibili: nessuna informazione dipende dal colore.

## Confronto bounded `/territori`

| Candidato | Altezza documento | Altezza ranking | Distanza media nome→valore | Tabelle esatte | Esito |
| --- | ---: | ---: | ---: | --- | --- |
| A · full-width stacked | 4.820 px | 1.721 px | 453 px | sì, 20 righe | respinto: scansione troppo lunga |
| B · ranking bilanciato | 4.008 px nel prototipo; 4.174 px current head con fonti finali | 909 px | 233 px | sì, 20 righe | scelto |

Il candidato B riduce la profondità del ranking del 47% e la distanza di scansione del 49%, senza reintrodurre una colonna vuota strutturale. L'ordine DOM e tastiera resta 1–10, poi 11–20.

## Implementazione

- Jump mobile `/spese`, focus verificabile e destinazione non coperta da header sticky.
- Palette categoriale semantica per le sette voci additive, percentuale e valore esatto invariati.
- Tabella regionale full-width con hint mobile, focus visibile e scorrimento ArrowRight fino alla quinta colonna.
- Ranking comunale in due tabelle esatte e bilanciate.
- Copy temporale esplicita (`ad agosto`) e blocchi completi `Fonti e metodo` in fondo.
- Test statici per ordine DOM, palette, link, tabelle e affordance responsive.

La composizione delle sette voci SIOPE è un candidato valido per una futura treemap perché usa un'unica misura additiva, omogenea e con denominatore dichiarato. Questa slice non aggiunge una treemap decorativa: mantiene barre proporzionali e tabella/valori esatti. La mappa Italia resta invariata.

## Verifica current head `e945806`

Viewport: mobile 390×844, desktop 1280×1000. Le quattro sezioni sono contigue e coprono il 100% di ogni documento.

| Route | Viewport | Sezione | Intervallo verticale | Osservazione / criterio | Verdetto |
| --- | --- | --- | ---: | --- | --- |
| `/spese` | mobile | S1 | 0–1336 | dato e jump prima della fonte tecnica; jump y=304, fondo=328 ≤844 | PASS |
| `/spese` | mobile | S2 | 1336–2673 | composizione leggibile, percentuali + valori, nessun color-only | PASS |
| `/spese` | mobile | S3 | 2673–4010 | flussi e tabella esatta senza overflow body | PASS |
| `/spese` | mobile | S4 | 4010–5347 | `Fonti e metodo` completo dopo i dataset | PASS |
| `/spese` | desktop | S1 | 0–745 | H1, periodo/unità, KPI e contenuto prima della fonte | PASS |
| `/spese` | desktop | S2 | 745–1491 | gerarchia e categorie distinguibili senza rosso ripetitivo | PASS |
| `/spese` | desktop | S3 | 1491–2237 | valori e confronto conservati | PASS |
| `/spese` | desktop | S4 | 2237–2983 | metodo e fonte chiudono la pagina | PASS |
| `/territori` | mobile | S1 | 0–1537 | margine sinistro completo con `scrollLeft=0`; hint visibile | PASS |
| `/territori` | mobile | S2 | 1537–3075 | cinque colonne raggiungibili; ArrowRight 0→3, ripetuto fino a 219 | PASS |
| `/territori` | mobile | S3 | 3075–4613 | ranking 1–20, ordine DOM coerente, nessun overflow body | PASS |
| `/territori` | mobile | S4 | 4613–6151 | fonte, data, periodo, denominatore e caveat completi | PASS |
| `/territori` | desktop | S1 | 0–1043 | tabella regionale senza colonna vuota >300 px | PASS |
| `/territori` | desktop | S2 | 1043–2087 | ranking compatto, nomi e valori più vicini | PASS |
| `/territori` | desktop | S3 | 2087–3130 | tabelle esatte complete e simmetriche | PASS |
| `/territori` | desktop | S4 | 3130–4174 | metodo e provenienza alla fine | PASS |

Prove trasversali:

- `documentElement.scrollWidth === clientWidth` e body senza overflow in tutti e quattro i render.
- CLS misurato `0`; errori runtime `[]`.
- Reflow 320 px: H1 visibile e larghezza documento = viewport per entrambe le route.
- `/territori` mobile: `scrollLeft=0` iniziale, tutte e cinque le intestazioni rilevate, focus-visible attivo, quinta colonna raggiunta a `scrollLeft=219`.
- `/spese` mobile: attivazione jump verificata; target non coperto da header sticky.
- Filled/light PASS. Dark, loading, empty ed error non sono stati dichiarati da queste route e sono N/A, non PASS.
- Consulenza: form, consenso e submit sintetico PASS; comportamento email di default invariato.

## Gate locali

- `npm test`: 267/267 PASS
- `npm run typecheck`: PASS
- `npm run lint`: PASS
- `npm run design:check`: PASS (Impeccable completo)
- `npm run build`: PASS, 37 pagine generate
- `git diff --check`: PASS
- scan riferimenti privati: PASS

`main` contiene un refresh dati Consulenti Pubblici non sovrapposto; per mantenere la review atomica questa PR resta stacked sulla route matrix aggiornata.
