### PR TITLE
feat(appalti): add ANAC CIG 2025 public view

### DIFF
--- a/src/app/appalti/appalti.module.css
+++ b/src/app/appalti/appalti.module.css
@@ -179,6 +179,7 @@
 }
 
 .detailTable {
+  min-width: 0;
   border-top: 1px solid var(--color-neutral-300);
   padding-top: var(--space-3);
 }
@@ -221,6 +222,13 @@
   color: var(--color-neutral-700);
   font-size: 13px;
   line-height: 1.55;
+}
+
+.definitionSource {
+  display: block;
+  margin-top: var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
 }
 
 .thresholdPanel table,

--- a/src/app/appalti/appalti.module.css
+++ b/src/app/appalti/appalti.module.css
@@ -1,0 +1,336 @@
+.page {
+  gap: var(--space-6);
+}
+
+.intro {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.scopeLine {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  margin: 0;
+  padding: 10px 0;
+  border-top: 1px solid var(--color-neutral-300);
+  border-bottom: 1px solid var(--color-neutral-300);
+  color: var(--color-neutral-700);
+  font-size: 12px;
+}
+
+.scopeLine strong {
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.readingNotice {
+  border-color: var(--color-neutral-400);
+}
+
+.readingNotice strong {
+  display: inline;
+  color: var(--color-text);
+  font-size: inherit;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.leadPanel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(220px, .65fr);
+  gap: var(--space-8);
+  align-items: end;
+}
+
+.leadCopy p,
+.sectionHeading p,
+.sourcePanel > p,
+.exactAmounts p {
+  max-width: 75ch;
+  margin: 0;
+  color: var(--color-neutral-800);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.leadCopy strong {
+  color: var(--color-text);
+}
+
+.leadMeasure {
+  display: grid;
+  gap: 4px;
+  padding-top: var(--space-4);
+  border-top: 3px solid var(--chart-primary);
+}
+
+.leadMeasure span {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.leadMeasure strong {
+  font-family: var(--font-heading);
+  font-size: 44px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: -.03em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.leadMeasure small {
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.procedurePanel,
+.subsetPanel,
+.thresholdPanel,
+.coveragePanel,
+.sourcePanel {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+
+.sectionHeading .tag {
+  flex: 0 0 auto;
+}
+
+.barList {
+  display: grid;
+  gap: var(--space-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.barList li {
+  position: relative;
+  display: grid;
+  gap: 6px;
+  padding-left: 30px;
+}
+
+.barMeta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.barMeta > span {
+  min-width: 0;
+  color: var(--color-text);
+}
+
+.barMeta strong {
+  flex: 0 0 auto;
+  color: var(--color-text);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.barMeta small {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.barTrack {
+  height: 12px;
+  background: var(--color-neutral-200);
+}
+
+.barTrack i {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  background: var(--chart-primary);
+}
+
+.barList li:nth-child(2) .barTrack i { background: var(--chart-secondary); }
+.barList li:nth-child(3) .barTrack i { background: var(--chart-tertiary); }
+.barList li:nth-child(4) .barTrack i { background: var(--chart-quaternary); }
+.barList li:nth-child(5) .barTrack i { background: var(--chart-quinary); }
+.barList li:nth-child(6) .barTrack i { background: var(--color-neutral-700); }
+.barList li:nth-child(7) .barTrack i { background: var(--color-neutral-400); }
+
+.barRank {
+  position: absolute;
+  top: 1px;
+  left: 0;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.detailTable {
+  border-top: 1px solid var(--color-neutral-300);
+  padding-top: var(--space-3);
+}
+
+.detailTable summary,
+.methodDetails summary {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--color-accent-700);
+  font-weight: 700;
+}
+
+.detailTable .table-scroll {
+  margin-top: var(--space-3);
+}
+
+.detailTable table {
+  min-width: 680px;
+}
+
+.threeStats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.threeStats > div:nth-child(3n) {
+  border-right: 0;
+}
+
+.note {
+  margin: 0;
+  color: var(--color-neutral-700);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.thresholdPanel table,
+.coveragePanel table,
+.sourcePanel table {
+  min-width: 760px;
+}
+
+.thresholdPanel td.num:last-child,
+.thresholdPanel th.num:last-child {
+  white-space: normal;
+  min-width: 250px;
+}
+
+.exactAmounts {
+  display: grid;
+  gap: var(--space-3);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.exactAmounts h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 18px;
+}
+
+.sourcePanel {
+  scroll-margin-top: var(--space-4);
+}
+
+.sourceList {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 var(--space-6);
+  margin: 0;
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.sourceList > div {
+  display: grid;
+  grid-template-columns: minmax(110px, .4fr) minmax(0, 1fr);
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+
+.sourceList dt {
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.sourceList dd {
+  margin: 0;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+}
+
+.methodDetails {
+  border-top: 1px solid var(--color-neutral-300);
+  padding-top: var(--space-3);
+}
+
+.methodDetails ul {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0 0 0 18px;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.nextStep {
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-neutral-300);
+  color: var(--color-neutral-700);
+  font-size: 13px;
+}
+
+@media (max-width: 760px) {
+  .leadPanel {
+    grid-template-columns: 1fr;
+    gap: var(--space-6);
+  }
+
+  .leadMeasure {
+    max-width: 22rem;
+  }
+
+  .sectionHeading {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .barMeta {
+    display: grid;
+    gap: 3px;
+  }
+
+  .barMeta strong {
+    justify-self: start;
+  }
+
+  .sourceList {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .leadMeasure strong {
+    font-size: 36px;
+  }
+
+  .scopeLine {
+    line-height: 1.5;
+  }
+}

--- a/src/app/appalti/appalti.module.css
+++ b/src/app/appalti/appalti.module.css
@@ -201,6 +201,13 @@
   min-width: 680px;
 }
 
+.tableHint {
+  display: none;
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
 .threeStats {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
@@ -322,6 +329,10 @@
 
   .sourceList {
     grid-template-columns: 1fr;
+  }
+
+  .tableHint {
+    display: block;
   }
 }
 

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -1,0 +1,415 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { anacCigSnapshot } from "@/lib/anac-cig-snapshot";
+import { exactEuro, integer, longDate, percent } from "@/lib/format";
+import styles from "./appalti.module.css";
+
+export const metadata: Metadata = {
+  title: "Appalti pubblici",
+  description:
+    "CIG 2025, procedure e segnali sulle soglie degli appalti pubblici ANAC, spiegati con perimetro e limiti chiari.",
+};
+
+const data = anacCigSnapshot;
+const totalCigs = data.population.records;
+const procedureEntries = Object.entries(data.procedureChoice.allLabels)
+  .map(([label, records]) => ({ label, records }))
+  .sort((left, right) => right.records - left.records);
+const featuredProcedureEntries = procedureEntries.slice(0, 6);
+const otherProcedureEntries = procedureEntries.slice(6);
+const otherProcedureCount = otherProcedureEntries.reduce((sum, row) => sum + row.records, 0);
+const procedureRows = [
+  ...featuredProcedureEntries,
+  { label: `Altre ${otherProcedureEntries.length} etichette`, records: otherProcedureCount },
+];
+const largestProcedureCount = procedureRows[0]?.records ?? 1;
+
+const directAward = data.procedureChoice.directAward;
+const directAwardFamily = data.procedureChoice.directAwardFamily;
+const servicesAndSupplies = data.population.servicesAndSupplies;
+const below140000 = data.servicesAndSuppliesBelow140000;
+const thresholdBand = data.thresholdBand135000To140000;
+
+function share(records: number, denominator: number): string {
+  return percent((records / denominator) * 100);
+}
+
+const exactAmountRows = Object.entries(data.exactContractAmounts)
+  .map(([amount, records]) => ({ amount: Number(amount), records }))
+  .sort((left, right) => right.records - left.records);
+
+export default function AppaltiPage() {
+  return (
+    <main className={`shell page ${styles.page}`}>
+      <div className={styles.intro}>
+        <div className="page-intro">
+          <h1>Appalti pubblici: che cosa mostrano i CIG 2025</h1>
+          <p>
+            Una lettura dei codici di gara pubblicati da ANAC per capire quali procedure ricorrono
+            di più e quali numeri meritano un controllo più vicino.
+          </p>
+        </div>
+        <p className={styles.scopeLine}>
+          <strong>Periodo: 2025</strong>
+          <span>·</span>
+          <span>{integer(totalCigs)} CIG unici</span>
+          <span>·</span>
+          <span>valori in euro dichiarati per il lotto</span>
+        </p>
+      </div>
+
+      <section className="stat-strip" aria-label="Numeri principali del perimetro ANAC">
+        <div>
+          <span className="stat-label">CIG unici</span>
+          <span className="stat-value">{integer(totalCigs)}</span>
+          <span className="stat-note">dopo i controlli di unicità sul 2025</span>
+        </div>
+        <div>
+          <span className="stat-label">Affidamento diretto · CIG osservati</span>
+          <span className="stat-value">{share(directAward.records, totalCigs)}</span>
+          <span className="stat-note">{integer(directAward.records)} su {integer(totalCigs)} CIG · non è quota di euro o pagamenti</span>
+        </div>
+        <div>
+          <span className="stat-label">Servizi e forniture</span>
+          <span className="stat-value">{integer(servicesAndSupplies)}</span>
+          <span className="stat-note">{share(servicesAndSupplies, totalCigs)} del totale CIG</span>
+        </div>
+        <div>
+          <span className="stat-label">Copertura</span>
+          <span className="stat-value">12/12</span>
+          <span className="stat-note">file mensili presenti nello snapshot</span>
+        </div>
+      </section>
+
+      <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="appalti-reading-title">
+        <h2 id="appalti-reading-title">La lettura corretta in una frase</h2>
+        <p>
+          Questi conteggi mostrano come sono classificati i CIG pubblicati. Indicano dove guardare
+          meglio, ma non dimostrano da soli spreco, illecito, corruzione, frazionamento o qualità
+          del contratto.
+        </p>
+        <div className="scope-notice__section">
+          <h3>Che cosa misura il valore</h3>
+          <p>
+            <strong>importo_lotto</strong> è il valore dichiarato del lotto nella banca dati: non è un prezzo unitario e non è necessariamente quanto è stato pagato alla fine.
+          </p>
+        </div>
+      </section>
+
+      <section className={`panel ${styles.leadPanel}`} aria-labelledby="procedure-title">
+        <div className={styles.leadCopy}>
+          <h2 id="procedure-title" className="panel-title">Le procedure che ricorrono di più</h2>
+          <p>
+            La voce <strong>AFFIDAMENTO DIRETTO</strong> è l&apos;etichetta più frequente: rappresenta
+            {" "}{share(directAward.records, totalCigs)} dei {integer(totalCigs)} CIG unici osservati
+            (non degli euro o dei pagamenti). La
+            famiglia più ampia delle etichette che iniziano con “AFFIDAMENTO DIRETTO” arriva a
+            {" "}{share(directAwardFamily.records, totalCigs)}: non sono tutte la stessa procedura.
+          </p>
+        </div>
+        <div className={styles.leadMeasure}>
+          <span>Etichetta più frequente</span>
+          <strong>{share(directAward.records, totalCigs)}</strong>
+          <small>del totale CIG · denominatore: {integer(totalCigs)}</small>
+        </div>
+      </section>
+
+      <section className={`panel ${styles.procedurePanel}`} aria-labelledby="procedure-breakdown-title">
+        <div className={styles.sectionHeading}>
+          <div>
+            <h2 id="procedure-breakdown-title" className="panel-title">Distribuzione delle etichette</h2>
+            <p>
+              Le prime sei voci coprono {share(
+                featuredProcedureEntries.reduce((sum, row) => sum + row.records, 0),
+                totalCigs,
+              )} dei CIG. Le altre sono accorpate solo nel grafico e nella tabella equivalente qui
+              sotto; il dettaglio delle 32 etichette resta apribile più avanti.
+            </p>
+          </div>
+          <span className="tag tag-neutral">Denominatore: tutti i CIG unici 2025</span>
+        </div>
+
+        <ol className={styles.barList} aria-label="Le sei etichette di procedura più frequenti e le altre etichette">
+          {procedureRows.map((row, index) => (
+            <li key={row.label}>
+              <div className={styles.barMeta}>
+                <span>{row.label}</span>
+                <strong>
+                  {integer(row.records)} <small>· {share(row.records, totalCigs)}</small>
+                </strong>
+              </div>
+              <div className={styles.barTrack} aria-hidden="true">
+                <i style={{ width: `${(row.records / largestProcedureCount) * 100}%` }} />
+              </div>
+              <span className={styles.barRank}>#{index + 1}</span>
+            </li>
+          ))}
+        </ol>
+
+        <div className="table-scroll" role="region" aria-label="Tabella esatta della distribuzione delle procedure" tabIndex={0}>
+          <table className="table">
+            <caption>Le stesse categorie rappresentate nel grafico, con conteggio e quota sul totale dei CIG unici 2025</caption>
+            <thead>
+              <tr>
+                <th scope="col">Etichetta</th>
+                <th scope="col" className="num">CIG</th>
+                <th scope="col" className="num">Quota</th>
+              </tr>
+            </thead>
+            <tbody>
+              {procedureRows.map((row) => (
+                <tr key={row.label}>
+                  <th scope="row">{row.label}</th>
+                  <td className="num">{integer(row.records)}</td>
+                  <td className="num">{share(row.records, totalCigs)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <details className={styles.detailTable}>
+          <summary>Apri tutte le 32 etichette originali</summary>
+          <div className="table-scroll" role="region" aria-label="Tutte le etichette originali delle procedure ANAC" tabIndex={0}>
+            <table className="table">
+              <caption>Tutte le etichette presenti nel campo procedura del perimetro ANAC CIG 2025</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Etichetta originale</th>
+                  <th scope="col" className="num">CIG</th>
+                  <th scope="col" className="num">Quota</th>
+                </tr>
+              </thead>
+              <tbody>
+                {procedureEntries.map((row) => (
+                  <tr key={row.label}>
+                    <th scope="row">{row.label}</th>
+                    <td className="num">{integer(row.records)}</td>
+                    <td className="num">{share(row.records, totalCigs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      </section>
+
+      <section className={`panel ${styles.subsetPanel}`} aria-labelledby="subset-title">
+        <div className={styles.sectionHeading}>
+          <div>
+            <h2 id="subset-title" className="panel-title">Che cosa significa “sotto 140.000 €”</h2>
+            <p>
+              È un sottoinsieme di CIG per <strong>servizi e forniture</strong> con importo del lotto
+              sotto 140.000 €. Il suo denominatore non coincide con tutti gli appalti del Paese.
+            </p>
+          </div>
+          <span className="tag tag-neutral">{integer(below140000.records)} CIG nel sottoinsieme</span>
+        </div>
+
+        <div className={`stat-strip ${styles.threeStats}`}>
+          <div>
+            <span className="stat-label">Affidamento diretto</span>
+            <span className="stat-value">{share(below140000.directAwardRecords, below140000.records)}</span>
+            <span className="stat-note">{integer(below140000.directAwardRecords)} su {integer(below140000.records)} CIG</span>
+          </div>
+          <div>
+            <span className="stat-label">Famiglia affidamento diretto</span>
+            <span className="stat-value">{share(below140000.directAwardFamilyRecords, below140000.records)}</span>
+            <span className="stat-note">{integer(below140000.directAwardFamilyRecords)} su {integer(below140000.records)} CIG</span>
+          </div>
+          <div>
+            <span className="stat-label">Servizi e forniture nel 2025</span>
+            <span className="stat-value">{share(below140000.records, servicesAndSupplies)}</span>
+            <span className="stat-note">{integer(below140000.records)} su {integer(servicesAndSupplies)} CIG</span>
+          </div>
+        </div>
+
+        <p className={styles.note}>
+          La famiglia include etichette diverse: “AFFIDAMENTO DIRETTO” esatto e altre etichette che
+          iniziano nello stesso modo. Leggerle come se fossero una sola procedura gonfierebbe il
+          confronto.
+        </p>
+      </section>
+
+      <section className={`panel ${styles.thresholdPanel}`} aria-labelledby="threshold-title">
+        <div className={styles.sectionHeading}>
+          <div>
+            <h2 id="threshold-title" className="panel-title">Un segnale vicino alla soglia</h2>
+            <p>
+              Nella fascia <strong>[135.000 €, 140.000 €)</strong> ci sono {integer(thresholdBand.servicesAndSuppliesRecords)}
+              {" "}CIG di servizi e forniture. La fascia serve a scegliere cosa verificare negli atti
+              originali: non dimostra da sola un frazionamento o un comportamento scorretto.
+            </p>
+          </div>
+          <span className="tag tag-neutral">Intervallo dichiarato da ANAC</span>
+        </div>
+
+        <div className="table-scroll" role="region" aria-label="Indicatori della fascia tra 135 mila e 140 mila euro" tabIndex={0}>
+          <table className="table">
+            <caption>Conteggi della fascia di importo e denominatori espliciti</caption>
+            <thead>
+              <tr>
+                <th scope="col">Misura</th>
+                <th scope="col" className="num">CIG</th>
+                <th scope="col" className="num">Quota sul denominatore</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Servizi e forniture nella fascia</th>
+                <td className="num">{integer(thresholdBand.servicesAndSuppliesRecords)}</td>
+                <td className="num">{share(thresholdBand.servicesAndSuppliesRecords, servicesAndSupplies)} su tutti i servizi e forniture</td>
+              </tr>
+              <tr>
+                <th scope="row">Affidamento diretto nella fascia</th>
+                <td className="num">{integer(thresholdBand.directAwardRecords)}</td>
+                <td className="num">{share(thresholdBand.directAwardRecords, thresholdBand.servicesAndSuppliesRecords)} sulla fascia</td>
+              </tr>
+              <tr>
+                <th scope="row">Contratto d&apos;appalto · definizione stretta</th>
+                <td className="num">{integer(thresholdBand.strictContractRecords)}</td>
+                <td className="num">{share(thresholdBand.strictContractRecords, thresholdBand.servicesAndSuppliesRecords)} sulla fascia</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className={styles.exactAmounts}>
+          <h3>Valori del lotto che ricorrono spesso</h3>
+          <p>
+            Sono conteggi di CIG con lo stesso valore dichiarato. Li mostriamo come indizio
+            descrittivo, non come prova: il valore non dice da solo come è stata scelta la procedura
+            né quanto è stato pagato.
+          </p>
+          <div className="table-scroll" role="region" aria-label="Valori esatti del lotto più ricorrenti" tabIndex={0}>
+            <table className="table">
+              <caption>Conteggi per valore esatto di importo_lotto, quota sul totale dei CIG unici 2025</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Valore lotto dichiarato</th>
+                  <th scope="col" className="num">CIG</th>
+                  <th scope="col" className="num">Quota sul totale</th>
+                </tr>
+              </thead>
+              <tbody>
+                {exactAmountRows.map((row) => (
+                  <tr key={row.amount}>
+                    <th scope="row">{exactEuro(row.amount)}</th>
+                    <td className="num">{integer(row.records)}</td>
+                    <td className="num">{share(row.records, totalCigs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section className={`panel ${styles.coveragePanel}`} aria-labelledby="coverage-title">
+        <h2 id="coverage-title" className="panel-title">Che cosa è entrato nel conteggio</h2>
+        <div className="table-scroll" role="region" aria-label="Controlli di copertura del dataset ANAC" tabIndex={0}>
+          <table className="table">
+            <caption>Controlli di copertura e record esclusi dal perimetro pubblicato</caption>
+            <thead>
+              <tr>
+                <th scope="col">Controllo</th>
+                <th scope="col" className="num">Valore</th>
+                <th scope="col">Come leggerlo</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Righe grezze mensili</th>
+                <td className="num">{integer(data.population.rawRows)}</td>
+                <td>Righe lette prima della deduplicazione dei CIG.</td>
+              </tr>
+              <tr>
+                <th scope="row">CIG unici pubblicati</th>
+                <td className="num">{integer(totalCigs)}</td>
+                <td>Il denominatore usato nelle quote della pagina.</td>
+              </tr>
+              <tr>
+                <th scope="row">Importi non positivi</th>
+                <td className="num">{integer(data.population.nonPositiveAmountRecords)}</td>
+                <td>Esclusi dalle analisi di soglia e importo.</td>
+              </tr>
+              <tr>
+                <th scope="row">CIG senza CPV prevalente</th>
+                <td className="num">{integer(data.population.cigsWithoutPrevalentCpv)}</td>
+                <td>Restano fuori dalle classificazioni che richiedono quel campo.</td>
+              </tr>
+              <tr>
+                <th scope="row">Record inattivi esclusi</th>
+                <td className="num">{integer(data.population.inactiveRecordsExcluded)}</td>
+                <td>Nessuno escluso per questo motivo nello snapshot.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className={`panel ${styles.sourcePanel}`} id="fonti-metodo" aria-labelledby="sources-title">
+        <h2 id="sources-title" className="panel-title">Fonti, metodo e limiti</h2>
+        <p>
+          La fonte primaria è il dataset ufficiale ANAC dei CIG 2025. Abbiamo letto i dodici file
+          mensili disponibili, verificato la copertura annuale e mantenuto separati conteggi, valori
+          dichiarati e segnali di screening.
+        </p>
+        <dl className={styles.sourceList}>
+          <div>
+            <dt>Dataset ufficiale</dt>
+            <dd>
+              <a href={data.provenance.datasetUrl} target="_blank" rel="noreferrer">
+                ANAC · CIG 2025 ↗
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>Licenza</dt>
+            <dd>
+              <a href={data.provenance.licenseUrl} target="_blank" rel="noreferrer">
+                {data.provenance.license} ↗
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>Ultimo controllo</dt>
+            <dd>{longDate(data.observedAt)} · 12 mesi completi</dd>
+          </div>
+          <div>
+            <dt>Provenienza</dt>
+            <dd>{data.provenance.owner} · dati aperti BDNCP</dd>
+          </div>
+        </dl>
+
+        <details open className={styles.methodDetails}>
+          <summary>Perimetro tecnico e interpretazione</summary>
+          <ul>
+            <li>
+              Le quote delle procedure usano come denominatore tutti i {integer(totalCigs)} CIG unici
+              del 2025. Le quote del sottoinsieme sotto 140.000 € usano solo i {integer(below140000.records)}
+              {" "}CIG di servizi e forniture compresi in quel perimetro.
+            </li>
+            <li>
+              “Affidamento diretto” è l&apos;etichetta esatta; la famiglia più ampia comprende tutte le
+              etichette che iniziano con quella dicitura e non va letta come una procedura unica.
+            </li>
+            <li>{data.methodology.screeningOnly}</li>
+            <li>
+              Il dato non consente di collegare il valore a un soggetto: non mostra nomi di fornitori
+              e non misura la concentrazione per fornitore.
+            </li>
+            <li>
+              L&apos;importo del lotto non è un pagamento finale. Per verificare un caso servono l&apos;atto
+              originale, la procedura completa e le informazioni collegate pubblicate dalle fonti
+              ufficiali.
+            </li>
+          </ul>
+        </details>
+        <p className={styles.nextStep}>
+          Vuoi passare dal quadro ai controlli? Apri la pagina <Link href="/controlli">Cosa vale la pena controllare →</Link>.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { anacCigSnapshot } from "@/lib/anac-cig-snapshot";
 import { exactEuro, integer, longDate, percent } from "@/lib/format";
 import styles from "./appalti.module.css";
+import { ScrollRegion } from "./scroll-region";
 
 export const metadata: Metadata = {
   title: "Appalti pubblici",
@@ -22,7 +23,6 @@ const procedureRows = [
   ...featuredProcedureEntries,
   { label: `Altre ${otherProcedureEntries.length} etichette`, records: otherProcedureCount },
 ];
-const largestProcedureCount = procedureRows[0]?.records ?? 1;
 
 const directAward = data.procedureChoice.directAward;
 const directAwardFamily = data.procedureChoice.directAwardFamily;
@@ -139,14 +139,14 @@ export default function AppaltiPage() {
                 </strong>
               </div>
               <div className={styles.barTrack} aria-hidden="true">
-                <i style={{ width: `${(row.records / largestProcedureCount) * 100}%` }} />
+                <i style={{ width: `${(row.records / totalCigs) * 100}%` }} />
               </div>
               <span className={styles.barRank}>#{index + 1}</span>
             </li>
           ))}
         </ol>
 
-        <div className="table-scroll" role="region" aria-label="Tabella esatta della distribuzione delle procedure" tabIndex={0}>
+        <ScrollRegion className="table-scroll" role="region" aria-label="Tabella esatta della distribuzione delle procedure" tabIndex={0}>
           <table className="table">
             <caption>Le stesse categorie rappresentate nel grafico, con conteggio e quota sul totale dei CIG unici 2025</caption>
             <thead>
@@ -166,11 +166,11 @@ export default function AppaltiPage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </ScrollRegion>
 
         <details className={styles.detailTable}>
           <summary>Apri tutte le 32 etichette originali</summary>
-          <div className="table-scroll" role="region" aria-label="Tutte le etichette originali delle procedure ANAC" tabIndex={0}>
+          <ScrollRegion className="table-scroll" role="region" aria-label="Tutte le etichette originali delle procedure ANAC" tabIndex={0}>
             <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
             <table className="table">
               <caption>Tutte le etichette presenti nel campo procedura del perimetro ANAC CIG 2025</caption>
@@ -191,7 +191,7 @@ export default function AppaltiPage() {
                 ))}
               </tbody>
             </table>
-          </div>
+          </ScrollRegion>
         </details>
       </section>
 
@@ -245,7 +245,7 @@ export default function AppaltiPage() {
           <span className="tag tag-neutral">Intervallo dichiarato da ANAC</span>
         </div>
 
-        <div className="table-scroll" role="region" aria-label="Indicatori della fascia tra 135 mila e 140 mila euro" tabIndex={0}>
+        <ScrollRegion className="table-scroll" role="region" aria-label="Indicatori della fascia tra 135 mila e 140 mila euro" tabIndex={0}>
           <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
           <table className="table">
             <caption>Conteggi della fascia di importo e denominatori espliciti</caption>
@@ -274,7 +274,16 @@ export default function AppaltiPage() {
               </tr>
             </tbody>
           </table>
-        </div>
+        </ScrollRegion>
+
+        <p className={styles.note}>
+          <strong>Definizione stretta:</strong> per questa riga contiamo solo servizi o forniture con
+          etichetta “AFFIDAMENTO DIRETTO”, contratto d&apos;appalto e importo del lotto da 135.000 €
+          incluso a 140.000 € escluso.
+          <small className={styles.definitionSource}>
+            Regola dati: {thresholdBand.strictContractDefinition}
+          </small>
+        </p>
 
         <div className={styles.exactAmounts}>
           <h3>Valori del lotto che ricorrono spesso</h3>
@@ -283,7 +292,7 @@ export default function AppaltiPage() {
             descrittivo, non come prova: il valore non dice da solo come è stata scelta la procedura
             né quanto è stato pagato.
           </p>
-          <div className="table-scroll" role="region" aria-label="Valori esatti del lotto più ricorrenti" tabIndex={0}>
+          <ScrollRegion className="table-scroll" role="region" aria-label="Valori esatti del lotto più ricorrenti" tabIndex={0}>
             <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
             <table className="table">
               <caption>Conteggi per valore esatto di importo_lotto, quota sul totale dei CIG unici 2025</caption>
@@ -304,13 +313,13 @@ export default function AppaltiPage() {
                 ))}
               </tbody>
             </table>
-          </div>
+          </ScrollRegion>
         </div>
       </section>
 
       <section className={`panel ${styles.coveragePanel}`} aria-labelledby="coverage-title">
         <h2 id="coverage-title" className="panel-title">Che cosa è entrato nel conteggio</h2>
-        <div className="table-scroll" role="region" aria-label="Controlli di copertura del dataset ANAC" tabIndex={0}>
+        <ScrollRegion className="table-scroll" role="region" aria-label="Controlli di copertura del dataset ANAC" tabIndex={0}>
           <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
           <table className="table">
             <caption>Controlli di copertura e record esclusi dal perimetro pubblicato</caption>
@@ -349,7 +358,7 @@ export default function AppaltiPage() {
               </tr>
             </tbody>
           </table>
-        </div>
+        </ScrollRegion>
       </section>
 
       <section className={`panel ${styles.sourcePanel}`} id="fonti-metodo" aria-labelledby="sources-title">

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -171,6 +171,7 @@ export default function AppaltiPage() {
         <details className={styles.detailTable}>
           <summary>Apri tutte le 32 etichette originali</summary>
           <div className="table-scroll" role="region" aria-label="Tutte le etichette originali delle procedure ANAC" tabIndex={0}>
+            <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
             <table className="table">
               <caption>Tutte le etichette presenti nel campo procedura del perimetro ANAC CIG 2025</caption>
               <thead>
@@ -245,6 +246,7 @@ export default function AppaltiPage() {
         </div>
 
         <div className="table-scroll" role="region" aria-label="Indicatori della fascia tra 135 mila e 140 mila euro" tabIndex={0}>
+          <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
           <table className="table">
             <caption>Conteggi della fascia di importo e denominatori espliciti</caption>
             <thead>
@@ -282,6 +284,7 @@ export default function AppaltiPage() {
             né quanto è stato pagato.
           </p>
           <div className="table-scroll" role="region" aria-label="Valori esatti del lotto più ricorrenti" tabIndex={0}>
+            <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
             <table className="table">
               <caption>Conteggi per valore esatto di importo_lotto, quota sul totale dei CIG unici 2025</caption>
               <thead>
@@ -308,6 +311,7 @@ export default function AppaltiPage() {
       <section className={`panel ${styles.coveragePanel}`} aria-labelledby="coverage-title">
         <h2 id="coverage-title" className="panel-title">Che cosa è entrato nel conteggio</h2>
         <div className="table-scroll" role="region" aria-label="Controlli di copertura del dataset ANAC" tabIndex={0}>
+          <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
           <table className="table">
             <caption>Controlli di copertura e record esclusi dal perimetro pubblicato</caption>
             <thead>

--- a/src/app/appalti/scroll-region.tsx
+++ b/src/app/appalti/scroll-region.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { KeyboardEvent, ReactNode } from "react";
+
+type ScrollRegionProps = {
+  children: ReactNode;
+  className?: string;
+  role?: string;
+  "aria-label"?: string;
+  tabIndex?: number;
+};
+
+export function ScrollRegion({ children, ...props }: ScrollRegionProps) {
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    const element = event.currentTarget;
+    const step = Math.max(element.clientWidth * 0.8, 160);
+
+    if (event.key === "Home" || event.key === "ArrowLeft") {
+      element.scrollLeft = event.key === "Home" ? 0 : Math.max(0, element.scrollLeft - step);
+      event.preventDefault();
+    }
+
+    if (event.key === "End" || event.key === "ArrowRight") {
+      element.scrollLeft = event.key === "End"
+        ? element.scrollWidth
+        : Math.min(element.scrollWidth, element.scrollLeft + step);
+      event.preventDefault();
+    }
+  }
+
+  return <div {...props} onKeyDown={handleKeyDown}>{children}</div>;
+}

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -181,7 +181,8 @@ export default async function ControlsPage({ searchParams }: PageProps) {
           <p>
             Il portale può confrontare casi omogenei, trovare dati mancanti e ordinare le verifiche.
             Non conduce indagini e non sostituisce Guardia di finanza, ANAC, Corte dei conti o il
-            controllo umano. Gli aggregati CIG 2025 verificati sono disponibili nel{" "}
+            controllo umano. Gli aggregati CIG 2025 verificati sono disponibili nella{" "}
+            <Link href="/appalti">pagina Appalti 2025</Link> e nel{" "}
             <Link href="/mcp">dataset MCP ANAC</Link>; il{" "}
             <a
               href="https://dati.anticorruzione.it/opendata/dataset"

--- a/src/lib/anac-cig-snapshot.ts
+++ b/src/lib/anac-cig-snapshot.ts
@@ -12,22 +12,22 @@ function isOfficialAnacUrl(value: string) {
   }
 }
 
-function assertManifest() {
-  if (rawManifest.schemaVersion !== 1 || rawManifest.referenceYear !== 2025) {
+export function assertAnacCigManifest(candidate: typeof rawManifest = rawManifest) {
+  if (candidate.schemaVersion !== 1 || candidate.referenceYear !== 2025) {
     throw new Error("Manifest ANAC CIG: schema o anno di riferimento inatteso.");
   }
-  if (!rawManifest.coverage.completeYear || rawManifest.coverage.missingMonths.length > 0) {
+  if (!candidate.coverage.completeYear || candidate.coverage.missingMonths.length > 0) {
     throw new Error("Manifest ANAC CIG: la copertura annuale non è completa.");
   }
   if (
-    rawManifest.coverage.observedMonths.length !== 12 ||
-    rawManifest.coverage.observedMonths.some((month, index) => month !== index + 1)
+    candidate.coverage.observedMonths.length !== 12 ||
+    candidate.coverage.observedMonths.some((month, index) => month !== index + 1)
   ) {
     throw new Error("Manifest ANAC CIG: mesi osservati non validi.");
   }
   if (
-    rawManifest.inputs.length !== 12 ||
-    rawManifest.inputs.some(
+    candidate.inputs.length !== 12 ||
+    candidate.inputs.some(
       (input) =>
         input.bytes <= 0 ||
         !SHA256.test(input.sha256) ||
@@ -39,13 +39,48 @@ function assertManifest() {
   ) {
     throw new Error("Manifest ANAC CIG: integrità degli input non valida.");
   }
-  if (rawManifest.population.records !== rawManifest.population.uniqueCigs) {
+  if (candidate.population.records !== candidate.population.uniqueCigs) {
     throw new Error("Manifest ANAC CIG: i record non riconciliano con i CIG unici.");
   }
-  return rawManifest;
+  const procedureRecords = Object.values(candidate.procedureChoice.allLabels).reduce(
+    (sum, records) => sum + records,
+    0,
+  );
+  if (procedureRecords !== candidate.population.records) {
+    throw new Error("Manifest ANAC CIG: la partizione delle procedure non riconcilia.");
+  }
+  if (
+    candidate.procedureChoice.directAward.records !==
+      candidate.procedureChoice.allLabels["AFFIDAMENTO DIRETTO"] ||
+    candidate.procedureChoice.directAwardFamily.records <
+      candidate.procedureChoice.directAward.records ||
+    candidate.procedureChoice.directAwardFamily.records > candidate.population.records
+  ) {
+    throw new Error("Manifest ANAC CIG: aggregati delle procedure incoerenti.");
+  }
+  if (
+    candidate.population.servicesAndSupplies > candidate.population.records ||
+    candidate.servicesAndSuppliesBelow140000.records > candidate.population.servicesAndSupplies ||
+    candidate.servicesAndSuppliesBelow140000.directAwardRecords >
+      candidate.servicesAndSuppliesBelow140000.records ||
+    candidate.servicesAndSuppliesBelow140000.directAwardFamilyRecords >
+      candidate.servicesAndSuppliesBelow140000.records ||
+    candidate.thresholdBand135000To140000.servicesAndSuppliesRecords >
+      candidate.population.servicesAndSupplies ||
+    candidate.thresholdBand135000To140000.directAwardRecords >
+      candidate.thresholdBand135000To140000.servicesAndSuppliesRecords ||
+    candidate.thresholdBand135000To140000.strictContractRecords >
+      candidate.thresholdBand135000To140000.servicesAndSuppliesRecords
+  ) {
+    throw new Error("Manifest ANAC CIG: sottoinsiemi oltre il denominatore.");
+  }
+  if (Object.values(candidate.exactContractAmounts).some((records) => records < 0)) {
+    throw new Error("Manifest ANAC CIG: conteggio importo negativo.");
+  }
+  return candidate;
 }
 
-const manifest = assertManifest();
+const manifest = assertAnacCigManifest();
 
 export const availableAnacCigYears = [manifest.referenceYear] as const;
 

--- a/tests/anac-cig-snapshot.test.mjs
+++ b/tests/anac-cig-snapshot.test.mjs
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
-const { anacCigSnapshot, getAnacCigSnapshot } = await import(
+const { anacCigSnapshot, assertAnacCigManifest, getAnacCigSnapshot } = await import(
   "../src/lib/anac-cig-snapshot.ts"
 );
+const manifestPath = new URL("../docs/research/data/anac-cigs-2025-2026-08-20.json", import.meta.url);
+
+function freshManifest() {
+  return JSON.parse(readFileSync(manifestPath, "utf8"));
+}
 
 test("ANAC CIG snapshot is complete, reconciled and carries source provenance", () => {
   assert.equal(anacCigSnapshot.schemaVersion, 1);
@@ -38,4 +44,28 @@ test("ANAC CIG snapshot is complete, reconciled and carries source provenance", 
 test("ANAC snapshot lookup fails closed outside the verified year", () => {
   assert.equal(getAnacCigSnapshot(2025), anacCigSnapshot);
   assert.throws(() => getAnacCigSnapshot(2024), /solo per il 2025/);
+});
+
+test("ANAC manifest fails closed when page aggregates drift", () => {
+  const partitionDrift = freshManifest();
+  partitionDrift.procedureChoice.allLabels["ACCORDO QUADRO"] += 1;
+  assert.throws(() => assertAnacCigManifest(partitionDrift), /partizione delle procedure/);
+
+  const labelDrift = freshManifest();
+  labelDrift.procedureChoice.directAward.records -= 1;
+  assert.throws(() => assertAnacCigManifest(labelDrift), /aggregati delle procedure/);
+
+  const familyDrift = freshManifest();
+  familyDrift.procedureChoice.directAwardFamily.records =
+    familyDrift.procedureChoice.directAward.records - 1;
+  assert.throws(() => assertAnacCigManifest(familyDrift), /aggregati delle procedure/);
+
+  const subsetDrift = freshManifest();
+  subsetDrift.servicesAndSuppliesBelow140000.records =
+    subsetDrift.population.servicesAndSupplies + 1;
+  assert.throws(() => assertAnacCigManifest(subsetDrift), /sottoinsiemi oltre il denominatore/);
+
+  const amountDrift = freshManifest();
+  amountDrift.exactContractAmounts["39900"] = -1;
+  assert.throws(() => assertAnacCigManifest(amountDrift), /conteggio importo negativo/);
 });

--- a/tests/appalti-page.test.mjs
+++ b/tests/appalti-page.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const pageSource = readFileSync(new URL("../src/app/appalti/page.tsx", import.meta.url), "utf8");
+const controlsPageSource = readFileSync(new URL("../src/app/controlli/page.tsx", import.meta.url), "utf8");
+const { anacCigSnapshot } = await import("../src/lib/anac-cig-snapshot.ts");
+
+test("appalti page keeps the verified 2025 denominators and scope visible", () => {
+  assert.match(pageSource, /Periodo: 2025/);
+  assert.match(pageSource, /CIG unici/);
+  assert.match(pageSource, /servizi e forniture/);
+  assert.match(pageSource, /importo_lotto/);
+  assert.equal(anacCigSnapshot.population.records, 1_453_918);
+  assert.equal(anacCigSnapshot.population.servicesAndSupplies, 1_290_218);
+  assert.equal(anacCigSnapshot.procedureChoice.directAward.records, 1_192_083);
+  assert.equal(anacCigSnapshot.servicesAndSuppliesBelow140000.records, 1_159_940);
+  assert.equal(anacCigSnapshot.thresholdBand135000To140000.strictContractRecords, 13_393);
+  assert.match(pageSource, /non è quota di euro o pagamenti/);
+  assert.match(controlsPageSource, /href="\/appalti"/);
+});
+
+test("appalti page makes the chart/table equivalence and denominator explicit", () => {
+  assert.match(pageSource, /Distribuzione delle etichette/);
+  assert.match(pageSource, /Tabella esatta della distribuzione/);
+  assert.match(pageSource, /Denominatore: tutti i CIG unici 2025/);
+  assert.match(pageSource, /Quota sul denominatore/);
+  assert.match(pageSource, /Apri tutte le 32 etichette originali/);
+  assert.match(pageSource, /AFFIDAMENTO DIRETTO/);
+  assert.equal(anacCigSnapshot.provenance.license, "CC BY-SA 4.0");
+});
+
+test("appalti page treats threshold concentrations as screening signals, not findings", () => {
+  assert.match(pageSource, /non dimostrano da soli spreco, illecito, corruzione/);
+  assert.match(pageSource, /non dimostra da sola un frazionamento/);
+  assert.match(pageSource, /non è un prezzo unitario/);
+  assert.doesNotMatch(pageSource, /93%|quasi 95%|sprechi accertati|fornitori?\s*:/i);
+});
+
+test("appalti page keeps sources and methodology after the data sections", () => {
+  const dataStart = pageSource.indexOf("procedure-breakdown-title");
+  const sourceStart = pageSource.indexOf("sources-title");
+  assert.ok(dataStart >= 0);
+  assert.ok(sourceStart > dataStart);
+  assert.equal(anacCigSnapshot.provenance.license, "CC BY-SA 4.0");
+  assert.match(anacCigSnapshot.provenance.datasetUrl, /^https:\/\/dati\.anticorruzione\.it\//);
+  assert.match(pageSource, /12 mesi completi/);
+});
+
+test("appalti page avoids supplier attribution", () => {
+  assert.match(pageSource, /non mostra nomi di fornitori/);
+  assert.match(pageSource, /non consente di collegare il valore a un soggetto/);
+});

--- a/tests/appalti-page.test.mjs
+++ b/tests/appalti-page.test.mjs
@@ -28,6 +28,7 @@ test("appalti page makes the chart/table equivalence and denominator explicit", 
   assert.match(pageSource, /Quota sul denominatore/);
   assert.match(pageSource, /Apri tutte le 32 etichette originali/);
   assert.match(pageSource, /AFFIDAMENTO DIRETTO/);
+  assert.equal((pageSource.match(/Scorri la tabella verso destra/g) ?? []).length, 4);
   assert.equal(anacCigSnapshot.provenance.license, "CC BY-SA 4.0");
 });
 

--- a/tests/appalti-page.test.mjs
+++ b/tests/appalti-page.test.mjs
@@ -4,6 +4,8 @@ import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
 const pageSource = readFileSync(new URL("../src/app/appalti/page.tsx", import.meta.url), "utf8");
+const scrollRegionSource = readFileSync(new URL("../src/app/appalti/scroll-region.tsx", import.meta.url), "utf8");
+const stylesSource = readFileSync(new URL("../src/app/appalti/appalti.module.css", import.meta.url), "utf8");
 const controlsPageSource = readFileSync(new URL("../src/app/controlli/page.tsx", import.meta.url), "utf8");
 const { anacCigSnapshot } = await import("../src/lib/anac-cig-snapshot.ts");
 
@@ -28,6 +30,10 @@ test("appalti page makes the chart/table equivalence and denominator explicit", 
   assert.match(pageSource, /Quota sul denominatore/);
   assert.match(pageSource, /Apri tutte le 32 etichette originali/);
   assert.match(pageSource, /AFFIDAMENTO DIRETTO/);
+  assert.match(pageSource, /row\.records \/ totalCigs/);
+  assert.doesNotMatch(pageSource, /largestProcedureCount/);
+  assert.match(pageSource, /ScrollRegion/);
+  assert.match(scrollRegionSource, /event\.key === "End"/);
   assert.equal((pageSource.match(/Scorri la tabella verso destra/g) ?? []).length, 4);
   assert.equal(anacCigSnapshot.provenance.license, "CC BY-SA 4.0");
 });
@@ -36,6 +42,10 @@ test("appalti page treats threshold concentrations as screening signals, not fin
   assert.match(pageSource, /non dimostrano da soli spreco, illecito, corruzione/);
   assert.match(pageSource, /non dimostra da sola un frazionamento/);
   assert.match(pageSource, /non è un prezzo unitario/);
+  assert.match(pageSource, /Definizione stretta/);
+  assert.match(pageSource, /thresholdBand\.strictContractDefinition/);
+  assert.match(pageSource, /135\.000 €/);
+  assert.match(stylesSource, /\.detailTable\s*\{[^}]*min-width:\s*0/);
   assert.doesNotMatch(pageSource, /93%|quasi 95%|sprechi accertati|fornitori?\s*:/i);
 });
 


### PR DESCRIPTION
## Summary

Adds a small, server-rendered `/appalti` page for the verified ANAC CIG 2025 snapshot. The page puts scope and denominators first, uses a compact procedure comparison with an exact table equivalent, keeps the 32 original labels behind disclosure, and moves sources/method/limits to the end.

Adds one discoverability link from `/controlli` and a fail-closed manifest guard for the aggregates rendered by this page. The existing ANAC MCP dataset remains the machine-readable reuse surface; this PR does not add a second API or change an existing data contract.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| No dedicated citizen-facing procurement view | `/appalti` starts with period, CIG population, unit and coverage | Establishes what is being counted before interpretation |
| Procedure counts were not presented as a focused comparison | Six largest labels use a categorical bar view, with the same seven rows in an exact table | Makes the pattern scannable without losing values |
| Bars were normalized to the largest label | Each bar width is the row count divided by all observed CIG 2025 | A visible 82% means 82% of the named CIG denominator |
| The complete label set could overload the first view | All 32 original labels are available in an accessible disclosure/table | Preserves completeness while keeping the first read simple |
| Percentages could be mistaken for euro or payment shares | Every percentage names its CIG denominator; direct-award KPI explicitly says it is not a euro/payment share | Prevents a misleading interpretation |
| Wide tables had no mobile cue or reliable keyboard movement | Narrow layouts show “Scorri la tabella verso destra →”; focused regions support Home/End/Arrow navigation | Makes horizontal overflow discoverable and operable |
| The strict threshold subset was easy to misread | A plain-language definition is shown beside the threshold table, including the 135,000-inclusive/140,000-exclusive bounds | Makes the row's population and rule explicit |
| Source detail competed with the first read | Source, license, observation date, method and limits are the final section | Keeps provenance available without burying the main result |

## Data boundary

- Period: complete calendar year 2025, 12 official monthly files.
- Primary population: 1,453,918 unique CIG records; services and supplies subset: 1,290,218.
- `importo_lotto` is the declared lot value, not a unit price or necessarily the final paid amount.
- The exact `AFFIDAMENTO DIRETTO` label remains separate from the broader family of labels beginning with that phrase.
- Threshold bands and repeated exact amounts are screening signals for document review, not proof of splitting, waste, corruption, illegality or quality.
- The view does not show supplier names or infer supplier concentration.
- The snapshot gate rejects procedure partitions, family/label mismatches, subset counts beyond their denominators and negative exact-amount counts.

## Verification

- `npm test` — 263/263
- Focused ANAC/page tests — 8/8
- `npm run typecheck` — PASS
- `npm run lint` — PASS
- `npm run design:check` — PASS
- `npm run brand:check` — PASS
- `npm run build` — PASS; 38 routes, including `/appalti`
- Impeccable detector on changed UI targets — `[]`
- Real production browser proof on current head — PASS at 1280×900 and 390×844, split into S1–S4 artifacts. Each section was judged separately for hierarchy, readability, denominators, overflow, focus and runtime. Mobile disclosure was opened: body/document scroll width stayed 390px; wide table regions retained internal overflow; `End` moved the focused disclosure region to its maximum scroll position; long labels rendered without page overflow; strict threshold definition was visible; no runtime errors.
- Existing `/consulenza` focused regression — 25/25 related tests PASS, including default inbox behavior, form contract and no external submission.

## Limits

This is a read-only view over the committed verified snapshot. It does not resolve row-level acts, awardees or final payments, and it does not turn statistical signals into findings. The source and license links are shown at the bottom of the page.

## Data hygiene

No personal data, supplier names, local environment details or unversioned source material are added to the repository.
