### PR TITLE
fix(ui): stop home composition legend text overlap

### DIFF
--- a/src/components/italy-regions-map.module.css
+++ b/src/components/italy-regions-map.module.css
@@ -105,15 +105,19 @@
   text-overflow: ellipsis;
 }
 .detail span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
   font-size: 13px;
   font-weight: 600;
+  line-height: 1.25;
   font-variant-numeric: tabular-nums;
 }
 .detail small {
-  display: block;
   font-size: 10px;
   font-weight: 400;
+  line-height: 1.2;
   letter-spacing: .07em;
   text-transform: uppercase;
   color: var(--color-neutral-600);

--- a/src/components/spending-composition.module.css
+++ b/src/components/spending-composition.module.css
@@ -1,4 +1,9 @@
-.composition { display: grid; gap: var(--space-3); }
+.composition {
+  display: grid;
+  gap: var(--space-3);
+  container-type: inline-size;
+  container-name: composition;
+}
 .visual {
   position: relative;
   aspect-ratio: 100 / 62;
@@ -21,26 +26,45 @@
 }
 .tile:hover,
 .tile[data-active="true"] { z-index: 1; outline: 3px solid var(--color-text); outline-offset: -3px; }
-.tile > span { display: grid; gap: 2px; max-width: 16ch; text-align: center; line-height: 1.08; }
-.tile b { font-size: clamp(11px, 1.1vw, 15px); }
-.tile strong { font-size: clamp(13px, 1.4vw, 19px); font-variant-numeric: tabular-nums; }
-.tileIndex { font-weight: 800; }
+.tileCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 16ch;
+  text-align: center;
+  line-height: 1.2;
+}
+.tileCopy b { font-size: clamp(11px, 1.1vw, 15px); line-height: 1.2; }
+.tileCopy strong { font-size: clamp(13px, 1.4vw, 19px); line-height: 1.15; font-variant-numeric: tabular-nums; }
+.tileIndex { font-weight: 800; line-height: 1; }
 .services { background: var(--chart-family-services); }
 .investment { background: var(--chart-family-investment); }
 .pass-through { background: var(--chart-family-pass-through); }
 .financing { background: var(--chart-family-financing); }
 .other { background: var(--chart-family-other); }
 
-.legend { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
+/* Single column in the home rail (~360px); two columns only when the
+   composition surface itself is wide enough for readable labels. */
+.legend {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+@container composition (min-width: 420px) {
+  .legend { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
 .legend li { min-width: 0; }
 .legend button {
   display: grid;
   grid-template-columns: 10px minmax(0, 1fr) auto;
-  align-items: center;
+  align-items: start;
   gap: var(--space-2);
   width: 100%;
   min-height: 48px;
-  padding: 6px 8px;
+  padding: 8px;
   border: 1px solid transparent;
   background: transparent;
   color: var(--color-text);
@@ -49,13 +73,37 @@
 }
 .legend button:hover,
 .legend button[aria-pressed="true"] { border-color: var(--color-neutral-400); background: var(--color-neutral-100); }
-.legend button > i { width: 10px; height: 28px; }
-.legend button span { min-width: 0; }
-.legend button b,
-.legend button small { display: block; }
-.legend button b { overflow-wrap: anywhere; font-size: 12px; }
-.legend button small { margin-top: 2px; color: var(--color-neutral-600); font-size: 11px; }
-.legend button > strong { font-size: 12px; font-variant-numeric: tabular-nums; }
+.legendSwatch {
+  width: 10px;
+  align-self: stretch;
+  min-height: 28px;
+  margin-block: 2px;
+}
+/* Flex stack avoids Safari collapsing blockified phrasing inside <button>. */
+.legendCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding-block: 1px;
+}
+.legendLabel {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+.legendAmount {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.3;
+}
+.legendShare {
+  padding-top: 1px;
+  font-size: 12px;
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
+}
 .mobileBar { display: none; }
 .tooltip { padding: var(--space-3); background: var(--color-neutral-900); color: var(--color-on-strong); }
 .tooltip span { display: block; margin-top: 2px; font-variant-numeric: tabular-nums; }

--- a/src/components/spending-composition.tsx
+++ b/src/components/spending-composition.tsx
@@ -110,7 +110,10 @@ export function SpendingComposition({
               onClick={() => toggle(item)}
             >
               {labelMode === "full" ? (
-                <span><b>{item.label}</b><strong>{percent(share(item))}</strong></span>
+                <span className={styles.tileCopy}>
+                  <b>{item.label}</b>
+                  <strong>{percent(share(item))}</strong>
+                </span>
               ) : labelMode === "index" ? <span className={styles.tileIndex}>{index + 1}</span> : null}
             </button>
           );
@@ -136,9 +139,12 @@ export function SpendingComposition({
                 }
               }}
             >
-              <i className={styles[item.family]} aria-hidden="true" />
-              <span><b>{index + 1}. {item.label}</b><small>{compactEuro(item.valueEuro)}</small></span>
-              <strong>{percent(share(item))}</strong>
+              <i className={`${styles.legendSwatch} ${styles[item.family]}`} aria-hidden="true" />
+              <span className={styles.legendCopy}>
+                <b className={styles.legendLabel}>{index + 1}. {item.label}</b>
+                <small className={styles.legendAmount}>{compactEuro(item.valueEuro)}</small>
+              </span>
+              <strong className={styles.legendShare}>{percent(share(item))}</strong>
             </button>
             <i className={styles.mobileBar} aria-hidden="true">
               <span className={styles[item.family]} style={{ width: `${share(item)}%` }} />

--- a/tests/spending-composition.test.mjs
+++ b/tests/spending-composition.test.mjs
@@ -62,4 +62,8 @@ test("composition component keeps partial state, keyboard tooltip and exact tabl
   assert.match(component, /Partial composition cannot exceed its canonical total/);
   assert.match(css, /aspect-ratio: 100 \/ 62/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.visual \{ display: none; \}/);
+  assert.match(css, /\.legendCopy \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
+  assert.match(component, /styles\.legendCopy/);
+  assert.match(component, /styles\.legendLabel/);
+  assert.match(component, /styles\.legendAmount/);
 });


### PR DESCRIPTION
## Summary
- Fixes overlapping label/amount text in the home «Come si compone il totale» legend (Safari + cramped 2-col rail).
- Stacks legend and tile copy with flex, uses container queries for legend columns, and hardens the map region detail stack.

## Test plan
- [ ] Open `/` on Safari desktop: legend rows show label above amount with no overlap
- [ ] Same on Chrome/Firefox
- [ ] Resize below ~900px (full-width composition): 2-column legend when wide enough
- [ ] Click legend items / tiles: tooltip and pin still work
- [ ] Region detail under the map: Totale / Per abitante labels stack cleanly above values

Made with [Cursor](https://cursor.com)