### PR TITLE
fix(ui): appalti — quota sul valore oltre al conteggio CIG

### DIFF
--- a/src/app/appalti/appalti.module.css
+++ b/src/app/appalti/appalti.module.css
@@ -65,6 +65,50 @@
   border-top: 3px solid var(--chart-primary);
 }
 
+.valuePanel {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.valuePair {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.valueCard {
+  display: grid;
+  gap: 4px;
+  padding-top: var(--space-4);
+  border-top: 3px solid var(--color-neutral-400);
+}
+
+.valueCard[data-emphasis="value"] {
+  border-top-color: var(--chart-primary);
+}
+
+.valueCard span {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.valueCard strong {
+  font-family: var(--font-heading);
+  font-size: 40px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: -.03em;
+  line-height: 1;
+}
+
+.valueCard small {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .leadMeasure span {
   color: var(--color-neutral-700);
   font-size: 12px;
@@ -319,6 +363,10 @@
 
   .leadMeasure {
     max-width: 22rem;
+  }
+
+  .valuePair {
+    grid-template-columns: 1fr;
   }
 
   .sectionHeading {

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import IntegratedSectionPreview from "@/components/integrated-section-preview";
+import { getProcurementComparisonForYear } from "@/lib/audit-data";
 import { anacCigSnapshot } from "@/lib/anac-cig-snapshot";
 import { exactEuro, integer, longDate, percent } from "@/lib/format";
 import styles from "./appalti.module.css";
@@ -30,6 +31,11 @@ const directAwardFamily = data.procedureChoice.directAwardFamily;
 const servicesAndSupplies = data.population.servicesAndSupplies;
 const below140000 = data.servicesAndSuppliesBelow140000;
 const thresholdBand = data.thresholdBand135000To140000;
+const marketComparison = getProcurementComparisonForYear(data.referenceYear);
+const marketValueBillion =
+  marketComparison === null
+    ? null
+    : (marketComparison.totalValueBillion * marketComparison.byValue) / 100;
 
 function share(records: number, denominator: number): string {
   return percent((records / denominator) * 100);
@@ -71,12 +77,18 @@ export default function AppaltiPage() {
           <span className="stat-note">{integer(directAward.records)} su {integer(totalCigs)} CIG · quota sul numero di CIG</span>
         </div>
         <div>
-          <span className="stat-label">Servizi e forniture</span>
-          <span className="stat-value">{integer(servicesAndSupplies)}</span>
-          <span className="stat-note">{share(servicesAndSupplies, totalCigs)} del totale CIG</span>
+          <span className="stat-label">Affidamenti diretti · sul valore</span>
+          <span className="stat-value">
+            {marketComparison ? percent(marketComparison.byValue) : "Non disponibile"}
+          </span>
+          <span className="stat-note">
+            {marketComparison
+              ? `Relazione ANAC ${marketComparison.year} · procedure da 40.000 € in su`
+              : "manca la serie ANAC sul valore"}
+          </span>
         </div>
         <div>
-          <span className="stat-label">Copertura</span>
+          <span className="stat-label">Copertura CIG</span>
           <span className="stat-value">12/12</span>
           <span className="stat-note">file mensili presenti nello snapshot</span>
         </div>
@@ -85,8 +97,10 @@ export default function AppaltiPage() {
       <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="appalti-reading-title">
         <h2 id="appalti-reading-title">Come leggere questi numeri</h2>
         <p>
-          Contano come sono etichettati i CIG pubblicati. Il campo <strong>importo_lotto</strong> è
-          il valore dichiarato del lotto nella banca dati.
+          Contare i CIG e pesare il valore in euro sono due letture diverse. Qui lo snapshot CIG
+          misura quante etichette ricorrono; la Relazione ANAC sul mercato da 40.000 € in su misura
+          anche quanto pesano in euro. Il campo <strong>importo_lotto</strong> è il valore dichiarato
+          del lotto nella banca dati.
         </p>
       </section>
 
@@ -106,6 +120,57 @@ export default function AppaltiPage() {
           <small>del totale CIG · denominatore: {integer(totalCigs)}</small>
         </div>
       </section>
+
+      {marketComparison && marketValueBillion !== null ? (
+        <section className={`panel ${styles.valuePanel}`} aria-labelledby="value-share-title">
+          <div className={styles.sectionHeading}>
+            <div>
+              <h2 id="value-share-title" className="panel-title">
+                Sul valore in euro la storia cambia
+              </h2>
+              <p>
+                Nella Relazione annuale ANAC sul mercato delle procedure da 40.000 € in su, gli
+                affidamenti diretti sono il {percent(marketComparison.byNumber)} del numero e solo il{" "}
+                {percent(marketComparison.byValue)} del valore. Non è lo stesso perimetro dei CIG
+                sopra: qui conta quanto pesano i soldi, non quante etichette compaiono.
+              </p>
+            </div>
+            <span className="tag tag-neutral">Fonte: Relazione ANAC {marketComparison.year}</span>
+          </div>
+
+          <div className={styles.valuePair} aria-label="Confronto quota sul numero e sul valore">
+            <div className={styles.valueCard}>
+              <span>Quota sul numero</span>
+              <strong>{percent(marketComparison.byNumber)}</strong>
+              <small>
+                {integer(marketComparison.procedureCount)} procedure da 40.000 € in su
+              </small>
+            </div>
+            <div className={styles.valueCard} data-emphasis="value">
+              <span>Quota sul valore</span>
+              <strong>{percent(marketComparison.byValue)}</strong>
+              <small>
+                circa {marketValueBillion.toLocaleString("it-IT", {
+                  maximumFractionDigits: 1,
+                })}{" "}
+                mld € su {marketComparison.totalValueBillion.toLocaleString("it-IT", {
+                  maximumFractionDigits: 1,
+                })}{" "}
+                mld €
+              </small>
+            </div>
+          </div>
+
+          <p className={styles.note}>
+            {marketComparison.caveat}{" "}
+            <a href={marketComparison.sourceUrl} target="_blank" rel="noreferrer">
+              {marketComparison.sourceTitle} ↗
+            </a>
+            {" · "}
+            <Link href="/controlli">Serie e confronti in Controlli →</Link>
+          </p>
+        </section>
+      ) : null}
 
       <section className={`panel ${styles.procedurePanel}`} aria-labelledby="procedure-breakdown-title">
         <div className={styles.sectionHeading}>

--- a/tests/appalti-page.test.mjs
+++ b/tests/appalti-page.test.mjs
@@ -20,6 +20,10 @@ test("appalti page keeps the verified 2025 denominators and scope visible", () =
   assert.equal(anacCigSnapshot.servicesAndSuppliesBelow140000.records, 1_159_940);
   assert.equal(anacCigSnapshot.thresholdBand135000To140000.strictContractRecords, 13_393);
   assert.match(pageSource, /quota sul numero di CIG/);
+  assert.match(pageSource, /Affidamenti diretti · sul valore/);
+  assert.match(pageSource, /getProcurementComparisonForYear/);
+  assert.match(pageSource, /Sul valore in euro la storia cambia/);
+  assert.match(pageSource, /Quota sul valore/);
   assert.match(controlsPageSource, /href="\/appalti"/);
 });
 
@@ -41,11 +45,12 @@ test("appalti page makes the chart/table equivalence and denominator explicit", 
 test("appalti page treats threshold concentrations as screening signals, not findings", () => {
   assert.match(pageSource, /indicano dove guardare\s*\n?\s*meglio negli atti/);
   assert.match(pageSource, /serve a scegliere cosa verificare negli atti/);
-  assert.match(pageSource, /valore dichiarato del lotto nella banca dati/);
+  assert.match(pageSource, /valore dichiarato\s*\n?\s*del lotto nella banca dati/);
   assert.match(pageSource, /Definizione stretta/);
   assert.match(pageSource, /thresholdBand\.strictContractDefinition/);
   assert.match(pageSource, /135\.000 €/);
   assert.match(stylesSource, /\.detailTable\s*\{[^}]*min-width:\s*0/);
+  assert.match(stylesSource, /\.valuePair/);
   assert.doesNotMatch(pageSource, /93%|quasi 95%|sprechi accertati|fornitori?\s*:/i);
 });
 


### PR DESCRIPTION
## Summary
- Su `/appalti` il ~82% resta la quota **sul numero di CIG** (snapshot etichette).
- Aggiunge la lettura ufficiale Relazione ANAC 2025 sulle procedure da 40.000 € in su: **~55% sul numero** e **5,1% sul valore**.
- Chiarisce che i due perimetri non coincidono; link a fonte e a `/controlli`.

## Test plan
- [ ] Aprire `/appalti` e verificare strip + pannello “Sul valore in euro la storia cambia”
- [ ] Controllare mobile (due card una sotto l’altra)
- [ ] `node --test tests/appalti-page.test.mjs`

Made with [Cursor](https://cursor.com)