### PR TITLE
fix(copy): restore editorial gate contracts

### DIFF
--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -86,7 +86,7 @@ export default function AppaltiPage() {
         <h2 id="appalti-reading-title">Come leggere questi numeri</h2>
         <p>
           Contano come sono etichettati i CIG pubblicati. Il campo <strong>importo_lotto</strong> è
-          il valore dichiarato del lotto.
+          il valore dichiarato del lotto nella banca dati.
         </p>
       </section>
 
@@ -231,8 +231,8 @@ export default function AppaltiPage() {
             <h2 id="threshold-title" className="panel-title">Un segnale vicino alla soglia</h2>
             <p>
               Nella fascia <strong>[135.000 €, 140.000 €)</strong> ci sono {integer(thresholdBand.servicesAndSuppliesRecords)}
-              {" "}CIG di servizi e forniture. La fascia serve a scegliere cosa verificare negli atti
-              originali.
+              {" "}CIG di servizi e forniture. Questi numeri indicano dove guardare meglio negli atti.
+              La fascia serve a scegliere cosa verificare negli atti originali.
             </p>
           </div>
           <span className="tag tag-neutral">Intervallo dichiarato da ANAC</span>

--- a/src/app/coesione/asili/page.tsx
+++ b/src/app/coesione/asili/page.tsx
@@ -154,8 +154,8 @@ export default async function PnrrChildcareCatalog({ searchParams }: { searchPar
       <div className="notice">
         <strong>Pagamenti e ReGiS</strong>
         <p>
-          {pnrrChildcareMeta.methodology.fundingWarning} Se mancano i pagamenti ReGiS, li segniamo
-          come mancanti: non li stimiamo.
+          {pnrrChildcareMeta.methodology.fundingWarning} Il tracciato non contiene i pagamenti ReGiS. Se
+          mancano, li segniamo come mancanti: non li stimiamo.
         </p>
       </div>
     </main>

--- a/src/app/confronti/page.tsx
+++ b/src/app/confronti/page.tsx
@@ -186,7 +186,7 @@ export default function ConfrontiPage() {
         <p>
           Tre affidamenti simili hanno importi molto diversi. Con questi soli atti non possiamo dire
           che uno sia uno spreco: dimensioni e tecnica possono cambiare il lavoro. La domanda utile
-          è: <strong>quali elementi tecnici spiegano il divario?</strong>
+          è: <strong>quali elementi tecnici giustificano il divario?</strong>
         </p>
       </section>
 

--- a/src/app/spese/consulenze/page.tsx
+++ b/src/app/spese/consulenze/page.tsx
@@ -68,9 +68,8 @@ export default async function RgsConsultingPage({ searchParams }: ConsultingPage
         <p className={styles.eyebrow}>Rendiconto dello Stato · 2024-2025</p>
         <h1>Consulenze e lavoro parasubordinato nei conti RGS</h1>
         <p>
-          Tutte le 268 righe selezionate dai piani di gestione ufficiali: importi di cassa,
-          amministrazione, capitolo e classificazione economica, senza trasformarli in incarichi
-          individuali.
+          Tutte le 268 righe selezionate dai piani di gestione ufficiali: sono aggregati contabili per capitolo e piano di gestione,
+          non transazioni né contratti individuali.
         </p>
       </header>
 
@@ -100,9 +99,7 @@ export default async function RgsConsultingPage({ searchParams }: ConsultingPage
       <section className="notice scope-notice" aria-labelledby="consulting-boundary-title">
         <h2 id="consulting-boundary-title">Cosa misura questa pagina</h2>
         <p>
-          Totali per capitolo di spesa. Non elenca consulenti, contratti o singole prestazioni. Un
-          confronto tra amministrazioni non prova da solo spreco o irregolarità. Zero è un valore
-          pubblicato, non un dato mancante.
+          Totali per capitolo di spesa. La fonte non identifica consulenti, beneficiari, contratti o singole prestazioni. Un confronto tra amministrazioni non prova efficienza, irregolarità o spreco. Zero è un valore pubblicato, non un dato mancante.
         </p>
       </section>
 

--- a/src/app/spese/sanita/page.tsx
+++ b/src/app/spese/sanita/page.tsx
@@ -262,6 +262,7 @@ export default function HealthSpendingPage() {
       <div className="notice">
         <strong>Non è un conto di pagamenti</strong>
         <p>
+          Questo conto economico non sostituisce una contabilità dei pagamenti.
           Per i pagamenti dei Comuni vai a <Link href="/spese">Soldi</Link>; per l’invalidità civile
           ai dati <Link href="/spese/invalidita">INPS</Link>. Fonti e ambiti diversi.
         </p>


### PR DESCRIPTION
## Scopo
Ripristina i contratti editoriali richiesti dai test Node e dal controllo production SSN, senza modificare dati, ETL, workflow o test.

## Modifiche
- rende esplicito il segnale di screening sugli appalti e il valore dichiarato nella banca dati;
- chiarisce il confine ReGiS della pagina PNRR;
- ripristina il linguaggio contabile e i limiti interpretativi della pagina RGS;
- aggiunge il confine SSN: il conto economico non sostituisce una contabilità dei pagamenti.

## Verifiche
- ✔ appalti page keeps the verified 2025 denominators and scope visible (0.920458ms)
✔ appalti page makes the chart/table equivalence and denominator explicit (0.11475ms)
✔ appalti page treats threshold concentrations as screening signals, not findings (0.204666ms)
✔ appalti page keeps sources and methodology after the data sections (0.101084ms)
✔ appalti page avoids supplier attribution (0.087666ms)
✔ the verified comparison page exposes only the two publishable anomaly cards (0.655291ms)
✔ the page states the comparison, denominator and evidence boundary in plain Italian (0.610667ms)
✔ sources are last and every wide exact value remains available as a table (0.116ms)
✔ the comparison layout remains inside the viewport (0.229834ms)
✔ the new public surface contains no local archive provenance (1.072542ms)
✔ PNRR catalog is server-rendered, searchable, and semantically cautious (3.250959ms)
✔ project trace labels observed, linked, derived and missing evidence (1.007041ms)
✔ PNRR layouts collapse every major grid on narrow screens (1.60275ms)
✔ PNRR snapshot stays server-only and the new UI uses design tokens (1.272542ms)
✔ RGS consulting snapshot preserves exact coverage, source locks and cash reconciliation (1.577208ms)
✔ RGS consulting queries filter by exact year and administration with bounded pagination (0.526625ms)
✔ zero remains observed and cannot be confused with a missing amount (10.403792ms)
✔ RGS consulting contract fails closed on source, caveat and row drift (16.085708ms)
✔ RGS consulting page awaits GET filters and keeps the accounting boundary visible (0.450334ms)
ℹ tests 19
ℹ suites 0
ℹ pass 19
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 232.112042 — 19/19 pass;
- 
> dove-vanno-i-nostri-soldi@0.2.0 ci:static
> npm run lint && npm run typecheck && npm run design:check && npm run brand:check


> dove-vanno-i-nostri-soldi@0.2.0 lint
> eslint . --max-warnings=0


> dove-vanno-i-nostri-soldi@0.2.0 typecheck
> tsc --noEmit


> dove-vanno-i-nostri-soldi@0.2.0 design:check
> impeccable detect src/


> dove-vanno-i-nostri-soldi@0.2.0 brand:check
> node scripts/brand/generate-icons.mjs --check

Brand assets match the canonical SVG. — pass;
- 
> dove-vanno-i-nostri-soldi@0.2.0 build
> next build

▲ Next.js 16.3.1 (Turbopack)
✓ Running next.config.ts took 90ms

  Creating an optimized production build ...
✓ Compiled successfully in 1090ms
  Running TypeScript ...
  Finished TypeScript in 7.0s ...
  Collecting page data using 7 workers ...
  Generating static pages using 7 workers (0/76) ...
  Generating static pages using 7 workers (19/76) 
  Generating static pages using 7 workers (38/76) 
  Generating static pages using 7 workers (57/76) 
✓ Generating static pages using 7 workers (76/76) in 21.2s
  Finalizing page optimization ...

Route (app)
┌ ƒ /
├ ○ /_not-found
├ ƒ /.well-known/openai-apps-challenge
├ ƒ /api/assistant
├ ○ /api/coesione
├ ƒ /api/controlli
├ ƒ /api/controlli/spesa-comuni
├ ƒ /api/dati/[dataset]
├ ƒ /api/enti
├ ƒ /api/enti/[codice]
├ ƒ /api/enti/[codice]/struttura
├ ƒ /api/fonti/bdap
├ ƒ /api/fonti/catalogo
├ ƒ /api/fonti/stato
├ ○ /api/incarichi
├ ƒ /api/internal/refresh-sources
├ ƒ /api/location
├ ƒ /api/mcp
├ ƒ /api/opere
├ ƒ /api/palazzo-chigi
├ ƒ /api/parlamento
├ ○ /api/partecipazioni
├ ƒ /api/pnrr/asili
├ ○ /api/spese/comuni
├ ƒ /api/spese/comuni/distribuzione
├ ƒ /api/spese/comuni/fabbisogni
├ ƒ /api/spese/invalidita
├ ƒ /api/spese/sanita
├ ƒ /api/spese/stato
├ ƒ /api/spese/stato/amministrazioni/[codice]
├ ƒ /api/spese/stato/storico
├ ƒ /api/territori/fisco
├ ƒ /api/territori/irpef
├ ○ /appalti
├   /appalti/[topic]
│ ├ ● /appalti/affidamenti-diretti
│ ├ ● /appalti/fornitori
│ ├ ● /appalti/rinnovi-proroghe
│ └ ● /appalti/consip-da-confrontare
├ ○ /appalti/dettaglio
├ ○ /apple-icon.png
├ ○ /assistente
├ ○ /coesione
├ ƒ /coesione/asili
├ ○ /confronti
├   /confronti/[topic]
│ └ ● /confronti/catalogo
├ ƒ /controlli
├   /controlli/[topic]
│ ├ ● /controlli/segnalazioni
│ ├ ● /controlli/corte-dei-conti
│ └ ● /controlli/working-set
├ ƒ /dati
├ ƒ /dati/[dataset]
├ ƒ /enti
├ ƒ /enti/[codice]
├ ○ /fonti
├ ƒ /fonti/catalogo
├ ○ /fonti/copertura
├ ƒ /fonti/stato
├ ○ /icon.svg
├ ○ /incarichi
├   /incarichi/[topic]
│ ├ ● /incarichi/consulenze-legali
│ ├ ● /incarichi/pnrr
│ ├ ● /incarichi/nominativi
│ └ ● /incarichi/personale-organi
├ ○ /incarichi/dettaglio
├ ○ /istituzioni
├ ○ /manifest.webmanifest
├ ○ /mcp
├ ○ /metodologia
├ ○ /ministeri
├ ○ /palazzo-chigi
├ ○ /parlamento
├ ○ /partecipazioni
├ ○ /pnrr/incarichi
├ ○ /privacy
├ ƒ /progetti/[cup]
├ ƒ /regioni
├ ƒ /spese
├   /spese/[topic]
│ ├ ● /spese/eventi
│ ├ ● /spese/campagne
│ ├ ● /spese/affitti
│ └ ● [+4 more paths]
├ ƒ /spese/consulenze
├ ○ /spese/invalidita
├ ○ /spese/operative
├ ○ /spese/sanita
├ ƒ /spese/territoriale
├ ƒ /stato
├ ƒ /stato/amministrazioni/[codice]
├ ○ /supporter
├ ○ /supporto
├ ○ /termini
├ ƒ /territori
├ ƒ /territori/confronto
├ ○ /territori/fisco
├ ƒ /territori/irpef
├ ○ /trasparenza
└   /trasparenza/[topic]
  ├ ● /trasparenza/documenti-mancanti
  └ ● /trasparenza/perimetro-enti


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand — pass;
-  — pass.

La verifica browser locale non è stata eseguita perché il sandbox impedisce il bind del server; la conferma deve arrivare dal check production hosted. Chiedo review esplicita a Dom per il copy UI.