### PR TITLE
feat(supporter): acknowledge Clodo76 among individual donors

### DIFF
--- a/src/app/supporter/page.tsx
+++ b/src/app/supporter/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { BUY_ME_A_COFFEE_URL } from "@/lib/site";
-import { SITE_SUPPORTERS } from "@/lib/supporters";
+import { INDIVIDUAL_SUPPORTERS, SITE_SUPPORTERS } from "@/lib/supporters";
 import styles from "../legal-page.module.css";
 
 export const metadata: Metadata = {
@@ -15,17 +15,34 @@ export default function SupportersPage() {
         <h1>Chi ci sostiene</h1>
         <p>
           Il sito resta indipendente e open source. Qui riconosciamo chi ci dà infrastruttura,
-          tempo o una community in cui lavorare. Non sono fonti dei dati pubblici e non
-          influenzano i numeri pubblicati.
+          tempo, una community in cui lavorare o un contributo individuale. Non sono fonti dei
+          dati pubblici e non influenzano i numeri pubblicati.
         </p>
       </div>
 
       <section className="panel">
         <h2 className="panel-title">Donazioni individuali</h2>
         <p>
-          Se vuoi contribuire a compute e hosting puoi farlo su Buy Me a Coffee. Il contributo
-          resta volontario e non influenza i dati pubblicati.
+          Chi sostiene il progetto su{" "}
+          <a href={BUY_ME_A_COFFEE_URL} target="_blank" rel="noreferrer">
+            Buy Me a Coffee
+          </a>{" "}
+          aiuta a pagare compute e hosting. Il contributo resta volontario e non influenza i dati
+          pubblicati.
         </p>
+        <ul>
+          {INDIVIDUAL_SUPPORTERS.map((supporter) => (
+            <li key={supporter.href}>
+              <strong>
+                <a href={supporter.href} target="_blank" rel="noreferrer">
+                  {supporter.name}
+                </a>
+              </strong>
+              {" — "}
+              {supporter.contribution}
+            </li>
+          ))}
+        </ul>
         <p>
           <a className="btn btn-primary" href={BUY_ME_A_COFFEE_URL} target="_blank" rel="noreferrer">
             Buy me an AI compute

--- a/src/lib/supporters.ts
+++ b/src/lib/supporters.ts
@@ -4,6 +4,17 @@ export type SiteSupporter = Readonly<{
   contribution: string;
 }>;
 
+/** Individual donors acknowledged publicly (e.g. Buy Me a Coffee). */
+export const INDIVIDUAL_SUPPORTERS: readonly SiteSupporter[] = [
+  {
+    name: "Clodo76",
+    href: "https://github.com/Clodo76",
+    contribution:
+      "Primo sostegno su Buy Me a Coffee per aiutare a coprire compute e hosting del progetto.",
+  },
+];
+
+/** Organisations and communities that provide infrastructure, time or community. */
 export const SITE_SUPPORTERS: readonly SiteSupporter[] = [
   {
     name: "Regolo.ai",

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -114,7 +114,11 @@ test("supporters page lists the current acknowledgements", async () => {
   assert.match(supporters, /mantoventure\.com/);
   assert.match(supporters, /italianbuilders\.co/);
   assert.match(supporters, /modello GLM/);
+  assert.match(supporters, /INDIVIDUAL_SUPPORTERS/);
+  assert.match(supporters, /Clodo76/);
+  assert.match(supporters, /github\.com\/Clodo76/);
   assert.match(page, /SITE_SUPPORTERS/);
+  assert.match(page, /INDIVIDUAL_SUPPORTERS/);
   assert.match(page, /BUY_ME_A_COFFEE_URL/);
   assert.match(footer, /href="\/supporter"/);
   assert.match(footer, /BUY_ME_A_COFFEE_URL/);


### PR DESCRIPTION
## Summary
- Adds Clodo76 to `/supporter` under Donazioni individuali (first public Buy Me a Coffee supporter).
- Links to their GitHub profile and keeps institutional sponsors unchanged.

## Test plan
- [ ] Open `/supporter` and see Clodo76 listed under Donazioni individuali
- [ ] Name links to https://github.com/Clodo76
- [ ] BMC CTA still present
- [ ] `node --test tests/site-navigation.test.mjs` PASS

Made with [Cursor](https://cursor.com)