### PR TITLE
feat(ui): add Buy Me a Coffee support CTA in the footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -471,6 +471,59 @@ main { display: block; }
 }
 .footer-sitemap-group a:hover { color: var(--color-text); }
 
+.footer-support {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4) var(--space-6);
+  padding: 18px 0;
+  border-bottom: 1px solid var(--color-neutral-300);
+}
+.footer-support-copy {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  max-width: 62ch;
+}
+.footer-support-copy h2 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--color-text);
+}
+.footer-support-copy p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--color-neutral-700);
+}
+.footer-support-action {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 16px;
+  border: 1px solid var(--color-accent-700);
+  background: var(--color-accent-700);
+  color: var(--color-raised);
+  font-family: var(--font-heading);
+  font-size: 12px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.footer-support-action:hover {
+  background: var(--color-accent-800);
+  border-color: var(--color-accent-800);
+  color: var(--color-raised);
+}
+
 /* ── shared building blocks ─────────────────────────────────────────────── */
 
 .stat-strip {
@@ -681,6 +734,11 @@ main { display: block; }
   .stat-strip > div:nth-child(-n + 2) { border-bottom: 1px solid var(--color-neutral-200); }
   .footer-row { flex-wrap: wrap; gap: var(--space-2) var(--space-3); }
   .footer-row .footer-spacer { display: none; }
+  .footer-support {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .footer-support-action { width: 100%; }
 }
 
 @media (max-width: 620px) {

--- a/src/app/supporter/page.tsx
+++ b/src/app/supporter/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { BUY_ME_A_COFFEE_URL } from "@/lib/site";
 import { SITE_SUPPORTERS } from "@/lib/supporters";
 import styles from "../legal-page.module.css";
 
@@ -18,6 +19,19 @@ export default function SupportersPage() {
           influenzano i numeri pubblicati.
         </p>
       </div>
+
+      <section className="panel">
+        <h2 className="panel-title">Donazioni individuali</h2>
+        <p>
+          Se vuoi contribuire a compute e hosting puoi farlo su Buy Me a Coffee. Il contributo
+          resta volontario e non influenza i dati pubblicati.
+        </p>
+        <p>
+          <a className="btn btn-primary" href={BUY_ME_A_COFFEE_URL} target="_blank" rel="noreferrer">
+            Buy me an AI compute
+          </a>
+        </p>
+      </section>
 
       {SITE_SUPPORTERS.map((supporter) => (
         <section className="panel" key={supporter.href}>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -3,7 +3,7 @@ import {
   FOOTER_SITEMAP_COLUMNS,
   FOOTER_SITEMAP_GROUPS,
 } from "@/lib/site-navigation";
-import { REPO_URL } from "@/lib/site";
+import { BUY_ME_A_COFFEE_URL, REPO_URL } from "@/lib/site";
 
 type SiteFooterProps = Readonly<{
   latestTerritorialCheckLabel: string;
@@ -45,6 +45,24 @@ export function SiteFooter({ latestTerritorialCheckLabel }: SiteFooterProps) {
           ))}
         </div>
       </section>
+
+      <aside className="footer-support" aria-labelledby="footer-support-title">
+        <div className="footer-support-copy">
+          <h2 id="footer-support-title">Sostieni il progetto</h2>
+          <p>
+            Il sito resta indipendente e open source. Un contributo aiuta a pagare compute e
+            hosting; non influenza i dati pubblicati.
+          </p>
+        </div>
+        <a
+          className="footer-support-action"
+          href={BUY_ME_A_COFFEE_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Buy me an AI compute
+        </a>
+      </aside>
 
       <div className="footer-row">
         <span>Ultimo controllo SIOPE o IRPEF: {latestTerritorialCheckLabel}</span>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -7,4 +7,5 @@
 export const REPO_URL = "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi";
 export const PUBLIC_SITE_URL = "https://www.dovevannoinostrisoldi.com";
 export const PUBLIC_MCP_ENDPOINT = `${PUBLIC_SITE_URL}/api/mcp`;
+export const BUY_ME_A_COFFEE_URL = "https://www.buymeacoffee.com/dovevannoinostrisoldi";
 export const GOOGLE_ANALYTICS_MEASUREMENT_ID = "G-6NKJM5HWR4";

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -103,17 +103,26 @@ test("public legal pages do not expose a personal mailbox", async () => {
 });
 
 test("supporters page lists the current acknowledgements", async () => {
-  const [page, supporters, footer] = await Promise.all([
+  const [page, supporters, footer, site, globals] = await Promise.all([
     readFile(new URL("../src/app/supporter/page.tsx", import.meta.url), "utf8"),
     readFile(new URL("../src/lib/supporters.ts", import.meta.url), "utf8"),
     readFile(new URL("../src/components/site-footer.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/lib/site.ts", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/globals.css", import.meta.url), "utf8"),
   ]);
   assert.match(supporters, /regolo\.ai/);
   assert.match(supporters, /mantoventure\.com/);
   assert.match(supporters, /italianbuilders\.co/);
   assert.match(supporters, /modello GLM/);
   assert.match(page, /SITE_SUPPORTERS/);
+  assert.match(page, /BUY_ME_A_COFFEE_URL/);
   assert.match(footer, /href="\/supporter"/);
+  assert.match(footer, /BUY_ME_A_COFFEE_URL/);
+  assert.match(footer, /Buy me an AI compute/);
+  assert.match(site, /BUY_ME_A_COFFEE_URL = "https:\/\/www\.buymeacoffee\.com\/dovevannoinostrisoldi"/);
+  assert.match(globals, /\.footer-support \{/);
+  assert.match(globals, /\.footer-support-action \{/);
+  assert.doesNotMatch(footer, /cdnjs\.buymeacoffee\.com/);
   assert.match(navigationSource, /href: "\/supporter", label: "Chi ci sostiene"/);
 });
 


### PR DESCRIPTION
## Summary
- Adds a footer support band with Italian copy and a CTA to Buy Me a Coffee (`dovevannoinostrisoldi`).
- Styles the action with the existing accent/heading system instead of the Inter + emoji BMC widget script.
- Surfaces the same donation link on `/supporter`.

## Test plan
- [ ] Footer shows «Sostieni il progetto» between sitemap and meta rows
- [ ] CTA opens https://www.buymeacoffee.com/dovevannoinostrisoldi
- [ ] Mobile stacks copy + full-width button
- [ ] `/supporter` includes the donation section
- [ ] `node --test tests/site-navigation.test.mjs` PASS

Made with [Cursor](https://cursor.com)