### PR TITLE
feat(confronti): add verified restoration comparison

### DIFF
--- a/src/app/confronti/confronti.module.css
+++ b/src/app/confronti/confronti.module.css
@@ -1,0 +1,334 @@
+.page {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.breadcrumb a {
+  color: var(--color-neutral-700);
+}
+
+.breadcrumb a:hover {
+  color: var(--color-accent-800);
+}
+
+.scopeBand {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-raised);
+}
+
+.scopeBand > div {
+  min-width: 0;
+  padding: var(--space-4);
+  border-right: 1px solid var(--color-neutral-300);
+}
+
+.scopeBand > div:last-child {
+  border-right: 0;
+}
+
+.scopeBand span,
+.scopeBand strong {
+  display: block;
+}
+
+.scopeBand span {
+  margin-bottom: 6px;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.scopeBand strong {
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.finding {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, .8fr);
+  gap: var(--space-6);
+  align-items: start;
+}
+
+.finding h2,
+.sectionHead h2,
+.interpretation h2,
+.sources h2 {
+  margin: 0 0 var(--space-2);
+  font-size: 21px;
+}
+
+.finding p,
+.sectionHead p,
+.interpretation p,
+.sources p {
+  max-width: 72ch;
+  margin: 0;
+  color: var(--color-neutral-700);
+}
+
+.finding dl {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.finding dl > div {
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+
+.finding dt,
+.signalGrid dt {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.finding dd,
+.signalGrid dd {
+  margin: 4px 0 0;
+  font-family: var(--font-heading);
+  font-size: 19px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.sectionHead {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-5);
+  align-items: flex-start;
+  margin-bottom: var(--space-5);
+}
+
+.amountList {
+  display: grid;
+  gap: var(--space-5);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.amountHeading,
+.amountFoot {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.amountHeading > div {
+  min-width: 0;
+}
+
+.amountHeading span,
+.amountHeading small {
+  display: block;
+}
+
+.amountHeading span {
+  font-weight: 700;
+}
+
+.amountHeading small,
+.amountFoot,
+.legend {
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.amountHeading strong {
+  flex: 0 0 auto;
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
+}
+
+.track {
+  position: relative;
+  height: 18px;
+  margin: var(--space-2) 0;
+  background: var(--color-neutral-200);
+}
+
+.track i {
+  display: block;
+  height: 100%;
+  background: var(--chart-primary);
+}
+
+.track b {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
+  background: var(--color-text);
+  transform: translateX(-1px);
+}
+
+.legend {
+  margin: var(--space-5) 0 0;
+}
+
+.signalGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.signalGrid article {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.signalGrid h3,
+.signalGrid p,
+.signalGrid dl {
+  margin: 0;
+}
+
+.signalValue {
+  font-family: var(--font-heading);
+  font-size: 34px;
+  font-weight: 800;
+  letter-spacing: -.03em;
+  font-variant-numeric: tabular-nums;
+}
+
+.signalGrid dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-200);
+}
+
+.signalGrid a {
+  justify-self: start;
+  font-weight: 700;
+}
+
+.interpretation {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.methodList {
+  display: grid;
+  gap: var(--space-2);
+  max-width: 80ch;
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--color-neutral-700);
+}
+
+.exactTable {
+  min-width: 760px;
+}
+
+.tableHint {
+  display: none;
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.sources .sectionHead {
+  margin-bottom: var(--space-4);
+}
+
+.sources ul {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--color-neutral-300);
+  list-style: none;
+}
+
+.sources li {
+  display: grid;
+  grid-template-columns: minmax(210px, .65fr) minmax(0, 1.35fr);
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+
+.sources li a {
+  font-weight: 700;
+}
+
+.sources li span {
+  color: var(--color-neutral-700);
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .scopeBand {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .scopeBand > div:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .scopeBand > div:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--color-neutral-300);
+  }
+
+  .finding {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .tableHint {
+    display: block;
+  }
+
+  .scopeBand,
+  .signalGrid,
+  .signalGrid dl,
+  .sources li {
+    grid-template-columns: 1fr;
+  }
+
+  .scopeBand > div {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-neutral-300);
+  }
+
+  .scopeBand > div:last-child {
+    border-bottom: 0;
+  }
+
+  .sectionHead,
+  .amountHeading,
+  .amountFoot {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+}

--- a/src/app/confronti/page.tsx
+++ b/src/app/confronti/page.tsx
@@ -1,0 +1,262 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import type { EvidenceObservation } from "@/lib/data/public-spending-evidence-contract";
+import { exactEuro, longDate, percent } from "@/lib/format";
+import {
+  restorationBenchmarkReference,
+  restorationComparisonSnapshot,
+  restorationPublishableAnomalies,
+} from "@/lib/vive-restoration-snapshot";
+import styles from "./confronti.module.css";
+
+export const metadata: Metadata = {
+  title: "Confronti verificati sulla spesa pubblica",
+  description:
+    "Tre affidamenti ufficiali per restauri destinati alla stessa mostra, confrontati con importi, perimetro e limiti espliciti.",
+};
+
+function euros(cents: number): number {
+  return cents / 100;
+}
+
+function signedPercent(value: number): string {
+  const sign = value > 0 ? "+" : value < 0 ? "−" : "";
+  return sign + percent(Math.abs(value));
+}
+
+function benchmarkDeltaPercent(observation: EvidenceObservation): number {
+  const value = observation.benchmark?.targetDeltaPercent;
+  if (value === null || value === undefined) {
+    throw new Error("Snapshot confronti non valido: scostamento percentuale assente");
+  }
+  return value;
+}
+
+const observations = [...restorationComparisonSnapshot.observations].sort(
+  (left, right) => (right.amount?.valueCents ?? 0) - (left.amount?.valueCents ?? 0),
+);
+const sourceById = new Map(
+  restorationComparisonSnapshot.sources.map((source) => [source.id, source]),
+);
+const highest = observations[0];
+const lowest = observations.at(-1)!;
+const highestCents = highest.amount!.valueCents;
+const lowestCents = lowest.amount!.valueCents;
+const medianCents = restorationBenchmarkReference.amount!.valueCents;
+const rangeCents = highestCents - lowestCents;
+const highToLowRatio = highestCents / lowestCents;
+
+export default function ConfrontiPage() {
+  return (
+    <main className={"shell page " + styles.page}>
+      <nav className={styles.breadcrumb} aria-label="Percorso">
+        <Link href="/">Home</Link>
+        <span aria-hidden="true">/</span>
+        <Link href="/controlli">Cosa controllare</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Confronti verificati</span>
+      </nav>
+
+      <div className="page-intro">
+        <h1>Tre restauri, importi da 280 € a 6.270 €</h1>
+        <p>
+          Stesso ente, stessa mostra e stesso tipo di affidamento. Il valore più alto è{" "}
+          {highToLowRatio.toLocaleString("it-IT", { maximumFractionDigits: 1 })} volte quello più
+          basso. La differenza è reale; i dati disponibili non ne spiegano la causa.
+        </p>
+      </div>
+
+      <div className={styles.scopeBand} role="group" aria-label="Perimetro del confronto">
+        <div>
+          <span>Ente</span>
+          <strong>{highest.subject.spendingEntity.name}</strong>
+        </div>
+        <div>
+          <span>Procedura</span>
+          <strong>Affidamento diretto</strong>
+        </div>
+        <div>
+          <span>Oggetto confrontato</span>
+          <strong>Restauro di un singolo dipinto</strong>
+        </div>
+        <div>
+          <span>Importi</span>
+          <strong>Netti IVA · totale affidamento</strong>
+        </div>
+      </div>
+
+      <section className={"panel " + styles.finding} aria-labelledby="finding-title">
+        <div>
+          <h2 id="finding-title">Il divario che merita una spiegazione</h2>
+          <p>
+            Tra l&apos;affidamento più basso e quello più alto ci sono{" "}
+            <strong>{exactEuro(euros(rangeCents))}</strong>. Rispetto alla mediana della piccola
+            coorte, l&apos;importo più alto è {signedPercent(benchmarkDeltaPercent(highest))} e
+            quello più basso è {signedPercent(benchmarkDeltaPercent(lowest))}.
+          </p>
+        </div>
+        <dl>
+          <div>
+            <dt>Mediana</dt>
+            <dd>{exactEuro(euros(medianCents))}</dd>
+          </div>
+          <div>
+            <dt>Differenza massimo-minimo</dt>
+            <dd>{exactEuro(euros(rangeCents))}</dd>
+          </div>
+          <div>
+            <dt>Atti ufficiali confrontati</dt>
+            <dd>3</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="panel" aria-labelledby="amounts-title">
+        <div className={styles.sectionHead}>
+          <div>
+            <h2 id="amounts-title">Gli importi, dal più alto al più basso</h2>
+            <p>La lunghezza delle barre usa 6.270 € come massimo. I numeri esatti restano il riferimento.</p>
+          </div>
+          <span className="tag tag-neutral">Coorte: 3 affidamenti</span>
+        </div>
+        <ol className={styles.amountList}>
+          {observations.map((observation) => {
+            const amountCents = observation.amount!.valueCents;
+            const isReference = observation.id === restorationBenchmarkReference.id;
+            return (
+              <li key={observation.id}>
+                <div className={styles.amountHeading}>
+                  <div>
+                    <span>{observation.title.replace(" per la mostra Roma in moneta", "")}</span>
+                    <small>{isReference ? "Mediana della coorte" : "Segnale comparativo"}</small>
+                  </div>
+                  <strong>{exactEuro(euros(amountCents))}</strong>
+                </div>
+                <div className={styles.track} aria-hidden="true">
+                  <i style={{ width: String((amountCents / highestCents) * 100) + "%" }} />
+                  <b style={{ left: String((medianCents / highestCents) * 100) + "%" }} />
+                </div>
+                <div className={styles.amountFoot}>
+                  <span>{signedPercent(benchmarkDeltaPercent(observation))} rispetto alla mediana</span>
+                  <span>{sourceById.get(observation.sourceIds[0])?.identifier}</span>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+        <p className={styles.legend}>
+          La tacca verticale indica la mediana di {exactEuro(euros(medianCents))}. Il colore e la
+          posizione mostrano una differenza, non un giudizio sulla qualità del restauro.
+        </p>
+      </section>
+
+      <section className={styles.signalGrid} aria-labelledby="signals-title">
+        <h2 id="signals-title" className={styles.visuallyHidden}>I due segnali pubblicabili</h2>
+        {restorationPublishableAnomalies.map((observation) => {
+          const source = sourceById.get(observation.sourceIds[0])!;
+          const isAbove = observation.benchmark!.targetDeltaCents > 0;
+          return (
+            <article className="panel" key={observation.id}>
+              <h3 className="panel-title">{isAbove ? "Importo sopra la mediana" : "Importo sotto la mediana"}</h3>
+              <strong className={styles.signalValue}>
+                {signedPercent(benchmarkDeltaPercent(observation))}
+              </strong>
+              <p>{observation.title}</p>
+              <dl>
+                <div>
+                  <dt>Importo netto IVA</dt>
+                  <dd>{exactEuro(euros(observation.amount!.valueCents))}</dd>
+                </div>
+                <div>
+                  <dt>Differenza dalla mediana</dt>
+                  <dd>{exactEuro(euros(Math.abs(observation.benchmark!.targetDeltaCents)))}</dd>
+                </div>
+              </dl>
+              <a href={source.url} target="_blank" rel="noreferrer">
+                Verifica {source.identifier} ↗
+              </a>
+            </article>
+          );
+        })}
+      </section>
+
+      <section className={"notice " + styles.interpretation} aria-labelledby="interpretation-title">
+        <h2 id="interpretation-title">Che cosa possiamo dire, e che cosa manca</h2>
+        <p>
+          Possiamo dire che tre affidamenti confrontabili hanno importi molto diversi. Non possiamo
+          dire, con questi soli atti, che uno sia uno spreco: dimensioni, tecnica, stato conservativo
+          e complessità dell&apos;intervento possono cambiare il lavoro necessario.
+        </p>
+        <p>
+          La domanda pubblica corretta è quindi concreta: <strong>quali elementi tecnici giustificano
+          il divario?</strong> Una relazione, un computo o una motivazione più dettagliata permetterebbero
+          di distinguere una differenza spiegabile da una vera inefficienza.
+        </p>
+      </section>
+
+      <section className="panel" aria-labelledby="exact-table-title">
+        <h2 id="exact-table-title" className="panel-title">Tabella esatta</h2>
+        <p className={styles.tableHint}>Scorri la tabella verso destra per leggere tutti i campi.</p>
+        <div className="table-scroll" role="region" aria-label="Tabella esatta dei tre affidamenti" tabIndex={0}>
+          <table className={"table " + styles.exactTable}>
+            <caption>Tre restauri destinati alla stessa mostra, importi netti IVA</caption>
+            <thead>
+              <tr>
+                <th scope="col">Restauro</th>
+                <th scope="col">Atto e CIG</th>
+                <th scope="col" className="num">Importo</th>
+                <th scope="col" className="num">Scostamento dalla mediana</th>
+              </tr>
+            </thead>
+            <tbody>
+              {observations.map((observation) => {
+                const source = sourceById.get(observation.sourceIds[0])!;
+                return (
+                  <tr key={observation.id}>
+                    <th scope="row">{observation.title}</th>
+                    <td>{source.identifier}</td>
+                    <td className="num">{exactEuro(euros(observation.amount!.valueCents))}</td>
+                    <td className="num">{signedPercent(benchmarkDeltaPercent(observation))}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="panel" aria-labelledby="method-title">
+        <h2 id="method-title" className="panel-title">Metodo e limiti</h2>
+        <ul className={styles.methodList}>
+          <li>Mediana e percentili calcolati su tre soli affidamenti: è un confronto descrittivo, non un prezzo equo.</li>
+          <li>Dentro la coorte restano fissi ente, mostra, categoria, periodo, procedura, unità e base IVA.</li>
+          <li>Un atto di trasporto per la stessa mostra è escluso perché misura un servizio diverso.</li>
+          <li>I nomi dei contraenti non sono ripubblicati; atto e CIG permettono la verifica alla fonte.</li>
+        </ul>
+      </section>
+
+      <section className={"panel " + styles.sources} aria-labelledby="sources-title">
+        <div className={styles.sectionHead}>
+          <div>
+            <h2 id="sources-title">Fonti ufficiali</h2>
+            <p>
+              Atti dell&apos;Istituto Vittoriano e Palazzo Venezia, acquisiti il{" "}
+              {longDate(restorationComparisonSnapshot.generatedAt + "T00:00:00Z")}.
+            </p>
+          </div>
+          <a href="https://vive.cultura.gov.it/it/bandi-di-gara-procedura-sotto-soglia" target="_blank" rel="noreferrer">
+            Apri l&apos;indice ufficiale ↗
+          </a>
+        </div>
+        <ul>
+          {restorationComparisonSnapshot.sources.map((source) => (
+            <li key={source.id}>
+              <a href={source.url} target="_blank" rel="noreferrer">{source.identifier} ↗</a>
+              <span>{source.title}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/vive-restoration-snapshot.ts
+++ b/src/lib/vive-restoration-snapshot.ts
@@ -1,0 +1,74 @@
+import rawSnapshot from "@/data/generated/vive-roma-in-moneta-restoration.json";
+import {
+  assessSocialCardReadiness,
+  assertPublicSpendingEvidenceSnapshot,
+  type EvidenceObservation,
+} from "@/lib/data/public-spending-evidence-contract";
+
+const snapshot = assertPublicSpendingEvidenceSnapshot(rawSnapshot);
+
+function fail(message: string): never {
+  throw new Error("Snapshot confronti non valido: " + message);
+}
+
+function isPublishableAnomaly(observation: EvidenceObservation): boolean {
+  return observation.classification === "anomaly" && observation.publicationStatus === "publishable";
+}
+
+const publishableAnomalies = snapshot.observations.filter(isPublishableAnomaly);
+const benchmarkReferences = snapshot.observations.filter(
+  (observation) =>
+    observation.classification === "benchmark_reference" &&
+    observation.publicationStatus === "blocked",
+);
+
+if (snapshot.sources.length !== 3 || snapshot.observations.length !== 3) {
+  fail("sono attesi tre atti e tre osservazioni");
+}
+if (publishableAnomalies.length !== 2 || benchmarkReferences.length !== 1) {
+  fail("sono attesi due segnali pubblicabili e un riferimento non destinato a card");
+}
+if (
+  snapshot.observations.some(
+    (observation) =>
+      !observation.amount ||
+      observation.amount.valueCents <= 0 ||
+      !observation.benchmark ||
+      observation.benchmark.targetDeltaCents === null ||
+      observation.benchmark.targetDeltaPercent === null,
+  )
+) {
+  fail("ogni confronto richiede importo positivo e scostamenti riconciliati");
+}
+
+const cohortIds = new Set(snapshot.observations.map((observation) => observation.benchmark?.cohortId));
+const entities = new Set(
+  snapshot.observations.map((observation) => observation.subject.spendingEntity.name),
+);
+const dimensions = new Set(
+  snapshot.observations.map((observation) =>
+    [
+      observation.category,
+      observation.amount?.taxBasis,
+      observation.amount?.unit,
+      observation.procurementMethod?.value,
+      observation.period.start,
+      observation.period.end,
+    ].join("|"),
+  ),
+);
+
+if (cohortIds.size !== 1 || entities.size !== 1 || dimensions.size !== 1) {
+  fail("la coorte non mantiene ente, periodo e dimensioni confrontabili");
+}
+
+for (const observation of publishableAnomalies) {
+  const blockers = assessSocialCardReadiness(snapshot, observation);
+  if (blockers.length > 0) {
+    fail("segnale " + observation.id + " non pubblicabile: " + blockers.join(", "));
+  }
+}
+
+export const restorationComparisonSnapshot = snapshot;
+export const restorationPublishableAnomalies = publishableAnomalies;
+export const restorationBenchmarkReference = benchmarkReferences[0];

--- a/tests/confronti-page.test.mjs
+++ b/tests/confronti-page.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const pagePath = new URL("../src/app/confronti/page.tsx", import.meta.url);
+const stylePath = new URL("../src/app/confronti/confronti.module.css", import.meta.url);
+const loaderPath = new URL("../src/lib/vive-restoration-snapshot.ts", import.meta.url);
+
+const { restorationBenchmarkReference, restorationPublishableAnomalies } = await import(
+  "../src/lib/vive-restoration-snapshot.ts"
+);
+
+test("the verified comparison page exposes only the two publishable anomaly cards", () => {
+  assert.equal(restorationPublishableAnomalies.length, 2);
+  assert.ok(restorationPublishableAnomalies.every((item) => item.classification === "anomaly"));
+  assert.ok(restorationPublishableAnomalies.every((item) => item.publicationStatus === "publishable"));
+  assert.equal(restorationBenchmarkReference.classification, "benchmark_reference");
+  assert.equal(restorationBenchmarkReference.publicationStatus, "blocked");
+});
+
+test("the page states the comparison, denominator and evidence boundary in plain Italian", () => {
+  const page = readFileSync(pagePath, "utf8");
+
+  assert.match(page, /Tre restauri, importi da 280 € a 6\.270 €/);
+  assert.match(page, /Stesso ente, stessa mostra e stesso tipo di affidamento/);
+  assert.match(page, /importi netti IVA/i);
+  assert.match(page, /non possiamo\s+dire[\s\S]*spreco/i);
+  assert.match(page, /quali elementi tecnici giustificano/);
+  assert.match(page, /Mediana e percentili calcolati su tre soli affidamenti/);
+});
+
+test("sources are last and every wide exact value remains available as a table", () => {
+  const page = readFileSync(pagePath, "utf8");
+  const tableIndex = page.indexOf("Tabella esatta");
+  const methodIndex = page.indexOf("Metodo e limiti");
+  const sourceIndex = page.indexOf("Fonti ufficiali");
+
+  assert.ok(tableIndex > 0);
+  assert.ok(methodIndex > tableIndex);
+  assert.ok(sourceIndex > methodIndex);
+  assert.match(page, /role="region"/);
+  assert.match(page, /tabIndex=\{0\}/);
+  assert.match(page, /<caption>/);
+  assert.match(page, /Scorri la tabella verso destra/);
+  assert.match(page, /styles\.exactTable/);
+});
+
+test("the comparison layout remains inside the viewport", () => {
+  const styles = readFileSync(stylePath, "utf8");
+
+  assert.match(styles, /minmax\(0, 1fr\)/);
+  assert.match(styles, /@media \(max-width: 620px\)/);
+});
+
+test("the new public surface contains no local archive provenance", () => {
+  const text = [pagePath, stylePath, loaderPath]
+    .map((path) => readFileSync(path, "utf8"))
+    .join("\n");
+
+  assert.doesNotMatch(text, /\/Users\//);
+  assert.doesNotMatch(text, /Downloads/);
+  assert.doesNotMatch(text, /\.tar\.gz/i);
+  assert.doesNotMatch(text, /private (archive|document|source)/i);
+});


### PR DESCRIPTION
## Cosa cambia

- aggiunge la nuova route /confronti con tre affidamenti ufficiali confrontabili per il restauro di singoli dipinti destinati alla stessa mostra
- mostra importi netti IVA, mediana, scostamenti percentuali, differenza massimo-minimo e atti/CIG verificabili
- pubblica soltanto i due segnali che superano il contratto di evidenza; il valore di riferimento resta fuori dalle card
- mantiene fonti e metodo in fondo, tabella esatta accessibile e caveat tecnico esplicito

## Confini

- il divario è un segnale da spiegare, non una prova di spreco o illecito
- non vengono ripubblicati nomi di contraenti
- nessuna modifica a navigazione, route esistenti o CSS condivisi, per non sovrapporsi al lavoro UI concorrente

## Verifica locale

- test focalizzati: 20/20
- suite Node: 316/316
- suite ETL: 102/102
- typecheck, lint, build, design check e brand check: PASS
- rendering reale: desktop 1280 e mobile 390, nessun overflow o errore runtime; fonti ultima sezione; focus tabella PASS
- regressione Consulenza mobile: form e pulsante Invia la richiesta visibili, nessun overflow
- scansione privacy del diff: PASS

Nessun merge automatico finché i check della PR non sono verdi e il main non è stato ricontrollato.