### PR TITLE
feat: add accessible appointments overview

### DIFF
--- a/src/app/incarichi/incarichi.module.css
+++ b/src/app/incarichi/incarichi.module.css
@@ -1,0 +1,320 @@
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 12px;
+  color: var(--color-neutral-600);
+}
+
+.breadcrumb a { color: var(--color-neutral-700); }
+.breadcrumb a:hover { color: var(--color-accent-800); }
+
+.scopeBand {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-block: 1px solid var(--color-neutral-300);
+  background: var(--color-surface);
+}
+
+.scopeBand > div {
+  min-width: 0;
+  padding: 12px 16px;
+  border-right: 1px solid var(--color-neutral-300);
+}
+
+.scopeBand > div:last-child { border-right: 0; }
+
+.scopeBand span,
+.scopeBand strong {
+  display: block;
+}
+
+.scopeBand span {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.scopeBand strong {
+  margin-top: 4px;
+  font-family: var(--font-heading);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.latestGrid,
+.comparisonGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.latestGrid > h2,
+.comparisonGrid > h2 {
+  grid-column: 1 / -1;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sectionHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.sectionHead :global(.panel-title) { margin-bottom: var(--space-3); }
+
+.sectionHead > span {
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.metricList {
+  margin: 0;
+}
+
+.metricList > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 10px 0;
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+
+.metricList > div:last-child { border-bottom: 0; }
+.metricList dt { color: var(--color-neutral-700); }
+
+.metricList dd {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 21px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: -.02em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.metricList dd small,
+.moneyCell small {
+  display: block;
+  margin-top: 2px;
+  color: var(--color-neutral-600);
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.metricList dd strong,
+.moneyCell strong { display: block; }
+
+.note,
+.noteIntro {
+  margin: var(--space-3) 0 0;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  max-width: 100ch;
+}
+
+.noteIntro {
+  margin-top: -4px;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+}
+
+.tableHint {
+  display: none;
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.trend {
+  margin: 0;
+}
+
+.trend figcaption {
+  max-width: 88ch;
+  color: var(--color-neutral-700);
+  font-size: 13px;
+}
+
+.trendRows {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.trendYear {
+  display: grid;
+  grid-template-columns: 50px 1fr;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.trendYear > strong {
+  font-family: var(--font-heading);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+
+.trendLine {
+  display: grid;
+  grid-template-columns: 86px minmax(100px, 1fr) max-content;
+  gap: var(--space-2);
+  align-items: center;
+  min-height: 23px;
+}
+
+.trendLabel {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+}
+
+.track,
+.compositionTrack {
+  display: block;
+  height: 10px;
+  background: var(--color-neutral-200);
+}
+
+.track i,
+.compositionTrack i {
+  display: block;
+  height: 100%;
+}
+
+.externalBar { background: var(--color-neutral-800); }
+.employeeBar { background: var(--color-neutral-500); }
+
+.trendValue {
+  min-width: 70px;
+  color: var(--color-neutral-800);
+  font-size: 12px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.composition {
+  display: grid;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.compositionRow {
+  display: grid;
+  grid-template-columns: 150px minmax(120px, 1fr) max-content;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.compositionLabel {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-size: 13px;
+}
+
+.compositionLabel strong {
+  font-family: var(--font-heading);
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+}
+
+.compositionRow small {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.sourceGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+  margin: 0;
+}
+
+.sourceGrid dt {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.sourceGrid dd {
+  margin: 4px 0 0;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.methodNotes {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-neutral-200);
+}
+
+.methodNotes p {
+  margin: 0;
+  max-width: 90ch;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+}
+
+.methodNotes strong { font-weight: 700; }
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-6);
+}
+
+.backLink {
+  margin: 0;
+  font-size: 13px;
+}
+
+@media (max-width: 900px) {
+  .scopeBand { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .scopeBand > div:nth-child(2n) { border-right: 0; }
+  .scopeBand > div:nth-child(-n + 2) { border-bottom: 1px solid var(--color-neutral-300); }
+  .sourceGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 620px) {
+  .latestGrid,
+  .comparisonGrid { grid-template-columns: 1fr; }
+  .scopeBand { grid-template-columns: 1fr; }
+  .scopeBand > div { border-right: 0; border-bottom: 1px solid var(--color-neutral-300); }
+  .scopeBand > div:last-child { border-bottom: 0; }
+  .trendYear { grid-template-columns: 38px 1fr; gap: var(--space-2); }
+  .trendLine { grid-template-columns: 72px minmax(70px, 1fr) max-content; gap: 6px; }
+  .compositionRow { grid-template-columns: 1fr; gap: 6px; }
+  .compositionLabel { justify-content: flex-start; }
+  .compositionRow small { text-align: left; }
+  .sourceGrid { grid-template-columns: 1fr; }
+  .actions .btn { width: 100%; }
+  .tableHint { display: block; }
+  :global(.table-scroll) table { min-width: 900px; }
+}

--- a/src/app/incarichi/overview.ts
+++ b/src/app/incarichi/overview.ts
@@ -1,0 +1,33 @@
+import type { ConsulentiSnapshot } from "../../lib/data/consulenti-contract";
+
+export const INCARICHI_OVERVIEW_YEARS = [2023, 2024, 2025, 2026] as const;
+export const INCARICHI_OVERVIEW_DATASET = "Consulenti Pubblici · statistiche nazionali degli incarichi";
+export const INCARICHI_OVERVIEW_REUSE_TERMS =
+  "Riuso consentito con attribuzione e licenza identica o equivalente";
+
+export function assertIncarichiOverviewScope(snapshot: ConsulentiSnapshot): ConsulentiSnapshot {
+  const externalYears = snapshot.externalAppointments.map((item) => item.year);
+  const employeeYears = snapshot.employeeAppointments.map((item) => item.year);
+  const expectedYears = [...INCARICHI_OVERVIEW_YEARS];
+  const matchesExpectedYears = (years: number[]) =>
+    years.length === expectedYears.length &&
+    years.every((year, index) => year === expectedYears[index]);
+
+  if (!matchesExpectedYears(externalYears) || !matchesExpectedYears(employeeYears)) {
+    throw new Error("incarichi: copertura annuale 2023-2026 inattesa");
+  }
+  if (snapshot.latestYear !== INCARICHI_OVERVIEW_YEARS.at(-1)) {
+    throw new Error("incarichi: ultimo anno 2026 atteso");
+  }
+  if (snapshot.source.owner !== "Dipartimento della Funzione Pubblica") {
+    throw new Error("incarichi: titolare DFP inatteso");
+  }
+  if (snapshot.source.dataset !== INCARICHI_OVERVIEW_DATASET) {
+    throw new Error("incarichi: dataset DFP inatteso");
+  }
+  if (snapshot.source.reuseTerms !== INCARICHI_OVERVIEW_REUSE_TERMS) {
+    throw new Error("incarichi: condizioni di riuso inattese");
+  }
+
+  return snapshot;
+}

--- a/src/app/incarichi/page.tsx
+++ b/src/app/incarichi/page.tsx
@@ -1,0 +1,444 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { compactEuro, exactEuro, integer, longDate, percent } from "@/lib/format";
+import { consulentiSnapshot as snapshot } from "@/lib/consulenti-snapshot";
+import styles from "./incarichi.module.css";
+import { assertIncarichiOverviewScope } from "./overview";
+
+export const metadata: Metadata = {
+  title: "Incarichi pubblici",
+  description:
+    "Quadro nazionale annuale degli incarichi esterni e degli incarichi ai dipendenti pubblici, con fonte e limiti espliciti.",
+};
+
+function euros(paidCents: number): number {
+  return paidCents / 100;
+}
+
+function validShare(part: number, denominator: number): number | null {
+  if (denominator <= 0 || part < 0 || part > denominator) return null;
+  return (part / denominator) * 100;
+}
+
+function shareLabel(part: number, denominator: number): string {
+  const share = validShare(part, denominator);
+  return share === null ? "non disponibile" : percent(share);
+}
+
+const scopedSnapshot = assertIncarichiOverviewScope(snapshot);
+const firstYear = scopedSnapshot.externalAppointments[0].year;
+const yearRange = `${firstYear}-${scopedSnapshot.latestYear}`;
+const latestExternal = scopedSnapshot.externalAppointments.at(-1)!;
+const latestEmployee = scopedSnapshot.employeeAppointments.at(-1)!;
+const latestRecipientDenominator =
+  latestExternal.individualRecipients + latestExternal.organizationRecipients;
+const maxAssignments = Math.max(
+  ...scopedSnapshot.externalAppointments.map((item) => item.assignments),
+  ...scopedSnapshot.employeeAppointments.map((item) => item.assignments),
+);
+
+export default function IncarichiPage() {
+  return (
+    <main className="shell page">
+      <nav className={styles.breadcrumb} aria-label="Percorso">
+        <Link href="/">Home</Link>
+        <span aria-hidden="true">/</span>
+        <Link href="/enti">Enti e società</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Incarichi pubblici</span>
+      </nav>
+
+      <div className="page-intro">
+        <h1>Incarichi pubblici</h1>
+        <p>
+          Quadro nazionale annuale degli incarichi comunicati dalle amministrazioni. La serie copre
+          il periodo {yearRange}; gli importi mostrano quanto risulta pagato, non compensi lordi
+          previsti.
+        </p>
+      </div>
+
+      <div className={styles.scopeBand} role="group" aria-label="Perimetro della vista">
+        <div>
+          <span>Periodo</span>
+          <strong>{yearRange}</strong>
+        </div>
+        <div>
+          <span>Ambito</span>
+          <strong>Italia · aggregato nazionale</strong>
+        </div>
+        <div>
+          <span>Unità monetaria</span>
+          <strong>Quanto risulta pagato · euro</strong>
+        </div>
+        <div>
+          <span>Ultimo dato</span>
+          <strong>{scopedSnapshot.latestYear} · parziale</strong>
+        </div>
+      </div>
+
+      <div className="notice warning-notice">
+        <strong>2026 è un anno parziale</strong>
+        <p>
+          I dati più recenti possono crescere o cambiare con nuove comunicazioni. Per questo non
+          usiamo il 2026 come confronto definitivo con gli anni chiusi e non sommiamo le due serie.
+        </p>
+      </div>
+
+      <section className={styles.latestGrid} aria-labelledby="latest-title">
+        <h2 id="latest-title" className={styles.visuallyHidden}>
+          Ultimo anno osservato
+        </h2>
+        <article className="panel">
+          <div className={styles.sectionHead}>
+            <h2 className="panel-title">Incarichi esterni</h2>
+            <span>{latestExternal.year} · parziale</span>
+          </div>
+          <dl className={styles.metricList}>
+            <div>
+              <dt>Incarichi</dt>
+              <dd>{integer(latestExternal.assignments)}</dd>
+            </div>
+            <div>
+              <dt>Conclusi</dt>
+              <dd>{integer(latestExternal.completedAssignments)}</dd>
+            </div>
+            <div>
+              <dt>Quanto risulta pagato</dt>
+              <dd>
+                <strong>{compactEuro(euros(latestExternal.paidCents))}</strong>
+                <small>{exactEuro(euros(latestExternal.paidCents))}</small>
+              </dd>
+            </div>
+          </dl>
+          <p className={styles.note}>
+            La serie riguarda incarichi affidati a soggetti esterni; non include gli incarichi ai
+            dipendenti.
+          </p>
+        </article>
+
+        <article className="panel">
+          <div className={styles.sectionHead}>
+            <h2 className="panel-title">Incarichi ai dipendenti</h2>
+            <span>{latestEmployee.year} · parziale</span>
+          </div>
+          <dl className={styles.metricList}>
+            <div>
+              <dt>Incarichi</dt>
+              <dd>{integer(latestEmployee.assignments)}</dd>
+            </div>
+            <div>
+              <dt>Conclusi</dt>
+              <dd>{integer(latestEmployee.completedAssignments)}</dd>
+            </div>
+            <div>
+              <dt>Quanto risulta pagato</dt>
+              <dd>
+                <strong>{compactEuro(euros(latestEmployee.paidCents))}</strong>
+                <small>{exactEuro(euros(latestEmployee.paidCents))}</small>
+              </dd>
+            </div>
+          </dl>
+          <p className={styles.note}>
+            La serie riguarda incarichi a personale dipendente; non è la stessa popolazione degli
+            incarichi esterni.
+          </p>
+        </article>
+      </section>
+
+      <section className="panel" aria-labelledby="trend-title">
+        <div className={styles.sectionHead}>
+          <h2 id="trend-title" className="panel-title">
+            Trend degli incarichi
+          </h2>
+          <span>scala comune · le serie non si sommano</span>
+        </div>
+        <figure className={styles.trend}>
+          <figcaption>
+            Barre proporzionali al numero di incarichi più alto tra le due serie nel periodo. I
+            valori numerici restano il riferimento esatto.
+          </figcaption>
+          <div className={styles.trendRows}>
+            {scopedSnapshot.externalAppointments.map((external, index) => {
+              const employee = scopedSnapshot.employeeAppointments[index];
+              const externalWidth = (external.assignments / maxAssignments) * 100;
+              const employeeWidth = (employee.assignments / maxAssignments) * 100;
+              return (
+                <div className={styles.trendYear} key={external.year}>
+                  <strong>{external.year}</strong>
+                  <div className={styles.trendLine}>
+                    <span className={styles.trendLabel}>Esterni</span>
+                    <span className={styles.track} aria-hidden="true">
+                      <i className={styles.externalBar} style={{ width: `${externalWidth}%` }} />
+                    </span>
+                    <span className={styles.trendValue}>{integer(external.assignments)}</span>
+                  </div>
+                  <div className={styles.trendLine}>
+                    <span className={styles.trendLabel}>Dipendenti</span>
+                    <span className={styles.track} aria-hidden="true">
+                      <i className={styles.employeeBar} style={{ width: `${employeeWidth}%` }} />
+                    </span>
+                    <span className={styles.trendValue}>{integer(employee.assignments)}</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </figure>
+        <p className={styles.note}>
+          Il 2026 è evidenziato nel testo come parziale: le barre servono a orientarsi nella serie,
+          non a stabilire una graduatoria o una valutazione.
+        </p>
+      </section>
+
+      <section className={styles.comparisonGrid} aria-labelledby="composition-title">
+        <h2 id="composition-title" className={styles.visuallyHidden}>
+          Composizioni nell&apos;ultimo anno
+        </h2>
+        <section className="panel">
+          <h2 className="panel-title">Destinatari degli incarichi esterni</h2>
+          <p className={styles.noteIntro}>
+            Percentuali calcolate sul denominatore esplicito: destinatari individuali + organizzazioni
+            censite ({integer(latestRecipientDenominator)}).
+          </p>
+          <div className={styles.composition}>
+            <div className={styles.compositionRow}>
+              <div className={styles.compositionLabel}>
+                <span>Individuali</span>
+                <strong>{shareLabel(latestExternal.individualRecipients, latestRecipientDenominator)}</strong>
+              </div>
+              <div className={styles.compositionTrack} aria-hidden="true">
+                <i
+                  className={styles.externalBar}
+                  style={{ width: `${validShare(latestExternal.individualRecipients, latestRecipientDenominator) ?? 0}%` }}
+                />
+              </div>
+              <small>{integer(latestExternal.individualRecipients)} destinatari censiti</small>
+            </div>
+            <div className={styles.compositionRow}>
+              <div className={styles.compositionLabel}>
+                <span>Organizzazioni</span>
+                <strong>{shareLabel(latestExternal.organizationRecipients, latestRecipientDenominator)}</strong>
+              </div>
+              <div className={styles.compositionTrack} aria-hidden="true">
+                <i
+                  className={styles.employeeBar}
+                  style={{ width: `${validShare(latestExternal.organizationRecipients, latestRecipientDenominator) ?? 0}%` }}
+                />
+              </div>
+              <small>{integer(latestExternal.organizationRecipients)} destinatari censiti</small>
+            </div>
+          </div>
+          <p className={styles.note}>
+            Il denominatore non è il numero totale degli incarichi: le due grandezze rispondono a
+            domande diverse.
+          </p>
+        </section>
+
+        <section className="panel">
+          <h2 className="panel-title">Ruoli negli incarichi ai dipendenti</h2>
+          <p className={styles.noteIntro}>
+            Percentuali calcolate sul denominatore esplicito: totale incarichi ai dipendenti ({integer(
+              latestEmployee.assignments,
+            )}).
+          </p>
+          <div className={styles.composition}>
+            <div className={styles.compositionRow}>
+              <div className={styles.compositionLabel}>
+                <span>Dirigenti</span>
+                <strong>{shareLabel(latestEmployee.managerAssignments, latestEmployee.assignments)}</strong>
+              </div>
+              <div className={styles.compositionTrack} aria-hidden="true">
+                <i
+                  className={styles.externalBar}
+                  style={{ width: `${validShare(latestEmployee.managerAssignments, latestEmployee.assignments) ?? 0}%` }}
+                />
+              </div>
+              <small>{integer(latestEmployee.managerAssignments)} incarichi</small>
+            </div>
+            <div className={styles.compositionRow}>
+              <div className={styles.compositionLabel}>
+                <span>Non dirigenti</span>
+                <strong>{shareLabel(latestEmployee.nonManagerAssignments, latestEmployee.assignments)}</strong>
+              </div>
+              <div className={styles.compositionTrack} aria-hidden="true">
+                <i
+                  className={styles.employeeBar}
+                  style={{ width: `${validShare(latestEmployee.nonManagerAssignments, latestEmployee.assignments) ?? 0}%` }}
+                />
+              </div>
+              <small>{integer(latestEmployee.nonManagerAssignments)} incarichi</small>
+            </div>
+          </div>
+          <p className={styles.note}>
+            Qui il denominatore coincide con gli incarichi della serie: le due categorie riconciliano
+            con il totale.
+          </p>
+        </section>
+      </section>
+
+      <section className="panel" aria-labelledby="external-series-title">
+        <div className={styles.sectionHead}>
+          <h2 id="external-series-title" className="panel-title">
+            Serie annuale · incarichi esterni
+          </h2>
+          <span>ammontare erogato comunicato dalla fonte</span>
+        </div>
+        <p className={styles.tableHint}>Scorri la tabella →</p>
+        <div className="table-scroll" role="region" aria-label="Serie annuale degli incarichi esterni" tabIndex={0}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th scope="col">Anno</th>
+                <th scope="col" className="num">Incarichi</th>
+                <th scope="col" className="num">Conclusi</th>
+                <th scope="col" className="num">Quanto risulta pagato</th>
+                <th scope="col" className="num">Individuali</th>
+                <th scope="col" className="num">Organizzazioni</th>
+              </tr>
+            </thead>
+            <tbody>
+              {scopedSnapshot.externalAppointments.map((item) => (
+                <tr key={item.year}>
+                  <th scope="row">
+                    {item.year}
+                    {item.year === scopedSnapshot.latestYear ? <small>parziale</small> : null}
+                  </th>
+                  <td className="num">{integer(item.assignments)}</td>
+                  <td className="num">{integer(item.completedAssignments)}</td>
+                  <td className={`num ${styles.moneyCell}`}>
+                    <strong>{compactEuro(euros(item.paidCents))}</strong>
+                    <small>{exactEuro(euros(item.paidCents))}</small>
+                  </td>
+                  <td className="num">{integer(item.individualRecipients)}</td>
+                  <td className="num">{integer(item.organizationRecipients)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className={styles.note}>
+          L&apos;importo è quanto risulta pagato alla fonte, non il compenso lordo previsto. I
+          destinatari non sono usati come denominatore degli incarichi.
+        </p>
+      </section>
+
+      <section className="panel" aria-labelledby="employee-series-title">
+        <div className={styles.sectionHead}>
+          <h2 id="employee-series-title" className="panel-title">
+            Serie annuale · incarichi ai dipendenti
+          </h2>
+          <span>conteggi della serie dipendenti</span>
+        </div>
+        <p className={styles.tableHint}>Scorri la tabella →</p>
+        <div className="table-scroll" role="region" aria-label="Serie annuale degli incarichi ai dipendenti" tabIndex={0}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th scope="col">Anno</th>
+                <th scope="col" className="num">Incarichi</th>
+                <th scope="col" className="num">Conclusi</th>
+                <th scope="col" className="num">Quanto risulta pagato</th>
+                <th scope="col" className="num">Dirigenti</th>
+                <th scope="col" className="num">Non dirigenti</th>
+                <th scope="col" className="num">Record PA conferente</th>
+              </tr>
+            </thead>
+            <tbody>
+              {scopedSnapshot.employeeAppointments.map((item) => (
+                <tr key={item.year}>
+                  <th scope="row">
+                    {item.year}
+                    {item.year === scopedSnapshot.latestYear ? <small>parziale</small> : null}
+                  </th>
+                  <td className="num">{integer(item.assignments)}</td>
+                  <td className="num">{integer(item.completedAssignments)}</td>
+                  <td className={`num ${styles.moneyCell}`}>
+                    <strong>{compactEuro(euros(item.paidCents))}</strong>
+                    <small>{exactEuro(euros(item.paidCents))}</small>
+                  </td>
+                  <td className="num">{integer(item.managerAssignments)}</td>
+                  <td className="num">{integer(item.nonManagerAssignments)}</td>
+                  <td className="num">{integer(item.publicAdministrationGrantorRecords)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className={styles.note}>
+          “Record PA conferente” conserva il conteggio della fonte: non equivale al numero di
+          amministrazioni distinte.
+        </p>
+      </section>
+
+      <section className="panel" id="metodo" aria-labelledby="method-title">
+        <h2 id="method-title" className="panel-title">
+          Fonte, metodo e limiti
+        </h2>
+        <dl className={styles.sourceGrid}>
+          <div>
+            <dt>Titolare</dt>
+            <dd>{scopedSnapshot.source.owner}</dd>
+          </div>
+          <div>
+            <dt>Dataset</dt>
+            <dd>{scopedSnapshot.source.dataset}</dd>
+          </div>
+          <div>
+            <dt>Osservato</dt>
+            <dd>{longDate(scopedSnapshot.source.observedAt)}</dd>
+          </div>
+          <div>
+            <dt>Cadenza dichiarata</dt>
+            <dd>{scopedSnapshot.source.declaredCadence}</dd>
+          </div>
+          <div>
+            <dt>Controllo piattaforma</dt>
+            <dd>{scopedSnapshot.source.platformCheckCadence}</dd>
+          </div>
+          <div>
+            <dt>Licenza e riuso</dt>
+            <dd>{scopedSnapshot.source.reuseTerms}</dd>
+          </div>
+        </dl>
+        <div className={styles.methodNotes}>
+          <p>
+            <strong>Che cosa misura “pagato”.</strong> {scopedSnapshot.methodology.amountMeaning}
+          </p>
+          <p>
+            <strong>Copertura.</strong> Aggregato nazionale annuale, senza nomi individuali,
+            curriculum o graduatorie; la serie comprende solo {yearRange} nello snapshot verificato.
+            Questa serie DFP non equivale alle categorie contabili della Ragioneria generale dello
+            Stato.
+          </p>
+          <p>
+            <strong>Responsabilità.</strong> {scopedSnapshot.methodology.responsibilityWarning}
+          </p>
+          <p>
+            <strong>Conteggio PA conferente.</strong>{" "}
+            {scopedSnapshot.methodology.publicAdministrationGrantorMeaning}
+          </p>
+        </div>
+        <div className={styles.actions}>
+          <a className="btn btn-secondary" href={scopedSnapshot.source.landingUrl} target="_blank" rel="noreferrer">
+            Apri il progetto Consulenti Pubblici ↗
+          </a>
+          <a className="btn btn-secondary" href={scopedSnapshot.source.endpoint} target="_blank" rel="noreferrer">
+            Apri l&apos;endpoint ufficiale ↗
+          </a>
+          <a className="btn btn-secondary" href={scopedSnapshot.source.licenseUrl} target="_blank" rel="noreferrer">
+            Note legali e licenza ↗
+          </a>
+        </div>
+        <p className={styles.note}>
+          {scopedSnapshot.methodology.currentYearWarning} Le due serie restano separate perché hanno
+          significati e popolazioni diverse; questo quadro non è una valutazione di legittimità,
+          qualità o opportunità degli incarichi.
+        </p>
+      </section>
+
+      <p className={styles.backLink}>
+        <Link href="/enti">← Torna a enti e società</Link>
+      </p>
+    </main>
+  );
+}

--- a/tests/consulenti-overview-route.test.mjs
+++ b/tests/consulenti-overview-route.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { assertConsulentiSnapshot } from "../src/lib/data/consulenti-contract.ts";
+import {
+  assertIncarichiOverviewScope,
+  INCARICHI_OVERVIEW_DATASET,
+  INCARICHI_OVERVIEW_REUSE_TERMS,
+  INCARICHI_OVERVIEW_YEARS,
+} from "../src/app/incarichi/overview.ts";
+
+const page = await readFile(
+  new URL("../src/app/incarichi/page.tsx", import.meta.url),
+  "utf8",
+);
+const css = await readFile(
+  new URL("../src/app/incarichi/incarichi.module.css", import.meta.url),
+  "utf8",
+);
+const snapshotJson = JSON.parse(
+  await readFile(
+    new URL("../src/data/generated/consulenti-overview.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+test("the national appointments route keeps the two populations separate", () => {
+  assert.match(page, /consulentiSnapshot as snapshot/);
+  assert.match(page, /scopedSnapshot\.externalAppointments/);
+  assert.match(page, /scopedSnapshot\.employeeAppointments/);
+  assert.match(page, /le serie non si sommano/);
+  assert.match(page, /non include gli incarichi ai\s+dipendenti/);
+  assert.match(page, /non è la stessa popolazione degli\s+incarichi esterni/);
+  assert.doesNotMatch(page, /paidCents\s*\+[^\n]*paidCents/);
+});
+
+test("the route labels partial coverage, amount meaning, and valid denominators", () => {
+  assert.match(page, /const yearRange = `\$\{firstYear\}-\$\{scopedSnapshot\.latestYear\}`/);
+  assert.deepEqual(INCARICHI_OVERVIEW_YEARS, [2023, 2024, 2025, 2026]);
+  assert.match(page, /2026 è un anno parziale/);
+  assert.match(page, /Quanto risulta pagato/);
+  assert.match(page, /non compensi lordi\s+previsti/);
+  assert.match(page, /denominatore esplicito/);
+  assert.match(page, /destinatari individuali \+ organizzazioni/);
+  assert.match(page, /totale incarichi ai dipendenti/);
+  assert.match(page, /Record PA conferente/);
+  assert.match(page, /Scorri la tabella →/g);
+  assert.match(page, /non equivale al numero di\s+amministrazioni distinte/);
+  assert.match(page, /non equivale alle categorie contabili della Ragioneria generale dello\s+Stato/);
+});
+
+test("the route rejects a snapshot that drifts outside its promised years", () => {
+  const scoped = assertIncarichiOverviewScope(assertConsulentiSnapshot(snapshotJson));
+  assert.equal(scoped.latestYear, 2026);
+  assert.equal(scoped.source.dataset, INCARICHI_OVERVIEW_DATASET);
+  assert.equal(scoped.source.reuseTerms, INCARICHI_OVERVIEW_REUSE_TERMS);
+
+  const drifted = structuredClone(snapshotJson);
+  drifted.externalAppointments[0].year = 2022;
+  drifted.employeeAppointments[0].year = 2022;
+  assert.throws(
+    () => assertIncarichiOverviewScope(assertConsulentiSnapshot(drifted)),
+    /copertura annuale 2023-2026 inattesa/,
+  );
+
+  const datasetDrift = structuredClone(snapshotJson);
+  datasetDrift.source.dataset = "Dataset diverso";
+  assert.throws(
+    () => assertIncarichiOverviewScope(assertConsulentiSnapshot(datasetDrift)),
+    /dataset DFP inatteso/,
+  );
+
+  const ownerDrift = structuredClone(snapshotJson);
+  ownerDrift.source.owner = "Titolare diverso";
+  assert.throws(
+    () => assertIncarichiOverviewScope(assertConsulentiSnapshot(ownerDrift)),
+    /titolare DFP inatteso/,
+  );
+
+  const reuseDrift = structuredClone(snapshotJson);
+  reuseDrift.source.reuseTerms = "Termini diversi";
+  assert.throws(
+    () => assertIncarichiOverviewScope(assertConsulentiSnapshot(reuseDrift)),
+    /condizioni di riuso inattese/,
+  );
+});
+
+test("the page has source, method, license, and coverage boundaries", () => {
+  assert.match(page, /Fonte, metodo e limiti/);
+  assert.match(page, /scopedSnapshot\.source\.landingUrl/);
+  assert.match(page, /scopedSnapshot\.source\.endpoint/);
+  assert.match(page, /scopedSnapshot\.source\.licenseUrl/);
+  assert.match(page, /senza nomi individuali,?\s*\n?\s*curriculum o graduatorie/);
+  assert.doesNotMatch(page, /href="\/consulenza"/);
+  assert.doesNotMatch(page, /href="\/controlli"/);
+});
+
+test("the route gives landmarks and breadcrumb state real semantics", () => {
+  assert.match(page, /<span aria-current="page">Incarichi pubblici<\/span>/);
+  assert.match(
+    page,
+    /className=\{styles\.scopeBand\} role="group" aria-label="Perimetro della vista"/,
+  );
+  assert.doesNotMatch(page, /className=\{styles\.composition\} aria-label=/);
+});
+
+test("the overview stays flat and scroll-safe on narrow screens", () => {
+  assert.match(css, /\.scopeBand\s*\{/);
+  assert.match(css, /\.latestGrid,[\s\S]*\.comparisonGrid/);
+  assert.match(css, /\.compositionTrack/);
+  assert.match(css, /:global\(\.table-scroll\) table \{ min-width: 900px; \}/);
+  assert.match(css, /@media \(max-width: 620px\)/);
+  assert.doesNotMatch(css, /border-radius\s*:/);
+  assert.doesNotMatch(css, /gradient\s*\(/i);
+});


### PR DESCRIPTION
## Summary

- Add the national DFP appointments overview at /incarichi.
- Keep external and employee appointments separate, with explicit partial-2026 and paid-amount semantics.
- Add breadcrumb and grouping semantics from the accessibility review.

## Verification

- npm test: 263/263
- focused route/copy tests: 7/7
- typecheck, lint, build: PASS
- Impeccable detector on route diff: []
- Chrome 1280x900 and 390x844: S1-S4 present, focus-visible, no global overflow, layout-shift 0, runtime errors 0; mobile tables scroll internally.
- Consulenza: 200, form present, no submit/POST; lead configuration defaults test: PASS.

No shared shell, navigation, data snapshot, or Consulenza source files changed. Not merged.