### PR TITLE
ci: ETL contracts, generated-artifact registry, offline enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
             echo ""
             echo "| Check | Result |"
             echo "|-------|--------|"
-            echo "| ETL test suite (214 tests, offline) | ${{ job.status == 'success' && '✅ PASS' || '❌ FAIL' }} |"
+            echo "| ETL test suite (offline) | ${{ job.status == 'success' && '✅ PASS' || '❌ FAIL' }} |"
             echo "| Generated-artifact registry + offline checks | ${{ job.status == 'success' && '✅ PASS' || '❌ FAIL' }} |"
             echo "| Application-level network guard | active (loopback only) |"
             echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
-      # Application-level network guard: blocks outbound TCP during offline
-      # verification. Loopback (127.0.0.0/8, ::1) is allowed.
-      DVNS_OFFLINE_GUARD: "1"
+      # PYTHONPATH for ETL scripts that import sibling modules.
+      # The offline guard (DVNS_OFFLINE_GUARD) is set per-step below,
+      # AFTER dependency installation, so pip can reach PyPI.
       PYTHONPATH: scripts/etl:scripts/ci
     steps:
       - name: Checkout
@@ -103,9 +103,13 @@ jobs:
           --require-hashes -r requirements-etl.txt
 
       - name: ETL test suite (offline)
+        env:
+          DVNS_OFFLINE_GUARD: "1"
         run: npm run test:etl
 
       - name: Validate committed generated artifacts (offline)
+        env:
+          DVNS_OFFLINE_GUARD: "1"
         run: npm run test:snapshots
 
       - name: ETL gate summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
   etl:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      # Application-level network guard: blocks outbound TCP during offline
+      # verification. Loopback (127.0.0.0/8, ::1) is allowed.
+      DVNS_OFFLINE_GUARD: "1"
+      PYTHONPATH: scripts/etl:scripts/ci
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -97,8 +102,26 @@ jobs:
           python -m pip install --no-deps --only-binary=:all:
           --require-hashes -r requirements-etl.txt
 
-      - name: ETL test suite
-        run: python -m unittest discover -s tests/etl -p 'test_*.py'
+      - name: ETL test suite (offline)
+        run: npm run test:etl
+
+      - name: Validate committed generated artifacts (offline)
+        run: npm run test:snapshots
+
+      - name: ETL gate summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## ETL gate"
+            echo ""
+            echo "| Check | Result |"
+            echo "|-------|--------|"
+            echo "| ETL test suite (214 tests, offline) | ${{ job.status == 'success' && '✅ PASS' || '❌ FAIL' }} |"
+            echo "| Generated-artifact registry + offline checks | ${{ job.status == 'success' && '✅ PASS' || '❌ FAIL' }} |"
+            echo "| Application-level network guard | active (loopback only) |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
   production:
     runs-on: ubuntu-24.04

--- a/.github/workflows/consulenti-refresh.yml
+++ b/.github/workflows/consulenti-refresh.yml
@@ -9,13 +9,6 @@ on:
       - src/data/generated/consulenti-overview.json
       - tests/consulenti-contract.test.mjs
       - .github/workflows/consulenti-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/consulenti_snapshot.py
-      - src/lib/data/consulenti-contract.ts
-      - src/data/generated/consulenti-overview.json
-      - tests/consulenti-contract.test.mjs
-      - .github/workflows/consulenti-refresh.yml
   schedule:
     - cron: "37 */6 * * *"
   workflow_dispatch:
@@ -28,20 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-      - name: Validate committed snapshot offline
-        run: python scripts/etl/consulenti_snapshot.py --check
-
   refresh:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 6
     permissions:

--- a/.github/workflows/mef-irpef-refresh.yml
+++ b/.github/workflows/mef-irpef-refresh.yml
@@ -10,14 +10,6 @@ on:
       - src/data/generated/mef-irpef-2024.meta.json
       - src/data/generated/mef-irpef-2024.data.json
       - .github/workflows/mef-irpef-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/specs/mef-irpef-2024.source.json
-      - scripts/etl/mef_irpef_municipal_snapshot.py
-      - tests/etl/test_mef_irpef_municipal.py
-      - src/data/generated/mef-irpef-2024.meta.json
-      - src/data/generated/mef-irpef-2024.data.json
-      - .github/workflows/mef-irpef-refresh.yml
   schedule:
     - cron: "17 6 * * 1"
   workflow_dispatch:
@@ -36,7 +28,7 @@ concurrency:
 
 jobs:
   offline-contract:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/mef-participations-refresh.yml
+++ b/.github/workflows/mef-participations-refresh.yml
@@ -8,12 +8,6 @@ on:
       - src/data/generated/mef-participations-overview.json
       - tests/mef-participations.test.mjs
       - .github/workflows/mef-participations-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/mef_participations_snapshot.py
-      - src/data/generated/mef-participations-overview.json
-      - tests/mef-participations.test.mjs
-      - .github/workflows/mef-participations-refresh.yml
   schedule:
     - cron: "23 5 * * *"
   workflow_dispatch:
@@ -26,19 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-      - run: python scripts/etl/mef_participations_snapshot.py --check
-
   refresh:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/opencivitas-refresh.yml
+++ b/.github/workflows/opencivitas-refresh.yml
@@ -10,14 +10,6 @@ on:
       - src/data/generated/opencivitas-2022.json
       - tests/opencivitas-contract.test.mjs
       - .github/workflows/opencivitas-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/opencivitas_snapshot.py
-      - scripts/etl/certs/**
-      - src/lib/data/opencivitas-contract.ts
-      - src/data/generated/opencivitas-2022.json
-      - tests/opencivitas-contract.test.mjs
-      - .github/workflows/opencivitas-refresh.yml
   schedule:
     - cron: "23 4 * * *"
   workflow_dispatch:
@@ -30,20 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-      - name: Validate committed snapshot offline
-        run: python scripts/etl/opencivitas_snapshot.py --check
-
   refresh:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:

--- a/.github/workflows/opencoesione-refresh.yml
+++ b/.github/workflows/opencoesione-refresh.yml
@@ -11,13 +11,6 @@ on:
       - src/data/generated/opencoesione-overview.json
       - tests/opencoesione-contract.test.mjs
       - .github/workflows/opencoesione-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/opencoesione_snapshot.py
-      - src/lib/data/opencoesione-contract.ts
-      - src/data/generated/opencoesione-overview.json
-      - tests/opencoesione-contract.test.mjs
-      - .github/workflows/opencoesione-refresh.yml
   schedule:
     - cron: "17 */6 * * *"
   workflow_dispatch:
@@ -30,26 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 4
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout pull request merge commit
-        uses: actions/checkout@v6
-
-      - name: Setup Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Validate committed snapshot offline
-        run: python scripts/etl/opencoesione_snapshot.py --check
-
   refresh:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     permissions:

--- a/.github/workflows/parliament-sources.yml
+++ b/.github/workflows/parliament-sources.yml
@@ -12,16 +12,6 @@ on:
       - tests/etl/test_parliament_sources.py
       - tests/fixtures/parliament/**
       - .github/workflows/parliament-sources.yml
-  pull_request:
-    paths:
-      - scripts/etl/parliament_sources.py
-      - src/lib/data/parliament-contract.ts
-      - src/data/generated/parliament-overview.json
-      - src/data/generated/parliament-source-manifest.json
-      - tests/parliament-contract.test.mjs
-      - tests/etl/test_parliament_sources.py
-      - tests/fixtures/parliament/**
-      - .github/workflows/parliament-sources.yml
   schedule:
     - cron: "37 */6 * * *"
   workflow_dispatch:

--- a/.github/workflows/pnrr-childcare-refresh.yml
+++ b/.github/workflows/pnrr-childcare-refresh.yml
@@ -10,14 +10,6 @@ on:
       - src/data/generated/pnrr-childcare.data.json
       - src/data/generated/pnrr-childcare.meta.json
       - .github/workflows/pnrr-childcare-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/specs/pnrr-childcare.source.json
-      - scripts/etl/pnrr_childcare_snapshot.py
-      - tests/etl/test_pnrr_childcare_snapshot.py
-      - src/data/generated/pnrr-childcare.data.json
-      - src/data/generated/pnrr-childcare.meta.json
-      - .github/workflows/pnrr-childcare-refresh.yml
   schedule:
     - cron: "37 5 * * 1"
   workflow_dispatch:
@@ -36,7 +28,7 @@ concurrency:
 
 jobs:
   offline-contract:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/siope-refresh.yml
+++ b/.github/workflows/siope-refresh.yml
@@ -7,13 +7,7 @@ on:
       - feat/siope-territorial-dashboard
     paths:
       - scripts/etl/siope_municipal_snapshot.py
-      - src/lib/siope-municipality-detail.ts
-      - tests/municipality-profile.test.mjs
-      - tests/siope-snapshot.test.mjs
-      - .github/workflows/siope-refresh.yml
-  pull_request:
-    paths:
-      - scripts/etl/siope_municipal_snapshot.py
+      - scripts/etl/siope_snapshot_check.py
       - src/lib/siope-municipality-detail.ts
       - tests/municipality-profile.test.mjs
       - tests/siope-snapshot.test.mjs
@@ -40,7 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      TARGET_BRANCH: ${{ github.ref_name }}
+      PYTHONPATH: scripts/etl
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -93,163 +88,7 @@ jobs:
           done
 
       - name: Validate generated contract
-        shell: python
-        run: |
-          import json
-          import re
-          from pathlib import Path
-
-          path = Path("src/data/generated/siope-municipal.json")
-          if not path.exists():
-              raise SystemExit("Generated SIOPE snapshot is missing")
-          data = json.loads(path.read_text(encoding="utf-8"))
-          assert data["schemaVersion"] == 3
-          assert data["scope"] == "municipalities"
-          assert 1 <= data["latestMonth"] <= 12
-          assert data["totalPaid"] >= 0
-          assert 0 <= data["paymentsWithPopulation"] <= data["totalPaid"]
-          assert data["populationCovered"] > 0
-          assert abs(
-              data["nationalPerCapita"]
-              - data["paymentsWithPopulation"] / data["populationCovered"]
-          ) < 0.01
-          assert len(data["regions"]) >= 18
-          assert data["coverage"]["withMovements"] > 7000
-          assert data["coverage"]["includedMovementRows"] > 0
-          assert (
-              data["coverage"]["withPopulation"]
-              + data["coverage"]["withoutPopulation"]
-              == data["coverage"]["withMovements"]
-          )
-          assert (
-              data["coverage"]["withRegion"]
-              + data["coverage"]["withoutRegion"]
-              == data["coverage"]["withMovements"]
-          )
-          assert (
-              data["coverage"]["matchedToIpaRegion"]
-              + data["coverage"]["unmatchedToIpaRegion"]
-              == data["coverage"]["activeSiopeMunicipalities"]
-          )
-          assert data["coverage"]["withRegion"] <= data["coverage"]["matchedToIpaRegion"]
-          assert data["coverage"]["withoutRegion"] <= data["coverage"]["unmatchedToIpaRegion"]
-          assert abs(
-              sum(item["value"] for item in data["regions"])
-              + data["coverage"]["paymentsWithoutRegion"]
-              - data["totalPaid"]
-          ) < 0.05
-          assert len(data["topMunicipalitiesByValue"]) == 100
-          assert len(data["topMunicipalitiesByPerCapita"]) == 100
-          assert data["topMunicipalities"] == data["topMunicipalitiesByValue"]
-          assert all(
-              item["province"].strip() and item["region"].strip()
-              for ranking in (
-                  data["topMunicipalitiesByValue"],
-                  data["topMunicipalitiesByPerCapita"],
-              )
-              for item in ranking
-          )
-          assert all(
-              left["value"] >= right["value"]
-              for left, right in zip(
-                  data["topMunicipalitiesByValue"],
-                  data["topMunicipalitiesByValue"][1:],
-              )
-          )
-          assert all(
-              left["perCapita"] >= right["perCapita"]
-              for left, right in zip(
-                  data["topMunicipalitiesByPerCapita"],
-                  data["topMunicipalitiesByPerCapita"][1:],
-              )
-          )
-          assert data["source"]["siopeMovementsLastModified"]
-          assert data["source"]["siopeRegistryLastModified"]
-          for field in ("siopeMovementsEtag", "siopeRegistryEtag", "ipaEtag"):
-              assert isinstance(data["source"][field], str) and data["source"][field]
-          for field in ("siopeMovementsSha256", "siopeRegistrySha256", "ipaSha256"):
-              assert re.fullmatch(r"[0-9a-f]{64}", data["source"][field]), field
-          assert (
-              data["methodology"]["populationSourceLastModified"]
-              == data["source"]["siopeRegistryLastModified"]
-          )
-
-          distribution = data.get("distribution")
-          assert isinstance(distribution, dict), "Full-population distribution is missing"
-          assert distribution["schemaVersion"] == 2
-          assert distribution["measure"]["titleCode"] == "1"
-          assert distribution["measure"]["shareDenominator"] == (
-              "tutti i pagamenti SIOPE degli enti riconosciuti come Comuni "
-              "dall'anagrafica SIOPE nel periodo"
-          )
-          assert distribution["period"]["year"] == data["year"]
-          assert distribution["period"]["startMonth"] == 1
-          assert distribution["period"]["endMonth"] == data["latestMonth"]
-          assert distribution["period"]["completeness"] in ("complete", "partial")
-
-          coverage = distribution["coverage"]
-          assert coverage["municipalitiesWithMovements"] == data["coverage"]["withMovements"]
-          assert coverage["municipalitiesWithValidPopulation"] == data["coverage"]["withPopulation"]
-          assert coverage["municipalitiesWithoutPopulation"] == data["coverage"]["withoutPopulation"]
-          assert coverage["populationCovered"] == data["populationCovered"]
-          assert coverage["municipalitiesWithRegion"] == data["coverage"]["withRegion"]
-          assert coverage["municipalitiesWithoutRegion"] == data["coverage"]["withoutRegion"]
-          assert coverage["paymentsWithoutRegion"] == data["coverage"]["paymentsWithoutRegion"]
-          assert (
-              coverage["municipalitiesWithValidPopulation"]
-              - coverage["municipalitiesWithValidPopulationAndRegion"]
-              <= coverage["municipalitiesWithoutRegion"]
-          )
-          assert coverage["titlePaymentsWithoutRegion"] <= coverage["paymentsWithoutRegion"]
-          assert (
-              coverage["paymentsWithPopulationWithoutRegion"]
-              <= coverage["paymentsWithoutRegion"]
-          )
-          assert (
-              coverage["titlePaymentsWithPopulationWithoutRegion"]
-              <= coverage["titlePaymentsWithoutRegion"]
-          )
-          assert (
-              coverage["titlePaymentsWithPopulationWithoutRegion"]
-              <= coverage["paymentsWithPopulationWithoutRegion"]
-          )
-          assert abs(
-              coverage["paymentsWithoutPopulation"]
-              + data["paymentsWithPopulation"]
-              - data["totalPaid"]
-          ) < 0.05
-          assert 0 <= distribution["nationalShareAll"] <= 1
-          assert 0 <= distribution["nationalShareCovered"] <= 1
-
-          def check_quantiles(quantiles):
-              values = [quantiles[key] for key in ("p10", "p25", "p50", "p75", "p90")]
-              assert all(value is None or isinstance(value, (int, float)) for value in values)
-              present = [value for value in values if value is not None]
-              assert present == sorted(present)
-
-          for group in [
-              distribution["perCapita"],
-              *(item["perCapita"] for item in distribution["populationBands"]),
-              *(item["perCapita"] for item in distribution["regions"]),
-          ]:
-              check_quantiles(group["municipalityWeighted"])
-              check_quantiles(group["residentWeighted"])
-          assert sum(item["municipalities"] for item in distribution["populationBands"]) == coverage["municipalitiesWithValidPopulation"]
-          assert sum(item["municipalities"] for item in distribution["regions"]) == coverage["municipalitiesWithValidPopulationAndRegion"]
-          assert sum(item["population"] for item in distribution["populationBands"]) == coverage["populationCovered"]
-          assert sum(item["population"] for item in distribution["regions"]) == coverage["populationRegionalized"]
-          assert all("municipalities" not in item or item["municipalities"] >= 0 for item in distribution["regions"])
-          print(json.dumps({
-              "year": data["year"],
-              "latestMonth": data["latestMonthLabel"],
-              "totalPaid": data["totalPaid"],
-              "regions": len(data["regions"]),
-              "municipalities": data["coverage"]["withMovements"],
-              "municipalitiesWithPopulation": data["coverage"]["withPopulation"],
-              "matched": data["coverage"]["matchedToIpaRegion"],
-              "unmatched": data["coverage"]["unmatchedToIpaRegion"],
-              "movementRows": data["coverage"]["movementRows"],
-          }, ensure_ascii=False, indent=2))
+        run: python scripts/etl/siope_snapshot_check.py
 
       - name: Validate every published SIOPE year with the runtime contract
         run: >-
@@ -258,7 +97,6 @@ jobs:
           tests/municipality-profile.test.mjs
 
       - name: Commit source update
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         shell: bash
         run: |
           set -euo pipefail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ npm ci
 npm run ci:static
 npm run test:node
 npm run test:etl
+npm run test:snapshots
 npm run build
 git diff --check
 ```
@@ -48,6 +49,46 @@ git diff --check
 I test browser e Lighthouse richiedono un server `next start` attivo su
 `127.0.0.1:3000`; vedi `scripts/ci/run-production-gates.sh` per l'orchestrazione
 completa usata dalla CI.
+
+### ETL e artifact verification
+
+```bash
+npm run test:etl        # full ETL transformation/reconciliation test suite (214 tests)
+npm run test:snapshots  # generated-artifact registry + offline artifact checks
+```
+
+`test:etl` esegue l'intera suite di test Python (trasformazione, riconciliazione,
+contratti fail-closed) una sola volta.
+
+`test:snapshots` valida il registro degli artifact generati
+(`scripts/ci/generated-artifacts.json`), esegue i controlli offline `--check`
+uniche per ogni artifact, verifica la pulizia del worktree e rileva file
+generati non registrati. Non riesegue la suite ETL.
+
+### Limite di trust: PR vs fonti ufficiali
+
+Le pull request validano i dati versioneati **offline**: il registro dimostra
+che ogni artifact è internamente valido senza contattare fonti esterne.
+
+I workflow pianificati o manuali (`*-refresh.yml`) sono responsabili di
+osservare le fonti ufficiali esterne e aggiornare gli snapshot. Il validatore
+offline viene usato sia localmente sia nei workflow di refresh, garantendo una
+sola implementazione del contratto.
+
+### Network guard
+
+La CI attiva un **application-level network guard** durante la verifica ETL e
+artifact. Il guard blocca le connessioni TCP in uscita verso indirizzi non di
+loopback. Non è isolamento egress a livello kernel: intercetta i percorsi
+applicativi esercitati dalla suite (socket, urllib, http.client, http/https in
+Node). Loopback (127.0.0.0/8, ::1) è sempre consentito.
+
+Per attivarlo localmente:
+
+```bash
+DVNS_OFFLINE_GUARD=1 PYTHONPATH=scripts/etl:scripts/ci python3 -m unittest discover -s tests/etl
+DVNS_OFFLINE_GUARD=1 PYTHONPATH=scripts/etl:scripts/ci python3 scripts/ci/validate-generated-artifacts.py --run-checks
+```
 
 Una modifica UI richiede anche verifica Browser a 390, 768 e 1280 px, tastiera,
 focus, stati di errore/caricamento/vuoto, console e overflow. Una modifica MCP

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "node --experimental-strip-types --test tests/*.test.mjs",
     "test:node": "node --experimental-strip-types --test tests/*.test.mjs",
     "test:etl": "python3 -m unittest discover -s tests/etl -p 'test_*.py'",
+    "test:snapshots": "python3 scripts/ci/validate-generated-artifacts.py --run-checks",
     "test:browser:core": "node scripts/browser/core.mjs",
     "test:browser:editorial": "node --experimental-strip-types scripts/browser/editorial.mjs",
     "test:browser:e2e": "node scripts/browser/core.mjs",

--- a/scripts/browser/harness.mjs
+++ b/scripts/browser/harness.mjs
@@ -282,7 +282,14 @@ export async function navigate(
 ) {
   const response = await page.goto(url, { timeout: timeoutMs, waitUntil });
   assert.ok(response, `${label}: navigazione senza risposta HTTP`);
-  assert.equal(response.status(), 200, `${label}: HTTP ${response.status()}`);
+  // 200 is the normal response; 304 is a valid conditional-GET cache hit
+  // (Next.js returns it when the browser sends If-None-Match). Both are
+  // successful navigations — 304 is not an error.
+  const status = response.status();
+  assert.ok(
+    status === 200 || status === 304,
+    `${label}: HTTP ${status}`,
+  );
   if (readySelector) {
     await page.waitForSelector(readySelector, { visible: true, timeout: timeoutMs });
   }

--- a/scripts/browser/harness.mjs
+++ b/scripts/browser/harness.mjs
@@ -282,14 +282,7 @@ export async function navigate(
 ) {
   const response = await page.goto(url, { timeout: timeoutMs, waitUntil });
   assert.ok(response, `${label}: navigazione senza risposta HTTP`);
-  // 200 is the normal response; 304 is a valid conditional-GET cache hit
-  // (Next.js returns it when the browser sends If-None-Match). Both are
-  // successful navigations — 304 is not an error.
-  const status = response.status();
-  assert.ok(
-    status === 200 || status === 304,
-    `${label}: HTTP ${status}`,
-  );
+  assert.equal(response.status(), 200, `${label}: HTTP ${response.status()}`);
   if (readySelector) {
     await page.waitForSelector(readySelector, { visible: true, timeout: timeoutMs });
   }

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "generatedDataRoots": [
+    "src/data/generated",
+    "data/source-ledger"
+  ],
+  "exclusions": [
+    {
+      "path": "src/data/generated/italy-regions.ts",
+      "reason": "Static TypeScript reference table, not generated data. Validated by tests/italy-regions.test.mjs."
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "consulenti-pubblici",
+      "owner": "Consulenti Pubblici national snapshot",
+      "files": [
+        "src/data/generated/consulenti-overview.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/consulenti_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [
+        "tests/consulenti-contract.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/consulenti_snapshot.py",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/consulenti-refresh.yml",
+      "trustModel": "Scheduled workflow downloads official statistics and commits the snapshot. PR-side validation proves the committed file is internally valid offline."
+    },
+    {
+      "id": "cpt-regional-fiscal",
+      "owner": "CPT regional fiscal snapshot",
+      "files": [
+        "src/data/generated/cpt-regional-fiscal.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "etl-suite"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_cpt_regional_fiscal.py"
+      ],
+      "nodeTests": [
+        "tests/cpt-regional-fiscal.test.mjs",
+        "tests/cpt-regional-fiscal-route.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/cpt_regional_fiscal_snapshot.py --revenue ... --expenditure ... --population ... --output ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "trustModel": "No standalone offline check; the ETL test suite validates the transformation logic with fixtures."
+    },
+    {
+      "id": "indire-pnrr-assignments",
+      "owner": "INDIRE PNRR assignments",
+      "files": [
+        "src/data/generated/indire-pnrr-assignments.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/indire_pnrr_assignments.py --validate-committed",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_indire_pnrr_assignments.py"
+      ],
+      "nodeTests": [
+        "tests/indire-pnrr-assignments.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/indire_pnrr_assignments.py --input-xlsx ... --output ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "trustModel": "The --validate-committed flag validates the committed snapshot offline without network access."
+    },
+    {
+      "id": "inps-civil-invalidity",
+      "owner": "INPS civil invalidity",
+      "files": [
+        "src/data/generated/inps-civil-invalidity.json"
+      ],
+      "verificationMode": "curated-committed",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "node-tests"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [
+        "tests/inps-invalidity.test.mjs",
+        "tests/inps-invalidity-route.test.mjs"
+      ],
+      "generator": {
+        "command": null,
+        "requiresNetworkInput": false
+      },
+      "refreshWorkflow": null,
+      "trustModel": "Curated committed artifact with no Python generator. Validated by Node contract tests that assert structural and semantic invariants."
+    },
+    {
+      "id": "integrated-catalog",
+      "owner": "Integrated source release catalog",
+      "files": [
+        "src/data/generated/integrated/catalog.json"
+      ],
+      "verificationMode": "integrated-release",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "etl-suite"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_integrated_curated_datasets.py",
+        "tests/etl/test_integrated_source_release.py"
+      ],
+      "nodeTests": [
+        "tests/integrated-curated-datasets.test.mjs",
+        "tests/integrated-source-public-view.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/integrated_curated_datasets.py build",
+        "requiresNetworkInput": false
+      },
+      "refreshWorkflow": ".github/workflows/source-refresh.yml",
+      "trustModel": "Derived from committed source-ledger products. The standalone --check is too slow for CI (validates 11.9M rows); the ETL test suite validates the committed catalog."
+    },
+    {
+      "id": "integrated-rows",
+      "owner": "Integrated source release rows",
+      "files": [
+        "src/data/generated/integrated/rows"
+      ],
+      "verificationMode": "integrated-release",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "etl-suite"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_integrated_source_release.py"
+      ],
+      "nodeTests": [],
+      "generator": {
+        "command": "python scripts/etl/integrated_curated_datasets.py build",
+        "requiresNetworkInput": false
+      },
+      "refreshWorkflow": ".github/workflows/source-refresh.yml",
+      "trustModel": "Partitioned JSONL.gz row files derived from the source ledger. Validated by the ETL test suite which loads and checks the committed rows."
+    },
+    {
+      "id": "istat-regions-2024",
+      "owner": "ISTAT regional accounts 2024",
+      "files": [
+        "src/data/generated/istat-regions-2024.data.json",
+        "src/data/generated/istat-regions-2024.meta.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/istat_regions_account.py --validate-committed",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_istat_regions_account.py"
+      ],
+      "nodeTests": [
+        "tests/istat-regions-account.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/istat_regions_account.py --input ... --acquired-at ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "trustModel": "The --validate-committed flag validates the committed data and metadata offline."
+    },
+    {
+      "id": "mef-irpef-2024",
+      "owner": "MEF municipal IRPEF 2024",
+      "files": [
+        "src/data/generated/mef-irpef-2024.data.json",
+        "src/data/generated/mef-irpef-2024.meta.json"
+      ],
+      "verificationMode": "source-lock",
+      "offlineCheck": {
+        "command": "python scripts/etl/mef_irpef_municipal_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_mef_irpef_municipal.py"
+      ],
+      "nodeTests": [
+        "tests/mef-irpef.test.mjs",
+        "tests/mef-irpef-route.test.mjs",
+        "tests/mef-irpef-ui.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/mef_irpef_municipal_snapshot.py --input ... --observed-at ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/mef-irpef-refresh.yml",
+      "sourceSpec": "scripts/etl/specs/mef-irpef-2024.source.json",
+      "trustModel": "Source-lock: the upstream asset is pinned by SHA-256 and byte size. PR validation checks the committed artifact offline; the scheduled workflow verifies the pinned hash has not drifted."
+    },
+    {
+      "id": "mef-participations",
+      "owner": "MEF public participations",
+      "files": [
+        "src/data/generated/mef-participations-overview.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/mef_participations_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [
+        "tests/mef-participations.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/mef_participations_snapshot.py",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/mef-participations-refresh.yml",
+      "trustModel": "Scheduled workflow downloads official annual data and commits the snapshot."
+    },
+    {
+      "id": "opencivitas-2022",
+      "owner": "OpenCivitas municipal 2022",
+      "files": [
+        "src/data/generated/opencivitas-2022.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/opencivitas_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [
+        "tests/opencivitas-contract.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/opencivitas_snapshot.py",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/opencivitas-refresh.yml",
+      "trustModel": "Scheduled workflow downloads official data and commits the snapshot."
+    },
+    {
+      "id": "opencoesione",
+      "owner": "OpenCoesione national snapshot",
+      "files": [
+        "src/data/generated/opencoesione-overview.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/opencoesione_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [
+        "tests/opencoesione-contract.test.mjs",
+        "tests/opencoesione-derived.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/opencoesione_snapshot.py",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/opencoesione-refresh.yml",
+      "trustModel": "Scheduled workflow downloads official data and commits the snapshot."
+    },
+    {
+      "id": "parliament",
+      "owner": "Parliamentary source monitor",
+      "files": [
+        "src/data/generated/parliament-overview.json",
+        "src/data/generated/parliament-source-manifest.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/parliament_sources.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_parliament_sources.py"
+      ],
+      "nodeTests": [
+        "tests/parliament-contract.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/parliament_sources.py",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/parliament-sources.yml",
+      "trustModel": "Offline PR validation checks committed data. The scheduled workflow also performs a live official-register check with retry/warning behavior (PR4 scope to revisit)."
+    },
+    {
+      "id": "pcm-financial-2024",
+      "owner": "PCM financial account 2024",
+      "files": [
+        "src/data/generated/pcm-financial-2024.data.json",
+        "src/data/generated/pcm-financial-2024.meta.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/pcm_financial_account.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_pcm_financial_account.py"
+      ],
+      "nodeTests": [
+        "tests/pcm-financial.test.mjs",
+        "tests/pcm-financial-route.test.mjs",
+        "tests/pcm-financial-ui.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/pcm_financial_account.py --input ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "trustModel": "The --check flag validates the committed data and metadata offline."
+    },
+    {
+      "id": "pnrr-childcare",
+      "owner": "PNRR childcare snapshot",
+      "files": [
+        "src/data/generated/pnrr-childcare.data.json",
+        "src/data/generated/pnrr-childcare.meta.json"
+      ],
+      "verificationMode": "source-lock",
+      "offlineCheck": {
+        "command": "python scripts/etl/pnrr_childcare_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_pnrr_childcare_snapshot.py"
+      ],
+      "nodeTests": [
+        "tests/pnrr-childcare-route.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/pnrr_childcare_snapshot.py --projects-input ... --locations-input ... --tenders-input ... --awardees-input ... --observed-at ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/pnrr-childcare-refresh.yml",
+      "sourceSpec": "scripts/etl/specs/pnrr-childcare.source.json",
+      "trustModel": "Source-lock: four upstream CSVs are pinned by SHA-256 and byte size. PR validation checks the committed artifacts offline; the scheduled workflow verifies the pinned hashes."
+    },
+    {
+      "id": "rgs-consulting-payments",
+      "owner": "RGS consulting payments 2024-2025",
+      "files": [
+        "src/data/generated/rgs-consulting-payments-2024-2025.json"
+      ],
+      "verificationMode": "source-lock",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "etl-suite"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_rgs_consulting_payments_snapshot.py"
+      ],
+      "nodeTests": [],
+      "generator": {
+        "command": "python scripts/etl/rgs_consulting_payments_snapshot.py --input-2024 ... --input-2025 ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "sourceSpec": "scripts/etl/specs/rgs-consulting-payments-2024-2025.source.json",
+      "trustModel": "Source-lock: the standalone --check requires input files not available in CI. The ETL test suite loads and validates the committed artifact directly."
+    },
+    {
+      "id": "rgs-ministries-2025",
+      "owner": "RGS ministries account 2025",
+      "files": [
+        "src/data/generated/rgs-ministries-2025.data.json",
+        "src/data/generated/rgs-ministries-2025.meta.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/rgs_ministries_account.py --validate-committed",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_rgs_ministries_account.py"
+      ],
+      "nodeTests": [
+        "tests/ministries-ui.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/rgs_ministries_account.py --input ... --acquired-at ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "trustModel": "The --validate-committed flag validates the committed data and metadata offline."
+    },
+    {
+      "id": "rgs-state-budget-territorial-2023",
+      "owner": "RGS state budget territorial 2023",
+      "files": [
+        "src/data/generated/rgs-state-budget-territorial-2023.json"
+      ],
+      "verificationMode": "source-lock",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "etl-suite"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_rgs_state_budget_territorial_snapshot.py"
+      ],
+      "nodeTests": [],
+      "generator": {
+        "command": "python scripts/etl/rgs_state_budget_territorial_snapshot.py --input ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "sourceSpec": "scripts/etl/specs/rgs-state-budget-territorial-2023.source.json",
+      "trustModel": "Source-lock: the standalone --check requires input files not available in CI. The ETL test suite loads and validates the committed artifact directly."
+    },
+    {
+      "id": "siope-municipal",
+      "owner": "SIOPE municipal snapshot",
+      "files": [
+        "src/data/generated/siope-municipal.json",
+        "src/data/generated/siope-municipal-2024.json",
+        "src/data/generated/siope-municipal-2025.json",
+        "src/data/generated/siope-municipal-detail.json",
+        "src/data/generated/siope-municipal-detail-2024.json",
+        "src/data/generated/siope-municipal-detail-2025.json"
+      ],
+      "verificationMode": "online-refresh",
+      "offlineCheck": {
+        "command": "python scripts/etl/siope_municipal_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [
+        "tests/siope-snapshot.test.mjs",
+        "tests/municipality-profile.test.mjs"
+      ],
+      "generator": {
+        "command": "python scripts/etl/siope_municipal_snapshot.py --year ... --output ... --detail-output ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": ".github/workflows/siope-refresh.yml",
+      "trustModel": "The offline contract (scripts/etl/siope_snapshot_check.py) is the single implementation used locally, in CI, and in the refresh workflow. The scheduled workflow rebuilds from the official SIOPE source and commits."
+    },
+    {
+      "id": "ssn-cce-2024",
+      "owner": "SSN OpenBDAP CCE 2024",
+      "files": [
+        "src/data/generated/ssn-cce-2024.json"
+      ],
+      "verificationMode": "source-lock",
+      "offlineCheck": {
+        "command": "python scripts/etl/ssn_cce_snapshot.py --check",
+        "coveredBy": "standalone"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_ssn_cce_snapshot.py"
+      ],
+      "nodeTests": [],
+      "generator": {
+        "command": "python scripts/etl/ssn_cce_snapshot.py --national-input ... --regional-input ...",
+        "requiresNetworkInput": true
+      },
+      "refreshWorkflow": null,
+      "sourceSpec": "scripts/etl/specs/ssn-cce-2024.source.json",
+      "trustModel": "Source-lock: the upstream assets are pinned by SHA-256. The --check flag validates the committed artifact offline."
+    },
+    {
+      "id": "vive-roma-restoration",
+      "owner": "VIVE Roma in moneta restoration",
+      "files": [
+        "src/data/generated/vive-roma-in-moneta-restoration.json",
+        "src/data/generated/vive-roma-in-moneta-restoration.meta.json"
+      ],
+      "verificationMode": "curated-committed",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "node-tests"
+      },
+      "reconciliationTests": [],
+      "nodeTests": [],
+      "generator": {
+        "command": null,
+        "requiresNetworkInput": false
+      },
+      "refreshWorkflow": null,
+      "trustModel": "Curated committed artifact with no Python generator. Validated by the Node runtime contract in src/lib/vive-restoration-snapshot.ts."
+    },
+    {
+      "id": "source-ledger-proofs",
+      "owner": "Source ledger integrity proofs",
+      "files": [
+        "data/source-ledger/source-catalog-proof.json",
+        "data/source-ledger/release-proof.json",
+        "data/source-ledger/dataset-proof.json",
+        "data/source-ledger/receipt.json",
+        "data/source-ledger/sources.jsonl",
+        "data/source-ledger/datasets",
+        "data/source-ledger/elements"
+      ],
+      "verificationMode": "integrated-release",
+      "offlineCheck": {
+        "command": null,
+        "coveredBy": "etl-suite"
+      },
+      "reconciliationTests": [
+        "tests/etl/test_curated_source_catalog.py",
+        "tests/etl/test_curated_source_identity_ledger.py",
+        "tests/etl/test_source_corpus_intake.py"
+      ],
+      "nodeTests": [],
+      "generator": {
+        "command": "python scripts/etl/curated_source_catalog.py build",
+        "requiresNetworkInput": false
+      },
+      "refreshWorkflow": ".github/workflows/source-refresh.yml",
+      "trustModel": "Integrity proofs derived from the committed source corpus. The standalone check requires input files; the ETL test suite validates the committed proofs."
+    }
+  ]
+}

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -486,7 +486,9 @@
         "coveredBy": "node-tests"
       },
       "reconciliationTests": [],
-      "nodeTests": [],
+      "nodeTests": [
+        "tests/confronti-page.test.mjs"
+      ],
       "generator": {
         "command": null,
         "requiresNetworkInput": false

--- a/scripts/ci/node-offline-guard.mjs
+++ b/scripts/ci/node-offline-guard.mjs
@@ -1,0 +1,132 @@
+/**
+ * Application-level network guard for Node.js offline verification.
+ *
+ * This module monkey-patches the Node.js HTTP/HTTPS client APIs and global
+ * fetch to block accidental outbound network access during offline data-contract
+ * verification. It is **not** kernel-level egress isolation.
+ *
+ * It catches the application-level paths exercised by the Node test suite:
+ *   - globalThis.fetch
+ *   - http.request / http.get
+ *   - https.request / https.get
+ *
+ * Loopback addresses (127.0.0.0/8, ::1, localhost) are allowed.
+ *
+ * Activation:
+ *   Set DVNS_OFFLINE_GUARD=1 in the environment, then use:
+ *     --import ./scripts/ci/node-offline-guard.mjs
+ *   or:
+ *     NODE_OPTIONS="--import ./scripts/ci/node-offline-guard.mjs" DVNS_OFFLINE_GUARD=1 node ...
+ *
+ * Blocked connections throw an Error with a diagnostic message:
+ *   offline verification attempted outbound connection to example.com:443
+ */
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const http = require("http");
+const https = require("https");
+
+const isLoopback = (host) => {
+  if (host === "localhost") return true;
+  if (host === "::1" || host === "[::1]") return true;
+  if (host.startsWith("127.")) return true;
+  if (host === "::ffff:127.0.0.1") return true;
+  return false;
+};
+
+const blockMessage = (host, port) =>
+  `offline verification attempted outbound connection to ${host}:${port}`;
+
+const wrapUrl = (url) => {
+  if (typeof url === "string") {
+    try {
+      return new URL(url);
+    } catch {
+      return null;
+    }
+  }
+  return url;
+};
+
+const checkUrl = (parsed) => {
+  if (!parsed || !parsed.hostname) return;
+  if (!isLoopback(parsed.hostname)) {
+    throw new Error(blockMessage(parsed.hostname, parsed.port || 443));
+  }
+};
+
+const active = process.env.DVNS_OFFLINE_GUARD === "1";
+
+if (active) {
+  // --- Patch globalThis.fetch ---
+  if (typeof globalThis.fetch === "function") {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+      let parsed;
+      if (input instanceof URL) {
+        parsed = input;
+      } else if (typeof input === "string") {
+        parsed = wrapUrl(input);
+      } else if (input && typeof input.url === "string") {
+        parsed = wrapUrl(input.url);
+      }
+      if (parsed) {
+        checkUrl(parsed);
+      }
+      return originalFetch(input, init);
+    };
+  }
+
+  // --- Patch http and https (CJS objects are mutable) ---
+  const modules = [
+    [http, 80],
+    [https, 443],
+  ];
+
+  for (const [mod, defaultPort] of modules) {
+    const originalRequest = mod.request;
+
+    const patchedRequest = (urlOrOptions, optionsOrCallback, callback) => {
+      let hostname;
+      let port;
+
+      if (typeof urlOrOptions === "string" || urlOrOptions instanceof URL) {
+        const parsed = wrapUrl(urlOrOptions);
+        if (parsed) {
+          hostname = parsed.hostname;
+          port = parsed.port;
+        }
+      } else if (urlOrOptions && typeof urlOrOptions === "object") {
+        hostname = urlOrOptions.hostname || urlOrOptions.host;
+        port = urlOrOptions.port;
+        if (!hostname && typeof optionsOrCallback === "object") {
+          hostname = optionsOrCallback.hostname || optionsOrCallback.host;
+          port = optionsOrCallback.port;
+        }
+      }
+
+      if (hostname && !isLoopback(hostname)) {
+        throw new Error(blockMessage(hostname, port || defaultPort));
+      }
+
+      return originalRequest(urlOrOptions, optionsOrCallback, callback);
+    };
+
+    const patchedGet = (urlOrOptions, optionsOrCallback, callback) => {
+      const req = patchedRequest(urlOrOptions, optionsOrCallback, callback);
+      req.end();
+      return req;
+    };
+
+    mod.request = patchedRequest;
+    mod.get = patchedGet;
+  }
+
+  if (process.env.DVNS_OFFLINE_GUARD_DEBUG === "1") {
+    process.stderr.write("[node-offline-guard] active — external connections will be blocked\n");
+  }
+}
+
+export { isLoopback, blockMessage };

--- a/scripts/ci/offline_guard.py
+++ b/scripts/ci/offline_guard.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Application-level network guard for offline ETL verification.
+
+This module blocks accidental outbound TCP connections during offline
+verification paths. It is **not** kernel-level egress isolation — it patches
+``socket.socket.connect`` and ``socket.socket.connect_ex`` at the Python
+application level. Libraries built on sockets (urllib, http.client, requests,
+etc.) are caught because they all go through ``socket.connect``.
+
+Loopback addresses (127.0.0.0/8, ::1) and Unix domain sockets are allowed.
+
+Activation
+----------
+The guard activates when the ``DVNS_OFFLINE_GUARD`` environment variable is set
+to ``"1"``.  The companion ``sitecustomize.py`` calls ``install()`` at
+interpreter startup, so setting ``PYTHONPATH=scripts/ci`` plus
+``DVNS_OFFLINE_GUARD=1`` is sufficient.
+
+Direct usage::
+
+    from scripts.ci.offline_guard import install
+    install()
+
+Blocked connections raise ``ConnectionError`` with a diagnostic message::
+
+    offline verification attempted outbound connection to 93.184.216.34:443
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+
+_INSTALLED = False
+_ORIGINAL_CONNECT = None
+_ORIGINAL_CONNECT_EX = None
+
+ALLOWED_PREFIXES = (
+    "127.",
+    "::1",
+    "localhost",
+)
+
+
+def _is_loopback(host: str | None) -> bool:
+    if host is None:
+        return True  # Unix domain socket or unnamed — allow
+    if not isinstance(host, str):
+        return False
+    if host.lower() == "localhost":
+        return True
+    if host.startswith(ALLOWED_PREFIXES):
+        return True
+    # Numerical 127.x.x.x
+    try:
+        parts = host.split(".")
+        if len(parts) == 4 and parts[0] == "127":
+            return True
+    except (AttributeError, IndexError):
+        pass
+    return False
+
+
+def _block_connect(self, address, *args, **kwargs):
+    # address is (host, port) for AF_INET, (host, port, flowinfo, scopeid) for AF_INET6
+    if address and len(address) >= 1:
+        host = address[0]
+        if not _is_loopback(host):
+            port = address[1] if len(address) >= 2 else "?"
+            raise ConnectionError(
+                f"offline verification attempted outbound connection to {host}:{port}"
+            )
+    return _ORIGINAL_CONNECT(self, address, *args, **kwargs)
+
+
+def _block_connect_ex(self, address, *args, **kwargs):
+    if address and len(address) >= 1:
+        host = address[0]
+        if not _is_loopback(host):
+            port = address[1] if len(address) >= 2 else "?"
+            raise ConnectionError(
+                f"offline verification attempted outbound connection to {host}:{port}"
+            )
+    return _ORIGINAL_CONNECT_EX(self, address, *args, **kwargs)
+
+
+def install() -> None:
+    """Install the network guard by patching ``socket.socket``.
+
+    Safe to call multiple times — only installs once.
+    """
+    global _INSTALLED, _ORIGINAL_CONNECT, _ORIGINAL_CONNECT_EX
+
+    if _INSTALLED:
+        return
+
+    _ORIGINAL_CONNECT = socket.socket.connect
+    _ORIGINAL_CONNECT_EX = socket.socket.connect_ex
+    socket.socket.connect = _block_connect
+    socket.socket.connect_ex = _block_connect_ex
+    _INSTALLED = True
+
+
+def uninstall() -> None:
+    """Restore the original socket methods."""
+    global _INSTALLED, _ORIGINAL_CONNECT, _ORIGINAL_CONNECT_EX
+
+    if not _INSTALLED:
+        return
+
+    socket.socket.connect = _ORIGINAL_CONNECT
+    socket.socket.connect_ex = _ORIGINAL_CONNECT_EX
+    _INSTALLED = False
+
+
+def is_active() -> bool:
+    """Return True if the guard is currently installed."""
+    return _INSTALLED
+
+
+# Auto-install when the environment variable is set
+if os.environ.get("DVNS_OFFLINE_GUARD") == "1":
+    install()

--- a/scripts/ci/offline_guard.py
+++ b/scripts/ci/offline_guard.py
@@ -44,7 +44,7 @@ ALLOWED_PREFIXES = (
 
 def _is_loopback(host: str | None) -> bool:
     if host is None:
-        return True  # Unix domain socket or unnamed — allow
+        return True  # Unnamed address — allow (AF_UNIX handled separately)
     if not isinstance(host, str):
         return False
     if host.lower() == "localhost":
@@ -62,6 +62,10 @@ def _is_loopback(host: str | None) -> bool:
 
 
 def _block_connect(self, address, *args, **kwargs):
+    # Unix domain sockets use a string path, not a (host, port) tuple.
+    # They are local by definition — always allow.
+    if self.family == socket.AF_UNIX:
+        return _ORIGINAL_CONNECT(self, address, *args, **kwargs)
     # address is (host, port) for AF_INET, (host, port, flowinfo, scopeid) for AF_INET6
     if address and len(address) >= 1:
         host = address[0]
@@ -74,6 +78,10 @@ def _block_connect(self, address, *args, **kwargs):
 
 
 def _block_connect_ex(self, address, *args, **kwargs):
+    # Unix domain sockets use a string path, not a (host, port) tuple.
+    # They are local by definition — always allow.
+    if self.family == socket.AF_UNIX:
+        return _ORIGINAL_CONNECT_EX(self, address, *args, **kwargs)
     if address and len(address) >= 1:
         host = address[0]
         if not _is_loopback(host):

--- a/scripts/ci/sitecustomize.py
+++ b/scripts/ci/sitecustomize.py
@@ -1,0 +1,16 @@
+"""Python sitecustomize — auto-installs the offline network guard.
+
+When ``DVNS_OFFLINE_GUARD=1`` is set and this file is on ``PYTHONPATH``,
+Python imports it at interpreter startup, which activates the guard.
+
+This file is intentionally minimal — it delegates to ``offline_guard``.
+"""
+
+import os
+
+if os.environ.get("DVNS_OFFLINE_GUARD") == "1":
+    try:
+        from offline_guard import install  # type: ignore[import-not-found]
+        install()
+    except ImportError:
+        pass

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Validate the generated-artifact registry and run offline artifact checks.
+
+Usage:
+    python scripts/ci/validate-generated-artifacts.py            # validate registry only
+    python scripts/ci/validate-generated-artifacts.py --run-checks  # validate + run offline checks
+
+The validator:
+  1. Validates the registry schema and structural integrity.
+  2. Checks that all referenced files, tests, and workflows exist.
+  3. Detects unregistered generated-data files.
+  4. With --run-checks: executes unique standalone offline --check commands.
+  5. With --run-checks: verifies worktree cleanliness (checks must not modify committed files).
+
+It does NOT re-run the full ETL unittest suite.  Artifacts whose offline
+guarantee is provided by the ETL suite are recorded as "covered-by-etl-suite"
+and skipped.
+
+Exit code is 0 on success, 1 on any validation failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+REGISTRY_PATH = ROOT / "scripts" / "ci" / "generated-artifacts.json"
+
+VALID_MODES = frozenset(
+    {"online-refresh", "source-lock", "integrated-release", "curated-committed"}
+)
+VALID_COVERAGE = frozenset({"standalone", "etl-suite", "node-tests"})
+# Extensions considered "generated data" for unregistered-file detection.
+GENERATED_EXTENSIONS = frozenset({".json", ".jsonl", ".jsonl.gz", ".ts"})
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_registry() -> dict:
+    if not REGISTRY_PATH.exists():
+        raise ValidationError(f"Registry not found: {REGISTRY_PATH}")
+    try:
+        return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"Registry is not valid JSON: {exc}")
+
+
+def validate_schema(registry: dict) -> list[str]:
+    """Validate the registry schema. Returns a list of error strings."""
+    errors = []
+
+    if not isinstance(registry, dict):
+        return ["Registry root must be a JSON object."]
+    if registry.get("schemaVersion") != 1:
+        errors.append(f"Unsupported schemaVersion: {registry.get('schemaVersion')!r} (expected 1)")
+
+    artifacts = registry.get("artifacts")
+    if not isinstance(artifacts, list):
+        errors.append("'artifacts' must be a list.")
+        return errors
+
+    seen_ids: set[str] = set()
+    seen_files: dict[str, str] = {}
+    standalone_commands: set[str] = set()
+
+    for i, art in enumerate(artifacts):
+        prefix = f"artifact[{i}]"
+
+        if not isinstance(art, dict):
+            errors.append(f"{prefix}: must be an object.")
+            continue
+
+        # Required fields
+        art_id = art.get("id")
+        if not art_id or not isinstance(art_id, str):
+            errors.append(f"{prefix}: missing or invalid 'id'.")
+            art_id = f"<index-{i}>"
+        elif art_id in seen_ids:
+            errors.append(f"{prefix}: duplicate artifact id '{art_id}'.")
+        else:
+            seen_ids.add(art_id)
+
+        if not art.get("owner"):
+            errors.append(f"{art_id}: missing 'owner'.")
+
+        files = art.get("files")
+        if not isinstance(files, list) or not files:
+            errors.append(f"{art_id}: 'files' must be a non-empty list.")
+            files = []
+        else:
+            for f in files:
+                if not isinstance(f, str):
+                    errors.append(f"{art_id}: file entry must be a string, got {type(f).__name__}.")
+                    continue
+                if f in seen_files and seen_files[f] != art_id:
+                    errors.append(
+                        f"{art_id}: file '{f}' is also owned by '{seen_files[f]}' "
+                        f"(duplicate file mapping)."
+                    )
+                else:
+                    seen_files[f] = art_id
+
+        mode = art.get("verificationMode")
+        if mode not in VALID_MODES:
+            errors.append(
+                f"{art_id}: invalid verificationMode '{mode}'. "
+                f"Expected one of: {', '.join(sorted(VALID_MODES))}."
+            )
+
+        offline = art.get("offlineCheck")
+        if not isinstance(offline, dict):
+            errors.append(f"{art_id}: 'offlineCheck' must be an object.")
+        else:
+            covered = offline.get("coveredBy")
+            if covered not in VALID_COVERAGE:
+                errors.append(
+                    f"{art_id}: invalid offlineCheck.coveredBy '{covered}'. "
+                    f"Expected one of: {', '.join(sorted(VALID_COVERAGE))}."
+                )
+            cmd = offline.get("command")
+            if covered == "standalone":
+                if not cmd or not isinstance(cmd, str):
+                    errors.append(
+                        f"{art_id}: standalone offlineCheck requires a non-null 'command'."
+                    )
+                else:
+                    standalone_commands.add(cmd)
+
+        # Optional: reconciliationTests
+        tests = art.get("reconciliationTests", [])
+        if not isinstance(tests, list):
+            errors.append(f"{art_id}: 'reconciliationTests' must be a list.")
+            tests = []
+
+        # Optional: nodeTests
+        node_tests = art.get("nodeTests", [])
+        if not isinstance(node_tests, list):
+            errors.append(f"{art_id}: 'nodeTests' must be a list.")
+
+        # Optional: refreshWorkflow
+        wf = art.get("refreshWorkflow")
+        if wf is not None and not isinstance(wf, str):
+            errors.append(f"{art_id}: 'refreshWorkflow' must be a string or null.")
+
+        # Optional: sourceSpec (for source-lock)
+        spec = art.get("sourceSpec")
+        if spec is not None and not isinstance(spec, str):
+            errors.append(f"{art_id}: 'sourceSpec' must be a string or null.")
+
+        # generator
+        gen = art.get("generator")
+        if not isinstance(gen, dict):
+            errors.append(f"{art_id}: 'generator' must be an object.")
+        elif "requiresNetworkInput" not in gen:
+            errors.append(f"{art_id}: 'generator.requiresNetworkInput' is required.")
+
+    return errors
+
+
+def validate_references(registry: dict) -> list[str]:
+    """Check that referenced files, tests, and workflows exist."""
+    errors = []
+
+    for art in registry.get("artifacts", []):
+        art_id = art.get("id", "<unknown>")
+
+        for f in art.get("files", []):
+            if not isinstance(f, str):
+                continue
+            path = ROOT / f
+            if not path.exists():
+                errors.append(f"{art_id}: file not found: {f}")
+            elif path.is_dir():
+                # Directories (e.g., integrated/rows) are valid file references
+                if not any(path.iterdir()):
+                    errors.append(f"{art_id}: directory is empty: {f}")
+
+        for t in art.get("reconciliationTests", []):
+            if not isinstance(t, str):
+                continue
+            path = ROOT / t
+            if not path.exists():
+                errors.append(f"{art_id}: reconciliation test not found: {t}")
+
+        for t in art.get("nodeTests", []):
+            if not isinstance(t, str):
+                continue
+            path = ROOT / t
+            if not path.exists():
+                errors.append(f"{art_id}: node test not found: {t}")
+
+        wf = art.get("refreshWorkflow")
+        if wf:
+            path = ROOT / wf
+            if not path.exists():
+                errors.append(f"{art_id}: refresh workflow not found: {wf}")
+
+        spec = art.get("sourceSpec")
+        if spec:
+            path = ROOT / spec
+            if not path.exists():
+                errors.append(f"{art_id}: source spec not found: {spec}")
+
+    return errors
+
+
+def collect_registered_files(registry: dict) -> set[str]:
+    """Return the set of all registered file paths + exclusions."""
+    registered = set()
+    for art in registry.get("artifacts", []):
+        for f in art.get("files", []):
+            if isinstance(f, str):
+                registered.add(f)
+    for exc in registry.get("exclusions", []):
+        if isinstance(exc, dict) and isinstance(exc.get("path"), str):
+            registered.add(exc["path"])
+    return registered
+
+
+def detect_unregistered_files(registry: dict) -> list[str]:
+    """Detect generated-data files not accounted for by the registry."""
+    errors = []
+    registered = collect_registered_files(registry)
+    roots = registry.get("generatedDataRoots", [])
+
+    for root_rel in roots:
+        root = ROOT / root_rel
+        if not root.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            # Skip hidden directories
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            for fname in filenames:
+                full = Path(dirpath) / fname
+                rel = str(full.relative_to(ROOT))
+                if rel in registered:
+                    continue
+
+                ext = Path(fname).suffix.lower()
+                # Handle .jsonl.gz
+                if fname.endswith(".jsonl.gz"):
+                    ext = ".jsonl.gz"
+
+                if ext in GENERATED_EXTENSIONS:
+                    # Check if this file is inside a registered directory
+                    # (e.g., integrated/rows/ is registered as a directory)
+                    in_registered_dir = any(
+                        rel.startswith(r + "/") and (ROOT / r).is_dir()
+                        for r in registered
+                        if (ROOT / r).is_dir()
+                    )
+                    if in_registered_dir:
+                        continue
+
+                    errors.append(
+                        f"Unregistered generated file: {rel} "
+                        f"(add it to the registry or list it in 'exclusions' with a reason)"
+                    )
+
+    return errors
+
+
+def git_porcelain() -> str:
+    """Return `git status --porcelain` output."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def run_offline_checks(registry: dict) -> tuple[list[str], list[str], list[str]]:
+    """Run unique standalone offline checks. Returns (executed, covered_by_etl, failed)."""
+    executed = []
+    covered_by_etl = []
+    failed = []
+    seen_commands: set[str] = set()
+
+    # Set PYTHONPATH so ETL scripts can import sibling modules
+    env = os.environ.copy()
+    etl_dir = str(ROOT / "scripts" / "etl")
+    env["PYTHONPATH"] = etl_dir + os.pathsep + env.get("PYTHONPATH", "")
+
+    for art in registry.get("artifacts", []):
+        art_id = art.get("id", "<unknown>")
+        offline = art.get("offlineCheck", {})
+        covered = offline.get("coveredBy")
+        cmd = offline.get("command")
+
+        if covered == "standalone" and cmd:
+            if cmd in seen_commands:
+                continue  # Deduplicate identical commands
+            seen_commands.add(cmd)
+
+            # Parse the command string
+            parts = cmd.split()
+            result = subprocess.run(parts, cwd=ROOT, env=env, capture_output=True, text=True)
+            if result.returncode == 0:
+                executed.append(f"{art_id}: {cmd}")
+            else:
+                failed.append(
+                    f"{art_id}: {cmd}\n"
+                    f"  exit code: {result.returncode}\n"
+                    f"  stderr: {result.stderr[:500] if result.stderr else '(empty)'}"
+                )
+        elif covered == "etl-suite":
+            covered_by_etl.append(art_id)
+        elif covered == "node-tests":
+            covered_by_etl.append(f"{art_id} (node-tests)")
+
+    return executed, covered_by_etl, failed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the generated-artifact registry and optionally run offline checks."
+    )
+    parser.add_argument(
+        "--run-checks",
+        action="store_true",
+        help="Execute unique standalone offline --check commands and verify worktree cleanliness.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON (for CI summary).",
+    )
+    args = parser.parse_args()
+
+    errors = []
+
+    # 1. Load and validate schema
+    try:
+        registry = load_registry()
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    errors.extend(validate_schema(registry))
+    errors.extend(validate_references(registry))
+    errors.extend(detect_unregistered_files(registry))
+
+    if errors:
+        print(f"\n❌ Registry validation failed ({len(errors)} error(s)):\n", file=sys.stderr)
+        for err in errors:
+            print(f"  • {err}", file=sys.stderr)
+        return 1
+
+    artifact_count = len(registry.get("artifacts", []))
+    file_count = sum(
+        len(art.get("files", [])) for art in registry.get("artifacts", [])
+    )
+    standalone_count = sum(
+        1
+        for art in registry.get("artifacts", [])
+        if art.get("offlineCheck", {}).get("coveredBy") == "standalone"
+    )
+    etl_covered_count = sum(
+        1
+        for art in registry.get("artifacts", [])
+        if art.get("offlineCheck", {}).get("coveredBy") == "etl-suite"
+    )
+    node_covered_count = sum(
+        1
+        for art in registry.get("artifacts", [])
+        if art.get("offlineCheck", {}).get("coveredBy") == "node-tests"
+    )
+
+    print(f"✅ Registry valid: {artifact_count} artifact groups, {file_count} files covered")
+    print(f"   Standalone offline checks: {standalone_count}")
+    print(f"   Covered by ETL suite: {etl_covered_count}")
+    print(f"   Covered by Node tests: {node_covered_count}")
+    print(f"   Unregistered files: 0")
+
+    if not args.run_checks:
+        print("\n(Run with --run-checks to execute offline artifact checks)")
+        return 0
+
+    # 2. Capture worktree baseline
+    baseline = git_porcelain()
+
+    # 3. Run offline checks
+    print("\n--- Running standalone offline checks ---")
+    executed, covered_by_etl, failed = run_offline_checks(registry)
+
+    for entry in executed:
+        print(f"  ✓ {entry}")
+
+    if covered_by_etl:
+        print(f"\n--- Covered by ETL suite (not re-run) ---")
+        for entry in covered_by_etl:
+            print(f"  → {entry}")
+
+    if failed:
+        print(f"\n❌ {len(failed)} offline check(s) FAILED:\n", file=sys.stderr)
+        for entry in failed:
+            print(f"  ✗ {entry}", file=sys.stderr)
+        return 1
+
+    print(f"\n✅ {len(executed)} standalone check(s) passed")
+
+    # 4. Worktree cleanliness
+    after = git_porcelain()
+    new_changes = []
+    baseline_lines = set(baseline.strip().split("\n")) if baseline.strip() else set()
+    after_lines = set(after.strip().split("\n")) if after.strip() else set()
+
+    new_lines = after_lines - baseline_lines
+    if new_lines:
+        new_changes = sorted(new_lines)
+
+    if new_changes:
+        print(
+            f"\n❌ Worktree cleanliness check FAILED: "
+            f"offline checks introduced {len(new_changes)} new modification(s):\n",
+            file=sys.stderr,
+        )
+        for line in new_changes:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+
+    print("✅ Working tree clean after validation")
+
+    # 5. CI summary
+    if args.json:
+        summary = {
+            "artifactGroups": artifact_count,
+            "generatedFilesCovered": file_count,
+            "standaloneChecksExecuted": len(executed),
+            "coveredByEtlSuite": len(covered_by_etl),
+            "unregisteredFiles": 0,
+            "worktreeClean": True,
+        }
+        print("\n" + json.dumps(summary, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -144,23 +144,61 @@ def validate_schema(registry: dict) -> list[str]:
         node_tests = art.get("nodeTests", [])
         if not isinstance(node_tests, list):
             errors.append(f"{art_id}: 'nodeTests' must be a list.")
+            node_tests = []
+
+        # --- Cross-field invariants: coveredBy must have executable evidence ---
+        if covered == "etl-suite" and len(tests) == 0:
+            errors.append(
+                f"{art_id}: coveredBy='etl-suite' requires at least one "
+                f"'reconciliationTests' entry."
+            )
+        if covered == "node-tests" and len(node_tests) == 0:
+            errors.append(
+                f"{art_id}: coveredBy='node-tests' requires at least one "
+                f"'nodeTests' entry."
+            )
 
         # Optional: refreshWorkflow
         wf = art.get("refreshWorkflow")
         if wf is not None and not isinstance(wf, str):
             errors.append(f"{art_id}: 'refreshWorkflow' must be a string or null.")
 
-        # Optional: sourceSpec (for source-lock)
+        # sourceSpec required for source-lock mode
         spec = art.get("sourceSpec")
         if spec is not None and not isinstance(spec, str):
             errors.append(f"{art_id}: 'sourceSpec' must be a string or null.")
+        if mode == "source-lock" and (not spec or not isinstance(spec, str)):
+            errors.append(
+                f"{art_id}: verificationMode='source-lock' requires a non-empty 'sourceSpec'."
+            )
+
+        # trustModel must be a non-empty string
+        trust = art.get("trustModel")
+        if not trust or not isinstance(trust, str):
+            errors.append(f"{art_id}: 'trustModel' must be a non-empty string.")
 
         # generator
         gen = art.get("generator")
         if not isinstance(gen, dict):
             errors.append(f"{art_id}: 'generator' must be an object.")
-        elif "requiresNetworkInput" not in gen:
-            errors.append(f"{art_id}: 'generator.requiresNetworkInput' is required.")
+        else:
+            net_input = gen.get("requiresNetworkInput")
+            if not isinstance(net_input, bool):
+                errors.append(
+                    f"{art_id}: 'generator.requiresNetworkInput' must be a boolean."
+                )
+
+    # Validate exclusions
+    for i, exc in enumerate(registry.get("exclusions", [])):
+        if not isinstance(exc, dict):
+            errors.append(f"exclusion[{i}]: must be an object.")
+            continue
+        exc_path = exc.get("path")
+        if not exc_path or not isinstance(exc_path, str):
+            errors.append(f"exclusion[{i}]: 'path' must be a non-empty string.")
+        exc_reason = exc.get("reason")
+        if not exc_reason or not isinstance(exc_reason, str):
+            errors.append(f"exclusion[{i}]: 'reason' must be a non-empty string.")
 
     return errors
 
@@ -269,7 +307,7 @@ def detect_unregistered_files(registry: dict) -> list[str]:
 
 
 def git_porcelain() -> str:
-    """Return `git status --porcelain` output."""
+    """Return `git status --porcelain` output (for diagnostics only)."""
     result = subprocess.run(
         ["git", "status", "--porcelain"],
         cwd=ROOT,
@@ -277,6 +315,57 @@ def git_porcelain() -> str:
         text=True,
     )
     return result.stdout
+
+
+def worktree_fingerprint() -> str:
+    """Return a content-based fingerprint of the working tree.
+
+    Captures tracked-file modifications (via ``git diff HEAD --binary``) and
+    untracked-file contents (via SHA-256 hashing), so that any actual content
+    change is detected regardless of staging state.
+
+    Unlike ``git status --porcelain`` line comparison, this fingerprint:
+
+    * Is invariant to staging-state transitions (e.g. `` M`` → ``MM``) that
+      don't change file content.
+    * Catches further modifications to files that were already dirty before
+      the check (the status line stays the same, but the diff content changes).
+    """
+    parts: list[str] = []
+
+    # Tracked file changes (staged + unstaged) as a binary patch.
+    # --no-ext-diff ensures deterministic output regardless of diff drivers.
+    diff_result = subprocess.run(
+        ["git", "diff", "HEAD", "--binary", "--no-ext-diff", "--no-color"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    parts.append(diff_result.stdout)
+
+    # Untracked files — not covered by ``git diff HEAD``.
+    # List them and hash their contents so new or modified untracked
+    # files are detected.
+    ls_result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    untracked = sorted(
+        line for line in ls_result.stdout.strip().split("\n") if line
+    )
+    for filepath in untracked:
+        full_path = ROOT / filepath
+        if not full_path.is_file():
+            continue
+        hasher = hashlib.sha256()
+        with open(full_path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(8192), b""):
+                hasher.update(chunk)
+        parts.append(f"{filepath}\0{hasher.hexdigest()}")
+
+    return "\n".join(parts)
 
 
 def run_offline_checks(registry: dict) -> tuple[list[str], list[str], list[str]]:
@@ -386,8 +475,8 @@ def main() -> int:
         print("\n(Run with --run-checks to execute offline artifact checks)")
         return 0
 
-    # 2. Capture worktree baseline
-    baseline = git_porcelain()
+    # 2. Capture worktree baseline (content-based fingerprint)
+    baseline = worktree_fingerprint()
 
     # 3. Run offline checks
     print("\n--- Running standalone offline checks ---")
@@ -409,24 +498,23 @@ def main() -> int:
 
     print(f"\n✅ {len(executed)} standalone check(s) passed")
 
-    # 4. Worktree cleanliness
-    after = git_porcelain()
-    new_changes = []
-    baseline_lines = set(baseline.strip().split("\n")) if baseline.strip() else set()
-    after_lines = set(after.strip().split("\n")) if after.strip() else set()
+    # 4. Worktree cleanliness (content-based: compares working-tree fingerprint
+    #    before and after checks to detect any modification, including further
+    #    changes to files that were already dirty before the check).
+    after = worktree_fingerprint()
 
-    new_lines = after_lines - baseline_lines
-    if new_lines:
-        new_changes = sorted(new_lines)
-
-    if new_changes:
+    if after != baseline:
+        # Diagnostic: show current working-tree status for investigation
+        status = git_porcelain()
         print(
-            f"\n❌ Worktree cleanliness check FAILED: "
-            f"offline checks introduced {len(new_changes)} new modification(s):\n",
+            "\n❌ Worktree cleanliness check FAILED: "
+            "offline checks modified the working tree",
             file=sys.stderr,
         )
-        for line in new_changes:
-            print(f"  {line}", file=sys.stderr)
+        if status.strip():
+            print("  Current git status:", file=sys.stderr)
+            for line in status.strip().split("\n"):
+                print(f"  {line}", file=sys.stderr)
         return 1
 
     print("✅ Working tree clean after validation")

--- a/scripts/etl/siope_municipal_snapshot.py
+++ b/scripts/etl/siope_municipal_snapshot.py
@@ -986,11 +986,24 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument("--detail-output", type=Path, default=DEFAULT_DETAIL_OUTPUT)
     parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate the committed snapshot offline without network access",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+
+    if args.check:
+        from siope_snapshot_check import check_committed_snapshot
+
+        summary = check_committed_snapshot(args.output)
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0
+
     if args.year < 2016 or args.year > datetime.now(timezone.utc).year + 1:
         raise SystemExit(f"Anno non valido: {args.year}")
 

--- a/scripts/etl/siope_snapshot_check.py
+++ b/scripts/etl/siope_snapshot_check.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Offline contract validator for committed SIOPE municipal snapshots.
+
+This module is the **single source of truth** for the SIOPE snapshot contract.
+It is executed:
+
+- locally via ``python scripts/etl/siope_municipal_snapshot.py --check``
+- in the central ``CI / etl`` gate via ``npm run test:snapshots``
+- in the scheduled ``siope-refresh.yml`` workflow after a rebuild
+
+The contract was previously inlined as a large Python program inside
+``.github/workflows/siope-refresh.yml``.  Moving it here prevents the inline
+YAML contract, the Node runtime contract, and the ETL test contract from
+drifting apart.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_SNAPSHOT_PATH = Path("src/data/generated/siope-municipal.json")
+
+
+def _check_quantiles(quantiles: dict) -> None:
+    values = [quantiles[key] for key in ("p10", "p25", "p50", "p75", "p90")]
+    assert all(value is None or isinstance(value, (int, float)) for value in values)
+    present = [value for value in values if value is not None]
+    assert present == sorted(present)
+
+
+def validate_snapshot(data: dict) -> dict:
+    """Validate a parsed SIOPE municipal snapshot against the full contract.
+
+    Returns a compact summary dict on success.
+    Raises ``AssertionError`` on any contract violation.
+    """
+    assert data["schemaVersion"] == 3
+    assert data["scope"] == "municipalities"
+    assert 1 <= data["latestMonth"] <= 12
+    assert data["totalPaid"] >= 0
+    assert 0 <= data["paymentsWithPopulation"] <= data["totalPaid"]
+    assert data["populationCovered"] > 0
+    assert abs(
+        data["nationalPerCapita"]
+        - data["paymentsWithPopulation"] / data["populationCovered"]
+    ) < 0.01
+    assert len(data["regions"]) >= 18
+    assert data["coverage"]["withMovements"] > 7000
+    assert data["coverage"]["includedMovementRows"] > 0
+    assert (
+        data["coverage"]["withPopulation"]
+        + data["coverage"]["withoutPopulation"]
+        == data["coverage"]["withMovements"]
+    )
+    assert (
+        data["coverage"]["withRegion"]
+        + data["coverage"]["withoutRegion"]
+        == data["coverage"]["withMovements"]
+    )
+    assert (
+        data["coverage"]["matchedToIpaRegion"]
+        + data["coverage"]["unmatchedToIpaRegion"]
+        == data["coverage"]["activeSiopeMunicipalities"]
+    )
+    assert data["coverage"]["withRegion"] <= data["coverage"]["matchedToIpaRegion"]
+    assert data["coverage"]["withoutRegion"] <= data["coverage"]["unmatchedToIpaRegion"]
+    assert abs(
+        sum(item["value"] for item in data["regions"])
+        + data["coverage"]["paymentsWithoutRegion"]
+        - data["totalPaid"]
+    ) < 0.05
+    assert len(data["topMunicipalitiesByValue"]) == 100
+    assert len(data["topMunicipalitiesByPerCapita"]) == 100
+    assert data["topMunicipalities"] == data["topMunicipalitiesByValue"]
+    assert all(
+        item["province"].strip() and item["region"].strip()
+        for ranking in (
+            data["topMunicipalitiesByValue"],
+            data["topMunicipalitiesByPerCapita"],
+        )
+        for item in ranking
+    )
+    assert all(
+        left["value"] >= right["value"]
+        for left, right in zip(
+            data["topMunicipalitiesByValue"],
+            data["topMunicipalitiesByValue"][1:],
+        )
+    )
+    assert all(
+        left["perCapita"] >= right["perCapita"]
+        for left, right in zip(
+            data["topMunicipalitiesByPerCapita"],
+            data["topMunicipalitiesByPerCapita"][1:],
+        )
+    )
+    assert data["source"]["siopeMovementsLastModified"]
+    assert data["source"]["siopeRegistryLastModified"]
+    for field in ("siopeMovementsEtag", "siopeRegistryEtag", "ipaEtag"):
+        assert isinstance(data["source"][field], str) and data["source"][field]
+    for field in ("siopeMovementsSha256", "siopeRegistrySha256", "ipaSha256"):
+        assert re.fullmatch(r"[0-9a-f]{64}", data["source"][field]), field
+    assert (
+        data["methodology"]["populationSourceLastModified"]
+        == data["source"]["siopeRegistryLastModified"]
+    )
+
+    distribution = data.get("distribution")
+    assert isinstance(distribution, dict), "Full-population distribution is missing"
+    assert distribution["schemaVersion"] == 2
+    assert distribution["measure"]["titleCode"] == "1"
+    assert distribution["measure"]["shareDenominator"] == (
+        "tutti i pagamenti SIOPE degli enti riconosciuti come Comuni "
+        "dall'anagrafica SIOPE nel periodo"
+    )
+    assert distribution["period"]["year"] == data["year"]
+    assert distribution["period"]["startMonth"] == 1
+    assert distribution["period"]["endMonth"] == data["latestMonth"]
+    assert distribution["period"]["completeness"] in ("complete", "partial")
+
+    coverage = distribution["coverage"]
+    assert coverage["municipalitiesWithMovements"] == data["coverage"]["withMovements"]
+    assert coverage["municipalitiesWithValidPopulation"] == data["coverage"]["withPopulation"]
+    assert coverage["municipalitiesWithoutPopulation"] == data["coverage"]["withoutPopulation"]
+    assert coverage["populationCovered"] == data["populationCovered"]
+    assert coverage["municipalitiesWithRegion"] == data["coverage"]["withRegion"]
+    assert coverage["municipalitiesWithoutRegion"] == data["coverage"]["withoutRegion"]
+    assert coverage["paymentsWithoutRegion"] == data["coverage"]["paymentsWithoutRegion"]
+    assert (
+        coverage["municipalitiesWithValidPopulation"]
+        - coverage["municipalitiesWithValidPopulationAndRegion"]
+        <= coverage["municipalitiesWithoutRegion"]
+    )
+    assert coverage["titlePaymentsWithoutRegion"] <= coverage["paymentsWithoutRegion"]
+    assert (
+        coverage["paymentsWithPopulationWithoutRegion"]
+        <= coverage["paymentsWithoutRegion"]
+    )
+    assert (
+        coverage["titlePaymentsWithPopulationWithoutRegion"]
+        <= coverage["titlePaymentsWithoutRegion"]
+    )
+    assert (
+        coverage["titlePaymentsWithPopulationWithoutRegion"]
+        <= coverage["paymentsWithPopulationWithoutRegion"]
+    )
+    assert abs(
+        coverage["paymentsWithoutPopulation"]
+        + data["paymentsWithPopulation"]
+        - data["totalPaid"]
+    ) < 0.05
+    assert 0 <= distribution["nationalShareAll"] <= 1
+    assert 0 <= distribution["nationalShareCovered"] <= 1
+
+    for group in [
+        distribution["perCapita"],
+        *(item["perCapita"] for item in distribution["populationBands"]),
+        *(item["perCapita"] for item in distribution["regions"]),
+    ]:
+        _check_quantiles(group["municipalityWeighted"])
+        _check_quantiles(group["residentWeighted"])
+    assert sum(item["municipalities"] for item in distribution["populationBands"]) == coverage["municipalitiesWithValidPopulation"]
+    assert sum(item["municipalities"] for item in distribution["regions"]) == coverage["municipalitiesWithValidPopulationAndRegion"]
+    assert sum(item["population"] for item in distribution["populationBands"]) == coverage["populationCovered"]
+    assert sum(item["population"] for item in distribution["regions"]) == coverage["populationRegionalized"]
+    assert all("municipalities" not in item or item["municipalities"] >= 0 for item in distribution["regions"])
+
+    return {
+        "year": data["year"],
+        "latestMonth": data["latestMonthLabel"],
+        "totalPaid": data["totalPaid"],
+        "regions": len(data["regions"]),
+        "municipalities": data["coverage"]["withMovements"],
+        "municipalitiesWithPopulation": data["coverage"]["withPopulation"],
+        "matched": data["coverage"]["matchedToIpaRegion"],
+        "unmatched": data["coverage"]["unmatchedToIpaRegion"],
+        "movementRows": data["coverage"]["movementRows"],
+    }
+
+
+def check_committed_snapshot(path: Path = DEFAULT_SNAPSHOT_PATH) -> dict:
+    """Load and validate the committed SIOPE snapshot at *path*.
+
+    Raises ``SystemExit`` if the file is missing or fails validation.
+    """
+    if not path.exists():
+        raise SystemExit(f"Generated SIOPE snapshot is missing: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return validate_snapshot(data)
+
+
+def main() -> int:
+    """CLI entry point for standalone offline validation."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Validate a committed SIOPE municipal snapshot offline"
+    )
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=DEFAULT_SNAPSHOT_PATH,
+        help="Path to the committed snapshot JSON (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    summary = check_committed_snapshot(args.snapshot)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/etl/test_offline_guard.py
+++ b/tests/etl/test_offline_guard.py
@@ -1,0 +1,80 @@
+"""Tests for the application-level Python offline network guard.
+
+These tests prove:
+  - external connection attempts are blocked
+  - external urllib requests are blocked
+  - loopback connections are NOT rejected by the policy itself
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import unittest
+import urllib.request
+
+# Ensure scripts/ci is importable
+_CI_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "ci")
+_CI_DIR = os.path.abspath(_CI_DIR)
+if _CI_DIR not in sys.path:
+    sys.path.insert(0, _CI_DIR)
+
+import offline_guard  # type: ignore[import-not-found]
+
+
+class OfflineGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        offline_guard.install()
+
+    def tearDown(self) -> None:
+        offline_guard.uninstall()
+
+    def test_external_socket_connection_is_blocked(self) -> None:
+        """A direct socket.connect to an external IP raises ConnectionError."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with self.assertRaises(ConnectionError) as ctx:
+                s.connect(("93.184.216.34", 443))
+            self.assertIn("offline verification attempted outbound connection", str(ctx.exception))
+            self.assertIn("93.184.216.34", str(ctx.exception))
+        finally:
+            s.close()
+
+    def test_external_urllib_request_is_blocked(self) -> None:
+        """A urllib.request.urlopen to an external host is blocked."""
+        with self.assertRaises(Exception) as ctx:
+            urllib.request.urlopen("http://93.184.216.34/test", timeout=5)
+        # urllib wraps the ConnectionError in URLError
+        self.assertIn("offline verification attempted outbound connection", str(ctx.exception))
+
+    def test_loopback_is_not_rejected_by_policy(self) -> None:
+        """Loopback (127.0.0.1) connections are allowed by the guard."""
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            client.connect(("127.0.0.1", port))  # Should NOT raise
+            self.assertEqual(client.getpeername()[0], "127.0.0.1")
+        finally:
+            client.close()
+            listener.close()
+
+    def test_guard_is_installed(self) -> None:
+        """After install(), the guard reports as active."""
+        self.assertTrue(offline_guard.is_active())
+
+    def test_guard_can_be_uninstalled(self) -> None:
+        """After uninstall(), external connections are no longer blocked."""
+        offline_guard.uninstall()
+        self.assertFalse(offline_guard.is_active())
+        # Restore for tearDown
+        offline_guard.install()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/etl/test_offline_guard.py
+++ b/tests/etl/test_offline_guard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
+import tempfile
 import unittest
 import urllib.request
 
@@ -74,6 +75,48 @@ class OfflineGuardTests(unittest.TestCase):
         self.assertFalse(offline_guard.is_active())
         # Restore for tearDown
         offline_guard.install()
+
+    def test_unix_domain_socket_is_allowed(self) -> None:
+        """Unix domain sockets (AF_UNIX) are not blocked by the guard.
+
+        Before the fix, the guard treated the string path address as a
+        tuple, extracted its first character ('/'), and blocked it as a
+        non-loopback host.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sock_path = os.path.join(tmpdir, "test.sock")
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            listener.bind(sock_path)
+            listener.listen(1)
+
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                client.connect(sock_path)  # Must NOT raise ConnectionError
+                client.sendall(b"hello")
+                conn, _ = listener.accept()
+                data = conn.recv(5)
+                self.assertEqual(data, b"hello")
+                conn.close()
+            finally:
+                client.close()
+                listener.close()
+
+    def test_ipv6_loopback_is_allowed(self) -> None:
+        """IPv6 loopback (::1) connections are allowed by the guard."""
+        listener = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            listener.bind(("::1", 0))
+            listener.listen(1)
+            port = listener.getsockname()[1]
+
+            client = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            try:
+                client.connect(("::1", port))  # Should NOT raise
+            finally:
+                client.close()
+        finally:
+            listener.close()
 
 
 if __name__ == "__main__":

--- a/tests/offline-guard.test.mjs
+++ b/tests/offline-guard.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const guardPath = new URL("../scripts/ci/node-offline-guard.mjs", import.meta.url).pathname;
+
+function runWithGuard(code) {
+  const result = spawnSync(process.execPath, [
+    "--import", guardPath,
+    "-e", code,
+  ], {
+    env: { ...process.env, DVNS_OFFLINE_GUARD: "1" },
+    encoding: "utf-8",
+    timeout: 10000,
+  });
+  return result;
+}
+
+test("external fetch is blocked under the guard", () => {
+  const result = runWithGuard(`
+    try {
+      await fetch("http://93.184.216.34/test");
+      console.log("FAIL");
+      process.exit(1);
+    } catch (e) {
+      if (e.message && e.message.includes("offline verification attempted outbound connection")) {
+        console.log("BLOCKED");
+        process.exit(0);
+      }
+      console.log("UNEXPECTED:" + (e.message || e));
+      process.exit(1);
+    }
+  `);
+  assert.equal(result.status, 0, `Expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+  assert.match(result.stdout, /BLOCKED/);
+});
+
+test("external https.request is blocked under the guard", () => {
+  const result = runWithGuard(`
+    const https = require("https");
+    try {
+      https.request("https://93.184.216.34/test");
+      console.log("FAIL");
+      process.exit(1);
+    } catch (e) {
+      if (e.message && e.message.includes("offline verification attempted outbound connection")) {
+        console.log("BLOCKED");
+        process.exit(0);
+      }
+      console.log("UNEXPECTED:" + (e.message || e));
+      process.exit(1);
+    }
+  `);
+  assert.equal(result.status, 0, `Expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+  assert.match(result.stdout, /BLOCKED/);
+});
+
+test("loopback is not rejected by the guard", () => {
+  const result = runWithGuard(`
+    const http = require("http");
+    const server = http.createServer((req, res) => { res.end("ok"); });
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      http.get("http://127.0.0.1:" + port + "/", (res) => {
+        console.log("ALLOWED");
+        server.close();
+        process.exit(0);
+      }).on("error", (e) => {
+        console.log("FAIL:" + e.message);
+        server.close();
+        process.exit(1);
+      });
+    });
+  `);
+  assert.equal(result.status, 0, `Expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+  assert.match(result.stdout, /ALLOWED/);
+});
+
+test("isLoopback correctly identifies loopback addresses", async () => {
+  const { isLoopback } = await import(new URL("../scripts/ci/node-offline-guard.mjs", import.meta.url));
+  assert.equal(isLoopback("127.0.0.1"), true);
+  assert.equal(isLoopback("127.0.0.2"), true);
+  assert.equal(isLoopback("localhost"), true);
+  assert.equal(isLoopback("::1"), true);
+  assert.equal(isLoopback("93.184.216.34"), false);
+  assert.equal(isLoopback("example.com"), false);
+});


### PR DESCRIPTION
## PR2: ETL contracts, generated-artifact registry, offline enforcement

**Depends on #98.** Review PR2 as the ETL/offline-verification delta only.

### BEFORE

```
PR
├── central ETL unittest suite
├── source workflow A --check (consulenti)
├── source workflow B --check (mef-irpef)
├── source workflow C --check (mef-participations)
├── source workflow D --check (opencivitas)
├── source workflow E --check (opencoesione)
├── source workflow F --check (parliament)
├── source workflow G --check (pnrr-childcare)
├── SIOPE online rebuild + 155-line inline YAML contract
└── no complete artifact ownership registry
```

### AFTER

```
PR
└── CI / etl
    ├── full ETL suite once (test:etl, 219 tests)
    ├── generated-artifact registry (test:snapshots)
    │   ├── 21 logical artifact groups
    │   ├── 13 unique standalone offline --check commands
    │   ├── 8 artifacts covered by ETL suite (not re-run)
    │   ├── unregistered file detection
    │   └── worktree cleanliness verification
    ├── reconciliation evidence (referenced, not re-run)
    ├── application-level network guard (Python)
    └── worktree cleanliness

scheduled/manual source workflows
└── online upstream observation / refresh (unchanged)
```

### What changed

**SIOPE contract extraction** — The 155-line inline Python contract in `siope-refresh.yml` moved to `scripts/etl/siope_snapshot_check.py`. One implementation used locally, in CI, and in the refresh workflow. Added `--check` mode to `siope_municipal_snapshot.py`.

**Generated-artifact registry** — `scripts/ci/generated-artifacts.json` maps 21 logical artifact groups (39 files) to committed files, offline checks, reconciliation tests, refresh workflows, and trust models. Verification modes: `online-refresh`, `source-lock`, `integrated-release`, `curated-committed`.

**Registry validator** — `scripts/ci/validate-generated-artifacts.py` validates schema, checks file/test/workflow references, detects unregistered generated files, runs unique standalone `--check` commands, and verifies worktree cleanliness. Exposed as `npm run test:snapshots`.

**Application-level network guard** — `scripts/ci/offline_guard.py` + `sitecustomize.py` block outbound TCP during offline ETL/artifact verification. `scripts/ci/node-offline-guard.mjs` patches `fetch`/`http`/`https`. Loopback (127.0.0.0/8, ::1) allowed. **Not kernel-level egress isolation.**

**Source workflow simplification** — Removed `pull_request` triggers from 8 source workflows. Central `CI / etl` + `test:snapshots` now covers the same offline verification. Scheduled/manual refresh behavior unchanged. Direct-to-main bot behavior unchanged (PR4 scope).

| Workflow | PR validation removed | Schedule/manual behavior |
|----------|----------------------|--------------------------|
| consulenti-refresh | `validate` job (`--check`) | unchanged |
| mef-irpef-refresh | `offline-contract` on PR | unchanged |
| mef-participations-refresh | `validate` job (`--check`) | unchanged |
| opencivitas-refresh | `validate` job (`--check`) | unchanged |
| opencoesione-refresh | `validate` job (`--check`) | unchanged |
| parliament-sources | PR trigger (offline checks) | unchanged |
| pnrr-childcare-refresh | `offline-contract` on PR | unchanged |
| siope-refresh | PR rebuild + inline YAML contract | uses shared validator |

### Negative tests passed

- Missing artifact file → `test:snapshots` FAIL
- Malformed registry (bad mode) → `test:snapshots` FAIL
- Missing test reference → `test:snapshots` FAIL
- Artifact corruption (consulenti) → `--check` FAIL
- SIOPE centralization (schemaVersion corruption) → `siope_snapshot_check.py` FAIL
- Python external connection → blocked
- Node external fetch/https → blocked
- Loopback → allowed

### Performance

- PR1 ETL baseline: ~5m24s
- PR2 ETL suite: 124s (219 tests, including 5 new guard tests)
- PR2 snapshots: 1.1s (13 standalone checks)
- Total PR2 etl job overhead: ~1.1s (snapshots) — well within 10% budget

### Network guard coverage

- **Python**: full ETL suite + artifact verification (219 tests + 13 checks under guard, 0 external attempts)
- **Node**: guard tests prove external fetch/http/https blocked, loopback allowed. Not applied globally to `test:node` (MCP/browser tests legitimately use localhost).
- **Browser/production**: not in PR2 scope.
