### PR TITLE
feat(pnrr): add verified assignments page

### DIFF
--- a/src/app/pnrr/incarichi/incarichi-pnrr.module.css
+++ b/src/app/pnrr/incarichi/incarichi-pnrr.module.css
@@ -1,0 +1,235 @@
+.page {
+  gap: var(--space-6);
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.breadcrumb a {
+  color: inherit;
+}
+
+.intro {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.scopeLine {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  margin: 0;
+  padding: 10px 0;
+  border-block: 1px solid var(--color-neutral-300);
+  color: var(--color-neutral-700);
+  font-size: 12px;
+}
+
+.scopeLine strong {
+  color: var(--color-text);
+}
+
+.programPanel,
+.tierPanel,
+.assignmentsPanel,
+.sourcesPanel {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+
+.sectionHeading p,
+.sourcesPanel p {
+  max-width: 75ch;
+  margin: 0;
+  color: var(--color-neutral-700);
+}
+
+.sectionHeading > :last-child {
+  flex: 0 0 auto;
+}
+
+.programGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.programCard {
+  min-width: 0;
+  padding: var(--space-5);
+  border: 1px solid var(--color-neutral-300);
+  border-top: 4px solid var(--chart-primary);
+  background: var(--color-raised);
+}
+
+.programCard:nth-child(2) {
+  border-top-color: var(--chart-secondary);
+}
+
+.programCard > span {
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.programCard > strong {
+  display: block;
+  margin-top: var(--space-2);
+  font-family: var(--font-heading);
+  font-size: clamp(28px, 4vw, 42px);
+  line-height: 1;
+  letter-spacing: -.035em;
+}
+
+.programCard > p {
+  min-height: 3em;
+  margin: var(--space-3) 0 var(--space-5);
+  color: var(--color-neutral-700);
+}
+
+.programCard dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.programCard dl div {
+  min-width: 0;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.programCard dt {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+}
+
+.programCard dd {
+  margin: 4px 0 0;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.featuredMetric {
+  display: grid;
+  min-width: 160px;
+  padding-top: var(--space-3);
+  border-top: 3px solid var(--chart-tertiary);
+}
+
+.featuredMetric strong {
+  font-family: var(--font-heading);
+  font-size: 38px;
+  line-height: 1;
+}
+
+.featuredMetric span {
+  margin-top: 4px;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.tableRegion {
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.tierPanel table {
+  min-width: 640px;
+}
+
+.assignmentDetails {
+  min-width: 0;
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.assignmentDetails summary {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  cursor: pointer;
+  color: var(--color-accent-700);
+  font-weight: 800;
+}
+
+.assignmentDetails table {
+  min-width: 1180px;
+}
+
+.assignmentDetails th:first-child {
+  min-width: 190px;
+}
+
+.assignmentDetails td:nth-child(3) {
+  min-width: 280px;
+}
+
+.tableHint {
+  display: none;
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.readingNotice {
+  border-color: var(--color-neutral-400);
+}
+
+.sourcesPanel ul {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+  padding-left: var(--space-5);
+}
+
+.sourceNote {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-neutral-300);
+  font-size: 12px;
+}
+
+@media (max-width: 760px) {
+  .sectionHeading {
+    display: grid;
+  }
+
+  .sectionHeading > :last-child {
+    justify-self: start;
+  }
+
+  .programGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .programCard > p {
+    min-height: 0;
+  }
+
+  .tableHint {
+    display: block;
+  }
+}
+
+@media (max-width: 520px) {
+  .programCard dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/pnrr/incarichi/page.tsx
+++ b/src/app/pnrr/incarichi/page.tsx
@@ -1,0 +1,229 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { exactEuro, integer, longDate, percent } from "@/lib/format";
+import { indirePnrrAssignmentsSnapshot } from "@/lib/indire-pnrr-assignments-snapshot";
+import styles from "./incarichi-pnrr.module.css";
+
+export const metadata: Metadata = {
+  title: "Incarichi esterni PNRR INDIRE",
+  description:
+    "88 incarichi esterni PNRR pubblicati da INDIRE, con programmi, compensi contrattuali, selezioni e atti di conferimento.",
+};
+
+const data = indirePnrrAssignmentsSnapshot;
+const assignments = [...data.assignments].sort((left, right) =>
+  `${left.lastName} ${left.firstName}`.localeCompare(`${right.lastName} ${right.firstName}`, "it"),
+);
+const mostCommonTier = [...data.tiers].sort((left, right) => right.assignments - left.assignments)[0];
+
+function euroFromCents(valueCents: number): string {
+  return exactEuro(valueCents / 100);
+}
+
+function share(part: number, total: number): string {
+  return percent((part / total) * 100);
+}
+
+function shortProgram(id: (typeof data.programs)[number]["id"]): string {
+  return id === "m4c1-i3-1" ? "Investimento 3.1" : "Riforma 2.1";
+}
+
+export default function PnrrAssignmentsPage() {
+  return (
+    <main className={`shell page ${styles.page}`}>
+      <nav className={styles.breadcrumb} aria-label="Percorso">
+        <Link href="/">Home</Link>
+        <span aria-hidden="true">/</span>
+        <Link href="/coesione/asili">Traccia PNRR</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Incarichi INDIRE</span>
+      </nav>
+
+      <header className={styles.intro}>
+        <div className="page-intro">
+          <h1>88 incarichi PNRR, 5,98 milioni di compensi contrattuali</h1>
+          <p>
+            Chi ha ricevuto l&apos;incarico, per quale programma, per quanto tempo e con quale
+            compenso dichiarato. I numeri provengono dall&apos;elenco ufficiale INDIRE di aprile 2026.
+          </p>
+        </div>
+        <p className={styles.scopeLine}>
+          <strong>Aggiornamento: aprile 2026</strong>
+          <span>·</span>
+          <span>88 persone</span>
+          <span>·</span>
+          <span>importi per l&apos;intera durata contrattuale</span>
+        </p>
+      </header>
+
+      <section className="stat-strip" aria-label="Numeri principali degli incarichi PNRR INDIRE">
+        <div>
+          <span className="stat-label">Incarichi PNRR</span>
+          <span className="stat-value">{integer(data.coverage.pnrrAssignments)}</span>
+          <span className="stat-note">su {integer(data.coverage.workbookAssignments)} incarichi nel foglio</span>
+        </div>
+        <div>
+          <span className="stat-label">Compensi contrattuali</span>
+          <span className="stat-value">5,98 mln €</span>
+          <span className="stat-note">{euroFromCents(data.totals.contractCompensationCents)} esatti</span>
+        </div>
+        <div>
+          <span className="stat-label">Programmi PNRR</span>
+          <span className="stat-value">{integer(data.programs.length)}</span>
+          <span className="stat-note">tenuti separati nel confronto</span>
+        </div>
+        <div>
+          <span className="stat-label">Compensi noti</span>
+          <span className="stat-value">100%</span>
+          <span className="stat-note">88 su 88 incarichi PNRR</span>
+        </div>
+      </section>
+
+      <section className={`panel ${styles.programPanel}`} aria-labelledby="programs-title">
+        <div className={styles.sectionHeading}>
+          <div>
+            <h2 id="programs-title" className="panel-title">Per che cosa sono stati assegnati</h2>
+            <p>Due programmi diversi, senza sommare attività e finalità sotto un&apos;unica etichetta.</p>
+          </div>
+          <span className="tag tag-neutral">Denominatore: 88 incarichi</span>
+        </div>
+
+        <div className={styles.programGrid}>
+          {data.programs.map((program) => (
+            <article key={program.id} className={styles.programCard}>
+              <span>{shortProgram(program.id)}</span>
+              <strong>{integer(program.assignments)} incarichi</strong>
+              <p>{program.label}</p>
+              <dl>
+                <div>
+                  <dt>Quota incarichi</dt>
+                  <dd>{share(program.assignments, data.coverage.pnrrAssignments)}</dd>
+                </div>
+                <div>
+                  <dt>Compensi contrattuali</dt>
+                  <dd>{euroFromCents(program.compensationCents)}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={`panel ${styles.tierPanel}`} aria-labelledby="tiers-title">
+        <div className={styles.sectionHeading}>
+          <div>
+            <h2 id="tiers-title" className="panel-title">Quanto sono concentrati gli importi</h2>
+            <p>
+              {integer(mostCommonTier.assignments)} incarichi su 88, pari al {share(mostCommonTier.assignments, 88)},
+              hanno lo stesso compenso contrattuale di {euroFromCents(mostCommonTier.compensationCents)}.
+              È una concentrazione da leggere insieme a selezione, durata e programma, non una prova di irregolarità.
+            </p>
+          </div>
+          <div className={styles.featuredMetric}>
+            <strong>{share(mostCommonTier.assignments, 88)}</strong>
+            <span>{integer(mostCommonTier.assignments)} su 88 incarichi</span>
+          </div>
+        </div>
+
+        <div className={styles.tableRegion} role="region" aria-label="Distribuzione esatta dei compensi" tabIndex={0}>
+          <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
+          <table className="table">
+            <caption>Fasce di compenso per l&apos;intera durata contrattuale</caption>
+            <thead>
+              <tr>
+                <th scope="col">Compenso per incarico</th>
+                <th scope="col" className="num">Incarichi</th>
+                <th scope="col" className="num">Quota</th>
+                <th scope="col" className="num">Totale fascia</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.tiers.map((tier) => (
+                <tr key={tier.compensationCents}>
+                  <th scope="row">{euroFromCents(tier.compensationCents)}</th>
+                  <td className="num">{integer(tier.assignments)}</td>
+                  <td className="num">{share(tier.assignments, 88)}</td>
+                  <td className="num">{euroFromCents(tier.totalCents)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className={`panel ${styles.assignmentsPanel}`} aria-labelledby="assignments-title">
+        <div className={styles.sectionHeading}>
+          <div>
+            <h2 id="assignments-title" className="panel-title">Chi, quanto e con quale atto</h2>
+            <p>
+              L&apos;elenco completo conserva persona, programma, periodo, sede quando pubblicata,
+              selezione e decreto di conferimento.
+            </p>
+          </div>
+          <span className="tag tag-neutral">88 righe ufficiali</span>
+        </div>
+
+        <details className={styles.assignmentDetails}>
+          <summary>Apri l&apos;elenco completo degli incarichi</summary>
+          <div className={styles.tableRegion} role="region" aria-label="Elenco completo degli incarichi PNRR INDIRE" tabIndex={0}>
+            <p className={styles.tableHint}>Scorri la tabella verso destra →</p>
+            <table className="table">
+              <caption>Incarichi PNRR presenti nell&apos;aggiornamento INDIRE di aprile 2026</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Persona</th>
+                  <th scope="col">Programma</th>
+                  <th scope="col">Periodo</th>
+                  <th scope="col">Sede</th>
+                  <th scope="col" className="num">Compenso contrattuale</th>
+                  <th scope="col">Selezione</th>
+                  <th scope="col">Decreto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {assignments.map((assignment) => (
+                  <tr key={assignment.id}>
+                    <th scope="row">{assignment.firstName} {assignment.lastName}</th>
+                    <td>{shortProgram(assignment.programId)}</td>
+                    <td>dal {longDate(assignment.startDate)} al {longDate(assignment.endDate)}</td>
+                    <td>{assignment.location ?? "Non indicata"}</td>
+                    <td className="num">{euroFromCents(assignment.compensation.valueCents)}</td>
+                    <td>{assignment.selection}</td>
+                    <td>{assignment.decree}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      </section>
+
+      <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="reading-title">
+        <h2 id="reading-title">Come leggere questi numeri</h2>
+        <p>
+          Il totale somma compensi dichiarati per l&apos;intera durata dei contratti. Non misura quanto è
+          già stato pagato, non è un costo annuale e non consente da solo di stabilire utilità, qualità
+          o spreco. Lo snapshot è storico: descrive l&apos;aggiornamento di aprile 2026.
+        </p>
+      </section>
+
+      <section className={`panel ${styles.sourcesPanel}`} aria-labelledby="sources-title">
+        <div>
+          <h2 id="sources-title" className="panel-title">Fonti e metodo</h2>
+          <p>
+            Fonte primaria: Istituto Nazionale di Documentazione, Innovazione e Ricerca Educativa.
+            Sono incluse solo le righe il cui oggetto contiene un riferimento esplicito al PNRR.
+          </p>
+        </div>
+        <ul>
+          <li><a href={data.source.landingUrl}>Pagina ufficiale degli incarichi di collaborazione e consulenza</a></li>
+          <li><a href={data.source.resourceUrl}>Elenco ufficiale XLSX · aggiornamento aprile 2026</a></li>
+        </ul>
+        <p className={styles.sourceNote}>
+          Formato: {data.source.format}. Licenza di riuso non dichiarata nella pagina verificata.
+          Copertura: {integer(data.coverage.pnrrAssignments)} righe PNRR su {integer(data.coverage.workbookAssignments)} incarichi nel foglio.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/tests/pnrr-incarichi-page.test.mjs
+++ b/tests/pnrr-incarichi-page.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("PNRR assignments page keeps scope, denominators and amount meaning explicit", async () => {
+  const page = await source("../src/app/pnrr/incarichi/page.tsx");
+  assert.equal(page.match(/<h1\b/g)?.length, 1);
+  assert.match(page, /Aggiornamento: aprile 2026/);
+  assert.match(page, /88 persone/);
+  assert.match(page, /importi per l&apos;intera durata contrattuale/);
+  assert.match(page, /Denominatore: 88 incarichi/);
+  assert.match(page, /integer\(mostCommonTier\.assignments\)\} incarichi su 88/);
+  assert.match(page, /non una prova di irregolarità/);
+  assert.match(page, /Non misura quanto è\s*\n?\s*già stato pagato/);
+});
+
+test("PNRR assignments page exposes exact programs, tiers and all row fields", async () => {
+  const page = await source("../src/app/pnrr/incarichi/page.tsx");
+  for (const text of [
+    "Per che cosa sono stati assegnati",
+    "Quanto sono concentrati gli importi",
+    "Chi, quanto e con quale atto",
+    "Compenso contrattuale",
+    "Selezione",
+    "Decreto",
+  ]) assert.match(page, new RegExp(text));
+  assert.match(page, /data\.programs\.map/);
+  assert.match(page, /data\.tiers\.map/);
+  assert.match(page, /assignments\.map/);
+  assert.match(page, /Apri l&apos;elenco completo degli incarichi/);
+});
+
+test("PNRR assignments page keeps sources last and uses only official URLs", async () => {
+  const page = await source("../src/app/pnrr/incarichi/page.tsx");
+  const dataStart = page.indexOf("programs-title");
+  const rowsStart = page.indexOf("assignments-title");
+  const sourcesStart = page.indexOf("sources-title");
+  assert.ok(dataStart >= 0 && rowsStart > dataStart && sourcesStart > rowsStart);
+  assert.match(page, /data\.source\.landingUrl/);
+  assert.match(page, /data\.source\.resourceUrl/);
+  assert.match(page, /Licenza di riuso non dichiarata/);
+  assert.doesNotMatch(page, /\/Users\/|\/Downloads\/|\.tar\.gz|private\/tmp/i);
+});
+
+test("PNRR assignments page remains server-rendered and responsive", async () => {
+  const [page, css] = await Promise.all([
+    source("../src/app/pnrr/incarichi/page.tsx"),
+    source("../src/app/pnrr/incarichi/incarichi-pnrr.module.css"),
+  ]);
+  assert.doesNotMatch(page, /^["']use client["'];/m);
+  assert.match(page, /role="region"/);
+  assert.match(page, /tabIndex=\{0\}/);
+  assert.equal((page.match(/Scorri la tabella verso destra/g) ?? []).length, 2);
+  assert.match(css, /overflow-x:\s*auto/);
+  assert.match(css, /@media \(max-width: 760px\)[\s\S]*?grid-template-columns: 1fr/);
+  assert.doesNotMatch(css, /#[0-9a-f]{3,8}/i);
+});


### PR DESCRIPTION
## Obiettivo

Aggiunge la pagina dedicata `/pnrr/incarichi` per leggere gli incarichi esterni PNRR pubblicati da INDIRE nell'aggiornamento di aprile 2026.

## Contenuto

- 88 incarichi e 88 persone su 201 righe del foglio ufficiale.
- 5.978.075,04 euro di compensi dichiarati per l'intera durata contrattuale.
- Due programmi PNRR mostrati separatamente con conteggi, quote e importi.
- Cinque fasce di compenso con denominatore esplicito.
- Elenco completo di persona, programma, periodo, sede quando disponibile, compenso, selezione e decreto.
- Fonti e metodo collocati dopo tutte le sezioni dati.

La pagina presenta concentrazioni verificabili senza trasformarle in accuse: gli importi non sono pagamenti effettuati e, da soli, non provano sprechi o irregolarità.

## Confini della PR

- Tre file nuovi e route-locali.
- Nessuna modifica a menu globale, design system, colori condivisi, API o form.
- Nessuna modifica alla pagina Consulenza.

## Fonte

- Pagina ufficiale INDIRE: https://www.indire.it/amministrazione/titolari-di-incarichi-di-collaborazione-o-consulenza/
- Risorsa ufficiale XLSX: https://www.indire.it/wp-content/uploads/2026/05/Elenco-incarichi-di-prestazione-dopera_aprile-2026-3-1-1.xlsx
- Licenza non dichiarata nella pagina verificata.

## Verifica

- PASS: 327/327 test Node.
- PASS: lint, typecheck, design check, brand check e build Next.js, 45 pagine.
- PASS: render reale 1280×900 e 390×844, zero errori runtime e zero overflow globale.
- PASS: elenco completo 88/88; tabella mobile confinata in overflow interno e focusabile.
- PASS: regressione Consulenza mobile, form e pulsante presenti senza overflow.
- PASS: scansione privacy su file, branch, commit e diff.

Gli screenshot e il report browser restano locali e non sono committati.
