### PR TITLE
docs(readme): add Buy Me a Coffee support link at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Riunisce dati ufficiali sparsi su portali diversi. Ogni numero mostra **fonte**,
 
 **Sito:** [dovevannoinostrisoldi.com](https://www.dovevannoinostrisoldi.com)
 
+[![Buy me an AI compute](https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png)](https://www.buymeacoffee.com/dovevannoinostrisoldi)
+
+Il progetto resta indipendente. Un contributo su Buy Me a Coffee aiuta a pagare compute e hosting; non influenza i dati pubblicati.
+
 ![Home: pagamenti dei Comuni, mappa regionale e composizione della spesa](docs/readme/home.jpg)
 
 | Territori | Cosa controllare |

--- a/tests/copy-quality.test.mjs
+++ b/tests/copy-quality.test.mjs
@@ -21,6 +21,8 @@ async function filesBelow(relativePath) {
 test("readme shows live UI screenshots of home, territories and controls", async () => {
   const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
   assert.match(readme, /https:\/\/www\.dovevannoinostrisoldi\.com/);
+  assert.match(readme, /https:\/\/www\.buymeacoffee\.com\/dovevannoinostrisoldi/);
+  assert.match(readme, /Buy me an AI compute/);
   for (const file of ["home.jpg", "territori.jpg", "controlli.jpg"]) {
     assert.match(readme, new RegExp(`docs/readme/${file}`));
     await readFile(new URL(`../docs/readme/${file}`, import.meta.url));


### PR DESCRIPTION
## Summary
- Adds the Buy Me a Coffee button and a short independence note near the top of the README.
- Locks the link in the readme copy-quality test.

## Test plan
- [ ] README preview on GitHub shows the yellow BMC button under the site link
- [ ] Button opens https://www.buymeacoffee.com/dovevannoinostrisoldi
- [ ] `node --test tests/copy-quality.test.mjs` PASS

Made with [Cursor](https://cursor.com)