### PR TITLE
fix(mcp): normalizza filtro regione e segnala assenza di match

### DIFF
--- a/scripts/browser_e2e.mjs
+++ b/scripts/browser_e2e.mjs
@@ -183,6 +183,69 @@ async function assertResponsiveShell(page, label, width) {
   );
 }
 
+async function assertCohesionTracePanelContrast(page, label) {
+  const state = await page.evaluate(() => {
+    function luminance(red, green, blue) {
+      const channels = [red, green, blue]
+        .map((value) => value / 255)
+        .map((value) => (value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4));
+      return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+    }
+    function contrast(first, second) {
+      const [lighter, darker] = [luminance(...first), luminance(...second)].sort((left, right) => right - left);
+      return (lighter + 0.05) / (darker + 0.05);
+    }
+    function parseRgb(color) {
+      const match = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+      if (!match) return null;
+      return [Number(match[1]), Number(match[2]), Number(match[3])];
+    }
+
+    const section = [...document.querySelectorAll("main section")].find(
+      (candidate) => candidate.querySelector("h2")?.textContent?.includes("Il totale non basta"),
+    );
+    if (!section) return null;
+
+    const background = parseRgb(getComputedStyle(section).backgroundColor);
+    const heading = section.querySelector("h2");
+    const body = section.querySelector("p");
+    const kicker = section.querySelector("div > span");
+    const metricValue = section.querySelector("strong");
+    const metricLabel = metricValue?.nextElementSibling;
+
+    return {
+      background,
+      samples: [
+        ["heading", heading, 4.5],
+        ["body", body, 4.5],
+        ["kicker", kicker, 4.5],
+        ["metric value", metricValue, 4.5],
+        ["metric label", metricLabel, 4.5],
+      ].map(([name, element, minimum]) => {
+        const foreground = element ? parseRgb(getComputedStyle(element).color) : null;
+        return {
+          name,
+          minimum,
+          ratio: foreground && background ? contrast(foreground, background) : null,
+        };
+      }),
+    };
+  });
+
+  assert.ok(state, `${label}: pannello traccia PNRR non trovato`);
+  assert.ok(
+    state.background?.every((channel) => channel < 80),
+    `${label}: sfondo del pannello traccia non risulta scuro`,
+  );
+  for (const sample of state.samples) {
+    assert.ok(sample.ratio !== null, `${label}: colore ${sample.name} non misurabile`);
+    assert.ok(
+      sample.ratio >= sample.minimum,
+      `${label}: contrasto ${sample.name} ${sample.ratio.toFixed(2)} < ${sample.minimum}`,
+    );
+  }
+}
+
 async function assertCohesionStatusLayout(page, label) {
   const state = await page.$eval("main", (main) => {
     const section = [...main.querySelectorAll("section")].find(
@@ -1104,6 +1167,7 @@ try {
       width,
       validate: async (page) => {
         assertTextMatches(await bodyText(page), /A che punto sono i progetti/i, label);
+        await assertCohesionTracePanelContrast(page, label);
         await assertCohesionStatusLayout(page, label);
       },
     });

--- a/src/app/coesione/coesione.module.css
+++ b/src/app/coesione/coesione.module.css
@@ -17,7 +17,7 @@
   border-top: 3px solid var(--color-accent);
 }
 .tracePanel > div > span:first-child {
-  color: var(--color-accent);
+  color: var(--color-accent-300);
   font-size: 10px;
   font-weight: 800;
   letter-spacing: .12em;
@@ -49,7 +49,7 @@
 }
 .traceAction span {
   margin-bottom: var(--space-3);
-  color: var(--color-neutral-400);
+  color: var(--color-neutral-300);
   font-size: 11px;
 }
 

--- a/src/lib/assistant/intent.ts
+++ b/src/lib/assistant/intent.ts
@@ -6,29 +6,7 @@ import {
   type AssistantIntent,
   type AssistantResponse,
 } from "@/lib/assistant/contracts";
-
-const REGIONS = new Map<string, string>([
-  ["abruzzo", "Abruzzo"],
-  ["basilicata", "Basilicata"],
-  ["calabria", "Calabria"],
-  ["campania", "Campania"],
-  ["emilia romagna", "Emilia-Romagna"],
-  ["friuli venezia giulia", "Friuli-Venezia Giulia"],
-  ["lazio", "Lazio"],
-  ["liguria", "Liguria"],
-  ["lombardia", "Lombardia"],
-  ["marche", "Marche"],
-  ["molise", "Molise"],
-  ["piemonte", "Piemonte"],
-  ["puglia", "Puglia"],
-  ["sardegna", "Sardegna"],
-  ["sicilia", "Sicilia"],
-  ["toscana", "Toscana"],
-  ["trentino alto adige", "Trentino-Alto Adige/Südtirol"],
-  ["umbria", "Umbria"],
-  ["valle d aosta", "Valle d'Aosta/Vallée d'Aoste"],
-  ["veneto", "Veneto"],
-]);
+import { REGION_PROMPT_ALIASES } from "@/lib/region-query";
 
 const UNSAFE_PATTERNS = [
   /\b(frode|frodi|corruzion\p{Letter}*|evasione|truffa|colpevol\p{Letter}*|responsabilit\p{Letter}*|inculpat\p{Letter}*|reato\p{Letter}*|criminal\p{Letter}*|illegal\p{Letter}*|colpa)\b/u,
@@ -63,7 +41,7 @@ function yearFrom(prompt: string): number | null {
 }
 
 function regionFrom(prompt: string): string | undefined {
-  const found = [...REGIONS.entries()]
+  const found = [...REGION_PROMPT_ALIASES.entries()]
     .sort(([left], [right]) => right.length - left.length)
     .find(([alias]) => new RegExp(`\\b${alias.replace(/ /gu, "\\s+")}\\b`, "u").test(prompt));
   return found?.[1];

--- a/src/lib/mcp/datasets.ts
+++ b/src/lib/mcp/datasets.ts
@@ -1,4 +1,9 @@
 import { datasetCatalog, type DatasetQuery } from "@/lib/mcp/catalog";
+import {
+  formatRegionNotFoundError,
+  resolveCanonicalRegionName,
+  resolveOpenCivitasRegionName,
+} from "@/lib/region-query";
 
 const datasetFilters = new Map(datasetCatalog.map((dataset) => [dataset.id, new Set(dataset.filters)]));
 
@@ -65,15 +70,29 @@ export async function queryPublicDataset(
         throw new Error(`Anno SIOPE non disponibile. Anni validi: ${availableSiopeYears.join(", ")}.`);
       }
       const snapshot = getSiopeMunicipalSnapshot(year);
-      const region = query.region?.trim().toLocaleLowerCase("it-IT");
-      if (!region) return jsonSafe(snapshot);
+      const regionInput = query.region?.trim();
+      if (!regionInput) return jsonSafe(snapshot);
+      const canonicalRegion = resolveCanonicalRegionName(regionInput);
+      if (!canonicalRegion) {
+        throw new Error(formatRegionNotFoundError(regionInput));
+      }
+      const matchesRegion = (item: { region: string }) => item.region === canonicalRegion;
+      const filteredRegions = snapshot.regions.filter(matchesRegion);
+      if (filteredRegions.length === 0) {
+        throw new Error(formatRegionNotFoundError(regionInput));
+      }
       const { distribution: nationalDistribution, ...snapshotWithoutDistribution } = snapshot;
       return jsonSafe({
         ...snapshotWithoutDistribution,
-        regions: snapshot.regions.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
-        topMunicipalities: snapshot.topMunicipalities.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
-        topMunicipalitiesByValue: snapshot.topMunicipalitiesByValue.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
-        topMunicipalitiesByPerCapita: snapshot.topMunicipalitiesByPerCapita.filter((item) => item.region.toLocaleLowerCase("it-IT") === region),
+        regions: filteredRegions,
+        topMunicipalities: snapshot.topMunicipalities.filter(matchesRegion),
+        topMunicipalitiesByValue: snapshot.topMunicipalitiesByValue.filter(matchesRegion),
+        topMunicipalitiesByPerCapita: snapshot.topMunicipalitiesByPerCapita.filter(matchesRegion),
+        regionFilter: {
+          requested: regionInput,
+          resolved: canonicalRegion,
+          matched: true,
+        },
         queryLimitations: {
           regionAggregateComplete: false,
           regionAggregateCompleteDeprecated:
@@ -119,10 +138,17 @@ export async function queryPublicDataset(
       if (query.year && query.year !== openCivitasSnapshot.referenceYear) {
         throw new Error(`OpenCivitas è disponibile per il ${openCivitasSnapshot.referenceYear}.`);
       }
-      const region = query.region?.trim().toLocaleUpperCase("it-IT");
+      const regionInput = query.region?.trim();
+      const region = regionInput ? resolveOpenCivitasRegionName(regionInput) : null;
+      if (regionInput && !region) {
+        throw new Error(formatRegionNotFoundError(regionInput));
+      }
       const code = query.code?.trim();
       const matches = openCivitasSnapshot.municipalities.filter((item) =>
         (!region || item.region === region) && (!code || item.istatCode === code));
+      if (region && matches.length === 0) {
+        throw new Error(formatRegionNotFoundError(regionInput!));
+      }
       return jsonSafe({
         referenceYear: openCivitasSnapshot.referenceYear,
         publishedAt: openCivitasSnapshot.publishedAt,

--- a/src/lib/region-query.ts
+++ b/src/lib/region-query.ts
@@ -1,0 +1,84 @@
+import { REGION_NAME_BY_ISTAT_CODE } from "@/lib/italy-regions";
+
+export const CANONICAL_REGION_NAMES = Object.freeze(
+  Object.values(REGION_NAME_BY_ISTAT_CODE),
+);
+
+/** Lowercase aliases used in natural-language prompts and MCP filters. */
+export const REGION_PROMPT_ALIASES = Object.freeze(
+  new Map<string, string>([
+    ["abruzzo", "Abruzzo"],
+    ["basilicata", "Basilicata"],
+    ["calabria", "Calabria"],
+    ["campania", "Campania"],
+    ["emilia romagna", "Emilia-Romagna"],
+    ["friuli venezia giulia", "Friuli-Venezia Giulia"],
+    ["lazio", "Lazio"],
+    ["liguria", "Liguria"],
+    ["lombardia", "Lombardia"],
+    ["marche", "Marche"],
+    ["molise", "Molise"],
+    ["piemonte", "Piemonte"],
+    ["puglia", "Puglia"],
+    ["sardegna", "Sardegna"],
+    ["sicilia", "Sicilia"],
+    ["toscana", "Toscana"],
+    ["trentino alto adige", "Trentino-Alto Adige/Südtirol"],
+    ["umbria", "Umbria"],
+    ["valle d aosta", "Valle d'Aosta/Vallée d'Aoste"],
+    ["veneto", "Veneto"],
+  ]),
+);
+
+const REGION_BY_COMPARISON_KEY = buildRegionLookup();
+
+function buildRegionLookup(): ReadonlyMap<string, string> {
+  const lookup = new Map<string, string>();
+  for (const name of CANONICAL_REGION_NAMES) {
+    lookup.set(regionComparisonKey(name), name);
+  }
+  for (const [alias, canonical] of REGION_PROMPT_ALIASES) {
+    lookup.set(regionComparisonKey(alias), canonical);
+  }
+  for (const [code, name] of Object.entries(REGION_NAME_BY_ISTAT_CODE)) {
+    lookup.set(code, name);
+  }
+  return lookup;
+}
+
+/** Collapses spaces and hyphens so "Emilia Romagna" and "Emilia-Romagna" match. */
+export function regionComparisonKey(value: string): string {
+  return value
+    .normalize("NFKC")
+    .trim()
+    .toLocaleLowerCase("it-IT")
+    .replace(/[‘’`´']/g, " ")
+    .replace(/[‐‑‒–—-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function resolveCanonicalRegionName(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d{1,2}$/.test(trimmed)) {
+    const padded = trimmed.padStart(2, "0");
+    const byCode = REGION_NAME_BY_ISTAT_CODE[padded as keyof typeof REGION_NAME_BY_ISTAT_CODE];
+    if (byCode) return byCode;
+  }
+  return REGION_BY_COMPARISON_KEY.get(regionComparisonKey(trimmed)) ?? null;
+}
+
+export function formatRegionNotFoundError(value: string): string {
+  const trimmed = value.trim();
+  const suggestion = resolveCanonicalRegionName(trimmed.replace(/\s+/g, "-"));
+  if (suggestion && suggestion !== trimmed) {
+    return `Regione non trovata: ${trimmed}. Prova con il nome ufficiale ${suggestion}.`;
+  }
+  return `Regione non trovata: ${trimmed}. Usa uno dei nomi ufficiali ISTAT, ad esempio Emilia-Romagna.`;
+}
+
+export function resolveOpenCivitasRegionName(value: string): string | null {
+  const canonical = resolveCanonicalRegionName(value);
+  return canonical ? canonical.toLocaleUpperCase("it-IT") : null;
+}

--- a/tests/coesione-ui.test.mjs
+++ b/tests/coesione-ui.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const css = await readFile(new URL("../src/app/design-system.css", import.meta.url), "utf8");
+const coesioneCss = await readFile(new URL("../src/app/coesione/coesione.module.css", import.meta.url), "utf8");
+
+function token(name) {
+  const match = css.match(new RegExp(`--${name}:\\s*(#[0-9a-f]{6})`, "i"));
+  assert.ok(match, `token --${name} non trovato`);
+  return match[1];
+}
+
+function luminance(hex) {
+  const channels = hex.slice(1).match(/.{2}/g).map((value) => Number.parseInt(value, 16) / 255);
+  const linear = channels.map((value) => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrast(first, second) {
+  const [lighter, darker] = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+test("coesione trace panel keeps high-contrast text on the dark surface", () => {
+  const surface = token("color-neutral-900");
+  assert.match(coesioneCss, /\.tracePanel[\s\S]*background:\s*var\(--color-neutral-900\)/);
+  assert.match(coesioneCss, /\.tracePanel > div > span:first-child[\s\S]*color:\s*var\(--color-accent-300\)/);
+  assert.match(coesioneCss, /\.traceAction span[\s\S]*color:\s*var\(--color-neutral-300\)/);
+
+  const pairs = [
+    ["trace heading", token("color-raised"), surface],
+    ["trace body", token("color-neutral-300"), surface],
+    ["trace kicker", token("color-accent-300"), surface],
+    ["trace metric label", token("color-neutral-300"), surface],
+    ["trace metric value", token("color-raised"), surface],
+  ];
+
+  for (const [label, foreground, background] of pairs) {
+    assert.ok(contrast(foreground, background) >= 4.5, `${label} sotto 4.5:1 sul pannello scuro`);
+  }
+});

--- a/tests/mcp-datasets.test.mjs
+++ b/tests/mcp-datasets.test.mjs
@@ -55,6 +55,38 @@ test("SIOPE query validates years and can filter a region", async () => {
   assert.match(result.queryLimitations.distribution, /non è pubblicata|risposta nazionale/i);
 });
 
+test("SIOPE query resolves common region aliases and rejects unknown regions", async () => {
+  const aliased = await queryPublicDataset({
+    dataset: "siope_comuni",
+    year: 2025,
+    region: "Emilia Romagna",
+  });
+  assert.equal(aliased.regionFilter.resolved, "Emilia-Romagna");
+  assert.equal(aliased.regionFilter.matched, true);
+  assert.equal(aliased.regions.length, 1);
+  assert.equal(aliased.regions[0].region, "Emilia-Romagna");
+
+  await assert.rejects(
+    queryPublicDataset({ dataset: "siope_comuni", year: 2025, region: "Atlantide" }),
+    /Regione non trovata: Atlantide/,
+  );
+});
+
+test("OpenCivitas query resolves region aliases and rejects unknown regions", async () => {
+  const aliased = await queryPublicDataset({
+    dataset: "opencivitas_fabbisogni",
+    region: "Emilia Romagna",
+    limit: 5,
+  });
+  assert.ok(aliased.data.length > 0);
+  assert.ok(aliased.data.every((item) => item.region === "EMILIA-ROMAGNA"));
+
+  await assert.rejects(
+    queryPublicDataset({ dataset: "opencivitas_fabbisogni", region: "Sardegna" }),
+    /Regione non trovata: Sardegna/,
+  );
+});
+
 test("SIOPE national MCP query carries only compact full-population aggregates", async () => {
   const result = await queryPublicDataset({ dataset: "siope_comuni", year: 2026 });
   assert.equal(result.distribution.schemaVersion, 2);

--- a/tests/region-query.test.mjs
+++ b/tests/region-query.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const {
+  formatRegionNotFoundError,
+  regionComparisonKey,
+  resolveCanonicalRegionName,
+  resolveOpenCivitasRegionName,
+} = await import("../src/lib/region-query.ts");
+
+test("regionComparisonKey treats spaces and hyphens as equivalent", () => {
+  assert.equal(regionComparisonKey("Emilia Romagna"), regionComparisonKey("Emilia-Romagna"));
+  assert.equal(regionComparisonKey("Friuli Venezia Giulia"), regionComparisonKey("Friuli-Venezia Giulia"));
+});
+
+test("resolveCanonicalRegionName accepts official names, aliases and ISTAT codes", () => {
+  assert.equal(resolveCanonicalRegionName("Emilia-Romagna"), "Emilia-Romagna");
+  assert.equal(resolveCanonicalRegionName("Emilia Romagna"), "Emilia-Romagna");
+  assert.equal(resolveCanonicalRegionName("emilia romagna"), "Emilia-Romagna");
+  assert.equal(resolveCanonicalRegionName("08"), "Emilia-Romagna");
+  assert.equal(resolveCanonicalRegionName("Trentino Alto Adige"), "Trentino-Alto Adige/Südtirol");
+  assert.equal(resolveCanonicalRegionName("Valle d’Aosta"), "Valle d'Aosta/Vallée d'Aoste");
+  assert.equal(resolveCanonicalRegionName("Atlantide"), null);
+});
+
+test("resolveOpenCivitasRegionName maps to uppercase OpenCivitas labels", () => {
+  assert.equal(resolveOpenCivitasRegionName("Emilia Romagna"), "EMILIA-ROMAGNA");
+  assert.equal(resolveOpenCivitasRegionName("calabria"), "CALABRIA");
+});
+
+test("formatRegionNotFoundError suggests the official region name", () => {
+  assert.match(formatRegionNotFoundError("Emilia Romagna"), /Emilia-Romagna/);
+  assert.match(formatRegionNotFoundError("Atlantide"), /non trovata/i);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cosa cambia

Risolve #49 e #50.

### #49 — MCP filtro regione

`query_dataset` su `siope_comuni` ora:

- accetta alias comuni del nome regione (es. `Emilia Romagna` → `Emilia-Romagna`, codici ISTAT `08`);
- espone `regionFilter: { requested, resolved, matched }` quando il filtro regione è attivo;
- restituisce `ok: false` con messaggio esplicito se la regione non esiste o non produce dati.

Stessa normalizzazione su `opencivitas_fabbisogni`. Modulo condiviso `src/lib/region-query.ts` riusato dall'assistente deterministico.

### #50 — Contrasto pannello traccia PNRR su `/coesione`

Il kicker `Nuovo · traccia PNRR` usava `--color-accent` su sfondo `--color-neutral-900` (~3.35:1, sotto WCAG AA). Ora usa `--color-accent-300` (~9.3:1). Le label secondarie passano da `neutral-400` a `neutral-300`.

## Evidenza

- [x] Il diff è limitato ai problemi dichiarati.
- [x] Test unitari e e2e aggiunti/aggiornati.
- [x] `npm test`, typecheck, lint, design check, build passano.
- [x] MCP smoke/load, browser e2e (88 check incl. contrasto `/coesione` 320–1600px), Lighthouse passano in locale.

### UI e accessibilità

- [x] Contrasto pannello traccia verificato via token test + computed styles e2e su 5 viewport.

### API e MCP

- [x] Filtro regione non valido → errore esplicito leggibile dal client.

Closes #49
Closes #50
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a032b3-ca84-744e-81fd-1f967340754c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a032b3-ca84-744e-81fd-1f967340754c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

