### PR TITLE
Paginazione numerata e navigazione di sezione leggibili anche da tele…

### DIFF
--- a/src/app/controlli/controlli.module.css
+++ b/src/app/controlli/controlli.module.css
@@ -111,19 +111,17 @@
 }
 
 .signalMeta {
-  margin: 0 0 var(--space-2);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: .06em;
   text-transform: uppercase;
   color: var(--color-neutral-600);
-}
-
-.signalBadges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-bottom: var(--space-2);
 }
 
 .signalTone {
@@ -216,10 +214,19 @@
   align-items: center;
 }
 
+.readingGuide {
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-200);
+}
+
 .readingGuide summary {
   font-family: var(--font-heading);
-  font-size: 18px;
+  font-size: 14px;
   font-weight: var(--font-heading-weight);
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  color: var(--color-accent-700);
 }
 
 .readingGuide > p {
@@ -260,19 +267,6 @@
   line-height: 1.5;
 }
 
-.signalKind {
-  align-self: flex-start;
-  margin-bottom: var(--space-2);
-  padding: 4px 7px;
-  border: 1px solid var(--color-neutral-400);
-  color: var(--color-neutral-700);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: .05em;
-  line-height: 1;
-  text-transform: uppercase;
-}
-
 /* The tone says what kind of number this is: something measured, something to
    check, a policy choice, or an accumulated stock. It tints the rule above the
    value rather than the whole card, so no signal reads as an accusation. */
@@ -281,25 +275,28 @@
 .signals article[data-tone="policy"] .signalValue { border-top-color: var(--color-neutral-800); }
 .signals article[data-tone="stock"] .signalValue { border-top-color: var(--color-accent-300); }
 
-.signals article[data-tone="attention"] .signalKind {
-  border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-neutral-400));
-}
-
 .signalValue {
   display: block;
   padding-top: var(--space-3);
   border-top: 3px solid var(--color-neutral-400);
   font-family: var(--font-heading);
-  font-size: 32px;
+  font-size: 38px;
   font-weight: var(--font-heading-weight);
   letter-spacing: -.03em;
-  line-height: 1.05;
+  line-height: 1.02;
   font-variant-numeric: tabular-nums;
 }
 
+/* The label asks the question, the figure answers it: name first, number
+   second, so nobody meets a large number before knowing what it counts. */
 .signals h3 {
-  margin: var(--space-2) 0 var(--space-2);
+  margin: 0 0 var(--space-3);
   font-size: 15px;
+  color: var(--color-neutral-800);
+}
+
+.signalMeaning {
+  margin-top: var(--space-3);
 }
 
 .signals p {
@@ -544,4 +541,51 @@
     grid-template-columns: minmax(0, 1fr) 112px;
   }
   .breakdown li > i { display: none; }
+}
+
+/* The page carries five sections of different kinds. Without an index the only
+   way to reach the last one is to scroll past everything before it. */
+.pageIndex {
+  padding: 14px 18px;
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.pageIndex h2 {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-heading);
+  font-size: 11px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: var(--color-neutral-700);
+}
+
+.pageIndex ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pageIndex a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding-inline: var(--space-3);
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pageIndex a:hover {
+  color: var(--color-text);
+  background: var(--color-neutral-200);
+}
+
+@media (max-width: 620px) {
+  .pageIndex a { flex: 1 1 auto; justify-content: center; }
 }

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -144,6 +144,17 @@ export default async function ControlsPage({ searchParams }: PageProps) {
     limit: OUTLIER_TABLE_SIZE,
   });
   const topSpendingOutliers = spendingOutliers.outliers;
+  const showsMunicipalScreening =
+    selectedYear === null || selectedYear === openCivitasSnapshot.referenceYear;
+  const showsProcurement2025 = selectedYear === null || selectedYear === 2025;
+  const showsPolicyScenarios = selectedYear === null;
+  const pageSections = [
+    { id: "official-signals-title", label: "Segnali ufficiali", shown: true },
+    { id: "municipal-screening-title", label: "Comuni oltre la soglia", shown: showsMunicipalScreening },
+    { id: "appalti-related-title", label: "Appalti pubblici", shown: true },
+    { id: "procurement-2025-title", label: "Appalti 2025", shown: showsProcurement2025 },
+    { id: "policy-scenarios-title", label: "Ipotesi di miglioramento", shown: showsPolicyScenarios },
+  ].filter((section) => section.shown);
 
   return (
     <main className="shell page">
@@ -173,11 +184,22 @@ export default async function ControlsPage({ searchParams }: PageProps) {
         </div>
       </nav>
 
+      <nav className={styles.pageIndex} aria-labelledby="page-index-title">
+        <h2 id="page-index-title">In questa pagina</h2>
+        <ul>
+          {pageSections.map((section) => (
+            <li key={section.id}>
+              <a href={`#${section.id}`}>{section.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
       <section
         className="notice scope-notice"
         aria-labelledby="controlli-reading-title"
       >
-        <h2 id="controlli-reading-title">Come leggere questi dati</h2>
+        <h2 id="controlli-reading-title">Che cosa dicono e che cosa non dicono</h2>
         <p>
           Pagamenti, debiti, costi e ipotesi misurano cose diverse e restano separati. Un segnale
           indica cosa approfondire. Consulta le <Link href="/fonti">fonti
@@ -224,23 +246,22 @@ export default async function ControlsPage({ searchParams }: PageProps) {
             </li>
           ))}
         </ul>
+        <details className={styles.readingGuide}>
+          <summary>Definizioni dei tipi di segnale</summary>
+          <p>
+            Le etichette sulle schede riprendono le categorie sotto. Servono a capire quanto
+            possiamo concludere da ogni numero.
+          </p>
+          <dl>
+            {classificationEntries.map(([id, classification]) => (
+              <div key={id}>
+                <dt>{classification.label}</dt>
+                <dd>{classification.plainMeaning}</dd>
+              </div>
+            ))}
+          </dl>
+        </details>
       </section>
-
-      <details className={`panel ${styles.readingGuide}`}>
-        <summary>Definizioni dei tipi di segnale</summary>
-        <p>
-          Le etichette sulle schede riprendono le categorie sotto. Servono a capire quanto possiamo
-          concludere da ogni numero.
-        </p>
-        <dl>
-          {classificationEntries.map(([id, classification]) => (
-            <div key={id}>
-              <dt>{classification.label}</dt>
-              <dd>{classification.plainMeaning}</dd>
-            </div>
-          ))}
-        </dl>
-      </details>
 
       <section className={styles.signalSection} aria-labelledby="official-signals-title">
         <header className={styles.sectionIntro}>
@@ -250,26 +271,33 @@ export default async function ControlsPage({ searchParams }: PageProps) {
             perimetro, stato del dato e limiti di interpretazione.
           </p>
         </header>
+        {signals.length === 0 ? (
+          <p className={styles.note}>
+            Per l&apos;anno selezionato non ci sono segnali da relazioni ufficiali nel nostro
+            perimetro. Non significa che non ce ne siano stati: significa che noi non ne abbiamo
+            ancora uno documentato e verificabile.
+          </p>
+        ) : null}
+
         <div className={styles.signals}>
           {signals.map((signal) => (
             <article className="panel" key={signal.id} data-tone={signal.tone}>
               <p className={styles.signalMeta}>
-                {signal.area} · {referencePeriod(signal.referenceDate)}
-              </p>
-              <div className={styles.signalBadges}>
+                <span>{signal.area} · {referencePeriod(signal.referenceDate)}</span>
                 <span className={styles.signalTone} data-tone={signal.tone}>
                   {toneLabels[signal.tone]}
                 </span>
-                <span className={styles.signalKind}>
-                  {auditClassifications[signal.classification].label}
-                </span>
-              </div>
-              <strong className={styles.signalValue}>{formatSignal(signal)}</strong>
+              </p>
               <h3>{signal.label}</h3>
-              <p>{signal.plainMeaning}</p>
+              <strong className={styles.signalValue}>{formatSignal(signal)}</strong>
+              <p className={styles.signalMeaning}>{signal.plainMeaning}</p>
               <details className={styles.signalDetails}>
                 <summary>Perimetro e stato del dato</summary>
                 <dl>
+                  <div>
+                    <dt>Tipo di segnale</dt>
+                    <dd>{auditClassifications[signal.classification].label}</dd>
+                  </div>
                   <div>
                     <dt>Comprende</dt>
                     <dd>{signal.coverage}</dd>
@@ -291,7 +319,7 @@ export default async function ControlsPage({ searchParams }: PageProps) {
         </div>
       </section>
 
-      {(selectedYear === null || selectedYear === openCivitasSnapshot.referenceYear) && (
+      {showsMunicipalScreening && (
         <section className={`panel ${styles.derivedSection}`} aria-labelledby="municipal-screening-title">
           <header className={styles.sectionIntro}>
             <div>
@@ -529,9 +557,11 @@ export default async function ControlsPage({ searchParams }: PageProps) {
         </p>
       </section>
 
-      {(selectedYear === null || selectedYear === 2025) && (
-        <section className="panel">
-          <h2 className="panel-title">Appalti 2025: 55,3% e quasi 95% usano calcoli diversi</h2>
+      {showsProcurement2025 && (
+        <section className="panel" aria-labelledby="procurement-2025-title">
+          <h2 id="procurement-2025-title" className="panel-title">
+            Appalti 2025: 55,3% e quasi 95% usano calcoli diversi
+          </h2>
           <div className="stat-strip">
             <div>
               <span className="stat-label">Tutte le procedure da 40.000 euro in su</span>
@@ -608,7 +638,7 @@ export default async function ControlsPage({ searchParams }: PageProps) {
         </section>
       )}
 
-      {selectedYear === null && (
+      {showsPolicyScenarios && (
         <>
           <section className={`panel ${styles.policySection}`} aria-labelledby="policy-scenarios-title">
             <header className={styles.sectionIntro}>

--- a/src/app/dati/[dataset]/page.tsx
+++ b/src/app/dati/[dataset]/page.tsx
@@ -2,14 +2,19 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
+import Pagination from "@/components/pagination";
 import { integer } from "@/lib/format";
 import {
   getIntegratedDataOverview,
+  INTEGRATED_DEFAULT_LIMIT,
+  INTEGRATED_MAX_LIMIT,
   IntegratedDatasetNotFoundError,
   IntegratedQueryError,
   selectIntegratedDataset,
   type IntegratedDatasetResult,
 } from "@/lib/integrated-public-view";
+import { integratedDomainLabel } from "@/lib/integrated-domains";
+import { offsetFromPage, pageCountFromTotal, pageFromOffset } from "@/lib/pagination";
 import styles from "../dati.module.css";
 
 type SearchValue = string | string[] | undefined;
@@ -39,6 +44,56 @@ function pageHref(
   return `/dati/${datasetId}?${query.toString()}`;
 }
 
+/**
+ * The limit the selector will settle on, needed before the call so a `pagina`
+ * request can be translated into the offset the selector actually accepts.
+ * The selector stays the authority: an out-of-range value still fails there.
+ */
+function requestedLimit(value: SearchValue): number {
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    if (parsed >= 1 && parsed <= INTEGRATED_MAX_LIMIT) return parsed;
+  }
+  return INTEGRATED_DEFAULT_LIMIT;
+}
+
+/** `pagina` is the readable form of `offset`; an explicit offset still wins. */
+function requestedOffset(search: Record<string, SearchValue>, limit: number): SearchValue {
+  if (search.offset !== undefined && search.offset !== "") return search.offset;
+  if (search.q !== undefined && search.q !== "") return undefined;
+  const page = search.pagina;
+  if (typeof page === "string" && /^\d+$/.test(page) && Number(page) >= 1) {
+    return String(offsetFromPage(Number(page), limit));
+  }
+  return undefined;
+}
+
+/**
+ * Amount columns are right-aligned so a reader can scan the money down one
+ * edge. A header that merely sounds like an amount is not enough: no value on
+ * the page may contradict it, so a text column is never realigned.
+ */
+const AMOUNT_HEADER =
+  /^(importo|valore|spesa|spese|pagato|impegnato|residui|previsioni|compenso|corrispettivo|totale|ammontare)\b/i;
+const AMOUNT_VALUE = /^-?\d{1,3}(?:[.\s]\d{3})*(?:,\d+)?$|^-?\d+(?:[.,]\d+)?$/;
+
+function amountColumns(
+  headers: readonly string[],
+  rows: IntegratedDatasetResult["rows"],
+): ReadonlySet<string> {
+  return new Set(
+    headers.filter((header) => {
+      if (!AMOUNT_HEADER.test(header.replace(/[_-]+/g, " ").trim())) return false;
+      // An empty column still aligns with its populated siblings: what
+      // disqualifies a header is a value that is plainly not a number.
+      return rows
+        .map((row) => row.cells[header])
+        .filter((value): value is string => typeof value === "string" && value.trim() !== "")
+        .every((value) => AMOUNT_VALUE.test(value.trim()));
+    }),
+  );
+}
+
 function CellValue({ value }: { value: string | null }) {
   if (value === null) return <span className={styles.missingValue}>Dato non pubblicato</span>;
   if (value === "") return <span className={styles.missingValue}>Dato non presente</span>;
@@ -65,13 +120,15 @@ async function safeResult(
   datasetId: string,
   search: Record<string, SearchValue>,
 ): Promise<{ result: IntegratedDatasetResult; queryError: string | null }> {
+  const limit = requestedLimit(search.limit);
+  const offset = requestedOffset(search, limit);
   try {
     return {
       result: await selectIntegratedDataset({
         datasetId,
         q: search.q,
         limit: search.limit,
-        offset: search.offset,
+        offset,
         cursor: search.cursor,
       }),
       queryError: null,
@@ -79,9 +136,12 @@ async function safeResult(
   } catch (error) {
     if (error instanceof IntegratedDatasetNotFoundError) notFound();
     if (error instanceof IntegratedQueryError) {
+      const jumpedTooFar = search.pagina !== undefined && search.offset === undefined;
       return {
         result: await selectIntegratedDataset({ datasetId }),
-        queryError: error.message,
+        queryError: jumpedTooFar
+          ? "Quella pagina non esiste in questo dataset: sei tornato alla prima."
+          : error.message,
       };
     }
     throw error;
@@ -105,8 +165,10 @@ export default async function IntegratedDatasetPage({ params, searchParams }: Da
   const { dataset } = result;
   const firstVisible = result.pagination.scanStartSourceRow ?? 0;
   const lastVisible = result.pagination.scanEndSourceRow ?? 0;
-  const hasPrevious = result.query === null && firstVisible > 1;
   const hasNext = result.pagination.nextCursor !== null;
+  const amounts = amountColumns(dataset.headers, result.rows);
+  const currentPage = pageFromOffset(result.offset ?? 0, result.limit);
+  const pageCount = pageCountFromTotal(dataset.publicRows, result.limit);
   const resultSummary = result.query === null
     ? result.rows.length === 0
       ? "Nessuna riga disponibile."
@@ -126,7 +188,7 @@ export default async function IntegratedDatasetPage({ params, searchParams }: Da
       </nav>
 
       <div className="page-intro">
-        <p className={styles.eyebrow}>{dataset.domain}</p>
+        <p className={styles.eyebrow}>{integratedDomainLabel(dataset.domain)}</p>
         <h1>{dataset.title}</h1>
         <p>{dataset.publicationNote}</p>
       </div>
@@ -155,6 +217,184 @@ export default async function IntegratedDatasetPage({ params, searchParams }: Da
           <span className="stat-note">non equivale a un giudizio automatico</span>
         </div>
       </section>
+
+      {dataset.queryable ? (
+        <>
+          <section className={`panel ${styles.queryPanel}`} aria-labelledby="dataset-search-title">
+            <div>
+              <h2 id="dataset-search-title" className="panel-title">Cerca nelle celle pubbliche</h2>
+              <p>La ricerca non distingue maiuscole e minuscole e non interroga campi non pubblici.</p>
+            </div>
+            <form action={`/dati/${dataset.id}`} method="get" className={styles.searchForm}>
+              <label htmlFor="dataset-query">Testo da cercare</label>
+              <div>
+                <input
+                  className="input"
+                  id="dataset-query"
+                  name="q"
+                  defaultValue={result.query ?? ""}
+                  maxLength={200}
+                  placeholder="Ente, oggetto, CIG o altro valore"
+                />
+                <input type="hidden" name="limit" value={result.limit} />
+                <button className="btn btn-primary" type="submit">Cerca</button>
+              </div>
+            </form>
+          </section>
+
+          {queryError ? <p className={styles.queryError} role="alert">{queryError}</p> : null}
+
+          <section className={`panel ${styles.tablePanel}`} aria-labelledby="dataset-rows-title">
+            <div className={styles.tableHeading}>
+              <div>
+                <h2 id="dataset-rows-title" className="panel-title">Righe pubbliche</h2>
+                <p>{resultSummary}</p>
+              </div>
+              {result.query ? <span className="tag tag-neutral">Filtro: {result.query}</span> : null}
+            </div>
+
+            {/* The three conventions a reader needs before the first cell, next
+                to the cells rather than four panels above them. */}
+            <ul className={styles.valueLegend}>
+              <li>
+                <strong>0</strong>
+                <span>zero pubblicato dalla fonte</span>
+              </li>
+              <li>
+                <strong>Dato non presente</strong>
+                <span>cella vuota nella fonte</span>
+              </li>
+              <li>
+                <strong>Dato non pubblicato</strong>
+                <span>valore rimosso per protezione, non uno zero</span>
+              </li>
+            </ul>
+
+            {result.rows.length > 0 ? (
+              <div className={`table-scroll ${styles.dataTable}`} role="region" aria-label={`Righe di ${dataset.title}`} tabIndex={0}>
+                <table className="table">
+                  <caption>
+                    Valori pubblici esatti; la tabella può scorrere orizzontalmente
+                    {amounts.size > 0
+                      ? ". Le colonne di importo sono allineate a destra per confrontarle a colpo d’occhio."
+                      : ""}
+                  </caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Riga</th>
+                      {dataset.headers.map((header) => (
+                        <th
+                          scope="col"
+                          key={header}
+                          className={amounts.has(header) ? "num" : undefined}
+                        >
+                          {header}
+                        </th>
+                      ))}
+                      <th scope="col">Fonti puntuali</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.rows.map((row) => (
+                      <tr key={row.id}>
+                        <th scope="row">
+                          <code>{row.id}</code>
+                          <small>sorgente {integer(row.sourceRow)}</small>
+                        </th>
+                        {dataset.headers.map((header) => (
+                          <td
+                            key={header}
+                            className={amounts.has(header) ? `num ${styles.amountCell}` : undefined}
+                          >
+                            <CellValue value={row.cells[header] ?? null} />
+                          </td>
+                        ))}
+                        <td>
+                          {row.sourceUrls.length === 0 ? (
+                            dataset.sourceMetadata.canonicalUrls.length > 0 ? (
+                              <ul className={styles.sourceLinks}>
+                                {dataset.sourceMetadata.canonicalUrls.map((url, index) => (
+                                  <li key={url}>
+                                    <a href={url} target="_blank" rel="noreferrer">
+                                      Fonte del dataset {index + 1} ↗
+                                    </a>
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : (
+                              <span className={styles.missingValue}>
+                                URL puntuale non disponibile per questa riga
+                              </span>
+                            )
+                          ) : (
+                            <ul className={styles.sourceLinks}>
+                              {row.sourceUrls.map((url, index) => (
+                                <li key={url}>
+                                  <a href={url} target="_blank" rel="noreferrer">
+                                    Fonte {index + 1} ↗
+                                  </a>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            {result.query === null ? (
+              <Pagination
+                label="Pagine del dataset"
+                page={currentPage}
+                pageCount={pageCount}
+                summary={
+                  result.rows.length > 0
+                    ? `righe ${integer(firstVisible)}-${integer(lastVisible)} di ${integer(dataset.publicRows)}`
+                    : undefined
+                }
+                hrefForPage={(target) =>
+                  pageHref(dataset.id, result, { offset: offsetFromPage(target, result.limit) })
+                }
+                jump={{
+                  action: `/dati/${dataset.id}`,
+                  pageParam: "pagina",
+                  fields: { limit: String(result.limit) },
+                }}
+              />
+            ) : hasNext && result.pagination.nextCursor ? (
+              <nav className={styles.searchPagination} aria-label="Continua la ricerca">
+                <p>
+                  La ricerca avanza per passaggi sulle righe già esaminate, quindi non ha un
+                  numero di pagine noto in anticipo. Svuota la ricerca per navigare per pagina.
+                </p>
+                <Link
+                  className="btn btn-secondary"
+                  rel="next"
+                  href={pageHref(dataset.id, result, { cursor: result.pagination.nextCursor })}
+                >
+                  {result.rows.length === 0 ? "Continua la ricerca →" : "Passaggio successivo →"}
+                </Link>
+              </nav>
+            ) : null}
+          </section>
+        </>
+      ) : (
+        <section className={`panel ${styles.unavailablePanel}`} aria-labelledby="dataset-no-rows-title">
+          <h2 id="dataset-no-rows-title">Dataset contabilizzato senza righe pubbliche</h2>
+          <p>
+            Questa scheda non è vuota: documenta {integer(dataset.sourceRows)} righe sorgente e il
+            loro stato. Non vengono create righe sostitutive e non si usa zero al posto di un dato
+            non pubblicato.
+          </p>
+          <div>
+            <Link href="/fonti/copertura">Verifica la copertura completa →</Link>
+            <Link href="/fonti/catalogo">Consulta le identità di fonte →</Link>
+          </div>
+        </section>
+      )}
 
       <section className={`notice ${styles.contractNotice}`} aria-labelledby="dataset-contract-title">
         <h2 id="dataset-contract-title">Come leggere questa scheda</h2>
@@ -207,135 +447,6 @@ export default async function IntegratedDatasetPage({ params, searchParams }: Da
           </ul>
         </section>
       ) : null}
-
-      {dataset.queryable ? (
-        <>
-          <section className={`panel ${styles.queryPanel}`} aria-labelledby="dataset-search-title">
-            <div>
-              <h2 id="dataset-search-title" className="panel-title">Cerca nelle celle pubbliche</h2>
-              <p>La ricerca non distingue maiuscole e minuscole e non interroga campi non pubblici.</p>
-            </div>
-            <form action={`/dati/${dataset.id}`} method="get" className={styles.searchForm}>
-              <label htmlFor="dataset-query">Testo da cercare</label>
-              <div>
-                <input
-                  className="input"
-                  id="dataset-query"
-                  name="q"
-                  defaultValue={result.query ?? ""}
-                  maxLength={200}
-                  placeholder="Ente, oggetto, CIG o altro valore"
-                />
-                <input type="hidden" name="limit" value={result.limit} />
-                <button className="btn btn-primary" type="submit">Cerca</button>
-              </div>
-            </form>
-          </section>
-
-          {queryError ? <p className={styles.queryError} role="alert">{queryError}</p> : null}
-
-          <section className={`panel ${styles.tablePanel}`} aria-labelledby="dataset-rows-title">
-            <div className={styles.tableHeading}>
-              <div>
-                <h2 id="dataset-rows-title" className="panel-title">Righe pubbliche</h2>
-                <p>{resultSummary}</p>
-              </div>
-              {result.query ? <span className="tag tag-neutral">Filtro: {result.query}</span> : null}
-            </div>
-
-            {result.rows.length > 0 ? (
-              <div className={`table-scroll ${styles.dataTable}`} role="region" aria-label={`Righe di ${dataset.title}`} tabIndex={0}>
-                <table className="table">
-                  <caption>Valori pubblici esatti; la tabella può scorrere orizzontalmente</caption>
-                  <thead>
-                    <tr>
-                      <th scope="col">Riga</th>
-                      {dataset.headers.map((header) => <th scope="col" key={header}>{header}</th>)}
-                      <th scope="col">Fonti puntuali</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {result.rows.map((row) => (
-                      <tr key={row.id}>
-                        <th scope="row">
-                          <code>{row.id}</code>
-                          <small>sorgente {integer(row.sourceRow)}</small>
-                        </th>
-                        {dataset.headers.map((header) => (
-                          <td key={header}><CellValue value={row.cells[header] ?? null} /></td>
-                        ))}
-                        <td>
-                          {row.sourceUrls.length === 0 ? (
-                            dataset.sourceMetadata.canonicalUrls.length > 0 ? (
-                              <ul className={styles.sourceLinks}>
-                                {dataset.sourceMetadata.canonicalUrls.map((url, index) => (
-                                  <li key={url}>
-                                    <a href={url} target="_blank" rel="noreferrer">
-                                      Fonte del dataset {index + 1} ↗
-                                    </a>
-                                  </li>
-                                ))}
-                              </ul>
-                            ) : (
-                              <span className={styles.missingValue}>
-                                URL puntuale non disponibile per questa riga
-                              </span>
-                            )
-                          ) : (
-                            <ul className={styles.sourceLinks}>
-                              {row.sourceUrls.map((url, index) => (
-                                <li key={url}>
-                                  <a href={url} target="_blank" rel="noreferrer">
-                                    Fonte {index + 1} ↗
-                                  </a>
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : null}
-
-            {(hasPrevious || hasNext) ? (
-              <nav className={styles.pagination} aria-label="Pagine del dataset">
-                {hasPrevious ? (
-                  <Link href={pageHref(dataset.id, result, {
-                    offset: Math.max(0, firstVisible - 1 - result.limit),
-                  })}>
-                    ← Pagina precedente
-                  </Link>
-                ) : <span />}
-                {hasNext && result.pagination.nextCursor ? (
-                  <Link href={pageHref(dataset.id, result, {
-                    cursor: result.pagination.nextCursor,
-                  })}>
-                    {result.query && result.rows.length === 0
-                      ? "Continua la ricerca →"
-                      : "Pagina successiva →"}
-                  </Link>
-                ) : null}
-              </nav>
-            ) : null}
-          </section>
-        </>
-      ) : (
-        <section className={`panel ${styles.unavailablePanel}`} aria-labelledby="dataset-no-rows-title">
-          <h2 id="dataset-no-rows-title">Dataset contabilizzato senza righe pubbliche</h2>
-          <p>
-            Questa scheda non è vuota: documenta {integer(dataset.sourceRows)} righe sorgente e il
-            loro stato. Non vengono create righe sostitutive e non si usa zero al posto di un dato
-            non pubblicato.
-          </p>
-          <div>
-            <Link href="/fonti/copertura">Verifica la copertura completa →</Link>
-            <Link href="/fonti/catalogo">Consulta le identità di fonte →</Link>
-          </div>
-        </section>
-      )}
     </main>
   );
 }

--- a/src/app/dati/dati.module.css
+++ b/src/app/dati/dati.module.css
@@ -32,9 +32,12 @@
 }
 
 .sectionHeading > span {
+  min-width: 0;
   color: var(--color-neutral-600);
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+  text-align: right;
+  text-wrap: balance;
 }
 
 .datasetGrid {
@@ -303,13 +306,30 @@
   margin-top: var(--space-1);
 }
 
-.pagination {
+/* A filtered scan advances by cursor, so it has no page count to show: it
+   gets a plain next step and a sentence saying why the numbers are absent. */
+.searchPagination {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: space-between;
-  gap: var(--space-4);
+  gap: var(--space-3);
   padding: 14px 18px;
   border-top: 1px solid var(--color-neutral-300);
-  font-weight: 700;
+}
+
+.searchPagination p {
+  flex: 1 1 32ch;
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-neutral-600);
+}
+
+/* An amount reads as a quantity, not as prose: same digit width down the
+   column so two rows can be compared without re-reading them. */
+.amountCell {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
 }
 
 .unavailablePanel p {
@@ -365,3 +385,112 @@
     width: 100%;
   }
 }
+
+/* An index for a page that lists seventy-nine sets: without it the only way to
+   reach an area is to scroll past every other one. */
+.domainIndex {
+  padding: 16px 18px;
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.domainIndex h2 {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-heading);
+  font-size: 11px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: var(--color-neutral-700);
+}
+
+.domainIndex ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.domainIndex a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding-inline: var(--space-3);
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.domainIndex a:hover {
+  color: var(--color-text);
+  background: var(--color-neutral-200);
+}
+
+.domainIndex a span {
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The size of a set is the first thing that tells a reader whether it is worth
+   opening, so it gets the weight of a figure rather than a line of metadata. */
+.cardCount {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+}
+
+.cardCount strong {
+  font-family: var(--font-heading);
+  font-size: 24px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.cardCount span {
+  font-size: 12px;
+  color: var(--color-neutral-600);
+}
+
+@media (max-width: 620px) {
+  .domainIndex ul {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .domainIndex li { display: flex; }
+  .domainIndex a { flex: 1; justify-content: space-between; }
+}
+
+/* The reading conventions belong beside the cells they explain, not in a
+   panel the reader has already scrolled past. */
+.valueLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  margin: 0 0 var(--space-3);
+  padding: var(--space-2) 0;
+  border-block: 1px solid var(--color-neutral-200);
+  list-style: none;
+}
+
+.valueLegend li {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  font-size: 12px;
+}
+
+.valueLegend strong {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.valueLegend span { color: var(--color-neutral-600); }

--- a/src/app/dati/page.tsx
+++ b/src/app/dati/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { integer } from "@/lib/format";
+import { INTEGRATED_DOMAIN_ORDER, integratedDomainLabel } from "@/lib/integrated-domains";
 import { getIntegratedDataOverview } from "@/lib/integrated-public-view";
 import styles from "./dati.module.css";
 
@@ -8,24 +9,6 @@ export const metadata: Metadata = {
   title: "Catalogo dei dati integrati",
   description: "Tutti i dataset integrati, con righe, stato di pubblicazione, limiti e fonti.",
 };
-
-const DOMAIN_LABELS: Record<string, string> = {
-  procurement: "Appalti e fornitori",
-  consultancies: "Consulenze e incarichi",
-  personnel: "Personale e organi",
-  operations: "Spese operative",
-  transparency: "Trasparenza",
-  oversight: "Controlli e atti",
-  benchmarks: "Benchmark",
-  evidence: "Segnali ed evidenze",
-  sources: "Indici delle fonti",
-  entities: "Enti",
-  "state-accounts": "Conti dello Stato",
-  projects: "Progetti",
-  "candidate-batches": "Working set contabilizzati",
-};
-
-const DOMAIN_ORDER = Object.keys(DOMAIN_LABELS);
 
 function publicationLabel(publication: string): string {
   if (publication === "rows") return "Righe interrogabili";
@@ -37,10 +20,22 @@ function publicationLabel(publication: string): string {
 export default async function IntegratedDataPage() {
   const overview = await getIntegratedDataOverview();
   const grouped = new Map<string, typeof overview.datasets>();
-  for (const domain of DOMAIN_ORDER) grouped.set(domain, []);
+  for (const domain of INTEGRATED_DOMAIN_ORDER) grouped.set(domain, []);
   for (const dataset of overview.datasets) {
     grouped.set(dataset.domain, [...(grouped.get(dataset.domain) ?? []), dataset]);
   }
+  // Within a domain the largest set is the one most readers are looking for,
+  // so the order is by size and the heading says so; nothing is hidden.
+  const domains = [...grouped.entries()]
+    .filter(([, datasets]) => datasets.length > 0)
+    .map(([domain, datasets]) => ({
+      domain,
+      label: integratedDomainLabel(domain),
+      datasets: [...datasets].sort(
+        (left, right) => right.publicRows - left.publicRows || right.sourceRows - left.sourceRows,
+      ),
+      queryable: datasets.filter((dataset) => dataset.queryable).length,
+    }));
 
   return (
     <main className={`shell page ${styles.page}`}>
@@ -88,45 +83,67 @@ export default async function IntegratedDataPage() {
         </p>
       </div>
 
-      {[...grouped.entries()].map(([domain, datasets]) =>
-        datasets.length > 0 ? (
-          <section className={styles.domainSection} key={domain} aria-labelledby={`domain-${domain}`}>
-            <div className={styles.sectionHeading}>
-              <h2 id={`domain-${domain}`}>{DOMAIN_LABELS[domain] ?? domain}</h2>
-              <span>{integer(datasets.length)} dataset</span>
-            </div>
-            <ul className={styles.datasetGrid}>
-              {datasets.map((dataset) => (
-                <li className={styles.datasetCard} key={dataset.id}>
-                  <div className={styles.cardTopline}>
-                    <span className={`tag ${dataset.queryable ? "tag-accent" : "tag-neutral"}`}>
-                      {publicationLabel(dataset.publication)}
-                    </span>
-                    <span>{integer(dataset.sourceRows)} righe</span>
+      <nav className={styles.domainIndex} aria-labelledby="domain-index-title">
+        <h2 id="domain-index-title">Vai a un ambito</h2>
+        <ul>
+          {domains.map((entry) => (
+            <li key={entry.domain}>
+              <a href={`#domain-${entry.domain}`}>
+                {entry.label}
+                <span>{integer(entry.datasets.length)}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {domains.map((entry) => (
+        <section
+          className={styles.domainSection}
+          key={entry.domain}
+          aria-labelledby={`domain-${entry.domain}`}
+        >
+          <div className={styles.sectionHeading}>
+            <h2 id={`domain-${entry.domain}`}>{entry.label}</h2>
+            <span>
+              {integer(entry.datasets.length)} dataset · {integer(entry.queryable)} con righe
+              interrogabili · in ordine di righe
+            </span>
+          </div>
+          <ul className={styles.datasetGrid}>
+            {entry.datasets.map((dataset) => (
+              <li className={styles.datasetCard} key={dataset.id}>
+                <div className={styles.cardTopline}>
+                  <span className={`tag ${dataset.queryable ? "tag-accent" : "tag-neutral"}`}>
+                    {publicationLabel(dataset.publication)}
+                  </span>
+                </div>
+                <h3>
+                  <Link href={`/dati/${dataset.id}`}>{dataset.title}</Link>
+                </h3>
+                <p className={styles.cardCount}>
+                  <strong>{integer(dataset.sourceRows)}</strong>
+                  <span>righe sorgente</span>
+                </p>
+                <p>{dataset.publicationNote}</p>
+                <dl className={styles.cardMetadata}>
+                  <div>
+                    <dt>Autorità</dt>
+                    <dd>{dataset.authority}</dd>
                   </div>
-                  <h3>
-                    <Link href={`/dati/${dataset.id}`}>{dataset.title}</Link>
-                  </h3>
-                  <p>{dataset.publicationNote}</p>
-                  <dl className={styles.cardMetadata}>
-                    <div>
-                      <dt>Autorità</dt>
-                      <dd>{dataset.authority}</dd>
-                    </div>
-                    <div>
-                      <dt>Fonti puntuali</dt>
-                      <dd>{integer(dataset.rowsWithPublicSource)} righe</dd>
-                    </div>
-                  </dl>
-                  <Link className={styles.cardLink} href={`/dati/${dataset.id}`}>
-                    Apri scheda e limiti →
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ) : null,
-      )}
+                  <div>
+                    <dt>Fonti puntuali</dt>
+                    <dd>{integer(dataset.rowsWithPublicSource)} righe</dd>
+                  </div>
+                </dl>
+                <Link className={styles.cardLink} href={`/dati/${dataset.id}`}>
+                  {dataset.queryable ? "Apri le righe e i limiti →" : "Apri scheda e limiti →"}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
 
       <section className={`panel ${styles.finalLinks}`}>
         <h2 className="panel-title">Verifica la copertura</h2>

--- a/src/app/fonti/catalogo/catalogo.module.css
+++ b/src/app/fonti/catalogo/catalogo.module.css
@@ -97,15 +97,6 @@
   font-style: italic;
 }
 
-.pagination {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: 14px 18px;
-  border-top: 1px solid var(--color-neutral-300);
-  font-weight: 700;
-}
-
 .finalLinks {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/fonti/catalogo/page.tsx
+++ b/src/app/fonti/catalogo/page.tsx
@@ -1,12 +1,15 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import Pagination from "@/components/pagination";
 import { integer } from "@/lib/format";
 import {
   getIntegratedSourceCoverage,
+  INTEGRATED_DEFAULT_LIMIT,
   IntegratedQueryError,
   selectPublicSourceCatalog,
   type PublicSourceResult,
 } from "@/lib/integrated-public-view";
+import { offsetFromPage, pageCountFromTotal, pageFromOffset } from "@/lib/pagination";
 import styles from "./catalogo.module.css";
 
 export const metadata: Metadata = {
@@ -39,6 +42,23 @@ function pageHref(result: PublicSourceResult, offset: number): string {
   return `/fonti/catalogo?${query.toString()}`;
 }
 
+/**
+ * `pagina` is the readable form of `offset` and only fills in when no explicit
+ * offset is given; the selector still validates whatever comes out of it.
+ */
+function requestedOffset(search: Record<string, SearchValue>): SearchValue {
+  if (search.offset !== undefined && search.offset !== "") return search.offset;
+  const page = search.pagina;
+  if (typeof page === "string" && /^\d+$/.test(page) && Number(page) >= 1) {
+    const limit =
+      typeof search.limit === "string" && /^\d+$/.test(search.limit) && Number(search.limit) >= 1
+        ? Number(search.limit)
+        : INTEGRATED_DEFAULT_LIMIT;
+    return String(offsetFromPage(Number(page), limit));
+  }
+  return undefined;
+}
+
 async function safeResult(search: Record<string, SearchValue>) {
   try {
     return {
@@ -46,7 +66,7 @@ async function safeResult(search: Record<string, SearchValue>) {
         q: search.q,
         disposition: search.disposition,
         limit: search.limit,
-        offset: search.offset,
+        offset: requestedOffset(search),
       }),
       queryError: null,
     };
@@ -66,8 +86,6 @@ export default async function PublicSourceCatalogPage({ searchParams }: SourceCa
   ]);
   const firstVisible = result.sources.length === 0 ? 0 : result.offset + 1;
   const lastVisible = result.offset + result.sources.length;
-  const hasPrevious = result.offset > 0;
-  const hasNext = lastVisible < result.matchedSources;
 
   return (
     <main className={`shell page ${styles.page}`}>
@@ -216,18 +234,26 @@ export default async function PublicSourceCatalogPage({ searchParams }: SourceCa
           </div>
         ) : null}
 
-        {(hasPrevious || hasNext) ? (
-          <nav className={styles.pagination} aria-label="Pagine del catalogo fonti">
-            {hasPrevious ? (
-              <Link href={pageHref(result, Math.max(0, result.offset - result.limit))}>
-                ← Pagina precedente
-              </Link>
-            ) : <span />}
-            {hasNext ? (
-              <Link href={pageHref(result, result.offset + result.limit)}>Pagina successiva →</Link>
-            ) : null}
-          </nav>
-        ) : null}
+        <Pagination
+          label="Pagine del catalogo fonti"
+          page={pageFromOffset(result.offset, result.limit)}
+          pageCount={pageCountFromTotal(result.matchedSources, result.limit)}
+          summary={
+            result.sources.length > 0
+              ? `identità ${integer(firstVisible)}-${integer(lastVisible)} di ${integer(result.matchedSources)}`
+              : undefined
+          }
+          hrefForPage={(target) => pageHref(result, offsetFromPage(target, result.limit))}
+          jump={{
+            action: "/fonti/catalogo",
+            pageParam: "pagina",
+            fields: {
+              limit: String(result.limit),
+              ...(result.query ? { q: result.query } : {}),
+              ...(result.disposition ? { disposition: result.disposition } : {}),
+            },
+          }}
+        />
       </section>
 
       <section className={`panel ${styles.finalLinks}`}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,6 +65,8 @@ main td a:not(.btn) {
   text-decoration-thickness: 1px;
   text-underline-offset: .18em;
 }
+main li a:where(.btn),
+nav li a { text-decoration: none; }
 
 /* The shell bounds every band of the page — header, nav, main and footer all
    share one measure so their rules line up vertically. */
@@ -239,6 +241,7 @@ main td a:not(.btn) {
 /* ── primary navigation ─────────────────────────────────────────────────── */
 
 .nav-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-4);
@@ -257,29 +260,51 @@ main td a:not(.btn) {
   padding: 0;
   list-style: none;
 }
-.nav-item { position: relative; flex: none; }
+/* The label and its caret are two controls on one underline: the label goes to
+   the section, the caret opens the list of its pages. */
+.nav-item {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  flex: none;
+  border-bottom: 2px solid transparent;
+}
+.nav-item[data-section-active="true"] { border-bottom-color: var(--color-accent); }
 .nav-item > a {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
   padding: 14px 16px;
   font-size: 14px;
   font-weight: 600;
   white-space: nowrap;
   color: var(--color-neutral-600);
-  border-bottom: 2px solid transparent;
 }
+.nav-item-has-menu > a { padding-right: 6px; }
 .nav-item > a:hover { color: var(--color-text); }
 .nav-item > a[aria-current="page"],
-.nav-item > a[data-section-active="true"] {
-  color: var(--color-text);
-  border-bottom-color: var(--color-accent);
-}
-.nav-item-caret {
+.nav-item > a[data-section-active="true"] { color: var(--color-text); }
+
+/* Hover cannot open anything on a touch screen, so the caret is a button and
+   not a glyph: it is the only way a phone reaches a section's pages. */
+.nav-item-toggle {
+  display: grid;
+  place-items: center;
+  min-width: 30px;
+  padding: 0 8px 0 2px;
   font-size: 10px;
-  color: var(--color-neutral-600);
   line-height: 1;
+  color: var(--color-neutral-600);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
 }
+.nav-item-toggle:hover { color: var(--color-text); }
+.nav-item-toggle > span {
+  display: block;
+  transition: transform 140ms var(--ease-out);
+}
+.nav-item-toggle[aria-expanded="true"] > span { transform: rotate(180deg); }
+.nav-item[data-section-active="true"] .nav-item-toggle { color: var(--color-text); }
 .nav-submenu {
   display: none;
   position: absolute;
@@ -313,7 +338,8 @@ main td a:not(.btn) {
   background: var(--color-neutral-100);
 }
 .nav-item-has-menu:hover .nav-submenu,
-.nav-item-has-menu:focus-within .nav-submenu {
+.nav-item-has-menu:focus-within .nav-submenu,
+.nav-item-has-menu[data-open="true"] .nav-submenu {
   display: block;
 }
 
@@ -584,14 +610,35 @@ main { display: block; }
 
 /* ── responsive ─────────────────────────────────────────────────────────── */
 
-@media (max-width: 1000px) {
-  :root { --gutter: 20px; }
-  .header-search { width: 260px; }
+/* The nine sections need about 1250px to sit flat. Below that the row scrolls
+   inside itself rather than pushing the page sideways, and the note that
+   competes with it for the same line steps aside. */
+@media (max-width: 1260px) {
+  .nav-note { display: none; }
   .primary-nav {
     overflow-x: auto;
     scrollbar-width: none;
   }
   .primary-nav::-webkit-scrollbar { display: none; }
+  /* A scrolling row cannot show a panel that hangs out of it. Anchoring the
+     panel to the row instead of to its own item puts it outside that scrolling
+     box, so it is neither clipped by it nor placed against the document. */
+  .nav-item-has-menu[data-open="true"] { position: static; }
+  .nav-item-has-menu[data-open="true"] .nav-submenu {
+    top: 100%;
+    left: 0;
+    right: 0;
+    width: auto;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 1000px) {
+  :root { --gutter: 20px; }
+  .header-search { width: 260px; }
+  /* Below the desktop break the caret is the primary way in, so it gets a
+     full-height target instead of the hairline it needs beside a pointer. */
+  .nav-item-toggle { min-width: 40px; padding-inline: 8px; }
 }
 
 /* Keep the header's fixed actions inside the viewport before the full
@@ -640,6 +687,7 @@ main { display: block; }
   .brand-text strong { font-size: 17px; }
   .header-action { padding-inline: 14px; }
   .primary-nav a { padding: 12px 12px; font-size: 13px; }
+  .nav-item-has-menu > a { padding-right: 4px; }
   .primary-nav { scrollbar-width: thin; }
   .primary-nav::-webkit-scrollbar { display: block; height: 3px; }
   .primary-nav::-webkit-scrollbar-thumb { background: var(--color-neutral-400); }

--- a/src/app/incarichi/incarichi.module.css
+++ b/src/app/incarichi/incarichi.module.css
@@ -219,7 +219,7 @@
 
 .compositionRow {
   display: grid;
-  grid-template-columns: 150px minmax(120px, 1fr) max-content;
+  grid-template-columns: 150px minmax(120px, 1fr) minmax(0, max-content);
   gap: var(--space-3);
   align-items: center;
 }
@@ -239,10 +239,16 @@
 }
 
 .compositionRow small {
+  min-width: 0;
   color: var(--color-neutral-600);
   font-size: 11px;
   text-align: right;
-  white-space: nowrap;
+}
+
+/* Between the tablet width and the stacked layout the caption wraps instead of
+   holding the row open wider than the viewport. */
+@media (min-width: 621px) and (max-width: 900px) {
+  .compositionRow { grid-template-columns: 130px minmax(100px, 1fr) minmax(0, 22ch); }
 }
 
 .sourceGrid {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Archivo } from "next/font/google";
 import { GoogleAnalytics } from "@/components/google-analytics";
 import { Navigation } from "@/components/navigation";
+import { SectionNav } from "@/components/section-nav";
 import { SiteFooter } from "@/components/site-footer";
 import { mefIrpefSourceMeta } from "@/lib/data/mef-irpef-source";
 import { siopeMunicipalSnapshot } from "@/lib/siope-snapshot";
@@ -54,6 +55,7 @@ export default function RootLayout({
         <a className="skip-link" href="#contenuto-principale">Salta al contenuto principale</a>
         <Navigation />
         <div id="contenuto-principale" tabIndex={-1}>{children}</div>
+        <SectionNav />
         <SiteFooter latestTerritorialCheckLabel={latestTerritorialCheckLabel} />
       </body>
     </html>

--- a/src/app/spese/consulenze/consulenze.module.css
+++ b/src/app/spese/consulenze/consulenze.module.css
@@ -120,27 +120,6 @@
   font-weight: 400;
 }
 
-.pagination {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: var(--space-3);
-  margin-top: var(--space-4);
-  font-size: 13px;
-}
-
-.pagination > :last-child {
-  justify-self: end;
-}
-
-.pagination a {
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  color: var(--color-accent-700);
-  font-weight: 700;
-}
-
 .sourceGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -215,13 +194,4 @@
     border-top: 1px solid var(--color-neutral-300);
   }
 
-  .pagination {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .pagination > span:nth-child(2) {
-    grid-column: 1 / -1;
-    grid-row: 1;
-    justify-self: center;
-  }
-}
+    }

--- a/src/app/spese/consulenze/page.tsx
+++ b/src/app/spese/consulenze/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import Pagination from "@/components/pagination";
 import { integer } from "@/lib/format";
+import { offsetFromPage, pageCountFromTotal, pageFromOffset } from "@/lib/pagination";
 import {
   formatRgsEuroCents,
   queryRgsConsulting,
@@ -60,8 +61,6 @@ export default async function RgsConsultingPage({ searchParams }: ConsultingPage
   const { result, error } = safeQuery(params);
   const firstVisible = result.rows.length === 0 ? 0 : result.pagination.offset + 1;
   const lastVisible = result.pagination.offset + result.pagination.returned;
-  const previousOffset = Math.max(0, result.pagination.offset - result.pagination.limit);
-  const nextOffset = result.pagination.offset + result.pagination.limit;
 
   return (
     <main className={`shell page ${styles.page}`}>
@@ -202,17 +201,19 @@ export default async function RgsConsultingPage({ searchParams }: ConsultingPage
             </table>
           </div>
         ) : null}
-        {result.pagination.total > result.pagination.limit ? (
-          <nav className={styles.pagination} aria-label="Pagine delle righe RGS consulenze">
-            {result.pagination.offset > 0 ? (
-              <Link href={paginationHref(result, previousOffset)}>← Pagina precedente</Link>
-            ) : <span />}
-            <span>Pagina {integer(Math.floor(result.pagination.offset / result.pagination.limit) + 1)}</span>
-            {nextOffset < result.pagination.total ? (
-              <Link href={paginationHref(result, nextOffset)}>Pagina successiva →</Link>
-            ) : <span />}
-          </nav>
-        ) : null}
+        <Pagination
+          label="Pagine delle righe RGS consulenze"
+          page={pageFromOffset(result.pagination.offset, result.pagination.limit)}
+          pageCount={pageCountFromTotal(result.pagination.total, result.pagination.limit)}
+          summary={
+            result.rows.length > 0
+              ? `righe ${integer(firstVisible)}-${integer(lastVisible)} di ${integer(result.pagination.total)}`
+              : undefined
+          }
+          hrefForPage={(target) =>
+            paginationHref(result, offsetFromPage(target, result.pagination.limit))
+          }
+        />
       </section>
 
       <section className={`panel ${styles.sourcePanel}`} aria-labelledby="consulting-sources-title">

--- a/src/app/spese/territoriale/page.tsx
+++ b/src/app/spese/territoriale/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import Pagination from "@/components/pagination";
 import { integer } from "@/lib/format";
+import { offsetFromPage, pageCountFromTotal, pageFromOffset } from "@/lib/pagination";
 import {
   formatRgsTerritorialValue,
   queryRgsTerritorial,
+  RGS_TERRITORIAL_DEFAULT_LIMIT,
   rgsTerritorialMeasures,
   RgsTerritorialQueryError,
   rgsTerritorialSnapshot,
@@ -18,6 +20,7 @@ type TerritorialPageProps = {
     misura?: SearchValue;
     limit?: SearchValue;
     offset?: SearchValue;
+    pagina?: SearchValue;
   }>;
 };
 
@@ -47,6 +50,20 @@ function paginationHref(
   return `/spese/territoriale?${query.toString()}`;
 }
 
+/** `pagina` is the readable form of `offset`; an explicit offset still wins. */
+function requestedOffset(params: Awaited<TerritorialPageProps["searchParams"]>): SearchValue {
+  if (params.offset !== undefined && params.offset !== "") return params.offset;
+  const page = params.pagina;
+  if (typeof page === "string" && /^\d+$/.test(page) && Number(page) >= 1) {
+    const limit =
+      typeof params.limit === "string" && /^\d+$/.test(params.limit) && Number(params.limit) >= 1
+        ? Number(params.limit)
+        : RGS_TERRITORIAL_DEFAULT_LIMIT;
+    return String(offsetFromPage(Number(page), limit));
+  }
+  return undefined;
+}
+
 function safeQuery(params: Awaited<TerritorialPageProps["searchParams"]>) {
   try {
     return {
@@ -55,7 +72,7 @@ function safeQuery(params: Awaited<TerritorialPageProps["searchParams"]>) {
         territory: params.territorio,
         measure: params.misura,
         limit: params.limit,
-        offset: params.offset,
+        offset: requestedOffset(params),
       }),
       error: null,
     };
@@ -70,8 +87,6 @@ export default async function RgsTerritorialPage({ searchParams }: TerritorialPa
   const { result, error } = safeQuery(params);
   const firstVisible = result.rows.length === 0 ? 0 : result.pagination.offset + 1;
   const lastVisible = result.pagination.offset + result.pagination.returned;
-  const previousOffset = Math.max(0, result.pagination.offset - result.pagination.limit);
-  const nextOffset = result.pagination.offset + result.pagination.limit;
   const reconciliation = rgsTerritorialSnapshot.reconciliation;
 
   return (
@@ -216,17 +231,29 @@ export default async function RgsTerritorialPage({ searchParams }: TerritorialPa
             </table>
           </div>
         ) : null}
-        {result.pagination.total > result.pagination.limit ? (
-          <nav className={styles.pagination} aria-label="Pagine della distribuzione territoriale RGS">
-            {result.pagination.offset > 0 ? (
-              <Link href={paginationHref(result, previousOffset)}>← Pagina precedente</Link>
-            ) : <span />}
-            <span>Pagina {integer(Math.floor(result.pagination.offset / result.pagination.limit) + 1)}</span>
-            {nextOffset < result.pagination.total ? (
-              <Link href={paginationHref(result, nextOffset)}>Pagina successiva →</Link>
-            ) : <span />}
-          </nav>
-        ) : null}
+        <Pagination
+          label="Pagine della distribuzione territoriale RGS"
+          page={pageFromOffset(result.pagination.offset, result.pagination.limit)}
+          pageCount={pageCountFromTotal(result.pagination.total, result.pagination.limit)}
+          summary={
+            result.rows.length > 0
+              ? `righe ${integer(firstVisible)}-${integer(lastVisible)} di ${integer(result.pagination.total)}`
+              : undefined
+          }
+          hrefForPage={(target) =>
+            paginationHref(result, offsetFromPage(target, result.pagination.limit))
+          }
+          jump={{
+            action: "/spese/territoriale",
+            pageParam: "pagina",
+            fields: {
+              livello: result.query.level,
+              misura: result.query.measure,
+              limit: String(result.pagination.limit),
+              ...(result.query.territory ? { territorio: result.query.territory } : {}),
+            },
+          }}
+        />
       </section>
 
       <section className={`panel ${styles.reconciliationPanel}`} aria-labelledby="territorial-reconciliation-title">

--- a/src/app/spese/territoriale/territoriale.module.css
+++ b/src/app/spese/territoriale/territoriale.module.css
@@ -111,27 +111,6 @@
   font-weight: 400;
 }
 
-.pagination {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: var(--space-3);
-  margin-top: var(--space-4);
-  font-size: 13px;
-}
-
-.pagination > :last-child {
-  justify-self: end;
-}
-
-.pagination a {
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  color: var(--color-accent-700);
-  font-weight: 700;
-}
-
 .debtNotice {
   display: grid;
   gap: var(--space-2);
@@ -243,13 +222,4 @@
     border-bottom: 0;
   }
 
-  .pagination {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .pagination > span:nth-child(2) {
-    grid-column: 1 / -1;
-    grid-row: 1;
-    justify-self: center;
-  }
-}
+    }

--- a/src/app/territori/confronto/confronto.module.css
+++ b/src/app/territori/confronto/confronto.module.css
@@ -107,30 +107,6 @@
   font-size: 12px;
 }
 
-.pagination {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: var(--space-3);
-  margin-top: var(--space-4);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--color-neutral-200);
-}
-
-.pagination > :first-child {
-  justify-self: start;
-}
-
-.pagination > :last-child {
-  justify-self: end;
-}
-
-.pagination > span {
-  color: var(--color-neutral-600);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-
 .emptyState {
   display: flex;
   align-items: center;
@@ -208,23 +184,6 @@
   .emptyState {
     align-items: flex-start;
     flex-direction: column;
-  }
-
-  .pagination {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .pagination > span:nth-child(2) {
-    grid-column: 1 / -1;
-    grid-row: 1;
-    justify-self: center;
-  }
-
-  .pagination > :first-child,
-  .pagination > :last-child {
-    grid-row: 2;
-    width: 100%;
-    min-height: 44px;
   }
 
   .provenance dl {

--- a/src/app/territori/confronto/page.tsx
+++ b/src/app/territori/confronto/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Form from "next/form";
 import Link from "next/link";
+import Pagination from "@/components/pagination";
 import { exactEuro, integer, longDate } from "@/lib/format";
 import { municipalityName } from "@/lib/municipality-name";
 import { openCivitasSnapshot } from "@/lib/opencivitas-snapshot";
@@ -328,33 +329,26 @@ export default async function MunicipalComparisonPage({
           servizi rispetto ai Comuni della stessa fascia di popolazione.
         </p>
 
-        {pageCount > 1 ? (
-          <nav className={styles.pagination} aria-label="Pagine dei risultati">
-            {page > 1 ? (
-              <Link
-                className="btn btn-secondary"
-                href={pageUrl({ query, region, sort, page: page - 1 })}
-              >
-                Pagina precedente
-              </Link>
-            ) : (
-              <span />
-            )}
-            <span>
-              Pagina {integer(page)} di {integer(pageCount)}
-            </span>
-            {page < pageCount ? (
-              <Link
-                className="btn btn-secondary"
-                href={pageUrl({ query, region, sort, page: page + 1 })}
-              >
-                Pagina successiva
-              </Link>
-            ) : (
-              <span />
-            )}
-          </nav>
-        ) : null}
+        <Pagination
+          label="Pagine dei risultati"
+          page={page}
+          pageCount={pageCount}
+          summary={
+            filtered.length > 0
+              ? `Comuni ${integer(firstResult)}-${integer(lastResult)} di ${integer(filtered.length)}`
+              : undefined
+          }
+          hrefForPage={(target) => pageUrl({ query, region, sort, page: target })}
+          jump={{
+            action: "/territori/confronto",
+            pageParam: "pagina",
+            fields: {
+              ...(query ? { comune: query } : {}),
+              ...(region ? { regione: region } : {}),
+              ...(sort !== "per-abitante" ? { ordine: sort } : {}),
+            },
+          }}
+        />
       </section>
 
       <section className="panel" aria-labelledby="source-title">

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { HeaderSearch } from "@/components/header-search";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { GithubIcon } from "@hugeicons/core-free-icons";
@@ -18,6 +18,18 @@ export function Navigation() {
   const pathname = usePathname();
   const navigationRef = useRef<HTMLElement>(null);
   const activeLinkRef = useRef<HTMLAnchorElement>(null);
+  /**
+   * Which submenu a tap has opened. Hover alone cannot reach these on a touch
+   * screen, so the caret is a real control and this is the state it drives.
+   *
+   * The path it was opened on travels with it: a completed navigation has
+   * already answered the menu, so the open state simply stops applying rather
+   * than being cleared from an effect after the new page has painted.
+   */
+  const [openMenu, setOpenMenu] = useState<{ href: string; pathname: string } | null>(null);
+  const openHref = openMenu?.pathname === pathname ? openMenu.href : null;
+
+  const closeMenu = useCallback(() => setOpenMenu(null), []);
 
   useEffect(() => {
     const navigation = navigationRef.current;
@@ -29,6 +41,22 @@ export function Navigation() {
       activeLink.scrollIntoView({ block: "nearest", inline: "center" });
     }
   }, [pathname]);
+
+  useEffect(() => {
+    if (openHref === null) return;
+    function dismissOutside(event: PointerEvent) {
+      if (!navigationRef.current?.contains(event.target as Node)) closeMenu();
+    }
+    function dismissOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") closeMenu();
+    }
+    document.addEventListener("pointerdown", dismissOutside);
+    document.addEventListener("keydown", dismissOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", dismissOutside);
+      document.removeEventListener("keydown", dismissOnEscape);
+    };
+  }, [openHref, closeMenu]);
 
   return (
     <header className="site-header">
@@ -75,48 +103,61 @@ export function Navigation() {
             {PRIMARY_NAV.map((item) => {
               const active = isNavSectionActive(pathname, item);
               const hasChildren = Boolean(item.children?.length);
+              const menuId = `nav-menu-${item.href.replace(/\W+/g, "-")}`;
+              const open = openHref === item.href;
               return (
                 <li
                   key={item.href}
                   className={hasChildren ? "nav-item nav-item-has-menu" : "nav-item"}
+                  data-section-active={active ? "true" : undefined}
+                  data-open={open ? "true" : undefined}
                 >
                   <Link
                     href={item.href}
                     aria-current={pathname === item.href ? "page" : undefined}
-                    aria-haspopup={hasChildren ? "true" : undefined}
                     data-section-active={active ? "true" : undefined}
                     ref={active ? activeLinkRef : undefined}
                   >
                     {item.label}
-                    {hasChildren ? (
-                      <span className="nav-item-caret" aria-hidden="true">
-                        ▾
-                      </span>
-                    ) : null}
                   </Link>
                   {hasChildren && item.children ? (
-                    <div
-                      className="nav-submenu"
-                      role="region"
-                      aria-label={`Pagine in ${item.label}`}
-                    >
-                      <ul>
-                        {item.children.map((child) => (
-                          <li key={child.href}>
-                            <Link
-                              href={child.href}
-                              aria-current={
-                                isNavChildActive(pathname, child.href, item.children!)
-                                  ? "page"
-                                  : undefined
-                              }
-                            >
-                              {child.label}
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
+                    <>
+                      <button
+                        type="button"
+                        className="nav-item-toggle"
+                        aria-expanded={open}
+                        aria-controls={menuId}
+                        aria-label={`${open ? "Chiudi" : "Apri"} le pagine in ${item.label}`}
+                        onClick={() =>
+                          setOpenMenu(open ? null : { href: item.href, pathname })
+                        }
+                      >
+                        <span aria-hidden="true">▾</span>
+                      </button>
+                      <div
+                        className="nav-submenu"
+                        id={menuId}
+                        role="region"
+                        aria-label={`Pagine in ${item.label}`}
+                      >
+                        <ul>
+                          {item.children.map((child) => (
+                            <li key={child.href}>
+                              <Link
+                                href={child.href}
+                                aria-current={
+                                  isNavChildActive(pathname, child.href, item.children!)
+                                    ? "page"
+                                    : undefined
+                                }
+                              >
+                                {child.label}
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </>
                   ) : null}
                 </li>
               );

--- a/src/components/pagination.module.css
+++ b/src/components/pagination.module.css
@@ -1,0 +1,157 @@
+/*
+ * Shared pagination.
+ *
+ * Every paginated list in the registry uses this one control, so a reader
+ * learns the shape once: where they are, how far the list goes, and every
+ * destination in reach. Numbers are links, not decoration, and the row wraps
+ * inside its panel instead of pushing the page sideways.
+ */
+
+.pagination {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-3);
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-neutral-600);
+}
+
+.summary strong {
+  font-family: var(--font-heading);
+  font-size: 13px;
+  font-weight: var(--font-heading-weight);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.pages {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* The numbers stay a single unbroken strip so their order reads as a range. */
+.page,
+.step { text-decoration: none; }
+
+.page {
+  display: grid;
+  place-items: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding-inline: 10px;
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-neutral-700);
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  transition: color 140ms var(--ease-out), background-color 140ms var(--ease-out);
+}
+
+.page:hover {
+  color: var(--color-text);
+  background: var(--color-neutral-200);
+}
+
+.page[aria-current="page"] {
+  color: var(--color-raised);
+  background: var(--color-accent-700);
+  border-color: var(--color-accent-700);
+}
+
+.page[aria-current="page"]:hover {
+  color: var(--color-raised);
+  background: var(--color-accent-800);
+}
+
+.stepLabel {
+  display: inline;
+}
+
+.step {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding-inline: var(--space-3);
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.step:hover {
+  color: var(--color-text);
+  background: var(--color-neutral-200);
+}
+
+/* A disabled end of the range keeps its slot so the row does not shift when
+   the reader moves between the first and second page. */
+.step[data-disabled="true"] {
+  color: var(--color-neutral-500);
+  border-color: var(--color-neutral-300);
+}
+
+.gap {
+  min-width: 22px;
+  color: var(--color-neutral-500);
+  text-align: center;
+  font-weight: 700;
+  user-select: none;
+}
+
+.jump {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-200);
+  font-size: 12px;
+  color: var(--color-neutral-700);
+}
+
+.jump label {
+  font-weight: 700;
+  color: var(--color-neutral-700);
+}
+
+.jump input {
+  /* Wide enough for the largest page number plus the browser's own spinner. */
+  width: 11ch;
+  font-variant-numeric: tabular-nums;
+}
+
+.jumpRange {
+  color: var(--color-neutral-600);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Below the tablet break the far anchors carry the reader to the ends of the
+   list and the near neighbours are what get dropped, not the reverse. */
+@media (max-width: 620px) {
+  .pagination { padding: 14px; }
+  .pageItem[data-distance="2"] { display: none; }
+  .page { min-width: 40px; padding-inline: 6px; }
+}
+
+@media (max-width: 420px) {
+  .stepLabel { display: none; }
+  .step { padding-inline: var(--space-2); }
+  .jump { width: 100%; }
+  .jump button { flex: 1; }
+}

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link";
+import { integer } from "@/lib/format";
+import { paginationWindow } from "@/lib/pagination";
+import styles from "./pagination.module.css";
+
+export type PaginationProps = {
+  /** Accessible name of the navigation landmark, e.g. "Pagine del dataset". */
+  label: string;
+  /** 1-based page currently on screen. */
+  page: number;
+  /** Total number of pages; the control renders nothing below two. */
+  pageCount: number;
+  /** Href for a given page number. */
+  hrefForPage: (page: number) => string;
+  /** What the visible slice covers, e.g. "righe 51-100 di 159.493". */
+  summary?: string;
+  /**
+   * Direct jump for lists too long to enumerate. The form posts a page number
+   * as `pageParam`; `fields` carries the filters that must survive the jump.
+   */
+  jump?: {
+    action: string;
+    pageParam: string;
+    fields?: Readonly<Record<string, string>>;
+  };
+};
+
+/** Beyond this many pages the numbered links cannot reach the middle alone. */
+const JUMP_THRESHOLD = 12;
+
+export default function Pagination({
+  label,
+  page,
+  pageCount,
+  hrefForPage,
+  summary,
+  jump,
+}: PaginationProps) {
+  if (pageCount <= 1) return null;
+  const current = Math.min(Math.max(Math.trunc(page), 1), pageCount);
+  const steps = paginationWindow(current, pageCount);
+  const showJump = Boolean(jump) && pageCount > JUMP_THRESHOLD;
+
+  return (
+    <nav className={styles.pagination} aria-label={label}>
+      <p className={styles.summary}>
+        <strong>
+          Pagina {integer(current)} di {integer(pageCount)}
+        </strong>
+        {summary ? <span>{summary}</span> : null}
+      </p>
+
+      <ul className={styles.pages}>
+        <li>
+          {current > 1 ? (
+            <Link
+              className={styles.step}
+              rel="prev"
+              href={hrefForPage(current - 1)}
+              aria-label="Pagina precedente"
+            >
+              <span aria-hidden="true">←</span>
+              <span className={styles.stepLabel}>Precedente</span>
+            </Link>
+          ) : (
+            <span className={styles.step} aria-hidden="true" data-disabled="true">
+              <span>←</span>
+              <span className={styles.stepLabel}>Precedente</span>
+            </span>
+          )}
+        </li>
+
+        {steps.map((step, index) =>
+          step === "gap" ? (
+            <li key={`gap-${index}`} className={styles.gap} aria-hidden="true">
+              …
+            </li>
+          ) : (
+            <li
+              key={step}
+              className={styles.pageItem}
+              data-distance={Math.min(Math.abs(step - current), 3)}
+            >
+              <Link
+                className={styles.page}
+                href={hrefForPage(step)}
+                aria-current={step === current ? "page" : undefined}
+                aria-label={`Pagina ${integer(step)}`}
+              >
+                {integer(step)}
+              </Link>
+            </li>
+          ),
+        )}
+
+        <li>
+          {current < pageCount ? (
+            <Link
+              className={styles.step}
+              rel="next"
+              href={hrefForPage(current + 1)}
+              aria-label="Pagina successiva"
+            >
+              <span className={styles.stepLabel}>Successiva</span>
+              <span aria-hidden="true">→</span>
+            </Link>
+          ) : (
+            <span className={styles.step} aria-hidden="true" data-disabled="true">
+              <span className={styles.stepLabel}>Successiva</span>
+              <span>→</span>
+            </span>
+          )}
+        </li>
+      </ul>
+
+      {showJump && jump ? (
+        <form className={styles.jump} action={jump.action} method="get">
+          {Object.entries(jump.fields ?? {}).map(([name, value]) => (
+            <input key={name} type="hidden" name={name} value={value} />
+          ))}
+          <label htmlFor={`${jump.pageParam}-jump`}>Vai alla pagina</label>
+          <input
+            className="input"
+            id={`${jump.pageParam}-jump`}
+            name={jump.pageParam}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={pageCount}
+            step={1}
+            defaultValue={current}
+            aria-describedby={`${jump.pageParam}-jump-range`}
+          />
+          <span id={`${jump.pageParam}-jump-range`} className={styles.jumpRange}>
+            da 1 a {integer(pageCount)}
+          </span>
+          <button className="btn btn-secondary" type="submit">
+            Vai
+          </button>
+        </form>
+      ) : null}
+    </nav>
+  );
+}

--- a/src/components/section-nav.module.css
+++ b/src/components/section-nav.module.css
@@ -1,0 +1,94 @@
+/*
+ * End-of-page section navigation.
+ *
+ * A band of flat links, not a second menu: it repeats the section the reader
+ * is already in so the next page is one tap away, and it marks the current
+ * page as a destination they have already reached rather than a link back to
+ * where they are.
+ */
+
+.sectionNav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-8);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.title {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: var(--color-neutral-600);
+}
+
+.title strong {
+  font-family: var(--font-heading);
+  font-weight: var(--font-heading-weight);
+  color: var(--color-text);
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.link,
+.current {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding-inline: var(--space-3);
+  border: 1px solid var(--color-neutral-400);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.link {
+  color: var(--color-text);
+  background: var(--color-raised);
+  transition: background-color 140ms var(--ease-out), border-color 140ms var(--ease-out);
+}
+
+.link:hover {
+  color: var(--color-text);
+  background: var(--color-neutral-200);
+  border-color: var(--color-neutral-500);
+}
+
+.current {
+  color: var(--color-neutral-700);
+  background: var(--color-neutral-100);
+  border-color: var(--color-neutral-300);
+  cursor: default;
+}
+
+.current small {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  color: var(--color-accent-700);
+}
+
+@media (max-width: 620px) {
+  .links {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .links li { display: flex; }
+
+  .link,
+  .current {
+    flex: 1;
+    justify-content: space-between;
+  }
+}

--- a/src/components/section-nav.tsx
+++ b/src/components/section-nav.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { activeNavSection, isNavChildActive } from "@/lib/site-navigation";
+import styles from "./section-nav.module.css";
+
+/**
+ * The other pages of the section the reader is in, at the end of the page.
+ *
+ * The header dropdowns are the way in from anywhere; this is the way onward
+ * once a page has been read, and it is the only one that needs no hover, so a
+ * phone reaches every page of a section without going back to the menu.
+ */
+export function SectionNav() {
+  const pathname = usePathname();
+  const section = activeNavSection(pathname);
+  const pages = section?.children ?? [];
+  if (pages.length < 2) return null;
+
+  return (
+    <nav
+      className={`shell ${styles.sectionNav}`}
+      aria-label={`Altre pagine in ${section!.label}`}
+    >
+      <p className={styles.title}>
+        Continua in <strong>{section!.label}</strong>
+      </p>
+      <ul className={styles.links}>
+        {pages.map((page) => {
+          const current = isNavChildActive(pathname, page.href, pages);
+          return (
+            <li key={page.href}>
+              {current ? (
+                <span className={styles.current} aria-current="page">
+                  {page.label}
+                  <small>sei qui</small>
+                </span>
+              ) : (
+                <Link className={styles.link} href={page.href}>
+                  {page.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/lib/integrated-domains.ts
+++ b/src/lib/integrated-domains.ts
@@ -1,0 +1,32 @@
+/**
+ * Italian names for the integrated catalogue's domains.
+ *
+ * The catalogue stores domains as English slugs. They are an internal key, not
+ * a label: every public surface reads them from here so a reader never meets a
+ * raw `appointments` or `participations` in the middle of an Italian page.
+ */
+
+export const INTEGRATED_DOMAIN_LABELS: Readonly<Record<string, string>> = {
+  procurement: "Appalti e fornitori",
+  consultancies: "Consulenze e incarichi",
+  appointments: "Incarichi nominativi",
+  personnel: "Personale e organi",
+  operations: "Spese operative",
+  transparency: "Trasparenza",
+  oversight: "Controlli e atti",
+  benchmarks: "Benchmark",
+  evidence: "Segnali ed evidenze",
+  sources: "Indici delle fonti",
+  entities: "Enti",
+  participations: "Partecipazioni pubbliche",
+  "state-accounts": "Conti dello Stato",
+  projects: "Progetti",
+  "candidate-batches": "Working set contabilizzati",
+};
+
+/** Reading order of the domains on the catalogue page. */
+export const INTEGRATED_DOMAIN_ORDER: readonly string[] = Object.keys(INTEGRATED_DOMAIN_LABELS);
+
+export function integratedDomainLabel(domain: string): string {
+  return INTEGRATED_DOMAIN_LABELS[domain] ?? domain;
+}

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,59 @@
+/**
+ * Page arithmetic for the shared pagination control.
+ *
+ * The public views paginate by offset, so the page number is derived rather
+ * than stored: it is always `offset / limit + 1`. Keeping the arithmetic here
+ * means a page and its API route can never disagree on which page a URL is.
+ */
+
+export type PaginationStep = number | "gap";
+
+/** Pages kept on either side of the current one before the list is elided. */
+export const PAGINATION_RADIUS = 2;
+
+export function pageCountFromTotal(total: number, limit: number): number {
+  if (!Number.isFinite(total) || !Number.isFinite(limit) || limit <= 0 || total <= 0) return 0;
+  return Math.ceil(total / limit);
+}
+
+export function pageFromOffset(offset: number, limit: number): number {
+  if (!Number.isFinite(offset) || !Number.isFinite(limit) || limit <= 0) return 1;
+  return Math.floor(Math.max(0, offset) / limit) + 1;
+}
+
+export function offsetFromPage(page: number, limit: number): number {
+  if (!Number.isFinite(page) || !Number.isFinite(limit) || limit <= 0) return 0;
+  return Math.max(0, Math.trunc(page) - 1) * limit;
+}
+
+/**
+ * The page numbers to render, with `"gap"` where the run is elided.
+ *
+ * A gap never stands in for a single page: eliding one number to draw an
+ * ellipsis of the same width costs the reader a destination and saves nothing.
+ */
+export function paginationWindow(
+  page: number,
+  pageCount: number,
+  radius = PAGINATION_RADIUS,
+): readonly PaginationStep[] {
+  if (!Number.isFinite(pageCount) || pageCount <= 1) return [];
+  const current = Math.min(Math.max(Math.trunc(page), 1), pageCount);
+  const wanted = new Set<number>([1, pageCount]);
+  for (let offset = -radius; offset <= radius; offset += 1) {
+    const candidate = current + offset;
+    if (candidate >= 1 && candidate <= pageCount) wanted.add(candidate);
+  }
+  const numbers = [...wanted].sort((left, right) => left - right);
+
+  const steps: PaginationStep[] = [];
+  let previous = 0;
+  for (const number of numbers) {
+    const missing = number - previous - 1;
+    if (previous !== 0 && missing === 1) steps.push(previous + 1);
+    else if (missing > 1) steps.push("gap");
+    steps.push(number);
+    previous = number;
+  }
+  return steps;
+}

--- a/src/lib/rgs-territorial-snapshot.ts
+++ b/src/lib/rgs-territorial-snapshot.ts
@@ -159,12 +159,15 @@ export function getRgsTerritorialSourceHealth() {
   };
 }
 
+/** Rows per page when the caller does not ask for a size. */
+export const RGS_TERRITORIAL_DEFAULT_LIMIT = 25;
+
 export function queryRgsTerritorial(query: RgsTerritorialQuery = {}) {
   const level = levelParam(query.level);
   const requestedTerritory = textParam(query.territory, "territorio");
   const measureId = measureParam(query.measure);
   const measureIndex = MEASURE_INDEX[measureId];
-  const limit = integerParam(query.limit, "limit", 25, 1, 100);
+  const limit = integerParam(query.limit, "limit", RGS_TERRITORIAL_DEFAULT_LIMIT, 1, 100);
   const offset = integerParam(query.offset, "offset", 0, 0, 100_000);
   const territories = rgsTerritorialSnapshot.dimensions.territories;
   const selectedTerritory = requestedTerritory

--- a/tests/integrated-source-public-view.test.mjs
+++ b/tests/integrated-source-public-view.test.mjs
@@ -529,3 +529,39 @@ test("the server boundary and pages preserve missing, zero and async Next route 
   assert.doesNotMatch(publicSurface, /\/Users\//);
   assert.doesNotMatch(publicSurface, /\.tar\.gz/i);
 });
+
+test("the dataset sheet puts the rows before the panels that describe them", async () => {
+  const detail = await readFile(
+    new URL("../src/app/dati/[dataset]/page.tsx", import.meta.url),
+    "utf8",
+  );
+  const rows = detail.indexOf('id="dataset-rows-title"');
+  const contract = detail.indexOf('id="dataset-contract-title"');
+  const provenance = detail.indexOf('id="dataset-source-title"');
+  const caveats = detail.indexOf('id="dataset-caveats-title"');
+  for (const [name, index] of Object.entries({ rows, contract, provenance, caveats })) {
+    assert.ok(index > 0, `sezione assente: ${name}`);
+  }
+  assert.ok(rows < contract, "le righe devono precedere la nota di lettura");
+  assert.ok(contract < provenance, "la nota di lettura deve precedere la provenienza");
+  assert.ok(provenance < caveats, "la provenienza deve precedere i limiti");
+  // The three value conventions travel with the cells they explain.
+  assert.match(detail, /valueLegend/);
+  // An amount column is realigned only when no value on the page contradicts
+  // the header, so a text column is never turned into a number column.
+  assert.match(detail, /const AMOUNT_HEADER =/);
+  assert.match(detail, /\.every\(\(value\) => AMOUNT_VALUE\.test\(value\.trim\(\)\)\)/);
+});
+
+test("the integrated catalogue indexes its domains and names them in Italian", async () => {
+  const [catalogPage, css] = await Promise.all([
+    readFile(new URL("../src/app/dati/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/dati/dati.module.css", import.meta.url), "utf8"),
+  ]);
+  assert.match(catalogPage, /INTEGRATED_DOMAIN_ORDER/);
+  assert.match(catalogPage, /integratedDomainLabel/);
+  assert.match(catalogPage, /domainIndex/);
+  // No page may print a raw domain slug as a heading.
+  assert.doesNotMatch(catalogPage, /DOMAIN_LABELS\[domain\] \?\? domain/);
+  assert.match(css, /\.domainIndex \{/);
+});

--- a/tests/pagination.test.mjs
+++ b/tests/pagination.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const {
+  offsetFromPage,
+  pageCountFromTotal,
+  pageFromOffset,
+  paginationWindow,
+} = await import("../src/lib/pagination.ts");
+
+const { INTEGRATED_DOMAIN_LABELS, integratedDomainLabel } = await import(
+  "../src/lib/integrated-domains.ts"
+);
+
+async function source(path) {
+  return readFile(new URL(path, import.meta.url), "utf8");
+}
+
+test("page arithmetic round-trips between offset and page number", () => {
+  assert.equal(pageFromOffset(0, 50), 1);
+  assert.equal(pageFromOffset(50, 50), 2);
+  assert.equal(pageFromOffset(159_450, 50), 3_190);
+  assert.equal(offsetFromPage(1, 50), 0);
+  assert.equal(offsetFromPage(3_190, 50), 159_450);
+  for (const page of [1, 2, 17, 640, 3_190]) {
+    assert.equal(pageFromOffset(offsetFromPage(page, 50), 50), page);
+  }
+});
+
+test("page arithmetic refuses to invent a page from unusable input", () => {
+  assert.equal(pageCountFromTotal(0, 50), 0);
+  assert.equal(pageCountFromTotal(120, 0), 0);
+  assert.equal(pageCountFromTotal(Number.NaN, 50), 0);
+  assert.equal(pageFromOffset(-10, 50), 1);
+  assert.equal(offsetFromPage(0, 50), 0);
+  assert.equal(offsetFromPage(-4, 50), 0);
+});
+
+test("a partial last page still counts as a page", () => {
+  assert.equal(pageCountFromTotal(159_493, 50), 3_190);
+  assert.equal(pageCountFromTotal(50, 50), 1);
+  assert.equal(pageCountFromTotal(51, 50), 2);
+});
+
+test("the window keeps both ends of the list reachable", () => {
+  assert.deepEqual(paginationWindow(1, 1), []);
+  assert.deepEqual(paginationWindow(1, 5), [1, 2, 3, 4, 5]);
+  assert.deepEqual(paginationWindow(1, 3_190), [1, 2, 3, "gap", 3_190]);
+  assert.deepEqual(paginationWindow(3_190, 3_190), [1, "gap", 3_188, 3_189, 3_190]);
+  assert.deepEqual(
+    paginationWindow(1_600, 3_190),
+    [1, "gap", 1_598, 1_599, 1_600, 1_601, 1_602, "gap", 3_190],
+  );
+});
+
+test("a gap never stands in for a single page", () => {
+  // Page 4 of 8 leaves exactly page 7 between the window and the last anchor:
+  // eliding one number to draw an ellipsis the same width helps nobody, so the
+  // number is drawn instead.
+  assert.deepEqual(paginationWindow(4, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
+  assert.deepEqual(paginationWindow(5, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
+  assert.deepEqual(paginationWindow(8, 20), [1, "gap", 6, 7, 8, 9, 10, "gap", 20]);
+  for (const steps of [paginationWindow(4, 8), paginationWindow(5, 9), paginationWindow(6, 11)]) {
+    const numbers = steps.filter((step) => step !== "gap");
+    for (let index = 0; index < steps.length; index += 1) {
+      if (steps[index] !== "gap") continue;
+      assert.ok(
+        steps[index + 1] - steps[index - 1] > 2,
+        `un salto copre una sola pagina: ${JSON.stringify(steps)}`,
+      );
+    }
+    assert.equal(new Set(numbers).size, numbers.length, "pagina ripetuta nella finestra");
+  }
+});
+
+test("the window clamps a page number outside the list", () => {
+  assert.deepEqual(paginationWindow(0, 5), paginationWindow(1, 5));
+  assert.deepEqual(paginationWindow(99, 5), paginationWindow(5, 5));
+});
+
+test("every paginated public view uses the one shared control", async () => {
+  const pages = [
+    "../src/app/dati/[dataset]/page.tsx",
+    "../src/app/fonti/catalogo/page.tsx",
+    "../src/app/spese/consulenze/page.tsx",
+    "../src/app/spese/territoriale/page.tsx",
+    "../src/app/territori/confronto/page.tsx",
+  ];
+  for (const path of pages) {
+    const content = await source(path);
+    assert.match(content, /import Pagination from "@\/components\/pagination"/, path);
+    assert.match(content, /<Pagination\b/, path);
+    assert.doesNotMatch(content, /Pagina precedente<\/Link>|← Pagina precedente/, path);
+  }
+});
+
+test("the pagination control names its pages and keeps its targets tappable", async () => {
+  const [component, css] = await Promise.all([
+    source("../src/components/pagination.tsx"),
+    source("../src/components/pagination.module.css"),
+  ]);
+  assert.match(component, /aria-label=\{`Pagina \$\{integer\(step\)\}`\}/);
+  assert.match(component, /aria-current=\{step === current \? "page" : undefined\}/);
+  assert.match(component, /rel="prev"/);
+  assert.match(component, /rel="next"/);
+  assert.match(component, /if \(pageCount <= 1\) return null;/);
+  assert.match(css, /min-width: 44px;\s*\n\s*min-height: 44px;/);
+  assert.doesNotMatch(css, /border-radius\s*:/);
+  assert.doesNotMatch(css, /#[0-9a-f]{3,6}\b/i);
+});
+
+test("the dataset views paginate by a readable page number", async () => {
+  for (const path of [
+    "../src/app/dati/[dataset]/page.tsx",
+    "../src/app/fonti/catalogo/page.tsx",
+    "../src/app/spese/territoriale/page.tsx",
+  ]) {
+    const content = await source(path);
+    assert.match(content, /search\.pagina|params\.pagina|pageParam: "pagina"/, path);
+    assert.match(content, /offsetFromPage/, path);
+  }
+});
+
+test("integrated domains carry an Italian label for every domain in the catalogue", async () => {
+  const catalog = JSON.parse(
+    await readFile(new URL("../src/data/generated/integrated/catalog.json", import.meta.url), "utf8"),
+  );
+  const domains = new Set(catalog.datasets.map((dataset) => dataset.domain));
+  for (const domain of domains) {
+    assert.ok(
+      Object.hasOwn(INTEGRATED_DOMAIN_LABELS, domain),
+      `dominio senza etichetta italiana: ${domain}`,
+    );
+    assert.doesNotMatch(integratedDomainLabel(domain), /^[a-z-]+$/, domain);
+  }
+});

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -36,6 +36,47 @@ test("primary navigation keeps dropdowns and no section subnav bar", async () =>
   assert.doesNotMatch(navigationComponent, /subnav-row|nav\.subnav|activeNavSection/);
 });
 
+test("a submenu can be opened without a pointer that can hover", async () => {
+  const navigationComponent = await readFile(
+    new URL("../src/components/navigation.tsx", import.meta.url),
+    "utf8",
+  );
+  // The caret is a control, not a glyph: on a touch screen it is the only way
+  // into a section's pages, since hover never fires and the label navigates.
+  assert.match(navigationComponent, /<button\s+type="button"\s+className="nav-item-toggle"/);
+  assert.match(navigationComponent, /aria-expanded=\{open\}/);
+  assert.match(navigationComponent, /aria-controls=\{menuId\}/);
+  assert.match(navigationComponent, /event\.key === "Escape"/);
+  assert.match(navigationComponent, /document\.addEventListener\("pointerdown", dismissOutside\)/);
+  // Open state carries the path it was opened on, so a completed navigation
+  // closes the menu without a setState in an effect.
+  assert.match(navigationComponent, /openMenu\?\.pathname === pathname/);
+
+  assert.match(globalsCss, /\.nav-item-has-menu\[data-open="true"\] \.nav-submenu/);
+  assert.match(globalsCss, /\.nav-item-toggle \{/);
+  assert.match(globalsCss, /@media \(max-width: 1260px\)/);
+  // Below that break the row scrolls, so the panel must be anchored outside it.
+  assert.match(globalsCss, /\.nav-row \{\n\s*position: relative;/);
+});
+
+test("every page offers the rest of its section without the header menu", async () => {
+  const [component, layout, css] = await Promise.all([
+    readFile(new URL("../src/components/section-nav.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/components/section-nav.module.css", import.meta.url), "utf8"),
+  ]);
+  assert.match(layout, /<SectionNav \/>/);
+  assert.match(component, /activeNavSection/);
+  assert.match(component, /isNavChildActive/);
+  // A section with a single page has nothing to offer and renders nothing.
+  assert.match(component, /if \(pages\.length < 2\) return null;/);
+  // The current page is a destination already reached, not a link back to here.
+  assert.match(component, /aria-current="page"/);
+  assert.doesNotMatch(component, /subnav-row|nav\.subnav/);
+  assert.match(css, /min-height: 44px/);
+  assert.doesNotMatch(css, /border-radius\s*:/);
+});
+
 test("public legal pages do not expose a personal mailbox", async () => {
   const files = await Promise.all([
     readFile(new URL("../src/app/privacy/page.tsx", import.meta.url), "utf8"),


### PR DESCRIPTION
…fono

Nelle liste lunghe si poteva solo andare avanti di una pagina alla volta: su parti-atti significava 3.190 clic per arrivare in fondo, senza sapere quante pagine ci fossero. E le tendine del menu si aprivano solo su :hover, quindi da telefono le pagine di una sezione erano irraggiungibili.

Paginazione
- Un solo controllo condiviso (src/components/pagination.tsx) su scheda dataset, catalogo fonti, consulenze RGS, spesa territoriale e confronto Comuni: numeri di pagina con estremi sempre raggiungibili, posizione ("Pagina 1.600 di 3.190"), righe coperte e salto diretto quando le pagine sono troppe per elencarle.
- L'aritmetica sta in src/lib/pagination.ts: un salto non sostituisce mai una pagina sola, perche' un'ellissi larga quanto il numero che nasconde toglie una destinazione senza far risparmiare spazio.
- Le viste accettano "pagina" come forma leggibile di "offset"; un offset esplicito ha comunque la precedenza e il selettore resta l'autorita' sulla validazione. Una pagina fuori intervallo torna alla prima con una frase in italiano invece del messaggio sul parametro.

Navigazione
- Il caret del menu e' un bottone, non un glifo: su touch e' l'unico modo di raggiungere le pagine di una sezione, visto che l'etichetta naviga e hover non esiste. Chiusura con Escape o toccando fuori.
- Sotto i 1260px la barra scorre invece di allargare la pagina, e la tendina aperta viene ancorata alla riga anziche' al proprio elemento, cosi' non e' tagliata dal contenitore che scorre ne' posizionata in fondo al documento.
- Ogni pagina chiude con le altre pagine della sua sezione (src/components/section-nav.tsx), raggiungibili senza aprire il menu.

Lettura
- La scheda dataset mette righe e ricerca prima dei pannelli che le descrivono, con le tre convenzioni sui valori accanto alle celle.
- Le colonne di importo si allineano a destra solo se nessun valore in pagina contraddice l'intestazione, quindi una colonna di testo non viene mai trattata come numerica.
- Catalogo dati: indice degli ambiti con conteggi e dataset in ordine di righe. I domini appointments e participations comparivano in inglese perche' mancavano dalla mappa delle etichette.
- Controlli: indice delle sezioni della pagina, un badge per scheda invece di due, etichetta prima della cifra, e stato esplicito quando per un anno non ci sono segnali documentati.

Correzioni responsive
- La riga di composizione degli incarichi allargava la pagina tra 621 e 900px: un binario max-content con didascalia nowrap non poteva restringersi.

Verificato: lint, typecheck, build, 388 test (14 nuovi), la suite browser del repo e una scansione di 70 rotte a 9 larghezze da 320 a 1600px senza scorrimento orizzontale ne' target sotto i 24px. Le rotte /enti/[codice] e la ricerca in header restano non verificabili qui: dipendono da indicepa.gov.it, che la rete di questo ambiente blocca.


Claude-Session: https://claude.ai/code/session_01TwSGNxLQhULesiBKnaHq5E

## Cosa cambia

Descrivi il risultato osservabile e il perimetro della PR.

## Evidenza

- [ ] Il diff è limitato al problema dichiarato.
- [ ] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [ ] `npm test`, test ETL Python, typecheck, lint, design check e build passano.
- [ ] Ho verificato `git diff --check`.

### Dati pubblici

Compila questa sezione se la PR aggiunge o modifica dati.

- [ ] URL ufficiale, titolare, licenza, periodo e data di osservazione sono espliciti.
- [ ] Schema, hash, provenienza e riconciliazioni falliscono in modo chiuso.
- [ ] Importi, frequenze, saldi, pagamenti e finanziamenti non vengono confusi.
- [ ] Il testo evita inferenze su spreco, frode, merito, qualità o responsabilità non dimostrate.

### UI e accessibilità

Compila questa sezione se la PR modifica una superficie utente.

- [ ] Ho verificato tastiera, focus, stati vuoto/errore/caricamento e console browser.
- [ ] Ho verificato 390, 768 e 1280 px senza overflow o contenuti irraggiungibili.
- [ ] Tabelle e grafici hanno un equivalente accessibile.

### API e MCP

Compila questa sezione se la PR modifica API o MCP.

- [ ] Input sconosciuti, duplicati, malformati e non limitati vengono rifiutati.
- [ ] La superficie MCP resta pubblica, stateless, limitata e read-only.
- [ ] Ho verificato il route HTTP reale, non soltanto import in-process.

## Limiti e prove non eseguite

Elenca con precisione check esterni, dispositivi, workflow o fonti non verificati.
