### PR TITLE
fix(copy): replace em dash on supporters page

### DIFF
--- a/src/app/supporter/page.tsx
+++ b/src/app/supporter/page.tsx
@@ -38,7 +38,7 @@ export default function SupportersPage() {
                   {supporter.name}
                 </a>
               </strong>
-              {" — "}
+              {": "}
               {supporter.contribution}
             </li>
           ))}


### PR DESCRIPTION
## Summary
- Replaces the forbidden em dash separator on `/supporter` so copy-quality passes after the individual-donors list.

## Test plan
- [ ] `node --test tests/copy-quality.test.mjs` PASS
- [ ] `/supporter` still lists Clodo76 cleanly

Made with [Cursor](https://cursor.com)