### PR TITLE
Add catalog search, recipients CTAs, and sticky result headers.

### DIFF
--- a/.agents/skills/verify-dvns-integrated-sources/features/integrated-data-catalog.md
+++ b/.agents/skills/verify-dvns-integrated-sources/features/integrated-data-catalog.md
@@ -24,10 +24,10 @@ Preconditions:
 - The skill doctor passes for the run-owned server.
 - `integrated_source_release.py --check` passes offline.
 
-- **Open catalog.** Run `node .agents/skills/verify-dvns-integrated-sources/scripts/verify.mjs drive integrated-data-catalog`. The H1 is `Tutti i dataset integrati`. The default view `/dati` leads with readable recipient/amount datasets (`Numeri da leggere`) and demotes coverage gaps (`Cosa manca ancora`); `/dati?vista=tutti` has 79 unique detail links.
+- **Open catalog.** Run `node .agents/skills/verify-dvns-integrated-sources/scripts/verify.mjs drive integrated-data-catalog`. The H1 is `Tutti i dataset integrati`. The default view `/dati` leads with readable recipient/amount datasets (`Numeri da leggere`) and demotes coverage gaps (`Cosa manca ancora`); the page has a catalog search box (`cerca`). `/dati?cerca=vincitori` narrows the priority list; `/dati?vista=tutti` has 79 unique detail links.
 - **Open detail.** The same drive navigates to `/dati/consulenze-legali?q=2024&limit=5`. The H1 is `Consulenze legali` and at most five matching rows render.
 - **Confirm API parity.** The drive requests `/api/dati/consulenze-legali?q=2024&limit=5`, requires the same dataset ID and row bound, and stores the response.
-- **Proof.** Retain `catalog.png`, `catalog-tutti.png`, `consulenze-legali.png`, `api-response.json` and `state.json` in the feature evidence directory.
+- **Proof.** Retain `catalog.png`, `catalog-cerca.png`, `catalog-tutti.png`, `consulenze-legali.png`, `api-response.json` and `state.json` in the feature evidence directory.
 
 ## Gotchas
 

--- a/.agents/skills/verify-dvns-integrated-sources/scripts/verify.mjs
+++ b/.agents/skills/verify-dvns-integrated-sources/scripts/verify.mjs
@@ -187,7 +187,23 @@ async function driveCatalog(page, directory) {
   );
   assert.ok(priorityLinks.length > 0 && priorityLinks.length < 79, "/dati: attesa solo la vista priorità");
   assert.ok(await page.$('nav[aria-label="Vista del catalogo"]'), "/dati: selettore vista assente");
+  assert.ok(await page.$('input[name="cerca"]'), "/dati: campo cerca catalogo assente");
+  const hasReadableSection = await page.evaluate(() =>
+    Boolean(document.getElementById("numeri-da-leggere")),
+  );
+  assert.ok(hasReadableSection, "/dati: sezione Numeri da leggere assente");
   await screenshot(page, directory, "catalog.png");
+
+  actions.push(await goto(page, "/dati?cerca=vincitori", "Tutti i dataset integrati"));
+  const searchLinks = await page.$$eval('a[href^="/dati/"]', (nodes) =>
+    [...new Set(nodes.map((node) => node.getAttribute("href")))].filter(Boolean),
+  );
+  assert.ok(
+    searchLinks.some((href) => href === "/dati/vincitori"),
+    "/dati?cerca=vincitori: scheda vincitori assente",
+  );
+  assert.ok(searchLinks.length < priorityLinks.length, "/dati?cerca=vincitori: atteso un sottoinsieme");
+  await screenshot(page, directory, "catalog-cerca.png");
 
   actions.push(await goto(page, "/dati?vista=tutti", "Tutti i dataset integrati"));
   const links = await page.$$eval('a[href^="/dati/"]', (nodes) =>

--- a/src/app/controlli/controlli.module.css
+++ b/src/app/controlli/controlli.module.css
@@ -32,6 +32,29 @@
   line-height: 1.55;
 }
 
+.entryActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.entryActions :global(.btn) {
+  min-height: 44px;
+}
+
+@media (max-width: 520px) {
+  .entryActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .entryActions :global(.btn) {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .typeLegend {
   display: flex;
   flex-direction: column;

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -164,6 +164,14 @@ export default async function ControlsPage({ searchParams }: PageProps) {
           Numeri presi da relazioni ufficiali, rivisti il {longDate(`${auditReviewedAt}T00:00:00Z`)}.
           Ogni numero dice una cosa precisa e mostra anche i suoi limiti.
         </p>
+        <div className={styles.entryActions}>
+          <Link className="btn btn-primary" href="/dati">
+            Vedi chi ha ricevuto di più
+          </Link>
+          <Link className="btn btn-secondary" href="/appalti/fornitori">
+            Fornitori e aggiudicatari
+          </Link>
+        </div>
       </div>
 
       <nav className={styles.yearFilter} aria-label="Filtra i controlli per anno">

--- a/src/app/dati/[dataset]/page.tsx
+++ b/src/app/dati/[dataset]/page.tsx
@@ -289,7 +289,7 @@ export default async function IntegratedDatasetPage({ params, searchParams }: Da
             {result.rows.length > 0 ? (
               <div className={`table-scroll ${styles.dataTable}`} role="region" aria-label={`Righe di ${dataset.title}`} tabIndex={0}>
                 <table className="table">
-                  <caption>
+                  <caption className={styles.tableCaption}>
                     Valori pubblici esatti
                     {amounts.size > 0 ? ". Colonne di importo allineate a destra." : "."}
                   </caption>

--- a/src/app/dati/dati.module.css
+++ b/src/app/dati/dati.module.css
@@ -159,6 +159,50 @@
   font-size: 14px;
 }
 
+.searchBar {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.searchBar label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  color: var(--color-neutral-600);
+}
+
+.searchBar > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2);
+}
+
+.searchHint,
+.searchClear {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-neutral-600);
+}
+
+.searchClear strong {
+  color: var(--color-text);
+}
+
+@media (max-width: 520px) {
+  .searchBar > div {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .searchBar button {
+    width: 100%;
+    min-height: 44px;
+  }
+}
+
 .filterBar {
   display: grid;
   gap: var(--space-3);
@@ -404,11 +448,31 @@
 
 .dataTable {
   border-top: 1px solid var(--color-neutral-300);
+  /* Tall enough for several rows, short enough that the sticky header stays
+     on screen while reading the results pane. */
+  max-height: min(60vh, 32rem);
+  background: var(--color-raised);
 }
 
 .dataTable table {
   width: max-content;
   min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+/* Keep the accessible caption out of the sticky scrollport so headings sit
+   flush at the top of the results pane. */
+.tableCaption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .dataTable th,
@@ -419,16 +483,34 @@
   overflow-wrap: anywhere;
 }
 
-.dataTable th:first-child {
-  min-width: 220px;
+.dataTable thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--color-raised);
+  box-shadow: inset 0 -1px 0 var(--color-neutral-400);
+}
+
+/* Keep the row id visible while scrolling sideways; the corner cell stays
+   above both the sticky header and the sticky first column. */
+.dataTable tbody th:first-child,
+.dataTable thead th:first-child {
   position: sticky;
   left: 0;
-  z-index: 1;
+  min-width: 220px;
   background: var(--color-raised);
 }
 
+.dataTable tbody th:first-child {
+  z-index: 1;
+  box-shadow: 1px 0 0 var(--color-neutral-200);
+}
+
 .dataTable thead th:first-child {
-  z-index: 2;
+  z-index: 3;
+  box-shadow:
+    inset 0 -1px 0 var(--color-neutral-400),
+    1px 0 0 var(--color-neutral-200);
 }
 
 .dataTable code {
@@ -664,10 +746,11 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2) var(--space-4);
-  margin: 0 0 var(--space-3);
-  padding: var(--space-2) 0;
+  margin: 0;
+  padding: var(--space-3) 18px;
   border-block: 1px solid var(--color-neutral-200);
   list-style: none;
+  background: color-mix(in srgb, var(--color-neutral-100) 70%, var(--color-raised));
 }
 
 .valueLegend li {
@@ -676,11 +759,13 @@
   gap: var(--space-2);
   min-width: 0;
   font-size: 12px;
+  line-height: 1.4;
 }
 
 .valueLegend strong {
   font-weight: 700;
   white-space: nowrap;
+  color: var(--color-text);
 }
 
 .valueLegend span { color: var(--color-neutral-600); }

--- a/src/app/dati/dati.module.css
+++ b/src/app/dati/dati.module.css
@@ -600,7 +600,8 @@
     flex-direction: column;
   }
 
-  .dataTable th:first-child {
+  .dataTable thead th:first-child,
+  .dataTable tbody th:first-child {
     position: static;
   }
 }

--- a/src/app/dati/dati.module.css
+++ b/src/app/dati/dati.module.css
@@ -451,6 +451,8 @@
   /* Tall enough for several rows, short enough that the sticky header stays
      on screen while reading the results pane. */
   max-height: min(60vh, 32rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   background: var(--color-raised);
 }
 
@@ -695,7 +697,6 @@
   margin: 0 0 var(--space-4);
   padding: 10px 12px;
   background: var(--color-neutral-100);
-  border-left: 3px solid var(--color-accent-700);
 }
 
 .cardTeaserLabel {

--- a/src/app/dati/page.tsx
+++ b/src/app/dati/page.tsx
@@ -2,13 +2,15 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { integer } from "@/lib/format";
 import {
-  activeFilterCount,
+  activeCatalogConstraintCount,
   catalogQueryHref,
   catalogViewHref,
+  CATALOG_SEARCH_MAX_LENGTH,
   hasReadableNumbers,
   INTEGRATED_EVIDENCE_LABELS,
   isPriorityDataset,
   matchesCatalogFilters,
+  matchesCatalogSearch,
   parseCatalogQuery,
   partitionPriorityCatalog,
   PRIORITY_EVIDENCE_ORDER,
@@ -137,11 +139,13 @@ export default async function IntegratedDataPage({
     evidenza?: string | string[];
     pubblicazione?: string | string[];
     riuso?: string | string[];
+    cerca?: string | string[];
+    q?: string | string[];
   }>;
 }) {
   const params = await searchParams;
   const query = parseCatalogQuery(params);
-  const { view, filters } = query;
+  const { view, filters, q } = query;
   const overview = await getIntegratedDataOverview();
 
   const prioritySplit = partitionPriorityCatalog(overview.datasets, filters);
@@ -149,17 +153,34 @@ export default async function IntegratedDataPage({
     view === "priorita"
       ? [...prioritySplit.readable, ...prioritySplit.missing]
       : overview.datasets;
-  const visible = scoped.filter((dataset) => matchesCatalogFilters(dataset, filters));
-  const teaserIds =
-    view === "priorita"
-      ? prioritySplit.readable.map((dataset) => dataset.id)
-      : visible.filter((dataset) => hasReadableNumbers(dataset)).map((dataset) => dataset.id);
-  const teasers = await loadDatasetInsightTeasers(teaserIds, { limit: 24 });
+  const filtered = scoped.filter((dataset) => matchesCatalogFilters(dataset, filters));
+  const teaserIds = filtered
+    .filter((dataset) => hasReadableNumbers(dataset))
+    .map((dataset) => dataset.id);
+  const teasers = await loadDatasetInsightTeasers(teaserIds, {
+    limit: q ? 48 : 24,
+  });
+
+  function datasetMatchesSearch(dataset: OverviewDataset): boolean {
+    if (!q) return true;
+    return matchesCatalogSearch(dataset, q, {
+      domainLabel: integratedDomainLabel(dataset.domain),
+      teaserLine: teasers.get(dataset.id)?.line ?? null,
+    });
+  }
+
+  const visible = filtered.filter(datasetMatchesSearch);
+  const readableVisible =
+    view === "priorita" ? prioritySplit.readable.filter(datasetMatchesSearch) : [];
+  const missingVisible =
+    view === "priorita" ? prioritySplit.missing.filter(datasetMatchesSearch) : [];
+
   const priorityDatasets = overview.datasets.filter(isPriorityDataset);
   const readableCount = overview.datasets.filter((dataset) => hasReadableNumbers(dataset)).length;
   const undeclaredCount = overview.datasets.filter(
     (dataset) => dataset.licenseStatus === "not-declared",
   ).length;
+  const constraintCount = activeCatalogConstraintCount(query);
 
   const grouped = new Map<string, OverviewDataset[]>();
   for (const domain of INTEGRATED_DOMAIN_ORDER) grouped.set(domain, []);
@@ -210,7 +231,7 @@ export default async function IntegratedDataPage({
           {VIEW_OPTIONS.map((option) => (
             <Link
               key={option.view}
-              href={catalogViewHref(option.view, filters)}
+              href={catalogViewHref(option.view, filters, q)}
               aria-current={option.view === view ? "page" : undefined}
             >
               {option.label}
@@ -229,8 +250,8 @@ export default async function IntegratedDataPage({
           <span className="stat-label">In questa vista</span>
           <span className="stat-value">{integer(visible.length)}</span>
           <span className="stat-note">
-            {activeFilterCount(filters) > 0
-              ? `dopo ${integer(activeFilterCount(filters))} filtri`
+            {constraintCount > 0
+              ? `dopo ${integer(constraintCount)} vincoli`
               : "senza filtri aggiuntivi"}
           </span>
         </div>
@@ -251,6 +272,42 @@ export default async function IntegratedDataPage({
         mediana restano in <Link href="/controlli">Cosa controllare</Link> e{" "}
         <Link href="/confronti">Confronti</Link>.
       </p>
+
+      <form className={styles.searchBar} action="/dati" method="get" role="search">
+        <label htmlFor="catalog-search">Cerca nel catalogo</label>
+        <div>
+          <input
+            className="input"
+            id="catalog-search"
+            name="cerca"
+            type="search"
+            defaultValue={q ?? ""}
+            maxLength={CATALOG_SEARCH_MAX_LENGTH}
+            placeholder="Titolo, ambito, società o id"
+            autoComplete="off"
+          />
+          {view !== "priorita" ? <input type="hidden" name="vista" value={view} /> : null}
+          {filters.evidence ? <input type="hidden" name="evidenza" value={filters.evidence} /> : null}
+          {filters.publication ? (
+            <input type="hidden" name="pubblicazione" value={filters.publication} />
+          ) : null}
+          {filters.undeclaredReuse ? <input type="hidden" name="riuso" value="non-dichiarato" /> : null}
+          <button className="btn btn-primary" type="submit">
+            Cerca
+          </button>
+        </div>
+        {q ? (
+          <p className={styles.searchClear}>
+            Ricerca: <strong>{q}</strong>
+            {" · "}
+            <Link href={catalogQueryHref({ ...query, q: null })}>Togli ricerca</Link>
+          </p>
+        ) : (
+          <p className={styles.searchHint}>
+            Cerca per titolo, ambito, autorità o nome che compare nel teaser del destinatario.
+          </p>
+        )}
+      </form>
 
       <nav className={styles.filterBar} aria-label="Filtri del catalogo">
         <div className={styles.filterGroup}>
@@ -310,30 +367,30 @@ export default async function IntegratedDataPage({
             </Link>
           </div>
         </div>
-        {activeFilterCount(filters) > 0 ? (
+        {constraintCount > 0 ? (
           <p className={styles.filterReset}>
-            <Link href={catalogViewHref(view)}>Togli tutti i filtri</Link>
+            <Link href={catalogViewHref(view)}>Togli ricerca e filtri</Link>
           </p>
         ) : null}
       </nav>
 
-      {view === "priorita" && (prioritySplit.readable.length > 0 || prioritySplit.missing.length > 0) ? (
+      {view === "priorita" && (readableVisible.length > 0 || missingVisible.length > 0) ? (
         <nav className={styles.domainIndex} aria-labelledby="priority-index-title">
           <h2 id="priority-index-title">Vai a una sezione</h2>
           <ul>
-            {prioritySplit.readable.length > 0 ? (
+            {readableVisible.length > 0 ? (
               <li>
                 <a href="#numeri-da-leggere">
                   Numeri da leggere
-                  <span>{integer(prioritySplit.readable.length)}</span>
+                  <span>{integer(readableVisible.length)}</span>
                 </a>
               </li>
             ) : null}
-            {prioritySplit.missing.length > 0 ? (
+            {missingVisible.length > 0 ? (
               <li>
                 <a href="#cosa-manca">
                   Cosa manca ancora
-                  <span>{integer(prioritySplit.missing.length)}</span>
+                  <span>{integer(missingVisible.length)}</span>
                 </a>
               </li>
             ) : null}
@@ -359,24 +416,26 @@ export default async function IntegratedDataPage({
 
       {visible.length === 0 ? (
         <section className={`panel ${styles.emptyFilters}`}>
-          <h2 className="panel-title">Nessun dataset con questi filtri</h2>
+          <h2 className="panel-title">Nessun dataset con questi criteri</h2>
           <p>
-            Prova a togliere un filtro oppure apri la vista{" "}
-            <Link href={catalogViewHref("tutti")}>Tutti</Link> per il registro completo.
+            {q
+              ? "Prova un’altra ricerca, togli un filtro oppure apri la vista "
+              : "Prova a togliere un filtro oppure apri la vista "}
+            <Link href={catalogViewHref("tutti", filters, q)}>Tutti</Link> per il registro completo.
           </p>
         </section>
       ) : null}
 
-      {view === "priorita" && prioritySplit.readable.length > 0 ? (
+      {view === "priorita" && readableVisible.length > 0 ? (
         <section className={styles.domainSection} aria-labelledby="numeri-da-leggere">
           <div className={styles.sectionHeading}>
             <h2 id="numeri-da-leggere">Numeri da leggere</h2>
             <span>
-              {integer(prioritySplit.readable.length)} dataset · società, importi e ricorrenze quando presenti
+              {integer(readableVisible.length)} dataset · società, importi e ricorrenze quando presenti
             </span>
           </div>
           <ul className={styles.datasetGrid}>
-            {prioritySplit.readable.map((dataset) => (
+            {readableVisible.map((dataset) => (
               <DatasetCard
                 dataset={dataset}
                 key={dataset.id}
@@ -387,16 +446,16 @@ export default async function IntegratedDataPage({
         </section>
       ) : null}
 
-      {view === "priorita" && prioritySplit.missing.length > 0 ? (
+      {view === "priorita" && missingVisible.length > 0 ? (
         <section className={`${styles.domainSection} ${styles.secondarySection}`} aria-labelledby="cosa-manca">
           <div className={styles.sectionHeading}>
             <h2 id="cosa-manca">Cosa manca ancora</h2>
             <span>
-              {integer(prioritySplit.missing.length)} dataset · segnali senza dettaglio pubblico da scorrere
+              {integer(missingVisible.length)} dataset · segnali senza dettaglio pubblico da scorrere
             </span>
           </div>
           <ul className={styles.datasetGrid}>
-            {prioritySplit.missing.map((dataset) => (
+            {missingVisible.map((dataset) => (
               <DatasetCard
                 dataset={dataset}
                 key={dataset.id}
@@ -424,10 +483,10 @@ export default async function IntegratedDataPage({
               <ul className={styles.datasetGrid}>
                 {entry.datasets.map((dataset) => (
                   <DatasetCard
-                dataset={dataset}
-                key={dataset.id}
-                teaser={teasers.get(dataset.id)}
-              />
+                    dataset={dataset}
+                    key={dataset.id}
+                    teaser={teasers.get(dataset.id)}
+                  />
                 ))}
               </ul>
             </section>

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -226,10 +226,11 @@ textarea.input {
   font-size: 11px;
   letter-spacing: .08em;
   text-transform: uppercase;
-  font-weight: 600;
-  color: var(--color-neutral-600);
+  font-weight: 700;
+  color: var(--color-neutral-700);
   padding: var(--space-2);
   border-bottom: 1px solid var(--color-neutral-400);
+  background: var(--color-raised);
 }
 .table thead th small {
   display: block;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -588,11 +588,30 @@ main { display: block; }
 .warning-notice strong { color: var(--color-warning); }
 
 /* Any table that can outgrow its column scrolls inside its own box rather
-   than pushing the page sideways. */
+   than pushing the page sideways. Tall result sets also scroll vertically so
+   the column headings can stay pinned as a reading reference. */
 .table-scroll {
   width: 100%;
-  overflow-x: auto;
+  max-height: min(60vh, 32rem);
+  overflow: auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
+/* Sticky headers need separate borders: collapse makes Chrome paint ghost
+   fragments of neighbouring cells while scrolling. */
+.table-scroll > table,
+.table-scroll > .table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.table-scroll thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--color-raised);
+  box-shadow: inset 0 -1px 0 var(--color-neutral-400);
 }
 
 .chart-data {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -588,30 +588,11 @@ main { display: block; }
 .warning-notice strong { color: var(--color-warning); }
 
 /* Any table that can outgrow its column scrolls inside its own box rather
-   than pushing the page sideways. Tall result sets also scroll vertically so
-   the column headings can stay pinned as a reading reference. */
+   than pushing the page sideways. */
 .table-scroll {
   width: 100%;
-  max-height: min(60vh, 32rem);
-  overflow: auto;
+  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
-}
-
-/* Sticky headers need separate borders: collapse makes Chrome paint ghost
-   fragments of neighbouring cells while scrolling. */
-.table-scroll > table,
-.table-scroll > .table {
-  border-collapse: separate;
-  border-spacing: 0;
-}
-
-.table-scroll thead th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--color-raised);
-  box-shadow: inset 0 -1px 0 var(--color-neutral-400);
 }
 
 .chart-data {

--- a/src/app/incarichi/incarichi.module.css
+++ b/src/app/incarichi/incarichi.module.css
@@ -322,5 +322,5 @@
   .sourceGrid { grid-template-columns: 1fr; }
   .actions .btn { width: 100%; }
   .tableHint { display: block; }
-  :global(.table-scroll) table { min-width: 900px; }
+  .tableHint + :global(.table-scroll) table { min-width: 900px; }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -108,6 +108,16 @@ export default async function HomePage({
     <main className={`shell ${styles.dashboard}`}>
       <h1 className={styles.pageTitle}>Dove vanno i nostri soldi pubblici</h1>
       <div className={styles.column}>
+        <section className="panel panel-accent" aria-labelledby="home-recipients-cta">
+          <h2 id="home-recipients-cta" className="panel-title">Destinatari e importi</h2>
+          <p className={styles.note}>
+            Società, affidamenti e ricorrenze nei dataset integrati, con grafici leggibili.
+          </p>
+          <Link className="btn btn-block" href="/dati">
+            Vedi chi ha ricevuto di più
+          </Link>
+        </section>
+
         <section className="panel">
           <div className={styles.panelHead}>
             <h2 className="panel-title">Pagamenti effettuati dai Comuni</h2>

--- a/src/lib/integrated-catalog-views.ts
+++ b/src/lib/integrated-catalog-views.ts
@@ -71,7 +71,11 @@ export type CatalogFilters = Readonly<{
 export type CatalogQuery = Readonly<{
   view: CatalogView;
   filters: CatalogFilters;
+  /** Free-text search over title, ambito, id, authority and teaser lines. */
+  q: string | null;
 }>;
+
+export const CATALOG_SEARCH_MAX_LENGTH = 80;
 
 function firstParam(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
@@ -81,6 +85,15 @@ export function parseCatalogView(value: string | string[] | undefined): CatalogV
   const raw = firstParam(value);
   if (raw === "ambito" || raw === "tutti" || raw === "priorita") return raw;
   return DEFAULT_CATALOG_VIEW;
+}
+
+/** Trims and bounds the catalog search box; empty becomes null. */
+export function parseCatalogSearch(value: string | string[] | undefined): string | null {
+  const raw = firstParam(value);
+  if (raw === undefined) return null;
+  const trimmed = raw.trim().replace(/\s+/g, " ");
+  if (trimmed === "") return null;
+  return trimmed.slice(0, CATALOG_SEARCH_MAX_LENGTH);
 }
 
 export function parseCatalogFilters(input: {
@@ -111,10 +124,13 @@ export function parseCatalogQuery(searchParams: {
   evidenza?: string | string[];
   pubblicazione?: string | string[];
   riuso?: string | string[];
+  cerca?: string | string[];
+  q?: string | string[];
 }): CatalogQuery {
   return {
     view: parseCatalogView(searchParams.vista),
     filters: parseCatalogFilters(searchParams),
+    q: parseCatalogSearch(searchParams.cerca ?? searchParams.q),
   };
 }
 
@@ -124,16 +140,21 @@ export function catalogQueryHref(query: CatalogQuery): string {
   if (query.filters.evidence) params.set("evidenza", query.filters.evidence);
   if (query.filters.publication) params.set("pubblicazione", query.filters.publication);
   if (query.filters.undeclaredReuse) params.set("riuso", "non-dichiarato");
+  if (query.q) params.set("cerca", query.q);
   const encoded = params.toString();
   return encoded ? `/dati?${encoded}` : "/dati";
 }
 
-export function catalogViewHref(view: CatalogView, filters: CatalogFilters = {
-  evidence: null,
-  publication: null,
-  undeclaredReuse: false,
-}): string {
-  return catalogQueryHref({ view, filters });
+export function catalogViewHref(
+  view: CatalogView,
+  filters: CatalogFilters = {
+    evidence: null,
+    publication: null,
+    undeclaredReuse: false,
+  },
+  q: string | null = null,
+): string {
+  return catalogQueryHref({ view, filters, q });
 }
 
 export function isPriorityDataset(dataset: Pick<CatalogDatasetSummary, "evidenceLabel">): boolean {
@@ -188,6 +209,28 @@ export function matchesCatalogFilters(
   return true;
 }
 
+/** Case-insensitive match on id, title, domain, authority, domain label and teaser. */
+export function matchesCatalogSearch(
+  dataset: CatalogDatasetSummary &
+    Partial<Readonly<{ title: string; authority: string }>>,
+  query: string,
+  extras: Readonly<{ domainLabel?: string; teaserLine?: string | null }> = {},
+): boolean {
+  const needle = query.trim().toLocaleLowerCase("it-IT");
+  if (needle === "") return true;
+  const haystack = [
+    dataset.id,
+    dataset.title ?? "",
+    dataset.authority ?? "",
+    dataset.domain,
+    extras.domainLabel ?? "",
+    extras.teaserLine ?? "",
+  ]
+    .join("\n")
+    .toLocaleLowerCase("it-IT");
+  return haystack.includes(needle);
+}
+
 export function relatedReadingForDataset(
   dataset: Pick<CatalogDatasetSummary, "id" | "domain">,
 ): RelatedReading | null {
@@ -234,4 +277,8 @@ export function activeFilterCount(filters: CatalogFilters): number {
     (filters.publication ? 1 : 0) +
     (filters.undeclaredReuse ? 1 : 0)
   );
+}
+
+export function activeCatalogConstraintCount(query: CatalogQuery): number {
+  return activeFilterCount(query.filters) + (query.q ? 1 : 0);
 }

--- a/tests/consulenti-overview-route.test.mjs
+++ b/tests/consulenti-overview-route.test.mjs
@@ -108,7 +108,7 @@ test("the overview stays flat and scroll-safe on narrow screens", () => {
   assert.match(css, /\.scopeBand\s*\{/);
   assert.match(css, /\.latestGrid,[\s\S]*\.comparisonGrid/);
   assert.match(css, /\.compositionTrack/);
-  assert.match(css, /:global\(\.table-scroll\) table \{ min-width: 900px; \}/);
+  assert.match(css, /\.tableHint \+ :global\(\.table-scroll\) table \{ min-width: 900px; \}/);
   assert.match(css, /@media \(max-width: 620px\)/);
   assert.doesNotMatch(css, /border-radius\s*:/);
   assert.doesNotMatch(css, /gradient\s*\(/i);

--- a/tests/integrated-catalog-views.test.mjs
+++ b/tests/integrated-catalog-views.test.mjs
@@ -4,12 +4,15 @@ import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
 const {
+  activeCatalogConstraintCount,
   catalogQueryHref,
   catalogViewHref,
   groupPriorityDatasets,
   isPriorityDataset,
   matchesCatalogFilters,
+  matchesCatalogSearch,
   parseCatalogQuery,
+  parseCatalogSearch,
   parseCatalogView,
   relatedReadingForDataset,
 } = await import("../src/lib/integrated-catalog-views.ts");
@@ -38,6 +41,7 @@ test("catalog filters compose into stable query strings", () => {
       publication: "catalog-only",
       undeclaredReuse: true,
     },
+    q: null,
   });
   assert.equal(
     catalogQueryHref(query),
@@ -73,6 +77,53 @@ test("catalog filters compose into stable query strings", () => {
     ),
     false,
   );
+});
+
+test("catalog search parses cerca, preserves it in hrefs, and matches title/ambito/teaser", () => {
+  assert.equal(parseCatalogSearch("  Acme   Spa  "), "Acme Spa");
+  assert.equal(parseCatalogSearch("   "), null);
+  assert.equal(parseCatalogSearch("x".repeat(100)).length, 80);
+
+  const withSearch = parseCatalogQuery({
+    vista: "tutti",
+    cerca: "vincitori",
+  });
+  assert.equal(withSearch.q, "vincitori");
+  assert.equal(
+    catalogQueryHref(withSearch),
+    "/dati?vista=tutti&cerca=vincitori",
+  );
+  assert.equal(
+    catalogViewHref("ambito", withSearch.filters, withSearch.q),
+    "/dati?vista=ambito&cerca=vincitori",
+  );
+  assert.equal(parseCatalogQuery({ q: "alias" }).q, "alias");
+  assert.equal(activeCatalogConstraintCount(withSearch), 1);
+  assert.equal(
+    activeCatalogConstraintCount({
+      ...withSearch,
+      filters: { ...withSearch.filters, evidence: "missing-data" },
+    }),
+    2,
+  );
+
+  const dataset = {
+    id: "vincitori",
+    domain: "procurement",
+    evidenceLabel: "documented-fact",
+    licenseStatus: "open",
+    publication: "rows",
+    title: "Fornitori per settore e importo",
+    authority: "ANAC",
+  };
+  assert.equal(matchesCatalogSearch(dataset, "fornitori"), true);
+  assert.equal(matchesCatalogSearch(dataset, "appalti", { domainLabel: "Appalti" }), true);
+  assert.equal(
+    matchesCatalogSearch(dataset, "acme", { teaserLine: "Acme S.p.A. · 1,2 mln €" }),
+    true,
+  );
+  assert.equal(matchesCatalogSearch(dataset, "inesistente"), false);
+  assert.equal(matchesCatalogSearch(dataset, ""), true);
 });
 
 test("priority groups use existing evidence labels without inventing medians", async () => {
@@ -135,8 +186,13 @@ test("dati page wires views, filters and reading links without median inventing"
   ]);
   assert.match(page, /parseCatalogQuery/);
   assert.match(page, /matchesCatalogFilters/);
+  assert.match(page, /matchesCatalogSearch/);
   assert.match(page, /partitionPriorityCatalog/);
   assert.match(page, /filterBar/);
+  assert.match(page, /searchBar/);
+  assert.match(page, /name="cerca"/);
+  assert.match(page, /readableVisible/);
+  assert.match(page, /missingVisible/);
   assert.match(page, /Da controllare/);
   assert.match(page, /Numeri da leggere/);
   assert.match(page, /Cosa manca ancora/);
@@ -147,5 +203,18 @@ test("dati page wires views, filters and reading links without median inventing"
   assert.match(page, /href="\/confronti"/);
   assert.doesNotMatch(page, /mediana di mercato sul catalogo/i);
   assert.match(css, /\.filterBar \{/);
+  assert.match(css, /\.searchBar \{/);
   assert.match(css, /\.filterGroup a\[aria-current="page"\]/);
+});
+
+test("home and controlli expose the recipients CTA into /dati", async () => {
+  const [home, controlli] = await Promise.all([
+    readFile(new URL("../src/app/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/controlli/page.tsx", import.meta.url), "utf8"),
+  ]);
+  assert.match(home, /Vedi chi ha ricevuto di più/);
+  assert.match(home, /href="\/dati"/);
+  assert.match(controlli, /Vedi chi ha ricevuto di più/);
+  assert.match(controlli, /href="\/dati"/);
+  assert.match(controlli, /href="\/appalti\/fornitori"/);
 });

--- a/tests/integrated-source-public-view.test.mjs
+++ b/tests/integrated-source-public-view.test.mjs
@@ -505,7 +505,7 @@ test("the server boundary and pages preserve missing, zero and async Next route 
   assert.match(detail, /value === ""/);
   assert.match(detail, /Dato non presente/);
   assert.match(detail, /value === "0"/);
-  assert.match(detail, /<caption>/);
+  assert.match(detail, /<caption className=\{styles\.tableCaption\}>/);
   assert.match(detail, /role="region"/);
   assert.match(detail, /Fonte, riuso e limiti/);
   assert.match(detail, /URL canonico non disponibile/);


### PR DESCRIPTION
Make /dati filterable by title/ambito/teaser, surface entry points from Home and Controlli, and keep dataset table headers visible while scrolling results.

## Cosa cambia

Descrivi il risultato osservabile e il perimetro della PR.

## Evidenza

- [ ] Il diff è limitato al problema dichiarato.
- [ ] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [ ] `npm test`, test ETL Python, typecheck, lint, design check e build passano.
- [ ] Ho verificato `git diff --check`.

### Dati pubblici

Compila questa sezione se la PR aggiunge o modifica dati.

- [ ] URL ufficiale, titolare, licenza, periodo e data di osservazione sono espliciti.
- [ ] Schema, hash, provenienza e riconciliazioni falliscono in modo chiuso.
- [ ] Importi, frequenze, saldi, pagamenti e finanziamenti non vengono confusi.
- [ ] Il testo evita inferenze su spreco, frode, merito, qualità o responsabilità non dimostrate.

### UI e accessibilità

Compila questa sezione se la PR modifica una superficie utente.

- [ ] Ho verificato tastiera, focus, stati vuoto/errore/caricamento e console browser.
- [ ] Ho verificato 390, 768 e 1280 px senza overflow o contenuti irraggiungibili.
- [ ] Tabelle e grafici hanno un equivalente accessibile.

### API e MCP

Compila questa sezione se la PR modifica API o MCP.

- [ ] Input sconosciuti, duplicati, malformati e non limitati vengono rifiutati.
- [ ] La superficie MCP resta pubblica, stateless, limitata e read-only.
- [ ] Ho verificato il route HTTP reale, non soltanto import in-process.

## Limiti e prove non eseguite

Elenca con precisione check esterni, dispositivi, workflow o fonti non verificati.
