### PR TITLE
fix(ui): restore desktop treemap geometry gate

### DIFF
--- a/src/components/spending-composition.module.css
+++ b/src/components/spending-composition.module.css
@@ -10,6 +10,7 @@
   width: 100%;
   min-width: 0;
   aspect-ratio: 100 / 62;
+  min-height: 250px;
   background: var(--color-neutral-100);
   border: 1px solid var(--color-neutral-400);
   contain: layout paint;


### PR DESCRIPTION
## Cosa cambia
Ripristina un’altezza minima di 250px per la treemap desktop della home. Il fix resta scoped a `src/components/spending-composition.module.css`; su mobile `.visual` resta nascosto.

## Evidenza
- Risolve il gate browser `Composizione spesa home 1280px: geometria treemap non riservata`.
- Test mirati Node: 15/15 PASS.
- `git diff --check`: PASS.
- Build sul merge simulato: PASS.

## Review richiesta
PR aperta per approvazione finale di Dom. Nessun altro file UI o dati modificato.

## Limiti
Il browser core locale richiede un server; il tentativo è stato bloccato dall’ambiente (`listen EPERM` su 0.0.0.0:3000). Hosted CI deve rieseguire il production gate.