### PR TITLE
fix(copy): box rossi più corti e linguaggio più semplice

### DIFF
--- a/src/app/appalti/dettaglio/page.tsx
+++ b/src/app/appalti/dettaglio/page.tsx
@@ -13,7 +13,7 @@ export default function ProcurementDetailPage() {
       introduction="Affidamenti diretti, CIG di ministeri e autorità, fornitori aggregati, gruppi societari, rinnovi, proroghe e materiale Consip sono raccolti senza confondere inventari incompleti con classifiche definitive."
       domains={["procurement"]}
       editorialSection="appalti"
-      interpretation="Un affidamento, una ripetizione o una differenza di prezzo è un fatto da contestualizzare. I record fuori Consip restano documentati, ma non sono presentati come sovrapprezzi quando mancano modello o SKU comparabili."
+      interpretation="Un affidamento o una differenza di prezzo va contestualizzato. Fuori Consip restiamo documentati, ma senza modello confrontabile non parliamo di sovrapprezzo."
       related={[
         {
           href: "/appalti",

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -83,17 +83,11 @@ export default function AppaltiPage() {
       </section>
 
       <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="appalti-reading-title">
-        <h2 id="appalti-reading-title">La lettura corretta in una frase</h2>
+        <h2 id="appalti-reading-title">Come leggere questi numeri</h2>
         <p>
-          Questi conteggi mostrano come sono classificati i CIG pubblicati e indicano dove guardare
-          meglio negli atti.
+          Contano come sono etichettati i CIG pubblicati. Il campo <strong>importo_lotto</strong> è
+          il valore dichiarato del lotto.
         </p>
-        <div className="scope-notice__section">
-          <h3>Che cosa misura il valore</h3>
-          <p>
-            <strong>importo_lotto</strong> è il valore dichiarato del lotto nella banca dati.
-          </p>
-        </div>
       </section>
 
       <section className={`panel ${styles.leadPanel}`} aria-labelledby="procedure-title">

--- a/src/app/coesione/asili/page.tsx
+++ b/src/app/coesione/asili/page.tsx
@@ -152,8 +152,11 @@ export default async function PnrrChildcareCatalog({ searchParams }: { searchPar
       </section>
 
       <div className="notice">
-        <strong>La distinzione che evita conclusioni sbagliate</strong>
-        <p>{pnrrChildcareMeta.methodology.fundingWarning} Lo snapshot non contiene i pagamenti ReGiS: quando mancano, li indichiamo come mancanti invece di stimarli.</p>
+        <strong>Pagamenti e ReGiS</strong>
+        <p>
+          {pnrrChildcareMeta.methodology.fundingWarning} Se mancano i pagamenti ReGiS, li segniamo
+          come mancanti: non li stimiamo.
+        </p>
       </div>
     </main>
   );

--- a/src/app/coesione/page.tsx
+++ b/src/app/coesione/page.tsx
@@ -163,9 +163,8 @@ export default function CohesionPage() {
       <div className="notice">
         <strong>Come leggere questi numeri</strong>
         <p>
-          La quota confronta ogni categoria con il costo pubblico nazionale. “Pagato sul costo”
-          è un rapporto tra soldi usciti e costo previsto. La media per progetto mescola record
-          molto diversi.
+          La quota confronta ogni tema con il costo pubblico nazionale. “Pagato sul costo” è soldi
+          usciti diviso costo previsto.
         </p>
       </div>
 
@@ -282,8 +281,7 @@ export default function CohesionPage() {
       <div className="notice">
         <strong>Come leggere «pagato»</strong>
         <p>
-          “Pagato” indica che i soldi sono usciti. Le categorie raccolgono progetti eterogenei.{" "}
-          {snapshot.methodology.territorialWarning}
+          “Pagato” significa che i soldi sono usciti. {snapshot.methodology.territorialWarning}
         </p>
       </div>
 

--- a/src/app/confronti/page.tsx
+++ b/src/app/confronti/page.tsx
@@ -182,16 +182,11 @@ export default function ConfrontiPage() {
       </section>
 
       <section className={"notice " + styles.interpretation} aria-labelledby="interpretation-title">
-        <h2 id="interpretation-title">Che cosa possiamo dire, e che cosa manca</h2>
+        <h2 id="interpretation-title">Cosa possiamo dire</h2>
         <p>
-          Possiamo dire che tre affidamenti confrontabili hanno importi molto diversi. Non possiamo
-          dire, con questi soli atti, che uno sia uno spreco: dimensioni, tecnica, stato conservativo
-          e complessità dell&apos;intervento possono cambiare il lavoro necessario.
-        </p>
-        <p>
-          La domanda pubblica corretta è quindi concreta: <strong>quali elementi tecnici giustificano
-          il divario?</strong> Una relazione, un computo o una motivazione più dettagliata permetterebbero
-          di distinguere una differenza spiegabile da una vera inefficienza.
+          Tre affidamenti simili hanno importi molto diversi. Con questi soli atti non possiamo dire
+          che uno sia uno spreco: dimensioni e tecnica possono cambiare il lavoro. La domanda utile
+          è: <strong>quali elementi tecnici spiegano il divario?</strong>
         </p>
       </section>
 

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -199,38 +199,28 @@ export default async function ControlsPage({ searchParams }: PageProps) {
         className="notice scope-notice"
         aria-labelledby="controlli-reading-title"
       >
-        <h2 id="controlli-reading-title">Che cosa dicono e che cosa non dicono</h2>
+        <h2 id="controlli-reading-title">Cosa dicono questi segnali</h2>
         <p>
-          Pagamenti, debiti, costi e ipotesi misurano cose diverse e restano separati. Un segnale
-          indica cosa approfondire. Consulta le <Link href="/fonti">fonti
-          ufficiali</Link> e il <Link href="/metodologia">metodo usato per leggere i dati</Link>.
+          Pagamenti, debiti e costi non si mescolano. Un segnale indica cosa approfondire; non sostituisce Guardia di finanza, ANAC, Corte dei conti o il controllo umano. Vedi le{" "}
+          <Link href="/fonti">fonti</Link>, il <Link href="/metodologia">metodo</Link>, gli{" "}
+          <Link href="/appalti">appalti</Link>, il <Link href="/mcp">dataset MCP ANAC</Link> e il{" "}
+          <a
+            href="https://dati.anticorruzione.it/opendata/dataset"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Apri il catalogo open data ANAC in una nuova scheda"
+          >
+            catalogo ANAC ↗
+          </a>
+          .
         </p>
-        <div className="scope-notice__section">
-          <h3>Dove l&apos;automazione aiuta davvero</h3>
-          <p>
-            Il portale può confrontare casi omogenei, trovare dati mancanti e ordinare le verifiche.
-            Non conduce indagini e non sostituisce Guardia di finanza, ANAC, Corte dei conti o il
-            controllo umano. Gli aggregati CIG 2025 verificati sono disponibili nella{" "}
-            <Link href="/appalti">pagina Appalti 2025</Link> e nel{" "}
-            <Link href="/mcp">dataset MCP ANAC</Link>; il{" "}
-            <a
-              href="https://dati.anticorruzione.it/opendata/dataset"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Apri il catalogo open data ANAC in una nuova scheda"
-            >
-              catalogo ufficiale ANAC ↗
-            </a>{" "}
-            resta la fonte primaria.
-          </p>
-        </div>
       </section>
 
       <section className={`panel ${styles.typeLegend}`} aria-labelledby="signal-types-title">
         <h2 id="signal-types-title" className="panel-title">Come leggere i numeri</h2>
         <p className={styles.legendLead}>
-          Ogni blocco indica un tipo di dato diverso. La riga colorata sopra la cifra principale
-          mostra quanto è forte il segnale, non una colpevolezza.
+          Ogni blocco è un tipo di dato diverso. La riga colorata mostra quanto è forte il segnale,
+          non una colpa.
         </p>
         <ul className={styles.toneLegend}>
           {(Object.keys(toneLabels) as Array<keyof typeof toneLabels>).map((tone) => (
@@ -267,15 +257,15 @@ export default async function ControlsPage({ searchParams }: PageProps) {
         <header className={styles.sectionIntro}>
           <h2 id="official-signals-title">Segnali da relazioni ufficiali</h2>
           <p>
-            Cifre pubblicate da autorità di controllo, indagine o vigilanza. Ogni scheda riporta
-            perimetro, stato del dato e limiti di interpretazione.
+            Cifre pubblicate da autorità di controllo. Ogni scheda indica ambito, stato del dato e
+            limiti di lettura.
           </p>
         </header>
         {signals.length === 0 ? (
           <p className={styles.note}>
             Per l&apos;anno selezionato non ci sono segnali da relazioni ufficiali nel nostro
-            perimetro. Non significa che non ce ne siano stati: significa che noi non ne abbiamo
-            ancora uno documentato e verificabile.
+            ambito. Non significa che non ce ne siano: significa che qui non ne abbiamo ancora uno
+            verificabile.
           </p>
         ) : null}
 

--- a/src/app/fonti/catalogo/page.tsx
+++ b/src/app/fonti/catalogo/page.tsx
@@ -133,8 +133,8 @@ export default async function PublicSourceCatalogPage({ searchParams }: SourceCa
       <div className="notice">
         <strong>Quarantena non significa omissione</strong>
         <p>
-          L&apos;ID, il numero di occorrenze, la classificazione e la ragione restano nel catalogo. Viene
-          trattenuto soltanto il valore che non supera il confine di pubblicazione.
+          ID, occorrenze, classificazione e motivo restano nel catalogo. Nascondiamo solo il valore
+          che non può essere pubblicato.
         </p>
       </div>
 

--- a/src/app/fonti/copertura/page.tsx
+++ b/src/app/fonti/copertura/page.tsx
@@ -85,9 +85,8 @@ export default async function SourceCoveragePage() {
       <div className="notice">
         <strong>Copertura completa, uso selettivo</strong>
         <p>
-          Il registro prova che niente è stato tralasciato. Le disposizioni distinguono ciò che può
-          alimentare il prodotto da copie, tentativi di raccolta, materiale tecnico e contenuti da
-          mantenere in quarantena. Manifest-only non significa elemento mancante.
+          Il registro mostra che niente è stato saltato. Poi si sceglie cosa entra nel prodotto e
+          cosa resta in quarantena. “Solo manifesto” non significa dato mancante.
         </p>
       </div>
 

--- a/src/app/fonti/page.tsx
+++ b/src/app/fonti/page.tsx
@@ -124,13 +124,12 @@ export default function SourcesPage() {
       </section>
 
       <div className="notice">
-        <strong>“Aggiornato” significa: aggiornato quanto la fonte</strong>
+        <strong>“Aggiornato” quanto la fonte</strong>
         <p>
-          Se una fonte pubblica nuovi dati una volta al mese, non li chiamiamo dati in tempo reale.
-          Mostriamo l&apos;ultimo periodo disponibile, quando lo abbiamo controllato e quando è
-          atteso il prossimo aggiornamento.{" "}
-          <Link href="/fonti/stato">Stato operativo delle fonti →</Link> ·{" "}
-          <Link href="/metodologia">Come leggiamo i dati →</Link>
+          Se la fonte pubblica i dati una volta al mese, non sono in tempo reale. Mostriamo ultimo
+          periodo, ultimo controllo e prossimo aggiornamento atteso.{" "}
+          <Link href="/fonti/stato">Stato delle fonti →</Link> ·{" "}
+          <Link href="/metodologia">Metodo →</Link>
         </p>
       </div>
     </main>

--- a/src/app/incarichi/dettaglio/page.tsx
+++ b/src/app/incarichi/dettaglio/page.tsx
@@ -13,7 +13,7 @@ export default function AppointmentsDetailPage() {
       introduction="Il dettaglio riunisce incarichi nominativi, consulenze legali e PNRR, collaboratori, CV, personale, staff e indennità, mantenendo separati perimetri e strati contabili incompatibili."
       domains={["appointments", "consultancies", "personnel"]}
       editorialSection="incarichi"
-      interpretation="Gli incarichi nominativi non vengono sommati ai capitoli contabili CE3; requisiti, durata, compenso e curriculum sono elementi distinti. Un confronto orienta la verifica, non attribuisce da solo inadeguatezza o responsabilità."
+      interpretation="Gli incarichi nominativi non si sommano ai capitoli CE3. Un confronto orienta la verifica: non decide da solo se qualcuno è inadeguato."
       related={[
         {
           href: "/incarichi",

--- a/src/app/incarichi/page.tsx
+++ b/src/app/incarichi/page.tsx
@@ -79,8 +79,8 @@ export default function IncarichiPage() {
       <div className="notice warning-notice">
         <strong>2026 è un anno parziale</strong>
         <p>
-          I dati più recenti possono crescere o cambiare con nuove comunicazioni. Per questo non
-          usiamo il 2026 come confronto definitivo con gli anni chiusi e non sommiamo le due serie.
+          I dati recenti possono ancora cambiare. Non usiamo il 2026 come confronto definitivo con
+          gli anni chiusi e non sommiamo le due serie.
         </p>
       </div>
 

--- a/src/app/metodologia/page.tsx
+++ b/src/app/metodologia/page.tsx
@@ -39,9 +39,8 @@ export default function MethodPage() {
       <div className="notice warning-notice">
         <strong>Controlli e approfondimenti</strong>
         <p>
-          DoveVannoINostriSoldi aiuta a trovare dati e segnali da approfondire. Il lavoro di ANAC,
-          Corte dei conti, magistratura e verifiche dell&apos;amministrazione resta quello ufficiale.
-          Nessun algoritmo attribuisce automaticamente illeciti o responsabilità personali.
+          Qui trovi dati e segnali da verificare. I controlli ufficiali restano di ANAC, Corte dei
+          conti, magistratura e amministrazioni. Nessun algoritmo decide da solo illeciti o colpe.
         </p>
       </div>
     </main>

--- a/src/app/palazzo-chigi/page.tsx
+++ b/src/app/palazzo-chigi/page.tsx
@@ -67,12 +67,11 @@ export default function PalazzoChigiPage() {
       </dl>
 
       <div className="notice">
-        <strong>Tre numeri diversi, tre significati diversi</strong>
+        <strong>Tre numeri diversi</strong>
         <p>
-          <strong>Disponibile</strong>: quanto c&apos;era in bilancio.
-          <strong> Impegnato</strong>: quanto si è deciso di spendere.
-          <strong> Pagato</strong>: quanto è davvero uscito nel 2024.
-          Tre passaggi dello stesso percorso contabile, letti uno per uno.
+          <strong>Disponibile</strong>: in bilancio.
+          <strong> Impegnato</strong>: deciso da spendere.
+          <strong> Pagato</strong>: davvero uscito nel 2024.
         </p>
       </div>
 

--- a/src/app/parlamento/page.tsx
+++ b/src/app/parlamento/page.tsx
@@ -87,8 +87,8 @@ export default function ParliamentPage() {
       <div className="notice">
         <strong>Come leggere questi numeri</strong>
         <p>
-          Un bilancio dice quanto si prevede di spendere. Un consuntivo dice quanto è stato
-          impegnato o pagato. Ogni documento resta sul suo perimetro.
+          Il bilancio è quanto si prevede di spendere. Il consuntivo è quanto è stato impegnato o
+          pagato. Ogni documento resta sul suo ambito.
         </p>
       </div>
 

--- a/src/app/pnrr/incarichi/page.tsx
+++ b/src/app/pnrr/incarichi/page.tsx
@@ -201,9 +201,8 @@ export default function PnrrAssignmentsPage() {
       <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="reading-title">
         <h2 id="reading-title">Come leggere questi numeri</h2>
         <p>
-          Il totale somma compensi dichiarati per l&apos;intera durata dei contratti. Non misura quanto è
-          già stato pagato, non è un costo annuale e non consente da solo di stabilire utilità, qualità
-          o spreco. Lo snapshot è storico: descrive l&apos;aggiornamento di aprile 2026.
+          Il totale somma i compensi dichiarati per tutta la durata dei contratti. Non misura quanto è
+          già stato pagato e non è una spesa annuale. Aggiornamento: aprile 2026.
         </p>
       </section>
 

--- a/src/app/regioni/page.tsx
+++ b/src/app/regioni/page.tsx
@@ -78,8 +78,8 @@ export default async function RegionsPage({
       <div className="notice">
         <strong>Perimetro di lettura</strong>
         <p>
-          Gli importi sono gli impegni assoluti di {selected.label}. Senza una popolazione Istat
-          allineata allo stesso anno non calcoliamo valori pro capite e non usiamo la mappa.
+          Sono gli impegni assoluti di {selected.label}. Senza popolazione Istat dello stesso anno
+          non calcoliamo il pro capite e non usiamo la mappa.
         </p>
       </div>
 

--- a/src/app/spese/consulenze/page.tsx
+++ b/src/app/spese/consulenze/page.tsx
@@ -98,15 +98,11 @@ export default async function RgsConsultingPage({ searchParams }: ConsultingPage
       </section>
 
       <section className="notice scope-notice" aria-labelledby="consulting-boundary-title">
-        <h2 id="consulting-boundary-title">Che cosa misura, e che cosa non misura</h2>
+        <h2 id="consulting-boundary-title">Cosa misura questa pagina</h2>
         <p>
-          Sono aggregati contabili per capitolo e piano di gestione. La fonte non identifica
-          consulenti, beneficiari, contratti o singole prestazioni. Il confronto tra
-          amministrazioni non prova efficienza, irregolarità o spreco.
-        </p>
-        <p>
-          Pagato CS è verificato come Pagato CP più Pagato RS. Un importo pari a zero è un valore
-          pubblicato nel Rendiconto, non un importo mancante ricostruito.
+          Totali per capitolo di spesa. Non elenca consulenti, contratti o singole prestazioni. Un
+          confronto tra amministrazioni non prova da solo spreco o irregolarità. Zero è un valore
+          pubblicato, non un dato mancante.
         </p>
       </section>
 

--- a/src/app/spese/invalidita/page.tsx
+++ b/src/app/spese/invalidita/page.tsx
@@ -62,9 +62,8 @@ export default function CivilInvalidityPage() {
       <div className="notice">
         <strong>La voce comprende tutte le prestazioni di invalidità civile</strong>
         <p>
-          La voce INPS comprende l’insieme delle prestazioni di invalidità civile. Nel dettaglio
-          contabile 2024 della Gestione n. 25 l’accompagnamento è la componente maggiore. Quel
-          dettaglio ha però un perimetro più ristretto e non si somma né si sottrae al totale sopra.
+          Nel dettaglio 2024 della Gestione n. 25 l’accompagnamento è la voce più grande. Quel
+          dettaglio ha un ambito più stretto: non si somma né si sottrae al totale sopra.
         </p>
       </div>
 

--- a/src/app/spese/operative/page.tsx
+++ b/src/app/spese/operative/page.tsx
@@ -13,7 +13,7 @@ export default function OperatingSpendingPage() {
       introduction="Canoni, auto, welfare, missioni, rimborsi, eventi, campagne, capitoli statali e progetti sono consultabili nel perimetro in cui sono stati osservati."
       domains={["operations", "state-accounts", "projects"]}
       editorialSection="spese"
-      interpretation="Pagamenti, previsioni e massimali restano separati. I capitoli di missione non sono trasferte individuali; i canoni senza superficie non producono un valore €/m²; una spesa documentata non è automaticamente uno spreco."
+      interpretation="Pagamenti, previsioni e massimali restano separati. I capitoli di missione non sono trasferte individuali. Una spesa documentata non è automaticamente uno spreco."
       related={[
         {
           href: "/spese/consulenze",

--- a/src/app/spese/page.tsx
+++ b/src/app/spese/page.tsx
@@ -119,42 +119,15 @@ export default async function MoneyPage({
         className="notice scope-notice"
         aria-labelledby="spese-scope-title"
       >
-        <h2 id="spese-scope-title">Quali spese vuoi vedere?</h2>
+        <h2 id="spese-scope-title">Qui vedi i pagamenti dei Comuni</h2>
         <p>
-          Questa pagina mostra uscite di cassa dei Comuni. Le contabilità degli altri enti restano
-          separate.
+          Solo uscite di cassa dei Comuni. Gli altri conti restano separati:{" "}
+          <Link href={`/territori?anno=${year}`}>territori</Link>,{" "}
+          <Link href="/spese/invalidita">invalidità INPS</Link>,{" "}
+          <Link href="/spese/sanita">sanità</Link>,{" "}
+          <Link href="/stato">Stato</Link>,{" "}
+          <Link href="/parlamento">Parlamento</Link>.
         </p>
-        <div className="scope-notice__section">
-          <h3>Comuni · dettaglio territoriale</h3>
-          <p>
-            Apri i <Link href={`/territori?anno=${year}`}>pagamenti per regione e le classifiche
-            comunali pubblicate</Link>. Il dataset attuale non contiene una ripartizione
-            provinciale né ogni voce di spesa per singolo Comune.
-          </p>
-        </div>
-        <div className="scope-notice__section">
-          <h3>Invalidità civile INPS · contabilità separata</h3>
-          <p>
-            È una contabilità diversa da SIOPE e resta separata. Abbiamo verificato spesa
-            nazionale, prestazioni vigenti e nuove pensioni per regione nei documenti ufficiali
-            INPS. <Link href="/spese/invalidita">Apri i dati sull&apos;invalidità civile →</Link>
-          </p>
-        </div>
-        <div className="scope-notice__section">
-          <h3>Enti SSN · Conto Economico consuntivo 2024</h3>
-          <p>
-            Il Conto Economico OpenBDAP misura costi di competenza economica e resta separato da
-            SIOPE e dalla contabilità INPS. <Link href="/spese/sanita">Apri
-            personale e servizi degli enti SSN →</Link>
-          </p>
-        </div>
-        <div className="scope-notice__section">
-          <h3>Altri livelli della spesa pubblica</h3>
-          <p>
-            Per gli altri livelli apri le <Link href="/stato">spese delle amministrazioni
-            centrali</Link> oppure le <Link href="/parlamento">spese del Parlamento</Link>.
-          </p>
-        </div>
       </section>
 
       <div className={styles.split}>

--- a/src/app/spese/sanita/page.tsx
+++ b/src/app/spese/sanita/page.tsx
@@ -83,7 +83,7 @@ export default function HealthSpendingPage() {
           La fonte non pubblica una voce chiamata “gettonisti” o “cooperative”. BA2080 è il
           <em> Totale Costo del personale</em>; BA1350 è “Consulenze, Collaborazioni, Interinale e
           altre prestazioni di lavoro sanitarie e sociosanitarie”. Non trasformiamo una voce
-          aggregata in una categoria contrattuale e non deduciamo qualità, efficienza o frodi.
+          aggregata in un tipo di contratto e non deduciamo qualità o frodi.
         </p>
       </div>
 
@@ -260,11 +260,10 @@ export default function HealthSpendingPage() {
       </div>
 
       <div className="notice">
-        <strong>Questo dataset non sostituisce una contabilità dei pagamenti</strong>
+        <strong>Non è un conto di pagamenti</strong>
         <p>
-          Per gli esborsi di cassa dei Comuni consulta <Link href="/spese">Soldi</Link>; per le
-          prestazioni di invalidità civile consulta i dati <Link href="/spese/invalidita">INPS</Link>.
-          Sono fonti, perimetri e definizioni diversi.
+          Per i pagamenti dei Comuni vai a <Link href="/spese">Soldi</Link>; per l’invalidità civile
+          ai dati <Link href="/spese/invalidita">INPS</Link>. Fonti e ambiti diversi.
         </p>
       </div>
     </main>

--- a/src/app/spese/territoriale/page.tsx
+++ b/src/app/spese/territoriale/page.tsx
@@ -125,15 +125,11 @@ export default async function RgsTerritorialPage({ searchParams }: TerritorialPa
       </section>
 
       <section className="notice warning-notice scope-notice" aria-labelledby="territorial-boundary-title">
-        <h2 id="territorial-boundary-title">Tre livelli sovrapposti, mai un unico totale</h2>
+        <h2 id="territorial-boundary-title">Non sommare Italia, macroaree e regioni</h2>
         <p>
-          Italia, macroaree e regioni descrivono lo stesso perimetro a livelli differenti e non
-          devono essere sommati insieme. Per questo ogni interrogazione restituisce un solo livello
-          territoriale e una sola misura.
-        </p>
-        <p>
-          Percentuale del PIL, euro per abitante ed euro per km² usano denominatori calcolati
-          dall’editore ma non versionati nel record. Non vengono ricalcolati né usati come addendi.
+          Sono tre livelli dello stesso conto e non devono essere sommati insieme. Ogni ricerca usa
+          un solo livello e una sola misura. PIL e euro per abitante usano denominatori calcolati
+          dall&apos;editore ma non versionati nel record: non li ricalcoliamo né li sommiamo.
         </p>
       </section>
 
@@ -295,12 +291,11 @@ export default async function RgsTerritorialPage({ searchParams }: TerritorialPa
       </section>
 
       <section className={`notice ${styles.debtNotice}`} aria-labelledby="territorial-debt-title">
-        <h2 id="territorial-debt-title">Interessi e debito: l’etichetta non risolve il perimetro</h2>
+        <h2 id="territorial-debt-title">Interessi e debito: etichette da non sommare a caso</h2>
         <p>
-          Per Italia, l’incrocio fra categoria 09 e missione 034 riporta 8.057,70 milioni di euro.
-          La landing descrive il dataset al netto degli interessi sul debito, mentre il CSV conserva
-          righe con queste etichette. La pagina non le elimina e non deduce da sola che ogni importo
-          sia incluso o escluso dal perimetro dichiarato.
+          Per l’Italia, categoria 09 e missione 034 danno 8.057,70 milioni di euro. La scheda RGS
+          parla di dati al netto degli interessi sul debito, ma il CSV tiene queste etichette. Qui non
+          le cancelliamo e non decidiamo da soli cosa rientra nel perimetro.
         </p>
       </section>
 

--- a/src/app/territori/confronto/page.tsx
+++ b/src/app/territori/confronto/page.tsx
@@ -180,10 +180,8 @@ export default async function MunicipalComparisonPage({
       <div className="notice">
         <strong>Come leggere il confronto</strong>
         <p>
-          Una differenza positiva indica che la spesa storica è superiore al
-          fabbisogno standard. Può dipendere dai servizi offerti, dai costi
-          locali o dal modo in cui sono usate le risorse. Il numero, da solo,
-          non permette di scegliere una spiegazione.
+          Se la differenza è positiva, la spesa storica supera il fabbisogno standard. Può dipendere
+          da servizi, costi locali o uso delle risorse. Il numero da solo non spiega il perché.
         </p>
       </div>
 

--- a/src/app/territori/page.tsx
+++ b/src/app/territori/page.tsx
@@ -128,9 +128,9 @@ export default async function TerritoriesPage({
           <p className={styles.note}>Nota di metodo: {data.methodology.warning}</p>
           <p className={styles.note}>Copertura pro capite: {data.methodology.perCapitaCoverage}.</p>
           <p className={styles.note}>
-            I link regionali aprono i dati CPT 2023, un perimetro distinto da SIOPE. Nei CPT,
-            Trento e Bolzano sono pubblicati come due Province autonome: il dato SIOPE aggregato
-            del Trentino-Alto Adige non viene collegato artificialmente a una sola voce.
+            I link regionali aprono i dati CPT 2023, separati da SIOPE. Nei CPT, Trento e Bolzano
+            restano due Province autonome: il totale SIOPE del Trentino-Alto Adige non viene forzato
+            su una sola voce.
           </p>
         </section>
 
@@ -209,39 +209,34 @@ export default async function TerritoriesPage({
           <div className="notice">
             <strong>Come leggere i totali assoluti</strong>
             <p>
-              Un Comune turistico serve molte più persone dei suoi residenti, e un Comune che
-              ricostruisce dopo un terremoto spende per opere che dureranno decenni. I totali
-              vanno letti con popolazione, servizi e contesto locale.
+              Un totale alto può dipendere da turismo, ricostruzione o servizi offerti a non
+              residenti. Guarda anche popolazione e contesto.
             </p>
           </div>
         </div>
       </div>
 
       <div className="notice">
-        <strong>Quanto entra e quanto viene speso sul territorio?</strong>
+        <strong>Entrate e spese sul territorio</strong>
         <p>
-          I Conti Pubblici Territoriali permettono di confrontare entrate e spese della Pubblica
-          Amministrazione consolidata su una base contabile coerente, con il pro capite come vista
-          iniziale. <Link href="/territori/fisco">Apri entrate, spese e saldo per regione →</Link>
+          Confronta entrate e spese della PA sul territorio.{" "}
+          <Link href="/territori/fisco">Apri i Conti Pubblici Territoriali →</Link>
         </p>
       </div>
 
       <div className="notice">
-        <strong>Redditi e imposta netta dichiarata</strong>
+        <strong>Redditi e imposte dichiarate</strong>
         <p>
-          Il MEF pubblica contribuenti, redditi, imposta netta dichiarata e addizionali per Comune.
-          Sono dati dichiarativi di imposta netta e restano separati dal saldo CPT.{" "}
-          <Link href="/territori/irpef">Apri i dati IRPEF per Regione, Provincia e Comune →</Link>
+          Dati MEF su contribuenti, redditi e imposta netta per Comune.{" "}
+          <Link href="/territori/irpef">Apri IRPEF →</Link>
         </p>
       </div>
 
       <div className="notice">
-        <strong>Confronta spesa e fabbisogno standard</strong>
+        <strong>Spesa e fabbisogno standard</strong>
         <p>
-          Per i Comuni delle Regioni a statuto ordinario puoi confrontare la spesa storica con il
-          fabbisogno calcolato da OpenCivitas. Il confronto include importo totale, valore per
-          abitante, percentuale e livello dei servizi.{" "}
-          <Link href="/territori/confronto">Apri il confronto tra Comuni →</Link>
+          Per i Comuni in Regioni a statuto ordinario: spesa storica vs fabbisogno OpenCivitas.{" "}
+          <Link href="/territori/confronto">Apri il confronto →</Link>
         </p>
       </div>
 

--- a/src/app/trasparenza/page.tsx
+++ b/src/app/trasparenza/page.tsx
@@ -21,7 +21,7 @@ export default function TransparencyPage() {
         "candidate-batches",
       ]}
       editorialSection="trasparenza"
-      interpretation="Un documento non reperito, un URL morto o uno scostamento richiede una verifica e può motivare accesso civico; non prova automaticamente occultamento, danno o spreco. Gli importi citati negli atti di controllo non sono necessariamente danni accertati."
+      interpretation="Documento mancante o scostamento vanno verificati e possono motivare accesso civico. Non provano da soli occultamento o spreco. Gli importi negli atti non sono automaticamente danni accertati."
       related={[
         {
           href: "/controlli/segnalazioni",


### PR DESCRIPTION
## Summary
- Accorcia i box rossi (`notice` / `scope-notice`) sulle pagine pubbliche, togliendo testo superfluo.
- Semplifica formulazioni dense in italiano più diretto, senza toccare layout, logica o frasi bloccate dai contract test.
- Solo copy in `src/app/**/page.tsx` (25 file); net −70 righe.

## Test plan
- [ ] Controllare a occhio i box rossi su `/spese`, `/controlli`, `/spese/territoriale`, `/territori`, `/appalti`, `/pnrr/incarichi`
- [ ] Verificare che i link nei box (fonti, metodologia, MCP, sanità, invalidità, ecc.) restino corretti
- [ ] `node --test tests/ui-contracts.test.mjs tests/copy-quality.test.mjs tests/mef-irpef-ui.test.mjs tests/rgs-territorial-public-view.test.mjs tests/pnrr-incarichi-page.test.mjs`


Made with [Cursor](https://cursor.com)