### PR TITLE
feat(data): add verified PNRR assignments snapshot

### DIFF
--- a/scripts/etl/indire_pnrr_assignments.py
+++ b/scripts/etl/indire_pnrr_assignments.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Build the verified INDIRE PNRR external-assignments snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import urllib.request
+import zipfile
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+
+LANDING_URL = "https://www.indire.it/amministrazione/titolari-di-incarichi-di-collaborazione-o-consulenza/"
+RESOURCE_URL = "https://www.indire.it/wp-content/uploads/2026/05/Elenco-incarichi-di-prestazione-dopera_aprile-2026-3-1-1.xlsx"
+SOURCE_OWNER = "Istituto Nazionale di Documentazione, Innovazione e Ricerca Educativa (INDIRE)"
+REFERENCE_PERIOD = "aggiornamento aprile 2026"
+EXPECTED_BYTES = 54_421
+EXPECTED_SHA256 = "d31dadc85a79b2b913608845202e146d0114469abeafe98a6d491d75f7f77a66"
+EXPECTED_DIMENSION = "A1:L205"
+EXPECTED_HEADERS = (
+    "Cognome",
+    "Nome",
+    "Oggetto dell'incarico",
+    "Data inizio",
+    "Data fine",
+    "Compenso annuo (netto dipendente)",
+    "Sede",
+    "Selezione",
+    "Curriculum\nvitae dell'incaricato Art.15, c.1, lettera b) D.Lgs.33/201 3",
+    "Art.15, c.1, lettera c) D.Lgs.33/2013 e Art.1, c.50 L.190/12",
+    "Attestazione ai sensi dell’art. 53, c.14, D.Lgs 165/01",
+    "Decreto conferimento",
+)
+EXPECTED_WORKBOOK_ASSIGNMENTS = 201
+EXPECTED_PNRR_ASSIGNMENTS = 88
+EXPECTED_TOTAL_CENTS = 597_807_504
+EXPECTED_END_DATE = "2026-04-30"
+PROGRAM_LABELS = {
+    "m4c1-i3-1": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+    "m4c1-r2-1": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+}
+NS = {"x": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+OUTPUT_PATH = Path(__file__).resolve().parents[2] / "src/data/generated/indire-pnrr-assignments.json"
+
+
+def fetch() -> bytes:
+    request = urllib.request.Request(
+        RESOURCE_URL,
+        headers={"User-Agent": "DoveVannoINostriSoldi/0.2 source-verifier"},
+    )
+    with urllib.request.urlopen(request, timeout=90) as response:
+        if response.status != 200:
+            raise ValueError(f"HTTP inatteso {response.status}")
+        return response.read()
+
+
+def column_index(reference: str) -> int:
+    match = re.match(r"[A-Z]+", reference)
+    if not match:
+        raise ValueError(f"Riferimento cella non valido: {reference}")
+    result = 0
+    for char in match.group(0):
+        result = result * 26 + ord(char) - 64
+    return result - 1
+
+
+def shared_strings(archive: zipfile.ZipFile) -> list[str]:
+    root = ET.fromstring(archive.read("xl/sharedStrings.xml"))
+    return ["".join(item.itertext()) for item in root.findall("x:si", NS)]
+
+
+def cell_value(cell: ET.Element, strings: list[str]) -> str | Decimal | None:
+    cell_type = cell.attrib.get("t")
+    value = cell.find("x:v", NS)
+    if cell_type == "inlineStr":
+        inline = cell.find("x:is", NS)
+        return "".join(inline.itertext()) if inline is not None else None
+    if value is None or value.text is None:
+        return None
+    if cell_type == "s":
+        return strings[int(value.text)]
+    if cell_type in {"str", "e"}:
+        return value.text
+    return Decimal(value.text)
+
+
+def parse_xlsx(payload: bytes) -> dict[int, list[str | Decimal | None]]:
+    if not payload.startswith(b"PK"):
+        raise ValueError("La fonte INDIRE non è un archivio XLSX")
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        strings = shared_strings(archive)
+        worksheet = ET.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+        dimension = worksheet.find("x:dimension", NS)
+        if dimension is None or dimension.attrib.get("ref") != EXPECTED_DIMENSION:
+            raise ValueError("Dimensione del foglio INDIRE inattesa")
+        rows: dict[int, list[str | Decimal | None]] = {}
+        for row in worksheet.findall(".//x:sheetData/x:row", NS):
+            row_number = int(row.attrib["r"])
+            values: list[str | Decimal | None] = [None] * len(EXPECTED_HEADERS)
+            for cell in row.findall("x:c", NS):
+                index = column_index(cell.attrib["r"])
+                if index < len(values):
+                    values[index] = cell_value(cell, strings)
+            rows[row_number] = values
+    headers = tuple(str(value or "").strip() for value in rows.get(4, []))
+    if headers != EXPECTED_HEADERS:
+        raise ValueError("Schema INDIRE inatteso: intestazioni cambiate")
+    return rows
+
+
+def excel_date(value: object) -> str:
+    if not isinstance(value, Decimal):
+        raise ValueError(f"Data Excel non numerica: {value!r}")
+    converted = date(1899, 12, 30) + timedelta(days=int(value))
+    return converted.isoformat()
+
+
+def compensation_cents(value: object) -> int:
+    if not isinstance(value, str):
+        raise ValueError(f"Compenso PNRR non testuale: {value!r}")
+    match = re.fullmatch(
+        r"€\s*([0-9.]+,[0-9]{2})\s+per l'intera durata contrattuale",
+        value.strip(),
+    )
+    if not match:
+        raise ValueError(f"Base del compenso PNRR inattesa: {value!r}")
+    amount = Decimal(match.group(1).replace(".", "").replace(",", "."))
+    return int((amount * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def program_for(subject: str) -> tuple[str, str]:
+    if "ERASMUS+" in subject.upper():
+        return (
+            "m4c1-i3-1",
+            PROGRAM_LABELS["m4c1-i3-1"],
+        )
+    if "RIFORMA 2.1" in subject.upper():
+        return (
+            "m4c1-r2-1",
+            PROGRAM_LABELS["m4c1-r2-1"],
+        )
+    raise ValueError("Oggetto PNRR fuori dai due programmi attesi")
+
+
+def stable_id(parts: list[str]) -> str:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
+    return f"indire-pnrr-{digest}"
+
+
+def canonical_bytes(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def build_snapshot(payload: bytes, acquired_at: str) -> dict:
+    asset_hash = hashlib.sha256(payload).hexdigest()
+    if len(payload) != EXPECTED_BYTES or asset_hash != EXPECTED_SHA256:
+        raise ValueError("Asset INDIRE diverso dalla versione ufficiale verificata")
+
+    rows = parse_xlsx(payload)
+    workbook_assignments = sum(
+        any(value is not None for value in rows.get(row_number, []))
+        for row_number in range(5, 206)
+    )
+    assignments = []
+    last_name = first_name = None
+    for row_number in range(5, 206):
+        row = rows.get(row_number, [None] * len(EXPECTED_HEADERS))
+        if row[0] is not None:
+            last_name = str(row[0]).strip()
+        if row[1] is not None:
+            first_name = str(row[1]).strip()
+        subject = str(row[2] or "").strip()
+        if "PNRR" not in subject.upper():
+            continue
+        if not last_name or not first_name:
+            raise ValueError(f"Nominativo mancante alla riga {row_number}")
+        start_date = excel_date(row[3])
+        end_date = excel_date(row[4])
+        amount_cents = compensation_cents(row[5])
+        program_id, program_label = program_for(subject)
+        selection = str(row[7] or "").strip()
+        decree = str(row[11] or "").strip()
+        if not selection or not decree:
+            raise ValueError(f"Selezione o decreto mancanti alla riga {row_number}")
+        assignment_id = stable_id(
+            [last_name, first_name, program_id, start_date, end_date, selection, decree]
+        )
+        assignments.append(
+            {
+                "compensation": {
+                    "basis": "contract_total",
+                    "valueCents": amount_cents,
+                },
+                "conflictCheckPublished": bool(str(row[10] or "").strip()),
+                "cvPublished": str(row[8] or "").strip().upper() == "CV",
+                "decree": decree,
+                "endDate": end_date,
+                "firstName": first_name,
+                "id": assignment_id,
+                "lastName": last_name,
+                "location": str(row[6]).strip() if row[6] is not None else None,
+                "programId": program_id,
+                "programLabel": program_label,
+                "selection": selection,
+                "sourceRow": row_number,
+                "startDate": start_date,
+            }
+        )
+
+    program_totals: dict[tuple[str, str], dict[str, int]] = defaultdict(
+        lambda: {"assignments": 0, "compensationCents": 0}
+    )
+    for assignment in assignments:
+        key = (assignment["programId"], assignment["programLabel"])
+        program_totals[key]["assignments"] += 1
+        program_totals[key]["compensationCents"] += assignment["compensation"]["valueCents"]
+
+    amount_counts = Counter(item["compensation"]["valueCents"] for item in assignments)
+    selection_counts = Counter(item["selection"] for item in assignments)
+    total_cents = sum(item["compensation"]["valueCents"] for item in assignments)
+    snapshot = {
+        "assignments": assignments,
+        "coverage": {
+            "compensationKnown": len(assignments),
+            "latestEndDate": max(item["endDate"] for item in assignments),
+            "pnrrAssignments": len(assignments),
+            "uniquePeople": len({(item["lastName"], item["firstName"]) for item in assignments}),
+            "workbookAssignments": workbook_assignments,
+        },
+        "dataset": "indire_pnrr_external_assignments",
+        "generatedAt": acquired_at,
+        "methodology": {
+            "compensation": "Ogni importo è indicato dalla fonte per l'intera durata contrattuale; non è un compenso annuo.",
+            "filter": "Righe il cui oggetto contiene il riferimento esplicito al PNRR.",
+            "scope": "Incarichi retribuiti di prestazione d'opera professionale conferiti a soggetti esterni da INDIRE.",
+            "warning": "Lo snapshot descrive gli incarichi elencati nell'aggiornamento di aprile 2026; non misura pagamenti effettuati né prova sprechi o irregolarità.",
+        },
+        "programs": [
+            {"id": key[0], "label": key[1], **value}
+            for key, value in sorted(program_totals.items())
+        ],
+        "schemaVersion": 1,
+        "selections": [
+            {"assignments": count, "code": code}
+            for code, count in sorted(selection_counts.items())
+        ],
+        "source": {
+            "asset": {
+                "bytes": len(payload),
+                "dimension": EXPECTED_DIMENSION,
+                "sha256": asset_hash,
+                "sheet": "Table 1",
+            },
+            "format": "XLSX",
+            "landingUrl": LANDING_URL,
+            "licenseStatus": "not-declared",
+            "owner": SOURCE_OWNER,
+            "referencePeriod": REFERENCE_PERIOD,
+            "resourceUrl": RESOURCE_URL,
+        },
+        "tiers": [
+            {
+                "assignments": count,
+                "compensationCents": amount,
+                "totalCents": amount * count,
+            }
+            for amount, count in sorted(amount_counts.items(), reverse=True)
+        ],
+        "totals": {"contractCompensationCents": total_cents},
+    }
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot: dict) -> None:
+    if snapshot.get("schemaVersion") != 1 or snapshot.get("dataset") != "indire_pnrr_external_assignments":
+        raise ValueError("Identità snapshot INDIRE inattesa")
+    source = snapshot.get("source", {})
+    asset = source.get("asset", {})
+    if (
+        source.get("owner") != SOURCE_OWNER
+        or source.get("landingUrl") != LANDING_URL
+        or source.get("resourceUrl") != RESOURCE_URL
+        or source.get("referencePeriod") != REFERENCE_PERIOD
+        or source.get("format") != "XLSX"
+        or source.get("licenseStatus") != "not-declared"
+        or asset.get("bytes") != EXPECTED_BYTES
+        or asset.get("sha256") != EXPECTED_SHA256
+        or asset.get("sheet") != "Table 1"
+        or asset.get("dimension") != EXPECTED_DIMENSION
+    ):
+        raise ValueError("Provenienza snapshot INDIRE inattesa")
+    assignments = snapshot.get("assignments", [])
+    coverage = snapshot.get("coverage", {})
+    if (
+        len(assignments) != EXPECTED_PNRR_ASSIGNMENTS
+        or coverage.get("pnrrAssignments") != EXPECTED_PNRR_ASSIGNMENTS
+        or coverage.get("uniquePeople") != EXPECTED_PNRR_ASSIGNMENTS
+        or coverage.get("compensationKnown") != EXPECTED_PNRR_ASSIGNMENTS
+        or coverage.get("workbookAssignments") != EXPECTED_WORKBOOK_ASSIGNMENTS
+        or coverage.get("latestEndDate") != EXPECTED_END_DATE
+    ):
+        raise ValueError("Copertura snapshot INDIRE inattesa")
+    if len({item["id"] for item in assignments}) != len(assignments):
+        raise ValueError("Identificatori incarico INDIRE duplicati")
+    if len({(item["lastName"], item["firstName"]) for item in assignments}) != len(assignments):
+        raise ValueError("Nominativi incarico INDIRE duplicati")
+    for item in assignments:
+        if (
+            not re.fullmatch(r"indire-pnrr-[a-f0-9]{16}", item["id"])
+            or not 5 <= item["sourceRow"] <= 205
+            or item["compensation"]["basis"] != "contract_total"
+            or item["compensation"]["valueCents"] <= 0
+            or item["programLabel"] != PROGRAM_LABELS.get(item["programId"])
+            or item["endDate"] < item["startDate"]
+            or not item["cvPublished"]
+            or not item["conflictCheckPublished"]
+        ):
+            raise ValueError("Dettaglio incarico INDIRE inatteso")
+    total = sum(item["compensation"]["valueCents"] for item in assignments)
+    if total != EXPECTED_TOTAL_CENTS or snapshot.get("totals", {}).get("contractCompensationCents") != total:
+        raise ValueError("Totale compensi INDIRE non riconciliato")
+    expected_programs = defaultdict(lambda: {"assignments": 0, "compensationCents": 0})
+    for item in assignments:
+        expected_programs[item["programId"]]["assignments"] += 1
+        expected_programs[item["programId"]]["compensationCents"] += item["compensation"]["valueCents"]
+    actual_programs = {
+        item["id"]: {
+            "assignments": item["assignments"],
+            "compensationCents": item["compensationCents"],
+        }
+        for item in snapshot.get("programs", [])
+        if item.get("label") == PROGRAM_LABELS.get(item.get("id"))
+    }
+    if actual_programs != dict(expected_programs):
+        raise ValueError("Programmi INDIRE non riconciliati")
+    if sum(item["compensationCents"] for item in snapshot.get("programs", [])) != total:
+        raise ValueError("Compensi per programma INDIRE non riconciliati")
+    expected_tiers = Counter(item["compensation"]["valueCents"] for item in assignments)
+    actual_tiers = {
+        item["compensationCents"]: item["assignments"]
+        for item in snapshot.get("tiers", [])
+        if item.get("totalCents") == item.get("compensationCents", 0) * item.get("assignments", 0)
+    }
+    if actual_tiers != dict(expected_tiers):
+        raise ValueError("Fasce compenso INDIRE non riconciliate")
+    if sum(item["totalCents"] for item in snapshot.get("tiers", [])) != total:
+        raise ValueError("Totali per fascia INDIRE non riconciliati")
+    expected_selections = Counter(item["selection"] for item in assignments)
+    actual_selections = {
+        item["code"]: item["assignments"] for item in snapshot.get("selections", [])
+    }
+    if actual_selections != dict(expected_selections):
+        raise ValueError("Selezioni INDIRE non riconciliate")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-xlsx", type=Path)
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH)
+    parser.add_argument("--acquired-at", default=datetime.now().date().isoformat())
+    parser.add_argument("--validate-committed", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.validate_committed:
+        validate_snapshot(json.loads(OUTPUT_PATH.read_text(encoding="utf-8")))
+        return
+    payload = args.input_xlsx.read_bytes() if args.input_xlsx else fetch()
+    snapshot = build_snapshot(payload, args.acquired_at)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(canonical_bytes(snapshot))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/generated/indire-pnrr-assignments.json
+++ b/src/data/generated/indire-pnrr-assignments.json
@@ -1,0 +1,1760 @@
+{
+  "assignments": [
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Giorgio",
+      "id": "indire-pnrr-8599a780b901ee49",
+      "lastName": "Alessandri",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 117,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Angelo",
+      "id": "indire-pnrr-17a030aacd14da62",
+      "lastName": "Alessandrini",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 118,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Flavia",
+      "id": "indire-pnrr-ccfe4a07199d18f3",
+      "lastName": "Barletta",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 119,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Maria Cristina",
+      "id": "indire-pnrr-cbdee5a72508e0d6",
+      "lastName": "Bevilacqua",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 120,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Laura",
+      "id": "indire-pnrr-0df8ee2c9f34e4aa",
+      "lastName": "Birtolo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 121,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Fulvia",
+      "id": "indire-pnrr-fdde68cfb461692b",
+      "lastName": "Bonifazio",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 122,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Ilaria",
+      "id": "indire-pnrr-df27019142b4eed4",
+      "lastName": "Calì",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 123,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Susanna",
+      "id": "indire-pnrr-6d20c23e19968221",
+      "lastName": "Callegari",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 124,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Vincent",
+      "id": "indire-pnrr-5a3715414b10330c",
+      "lastName": "Cardinale",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 125,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Federica",
+      "id": "indire-pnrr-9b7722c8d62ab076",
+      "lastName": "Carlomagno",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 126,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Roberto",
+      "id": "indire-pnrr-4e9f238b7bbadf1f",
+      "lastName": "Carnevali",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 127,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Valentina",
+      "id": "indire-pnrr-4b2064a48bc8305b",
+      "lastName": "Cedrone",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 128,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Andrea",
+      "id": "indire-pnrr-b59babaa2fe457ed",
+      "lastName": "Cenderello",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 129,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Valentina",
+      "id": "indire-pnrr-3aff68feb498ce13",
+      "lastName": "Ciampini",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 130,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Luca",
+      "id": "indire-pnrr-2d5ef47e447b289c",
+      "lastName": "Ciarambino",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 131,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Federica",
+      "id": "indire-pnrr-17ca8a97a1636309",
+      "lastName": "Cicala",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 132,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Giulia",
+      "id": "indire-pnrr-5c64665f64517f9c",
+      "lastName": "Contessa",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 133,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Palma",
+      "id": "indire-pnrr-7ba8fd3b68b68231",
+      "lastName": "Cordiano",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 134,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Fabio",
+      "id": "indire-pnrr-3f4bf42e3941ec63",
+      "lastName": "Croci",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 135,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Alessandra",
+      "id": "indire-pnrr-31e1e55fa29a7500",
+      "lastName": "Curreli",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 136,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Francesco",
+      "id": "indire-pnrr-499405a7a5c223c5",
+      "lastName": "De Vitto",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 137,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Francesca",
+      "id": "indire-pnrr-3e55ed250cbc1768",
+      "lastName": "Del Conte",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 138,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Sara",
+      "id": "indire-pnrr-b29d9ce7f9009305",
+      "lastName": "D'elia",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 139,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Irene",
+      "id": "indire-pnrr-abf83dcfd99b4375",
+      "lastName": "Di Donato",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 140,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Alba",
+      "id": "indire-pnrr-b5973746b3d29c78",
+      "lastName": "Di Filippo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 141,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Lorena Elisabetta",
+      "id": "indire-pnrr-5814368022675745",
+      "lastName": "Di Leo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 142,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Miriam",
+      "id": "indire-pnrr-4a5dd8f1a2ea0ca9",
+      "lastName": "Di Paolo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 143,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Luca Antonio Piero",
+      "id": "indire-pnrr-6627481f7ff320a4",
+      "lastName": "Di Salvo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 144,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Giacomo",
+      "id": "indire-pnrr-f02ba7de1a9dc438",
+      "lastName": "Fabbian",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 145,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 10646118
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Alessandro",
+      "id": "indire-pnrr-75d5c61d04aa06d3",
+      "lastName": "Falsina",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 146,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Matilde",
+      "id": "indire-pnrr-da47fb1567da2f83",
+      "lastName": "Ferraro",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 147,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Gian Luca",
+      "id": "indire-pnrr-5eac35efaf043111",
+      "lastName": "Filippi",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 148,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Lorenzo",
+      "id": "indire-pnrr-3db4ad193bd1457b",
+      "lastName": "Floresta",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 149,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Stefano",
+      "id": "indire-pnrr-80495d83f9bdf7ec",
+      "lastName": "Fogliata",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 150,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Lorenzo",
+      "id": "indire-pnrr-7e9501fb0291a34f",
+      "lastName": "Galli",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 151,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Nadia",
+      "id": "indire-pnrr-7e024f6095a72f8a",
+      "lastName": "Gatto",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 152,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Maurizio Claudio",
+      "id": "indire-pnrr-47dc2d7a3f0fee06",
+      "lastName": "Gerardini",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 153,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Alfredo",
+      "id": "indire-pnrr-a3d3e30225225b6c",
+      "lastName": "Giordano",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 154,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Lorenzo",
+      "id": "indire-pnrr-083911ec32ea290c",
+      "lastName": "Innocenti",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 155,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Benedetta",
+      "id": "indire-pnrr-b9b69f65032d1a2e",
+      "lastName": "Juon",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 156,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Liana",
+      "id": "indire-pnrr-31132d7c15aebedc",
+      "lastName": "La Bella",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 157,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Riccardo",
+      "id": "indire-pnrr-4832677dbfcd4d2f",
+      "lastName": "Lancioni",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 158,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Beatrice",
+      "id": "indire-pnrr-da2f0eeea3e56336",
+      "lastName": "Landi",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 159,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Elisabetta",
+      "id": "indire-pnrr-2fdbece258b2a158",
+      "lastName": "Leone",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 160,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Zaira",
+      "id": "indire-pnrr-0e1887cf8c640d2a",
+      "lastName": "Maranelli",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 161,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Margherita",
+      "id": "indire-pnrr-9ee1795b73b343ed",
+      "lastName": "Mare",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 162,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Alessandro",
+      "id": "indire-pnrr-ec0cc054fc1ec720",
+      "lastName": "Martignano",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 163,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Fabrizio",
+      "id": "indire-pnrr-6c1ae56bc41d9c7a",
+      "lastName": "Mascali",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 164,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Loredana",
+      "id": "indire-pnrr-3fe608e04f4f6e95",
+      "lastName": "Matarrese",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 165,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Paolo",
+      "id": "indire-pnrr-259d67825427556e",
+      "lastName": "Montana",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 166,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Sonia Sara",
+      "id": "indire-pnrr-d2a0e66faa96bd4c",
+      "lastName": "Mussari",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 167,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Salvatore",
+      "id": "indire-pnrr-bb06cc4fa101db06",
+      "lastName": "Nizzolino",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 168,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 10646118
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Marco",
+      "id": "indire-pnrr-44ee9fbb35f45440",
+      "lastName": "Palmigiani",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 169,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Sara",
+      "id": "indire-pnrr-a8107018dccb72fd",
+      "lastName": "Peruch",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 170,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Daniela",
+      "id": "indire-pnrr-3aada963c1d41ce4",
+      "lastName": "Pili",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 171,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Giovanni",
+      "id": "indire-pnrr-42cdf1ca646fbf9e",
+      "lastName": "Ricciardulli",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 172,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Sergio Francesco",
+      "id": "indire-pnrr-475682e9f9f75fe4",
+      "lastName": "Rizzo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 173,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Erica",
+      "id": "indire-pnrr-8171315babaf86d4",
+      "lastName": "Ruggeri",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 174,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Luisa",
+      "id": "indire-pnrr-3812d0c62071c1fd",
+      "lastName": "Russo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 175,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Paola",
+      "id": "indire-pnrr-d0cbb01b87e52796",
+      "lastName": "Russo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 176,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Claudia",
+      "id": "indire-pnrr-0d06653361dfda46",
+      "lastName": "Scelzo",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 177,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Catia",
+      "id": "indire-pnrr-0f7ff332ed9161dd",
+      "lastName": "Segnini",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 178,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Luciano",
+      "id": "indire-pnrr-457eccfac141052f",
+      "lastName": "Spinella",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 179,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Chiara",
+      "id": "indire-pnrr-e5ec3be21172e16d",
+      "lastName": "Spizzichino",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 180,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 10646118
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Angela",
+      "id": "indire-pnrr-770d0ade73aef3cb",
+      "lastName": "Visconti",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 181,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 8387550
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 47821 del 14/10/2024",
+      "endDate": "2026-04-30",
+      "firstName": "Matilde",
+      "id": "indire-pnrr-fc92c753f10512d7",
+      "lastName": "Zanella",
+      "location": null,
+      "programId": "m4c1-i3-1",
+      "programLabel": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+      "selection": "SEL 11/24",
+      "sourceRow": 182,
+      "startDate": "2024-10-17"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Maria Consilia",
+      "id": "indire-pnrr-ac5200870213351c",
+      "lastName": "Antonelli",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 183,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Sonia",
+      "id": "indire-pnrr-487480a65813e9a8",
+      "lastName": "Calamiello",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 184,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Manuela",
+      "id": "indire-pnrr-339977937be72a2a",
+      "lastName": "Carastro",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 185,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Sergio Vito",
+      "id": "indire-pnrr-390c7b56ce27dd0b",
+      "lastName": "De Luca",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 186,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Domenico",
+      "id": "indire-pnrr-591bc26675975188",
+      "lastName": "De Lucia",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 187,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Sara",
+      "id": "indire-pnrr-a90ffa0ce263c9b4",
+      "lastName": "Di Crescenzio",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 188,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Sergio",
+      "id": "indire-pnrr-96ea8a14896075fc",
+      "lastName": "Di Marco",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 189,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Maria Chiara",
+      "id": "indire-pnrr-e5ecf365662cd1ed",
+      "lastName": "Di Stanislao",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 190,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Floriana Anna Maria",
+      "id": "indire-pnrr-60198914173acc98",
+      "lastName": "Filippone",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 191,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Anna",
+      "id": "indire-pnrr-5dc7ec338cff47f5",
+      "lastName": "Infante",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 192,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1716750
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54036 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Greta",
+      "id": "indire-pnrr-233b9ad3c82c8d0c",
+      "lastName": "Landahl",
+      "location": "RM",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 11/24",
+      "sourceRow": 193,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1716750
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54036 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Marius Orlando",
+      "id": "indire-pnrr-9484ed9e3cf6864e",
+      "lastName": "Luca",
+      "location": "RM",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 11/24",
+      "sourceRow": 194,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Claudia",
+      "id": "indire-pnrr-56d59d441e7d4f5c",
+      "lastName": "Luciano",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 195,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Elena",
+      "id": "indire-pnrr-cd2733d8c09b6c89",
+      "lastName": "Mazzoni",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 196,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Clementina",
+      "id": "indire-pnrr-31a9d1f3db9832d5",
+      "lastName": "Miggiano",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 197,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Ioana Antonia",
+      "id": "indire-pnrr-0610c50bed5a598d",
+      "lastName": "Nistor",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 198,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Vanessa",
+      "id": "indire-pnrr-4865e2f315c1a4c8",
+      "lastName": "Palmigiani",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 199,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Stefano",
+      "id": "indire-pnrr-50ead5c667880f11",
+      "lastName": "Palumbo",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 200,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Stefania",
+      "id": "indire-pnrr-b55023f04a1b3416",
+      "lastName": "Piccolo",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 201,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Massimiliano",
+      "id": "indire-pnrr-69336f9b3108a9b2",
+      "lastName": "Sassetti",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 202,
+      "startDate": "2025-10-20"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 1435000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Patrizia",
+      "id": "indire-pnrr-f19643d8be6630a0",
+      "lastName": "Soffiati",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 203,
+      "startDate": "2025-10-22"
+    },
+    {
+      "compensation": {
+        "basis": "contract_total",
+        "valueCents": 2100000
+      },
+      "conflictCheckPublished": true,
+      "cvPublished": true,
+      "decree": "Decr. prot. n. 54040 del 06/10/2025",
+      "endDate": "2026-04-30",
+      "firstName": "Elisa",
+      "id": "indire-pnrr-616fca5dcc4b0b44",
+      "lastName": "Tomaselli",
+      "location": "FI",
+      "programId": "m4c1-r2-1",
+      "programLabel": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+      "selection": "SEL 9/24",
+      "sourceRow": 205,
+      "startDate": "2025-10-20"
+    }
+  ],
+  "coverage": {
+    "compensationKnown": 88,
+    "latestEndDate": "2026-04-30",
+    "pnrrAssignments": 88,
+    "uniquePeople": 88,
+    "workbookAssignments": 201
+  },
+  "dataset": "indire_pnrr_external_assignments",
+  "generatedAt": "2026-08-23",
+  "methodology": {
+    "compensation": "Ogni importo è indicato dalla fonte per l'intera durata contrattuale; non è un compenso annuo.",
+    "filter": "Righe il cui oggetto contiene il riferimento esplicito al PNRR.",
+    "scope": "Incarichi retribuiti di prestazione d'opera professionale conferiti a soggetti esterni da INDIRE.",
+    "warning": "Lo snapshot descrive gli incarichi elencati nell'aggiornamento di aprile 2026; non misura pagamenti effettuati né prova sprechi o irregolarità."
+  },
+  "programs": [
+    {
+      "assignments": 66,
+      "compensationCents": 560354004,
+      "id": "m4c1-i3-1",
+      "label": "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi"
+    },
+    {
+      "assignments": 22,
+      "compensationCents": 37453500,
+      "id": "m4c1-r2-1",
+      "label": "M4C1 · Riforma 2.1 · Formazione alla transizione digitale"
+    }
+  ],
+  "schemaVersion": 1,
+  "selections": [
+    {
+      "assignments": 68,
+      "code": "SEL 11/24"
+    },
+    {
+      "assignments": 20,
+      "code": "SEL 9/24"
+    }
+  ],
+  "source": {
+    "asset": {
+      "bytes": 54421,
+      "dimension": "A1:L205",
+      "sha256": "d31dadc85a79b2b913608845202e146d0114469abeafe98a6d491d75f7f77a66",
+      "sheet": "Table 1"
+    },
+    "format": "XLSX",
+    "landingUrl": "https://www.indire.it/amministrazione/titolari-di-incarichi-di-collaborazione-o-consulenza/",
+    "licenseStatus": "not-declared",
+    "owner": "Istituto Nazionale di Documentazione, Innovazione e Ricerca Educativa (INDIRE)",
+    "referencePeriod": "aggiornamento aprile 2026",
+    "resourceUrl": "https://www.indire.it/wp-content/uploads/2026/05/Elenco-incarichi-di-prestazione-dopera_aprile-2026-3-1-1.xlsx"
+  },
+  "tiers": [
+    {
+      "assignments": 3,
+      "compensationCents": 10646118,
+      "totalCents": 31938354
+    },
+    {
+      "assignments": 63,
+      "compensationCents": 8387550,
+      "totalCents": 528415650
+    },
+    {
+      "assignments": 8,
+      "compensationCents": 2100000,
+      "totalCents": 16800000
+    },
+    {
+      "assignments": 2,
+      "compensationCents": 1716750,
+      "totalCents": 3433500
+    },
+    {
+      "assignments": 12,
+      "compensationCents": 1435000,
+      "totalCents": 17220000
+    }
+  ],
+  "totals": {
+    "contractCompensationCents": 597807504
+  }
+}

--- a/src/lib/data/indire-pnrr-assignments-contract.ts
+++ b/src/lib/data/indire-pnrr-assignments-contract.ts
@@ -1,0 +1,279 @@
+export type IndirePnrrAssignment = {
+  id: string;
+  sourceRow: number;
+  firstName: string;
+  lastName: string;
+  programId: "m4c1-i3-1" | "m4c1-r2-1";
+  programLabel: string;
+  startDate: string;
+  endDate: string;
+  compensation: { basis: "contract_total"; valueCents: number };
+  location: string | null;
+  selection: string;
+  cvPublished: boolean;
+  conflictCheckPublished: boolean;
+  decree: string;
+};
+
+export type IndirePnrrAssignmentsSnapshot = {
+  schemaVersion: 1;
+  dataset: "indire_pnrr_external_assignments";
+  generatedAt: string;
+  source: {
+    owner: string;
+    landingUrl: string;
+    resourceUrl: string;
+    referencePeriod: "aggiornamento aprile 2026";
+    format: "XLSX";
+    licenseStatus: "not-declared";
+    asset: {
+      bytes: 54_421;
+      sha256: string;
+      sheet: "Table 1";
+      dimension: "A1:L205";
+    };
+  };
+  coverage: {
+    workbookAssignments: 201;
+    pnrrAssignments: 88;
+    uniquePeople: 88;
+    compensationKnown: 88;
+    latestEndDate: "2026-04-30";
+  };
+  totals: { contractCompensationCents: 597_807_504 };
+  programs: Array<{
+    id: IndirePnrrAssignment["programId"];
+    label: string;
+    assignments: number;
+    compensationCents: number;
+  }>;
+  tiers: Array<{
+    compensationCents: number;
+    assignments: number;
+    totalCents: number;
+  }>;
+  selections: Array<{ code: string; assignments: number }>;
+  assignments: IndirePnrrAssignment[];
+  methodology: {
+    filter: string;
+    scope: string;
+    compensation: string;
+    warning: string;
+  };
+};
+
+const LANDING_URL = "https://www.indire.it/amministrazione/titolari-di-incarichi-di-collaborazione-o-consulenza/";
+const RESOURCE_URL = "https://www.indire.it/wp-content/uploads/2026/05/Elenco-incarichi-di-prestazione-dopera_aprile-2026-3-1-1.xlsx";
+const SOURCE_SHA256 = "d31dadc85a79b2b913608845202e146d0114469abeafe98a6d491d75f7f77a66";
+const SOURCE_OWNER = "Istituto Nazionale di Documentazione, Innovazione e Ricerca Educativa (INDIRE)";
+const PROGRAM_LABELS = new Map<IndirePnrrAssignment["programId"], string>([
+  ["m4c1-i3-1", "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi"],
+  ["m4c1-r2-1", "M4C1 · Riforma 2.1 · Formazione alla transizione digitale"],
+]);
+
+function fail(message: string): never {
+  throw new Error(`Snapshot incarichi PNRR INDIRE non valido: ${message}`);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} non è un oggetto`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    fail(`${label} ha campi inattesi`);
+  }
+}
+
+function nonEmpty(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) fail(`${label} non è valorizzato`);
+  return value;
+}
+
+function safeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) fail(`${label} non è un intero valido`);
+  return value as number;
+}
+
+function isoDate(value: unknown, label: string): string {
+  const text = nonEmpty(value, label);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text) || Number.isNaN(Date.parse(`${text}T00:00:00Z`))) {
+    fail(`${label} non è una data ISO`);
+  }
+  return text;
+}
+
+function parseAssignment(value: unknown): IndirePnrrAssignment {
+  const item = record(value, "incarico");
+  exactKeys(
+    item,
+    [
+      "id", "sourceRow", "firstName", "lastName", "programId", "programLabel", "startDate",
+      "endDate", "compensation", "location", "selection", "cvPublished",
+      "conflictCheckPublished", "decree",
+    ],
+    "incarico",
+  );
+  const programId = nonEmpty(item.programId, "incarico.programId") as IndirePnrrAssignment["programId"];
+  const expectedLabel = PROGRAM_LABELS.get(programId);
+  if (!expectedLabel || item.programLabel !== expectedLabel) fail("programma incarico inatteso");
+  const compensation = record(item.compensation, "incarico.compensation");
+  exactKeys(compensation, ["basis", "valueCents"], "incarico.compensation");
+  if (compensation.basis !== "contract_total") fail("base compenso inattesa");
+  const startDate = isoDate(item.startDate, "incarico.startDate");
+  const endDate = isoDate(item.endDate, "incarico.endDate");
+  if (endDate < startDate) fail("periodo incarico invertito");
+  if (item.location !== null && typeof item.location !== "string") fail("sede incarico inattesa");
+  if (item.cvPublished !== true || item.conflictCheckPublished !== true) {
+    fail("evidenza CV o conflitto non pubblicata");
+  }
+  const id = nonEmpty(item.id, "incarico.id");
+  if (!/^indire-pnrr-[a-f0-9]{16}$/.test(id)) fail("identificatore incarico inatteso");
+  const sourceRow = safeInteger(item.sourceRow, "incarico.sourceRow");
+  const valueCents = safeInteger(compensation.valueCents, "incarico.compensation.valueCents");
+  if (sourceRow < 5 || sourceRow > 205) fail("riga fonte incarico inattesa");
+  if (valueCents === 0) fail("compenso incarico non positivo");
+  return {
+    id,
+    sourceRow,
+    firstName: nonEmpty(item.firstName, "incarico.firstName"),
+    lastName: nonEmpty(item.lastName, "incarico.lastName"),
+    programId,
+    programLabel: expectedLabel,
+    startDate,
+    endDate,
+    compensation: {
+      basis: "contract_total",
+      valueCents,
+    },
+    location: item.location as string | null,
+    selection: nonEmpty(item.selection, "incarico.selection"),
+    cvPublished: true,
+    conflictCheckPublished: true,
+    decree: nonEmpty(item.decree, "incarico.decree"),
+  };
+}
+
+function countBy<T>(values: T[], key: (value: T) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(key(value), (counts.get(key(value)) ?? 0) + 1);
+  return counts;
+}
+
+export function assertIndirePnrrAssignmentsSnapshot(value: unknown): IndirePnrrAssignmentsSnapshot {
+  const snapshot = record(value, "snapshot");
+  exactKeys(
+    snapshot,
+    ["schemaVersion", "dataset", "generatedAt", "source", "coverage", "totals", "programs", "tiers", "selections", "assignments", "methodology"],
+    "snapshot",
+  );
+  if (snapshot.schemaVersion !== 1 || snapshot.dataset !== "indire_pnrr_external_assignments") {
+    fail("identità dataset inattesa");
+  }
+  isoDate(snapshot.generatedAt, "generatedAt");
+
+  const source = record(snapshot.source, "source");
+  const asset = record(source.asset, "source.asset");
+  exactKeys(source, ["owner", "landingUrl", "resourceUrl", "referencePeriod", "format", "licenseStatus", "asset"], "source");
+  exactKeys(asset, ["bytes", "sha256", "sheet", "dimension"], "source.asset");
+  if (
+    source.owner !== SOURCE_OWNER
+    || source.landingUrl !== LANDING_URL
+    || source.resourceUrl !== RESOURCE_URL
+    || source.referencePeriod !== "aggiornamento aprile 2026"
+    || source.format !== "XLSX"
+    || source.licenseStatus !== "not-declared"
+    || asset.bytes !== 54_421
+    || asset.sha256 !== SOURCE_SHA256
+    || asset.sheet !== "Table 1"
+    || asset.dimension !== "A1:L205"
+  ) fail("provenienza ufficiale inattesa");
+
+  if (!Array.isArray(snapshot.assignments)) fail("elenco incarichi assente");
+  const assignments = snapshot.assignments.map(parseAssignment);
+  const uniqueIds = new Set(assignments.map((item) => item.id));
+  const uniquePeople = new Set(assignments.map((item) => `${item.lastName}|${item.firstName}`));
+  if (assignments.length !== 88 || uniqueIds.size !== 88 || uniquePeople.size !== 88) {
+    fail("copertura o identità incarichi inattesa");
+  }
+  const latestEndDate = assignments.map((item) => item.endDate).sort().at(-1);
+  if (latestEndDate !== "2026-04-30") {
+    fail("data finale inattesa");
+  }
+
+  const total = assignments.reduce((sum, item) => sum + item.compensation.valueCents, 0);
+  if (total !== 597_807_504) fail("totale compensi inatteso");
+
+  const coverage = record(snapshot.coverage, "coverage");
+  exactKeys(coverage, ["workbookAssignments", "pnrrAssignments", "uniquePeople", "compensationKnown", "latestEndDate"], "coverage");
+  if (
+    coverage.workbookAssignments !== 201
+    || coverage.pnrrAssignments !== 88
+    || coverage.uniquePeople !== 88
+    || coverage.compensationKnown !== 88
+    || coverage.latestEndDate !== "2026-04-30"
+  ) fail("copertura dichiarata non riconciliata");
+  const totals = record(snapshot.totals, "totals");
+  exactKeys(totals, ["contractCompensationCents"], "totals");
+  if (totals.contractCompensationCents !== total) fail("totale dichiarato non riconciliato");
+
+  if (!Array.isArray(snapshot.programs) || snapshot.programs.length !== 2) fail("programmi inattesi");
+  const programCounts = countBy(assignments, (item) => item.programId);
+  const programAmounts = new Map<string, number>();
+  for (const item of assignments) {
+    programAmounts.set(item.programId, (programAmounts.get(item.programId) ?? 0) + item.compensation.valueCents);
+  }
+  const seenProgramIds = new Set<string>();
+  for (const value of snapshot.programs) {
+    const item = record(value, "programma");
+    exactKeys(item, ["id", "label", "assignments", "compensationCents"], "programma");
+    const id = nonEmpty(item.id, "programma.id") as IndirePnrrAssignment["programId"];
+    if (seenProgramIds.has(id)) fail("programma duplicato");
+    seenProgramIds.add(id);
+    if (
+      item.label !== PROGRAM_LABELS.get(id)
+      || item.assignments !== programCounts.get(id)
+      || item.compensationCents !== programAmounts.get(id)
+    ) fail("programma non riconciliato");
+  }
+
+  if (!Array.isArray(snapshot.tiers) || snapshot.tiers.length !== 5) fail("fasce compenso inattese");
+  const tierCounts = countBy(assignments, (item) => String(item.compensation.valueCents));
+  const seenTierAmounts = new Set<number>();
+  for (const value of snapshot.tiers) {
+    const item = record(value, "fascia");
+    exactKeys(item, ["compensationCents", "assignments", "totalCents"], "fascia");
+    const amount = safeInteger(item.compensationCents, "fascia.compensationCents");
+    const count = safeInteger(item.assignments, "fascia.assignments");
+    if (amount === 0 || count === 0 || seenTierAmounts.has(amount)) fail("fascia compenso duplicata o vuota");
+    seenTierAmounts.add(amount);
+    if (count !== tierCounts.get(String(amount)) || item.totalCents !== amount * count) {
+      fail("fascia compenso non riconciliata");
+    }
+  }
+
+  if (!Array.isArray(snapshot.selections) || snapshot.selections.length !== 2) fail("selezioni inattese");
+  const selectionCounts = countBy(assignments, (item) => item.selection);
+  const seenSelectionCodes = new Set<string>();
+  for (const value of snapshot.selections) {
+    const item = record(value, "selezione");
+    exactKeys(item, ["code", "assignments"], "selezione");
+    const code = nonEmpty(item.code, "selezione.code");
+    if (seenSelectionCodes.has(code)) fail("selezione duplicata");
+    seenSelectionCodes.add(code);
+    if (item.assignments !== selectionCounts.get(code)) {
+      fail("selezione non riconciliata");
+    }
+  }
+
+  const methodology = record(snapshot.methodology, "methodology");
+  exactKeys(methodology, ["filter", "scope", "compensation", "warning"], "methodology");
+  for (const key of ["filter", "scope", "compensation", "warning"] as const) {
+    nonEmpty(methodology[key], `methodology.${key}`);
+  }
+
+  return value as IndirePnrrAssignmentsSnapshot;
+}

--- a/src/lib/indire-pnrr-assignments-snapshot.ts
+++ b/src/lib/indire-pnrr-assignments-snapshot.ts
@@ -1,0 +1,6 @@
+import "server-only";
+
+import rawSnapshot from "@/data/generated/indire-pnrr-assignments.json";
+import { assertIndirePnrrAssignmentsSnapshot } from "@/lib/data/indire-pnrr-assignments-contract";
+
+export const indirePnrrAssignmentsSnapshot = assertIndirePnrrAssignmentsSnapshot(rawSnapshot);

--- a/tests/etl/test_indire_pnrr_assignments.py
+++ b/tests/etl/test_indire_pnrr_assignments.py
@@ -1,0 +1,61 @@
+import copy
+import importlib.util
+import json
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/etl/indire_pnrr_assignments.py"
+SPEC = importlib.util.spec_from_file_location("indire_pnrr_assignments", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class IndirePnrrAssignmentsTests(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = json.loads(MODULE.OUTPUT_PATH.read_text(encoding="utf-8"))
+
+    def test_compensation_parser_requires_contract_total_wording(self):
+        self.assertEqual(
+            MODULE.compensation_cents("€ 83.875,50 per l'intera durata contrattuale"),
+            8_387_550,
+        )
+        for invalid in (Decimal("83875.50"), "€ 83.875,50 annui", "83.875,50"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "[Cc]ompenso PNRR|Base del compenso"):
+                    MODULE.compensation_cents(invalid)
+
+    def test_program_classifier_accepts_only_the_two_verified_programs(self):
+        self.assertEqual(MODULE.program_for("PNRR ERASMUS+"), (
+            "m4c1-i3-1",
+            "M4C1 · Investimento 3.1 · Nuove competenze e nuovi linguaggi",
+        ))
+        self.assertEqual(MODULE.program_for("PNRR Riforma 2.1"), (
+            "m4c1-r2-1",
+            "M4C1 · Riforma 2.1 · Formazione alla transizione digitale",
+        ))
+        with self.assertRaisesRegex(ValueError, "fuori dai due programmi"):
+            MODULE.program_for("PNRR programma non classificato")
+
+    def test_committed_snapshot_reconciles(self):
+        MODULE.validate_snapshot(self.snapshot)
+
+    def test_snapshot_rejects_source_and_total_drift(self):
+        source_drift = copy.deepcopy(self.snapshot)
+        source_drift["source"]["asset"]["sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "Provenienza"):
+            MODULE.validate_snapshot(source_drift)
+
+        total_drift = copy.deepcopy(self.snapshot)
+        total_drift["assignments"][0]["compensation"]["valueCents"] += 1
+        with self.assertRaisesRegex(ValueError, "Totale compensi"):
+            MODULE.validate_snapshot(total_drift)
+
+    def test_committed_snapshot_command_path_is_valid(self):
+        MODULE.validate_snapshot(json.loads(MODULE.OUTPUT_PATH.read_text(encoding="utf-8")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/indire-pnrr-assignments.test.mjs
+++ b/tests/indire-pnrr-assignments.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import snapshot from "../src/data/generated/indire-pnrr-assignments.json" with { type: "json" };
+import { assertIndirePnrrAssignmentsSnapshot } from "../src/lib/data/indire-pnrr-assignments-contract.ts";
+
+test("INDIRE PNRR assignments preserve coverage, totals and official provenance", () => {
+  const data = assertIndirePnrrAssignmentsSnapshot(snapshot);
+  assert.deepEqual(data.coverage, {
+    compensationKnown: 88,
+    latestEndDate: "2026-04-30",
+    pnrrAssignments: 88,
+    uniquePeople: 88,
+    workbookAssignments: 201,
+  });
+  assert.equal(data.totals.contractCompensationCents, 597_807_504);
+  assert.equal(data.source.owner, "Istituto Nazionale di Documentazione, Innovazione e Ricerca Educativa (INDIRE)");
+  assert.equal(data.source.referencePeriod, "aggiornamento aprile 2026");
+  assert.equal(data.source.licenseStatus, "not-declared");
+  assert.ok(data.assignments.every((item) => item.compensation.basis === "contract_total"));
+});
+
+test("INDIRE PNRR assignments reconcile programs, tiers and selections", () => {
+  assert.deepEqual(
+    snapshot.programs.map(({ id, assignments, compensationCents }) => ({ id, assignments, compensationCents })),
+    [
+      { id: "m4c1-i3-1", assignments: 66, compensationCents: 560_354_004 },
+      { id: "m4c1-r2-1", assignments: 22, compensationCents: 37_453_500 },
+    ],
+  );
+  assert.deepEqual(
+    Object.fromEntries(snapshot.tiers.map((item) => [item.compensationCents, item.assignments])),
+    { 10_646_118: 3, 8_387_550: 63, 2_100_000: 8, 1_716_750: 2, 1_435_000: 12 },
+  );
+  assert.deepEqual(snapshot.selections, [
+    { assignments: 68, code: "SEL 11/24" },
+    { assignments: 20, code: "SEL 9/24" },
+  ]);
+});
+
+test("INDIRE PNRR assignments fail closed on source, identity and amount drift", () => {
+  assert.throws(
+    () => assertIndirePnrrAssignmentsSnapshot({
+      ...snapshot,
+      source: {
+        ...snapshot.source,
+        referencePeriod: "aggiornamento successivo",
+        asset: { ...snapshot.source.asset, sha256: "0".repeat(64) },
+      },
+    }),
+    /provenienza ufficiale inattesa/,
+  );
+
+  const first = snapshot.assignments[0];
+  assert.throws(
+    () => assertIndirePnrrAssignmentsSnapshot({
+      ...snapshot,
+      assignments: [first, first, ...snapshot.assignments.slice(2)],
+    }),
+    /copertura o identità incarichi inattesa/,
+  );
+
+  assert.throws(
+    () => assertIndirePnrrAssignmentsSnapshot({
+      ...snapshot,
+      assignments: [
+        {
+          ...first,
+          compensation: { ...first.compensation, valueCents: first.compensation.valueCents + 1 },
+        },
+        ...snapshot.assignments.slice(1),
+      ],
+    }),
+    /totale compensi inatteso/,
+  );
+});
+
+test("INDIRE PNRR public artifacts contain no local or archive provenance", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const paths = [
+    "scripts/etl/indire_pnrr_assignments.py",
+    "src/data/generated/indire-pnrr-assignments.json",
+    "src/lib/data/indire-pnrr-assignments-contract.ts",
+    "src/lib/indire-pnrr-assignments-snapshot.ts",
+  ];
+  for (const path of paths) {
+    const content = await readFile(path, "utf8");
+    assert.doesNotMatch(content, /\/Users\/|\/Downloads\/|\.tar\.gz|private\/tmp/i, path);
+  }
+  const loader = await readFile("src/lib/indire-pnrr-assignments-snapshot.ts", "utf8");
+  assert.match(loader, /^import "server-only";/);
+});


### PR DESCRIPTION
## Obiettivo

Aggiunge uno snapshot riproducibile degli incarichi esterni PNRR pubblicati da INDIRE nell'aggiornamento di aprile 2026.

## Perimetro

- 201 incarichi presenti nel foglio ufficiale, 88 con riferimento esplicito al PNRR.
- 88 compensi noti, espressi dalla fonte per l'intera durata contrattuale.
- Due programmi PNRR mantenuti separati.
- Importi conservati in centesimi interi e riconciliati per programma, fascia e selezione.

Questa PR contiene solo ETL, snapshot, contratto runtime e test. Non modifica pagine, navigazione, stili o form.

## Fonte e limiti

- Pagina ufficiale INDIRE: https://www.indire.it/amministrazione/titolari-di-incarichi-di-collaborazione-o-consulenza/
- Risorsa ufficiale XLSX: https://www.indire.it/wp-content/uploads/2026/05/Elenco-incarichi-di-prestazione-dopera_aprile-2026-3-1-1.xlsx
- La licenza non è dichiarata nella pagina verificata.
- Gli importi sono compensi contrattuali dichiarati, non pagamenti effettuati e non una prova di spreco o irregolarità.

## Verifica

- PASS: 323/323 test Node.
- PASS: 107/107 test ETL Python.
- PASS: lint, typecheck, design check e brand check.
- PASS: build Next.js di produzione, 44 pagine.
- PASS: contratto fail-closed su hash, dimensione, schema, copertura, identità, importi e riconciliazioni.
- PASS: scansione privacy su file, diff e metadati pubblici.

## Slicing

La pagina dedicata sarà una PR successiva e separata, così il contratto dati può essere revisionato e integrato senza sovrapporsi al lavoro UI in corso.
