### PR TITLE
fix(ui): la tendina della nav non viene più tagliata

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -615,6 +615,17 @@ main { display: block; }
 
 /* ── responsive ─────────────────────────────────────────────────────────── */
 
+/* La tendina esce dal riquadro della barra, che scorre in orizzontale finché
+   le voci non ci stanno: sopra i 1040px la barra sta tutta e non deve clippare.
+   Sotto, resta scorrevole e le sotto-voci si raggiungono dalla subnav-row. */
+@media (min-width: 1040px) {
+  .primary-nav { overflow-x: visible; }
+}
+@media (max-width: 1039px) {
+  .nav-item-has-menu:hover .nav-submenu,
+  .nav-item-has-menu:focus-within .nav-submenu { display: none; }
+}
+
 @media (max-width: 1180px) {
   :root { --gutter: 20px; }
   .header-search { width: 260px; }


### PR DESCRIPTION
## Il problema

Passando il mouse su una voce di menu con sotto-pagine (per esempio "Soldi"), la tendina non si vedeva: restava tagliata dietro le card della pagina.

Non era un problema di z-index. La barra di navigazione ha `overflow-x: auto` per poter scorrere in orizzontale sugli schermi stretti, e un contenitore con overflow ritaglia i figli in `position: absolute` che escono dal suo riquadro. La tendina veniva quindi tagliata, non coperta.

<img width="437" height="182" alt="Screenshot 2026-08-24 at 17 56 05" src="https://github.com/user-attachments/assets/53622d0d-344d-49dc-bd38-efc15bb48104" />

## La soluzione

Sopra i 1040px la barra ci sta tutta (misura 961px), quindi lo scorrimento non serve e il ritaglio si può togliere:

- `@media (min-width: 1040px)` → `.primary-nav { overflow-x: visible; }`
- sotto quella soglia la barra resta scorrevole e la tendina viene nascosta, come già succedeva sotto i 900px: le sotto-voci restano raggiungibili dalla seconda riga di navigazione (`subnav-row`).

Un solo file toccato, `src/app/globals.css`.

## Il risultato

Verificato nel browser a 1280px: hover su "Soldi" apre la tendina sopra le card, con tutte e quattro le voci leggibili.

- `npm test`: 336/336 PASS
- `npm run lint`: PASS

Non verificato: audit di accessibilità completo e suite browser e2e.
