### PR TITLE
fix(ui): keep home treemap inside its panel

### DIFF
--- a/src/components/spending-composition.module.css
+++ b/src/components/spending-composition.module.css
@@ -1,13 +1,15 @@
 .composition {
   display: grid;
   gap: var(--space-3);
+  min-width: 0;
   container-type: inline-size;
   container-name: composition;
 }
 .visual {
   position: relative;
+  width: 100%;
+  min-width: 0;
   aspect-ratio: 100 / 62;
-  min-height: 260px;
   background: var(--color-neutral-100);
   border: 1px solid var(--color-neutral-400);
   contain: layout paint;

--- a/tests/spending-composition.test.mjs
+++ b/tests/spending-composition.test.mjs
@@ -61,6 +61,8 @@ test("composition component keeps partial state, keyboard tooltip and exact tabl
   assert.match(component, /Ready composition must reconcile with its total/);
   assert.match(component, /Partial composition cannot exceed its canonical total/);
   assert.match(css, /aspect-ratio: 100 \/ 62/);
+  assert.match(css, /\.visual \{[\s\S]*?width: 100%;[\s\S]*?min-width: 0;/);
+  assert.doesNotMatch(css, /\.visual \{[\s\S]*?min-height:\s*260px/);
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*?\.visual \{ display: none; \}/);
   assert.match(css, /\.legendCopy \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
   assert.match(component, /styles\.legendCopy/);


### PR DESCRIPTION
## Summary
- Removes the 260px minimum height that, together with the 100/62 aspect ratio, forced a ~419px minimum chart width inside the 322px home rail.
- Explicitly constrains the composition and treemap to their container.
- Adds a regression assertion for the containment contract.

## Verification
- Component tests: PASS (4/4)
- Browser measurement at 1280px: chart 322px, panel 360px, fully contained
- Browser measurement at 1600px: chart 322px, panel 360px, fully contained
- Browser measurement at 390px: treemap hidden in favor of mobile list; document width equals viewport

Made with [Cursor](https://cursor.com)