### PR TITLE
feat(appalti): valore economico riga per riga nelle etichette

### DIFF
--- a/docs/research/data/anac-cigs-2025-2026-08-20.json
+++ b/docs/research/data/anac-cigs-2025-2026-08-20.json
@@ -32,123 +32,147 @@
   "inputs": [
     {
       "bytes": 20798988,
-      "name": "dvns_cig_2025_01.zip",
-      "sha256": "8133cd5ea2b592b4e48afa1eb0ec2db1a831f00a254de077518f8263818a371c",
-      "observedMonths": [1],
+      "name": "cig_csv_2025_01.zip",
+      "observedMonths": [
+        1
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/a1a4be23-11f5-4a95-93d0-5e3267ec6c3f",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_01.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "8133cd5ea2b592b4e48afa1eb0ec2db1a831f00a254de077518f8263818a371c",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 21674004,
-      "name": "dvns_cig_2025_02.zip",
-      "sha256": "ddeb33a5c46fd3f1c4f2988c73e28ca148628670848b8a2a86fd12bffd02045f",
-      "observedMonths": [2],
+      "name": "cig_csv_2025_02.zip",
+      "observedMonths": [
+        2
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/a87a23dd-44a3-4b49-a7ad-b96566476979",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_02.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "ddeb33a5c46fd3f1c4f2988c73e28ca148628670848b8a2a86fd12bffd02045f",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 22468395,
-      "name": "dvns_cig_2025_03.zip",
-      "sha256": "231c2f7713af92c1aef4314a42ccafddb2914d5a6730d8159d13bd54590f3a1f",
-      "observedMonths": [3],
+      "name": "cig_csv_2025_03.zip",
+      "observedMonths": [
+        3
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/dab282d9-f5c5-4595-9a9b-e17cdae7c98f",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_03.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "231c2f7713af92c1aef4314a42ccafddb2914d5a6730d8159d13bd54590f3a1f",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 23640461,
-      "name": "dvns_cig_2025_04.zip",
-      "sha256": "2b8651f49312bca7e356a63b29dc47da5945dfbf7b78bed57ce9aaff54ba1055",
-      "observedMonths": [4],
+      "name": "cig_csv_2025_04.zip",
+      "observedMonths": [
+        4
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/a047f20f-84e4-48ac-8c54-f69127075d67",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_04.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "2b8651f49312bca7e356a63b29dc47da5945dfbf7b78bed57ce9aaff54ba1055",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 23204302,
-      "name": "dvns_cig_2025_05.zip",
-      "sha256": "8f4ef20c3d7a3bf43ff2181341b063e86abc10e0e09232cffd11d3e193aac7b4",
-      "observedMonths": [5],
+      "name": "cig_csv_2025_05.zip",
+      "observedMonths": [
+        5
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/28288080-14c7-45d1-8ff5-26e25fb4159a",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_05.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "8f4ef20c3d7a3bf43ff2181341b063e86abc10e0e09232cffd11d3e193aac7b4",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 22724612,
-      "name": "dvns_cig_2025_06.zip",
-      "sha256": "9006c457b0604f7040a2826ba0294da55379f75cd2756dcf1ad93a90276ebf34",
-      "observedMonths": [6],
+      "name": "cig_csv_2025_06.zip",
+      "observedMonths": [
+        6
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/039b8d17-756e-454b-a1a2-dda46237c6ea",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_06.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "9006c457b0604f7040a2826ba0294da55379f75cd2756dcf1ad93a90276ebf34",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 24551620,
-      "name": "dvns_cig_2025_07.zip",
-      "sha256": "ad0c6265c81e78749d703e6a474e387e043ec69f2e5400264fcd4f91599315e8",
-      "observedMonths": [7],
+      "name": "cig_csv_2025_07.zip",
+      "observedMonths": [
+        7
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/f99292f4-87a0-4e78-bf57-1c54bc4ba5ba",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_07.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "ad0c6265c81e78749d703e6a474e387e043ec69f2e5400264fcd4f91599315e8",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 14864424,
-      "name": "dvns_cig_2025_08.zip",
-      "sha256": "c16e7aa06d6fb0e0880cf797e6d04fdedf37e076c2fd83563dc4f4973e6b539f",
-      "observedMonths": [8],
+      "name": "cig_csv_2025_08.zip",
+      "observedMonths": [
+        8
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/fffb1c60-ff4e-43d4-b36f-1596eef7f079",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_08.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "c16e7aa06d6fb0e0880cf797e6d04fdedf37e076c2fd83563dc4f4973e6b539f",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 22343431,
-      "name": "dvns_cig_2025_09.zip",
-      "sha256": "1b7d009a7120b92444f9ffc8d986a75bdd008cf86623721692e7f74bbf9ff154",
-      "observedMonths": [9],
+      "name": "cig_csv_2025_09.zip",
+      "observedMonths": [
+        9
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/bd56cf08-e8a1-4b96-8c41-bfcdf05d3c9c",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_09.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "1b7d009a7120b92444f9ffc8d986a75bdd008cf86623721692e7f74bbf9ff154",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 25872938,
-      "name": "dvns_cig_2025_10.zip",
-      "sha256": "6e7e467cbb008cc846ee096d3b8e1955fe338d3426a913f0750218bca52901d5",
-      "observedMonths": [10],
+      "name": "cig_csv_2025_10.zip",
+      "observedMonths": [
+        10
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/12b9c75f-cc6c-43c7-aeb9-f73f262b3a23",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_10.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "6e7e467cbb008cc846ee096d3b8e1955fe338d3426a913f0750218bca52901d5",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 21871608,
-      "name": "dvns_cig_2025_11.zip",
-      "sha256": "cb40213cb6b294650099bf6a6ccd656d9139c374796c903302d17359accc2e60",
-      "observedMonths": [11],
+      "name": "cig_csv_2025_11.zip",
+      "observedMonths": [
+        11
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/8bc58a13-f600-4198-ad10-38738d4b4cc0",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_11.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "cb40213cb6b294650099bf6a6ccd656d9139c374796c903302d17359accc2e60",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     },
     {
       "bytes": 32708524,
-      "name": "dvns_cig_2025_12.zip",
-      "sha256": "6f696155e0b2ab4b2d608fe403e1bdc88a8a2c0d08812de325dd97ddedc6013a",
-      "observedMonths": [12],
+      "name": "cig_csv_2025_12.zip",
+      "observedMonths": [
+        12
+      ],
       "resourcePageUrl": "https://dati.anticorruzione.it/opendata/dataset/cig-2025/resource/ebf0b0df-0ce0-4242-b297-a0b9c5cecac7",
       "resourceUrl": "https://dati.anticorruzione.it/opendata/download/dataset/cig-2025/filesystem/cig_csv_2025_12.zip",
-      "sourcePublishedAt": null,
-      "sourceLastModified": "2026-01-16"
+      "sha256": "6f696155e0b2ab4b2d608fe403e1bdc88a8a2c0d08812de325dd97ddedc6013a",
+      "sourceLastModified": "2026-01-16",
+      "sourcePublishedAt": null
     }
   ],
   "interpretationLimits": [
@@ -201,19 +225,61 @@
       "PROCEDURA NEGOZIATA SENZA PREVIA PUBBLICAZIONE": 88185,
       "PROCEDURA RISTRETTA": 26406
     },
+    "allLabelsAmountEuroCents": {
+      "ACCORDO QUADRO": 115481742,
+      "AFFIDAMENTO DIRETTO": 23938909526365,
+      "AFFIDAMENTO DIRETTO A SOCIETA' IN HOUSE": 4296810141758,
+      "AFFIDAMENTO DIRETTO IN ADESIONE AD ACCORDO QUADRO/CONVENZIONE": 484750610773,
+      "ALTRA PROCEDURA A FASE UNICA": 442281914784,
+      "ALTRA PROCEDURA A PIU' FASI": 479197599483,
+      "CONFRONTO COMPETITIVO IN ADESIONE AD ACCORDO QUADRO/CONVENZIONE": 12695232698,
+      "DIALOGO COMPETITIVO": 8968030934,
+      "ND": 1184108581,
+      "ND AD2_25": 2690202709,
+      "ND AD2_26": 17601207,
+      "ND AD2_28": 5492067,
+      "ND P1_15_2": 0,
+      "ND P1_19": 2293015192190,
+      "ND P1_20": 41290991231,
+      "ND P1_21": 10881524494,
+      "ND P2_16": 413486022,
+      "ND P2_18": 241137554,
+      "ND P2_19": 48559477306,
+      "ND P3_1": 1597671897,
+      "ND P4_1": 55623456646,
+      "ND P4_4": 3827423600,
+      "ND P4_5": 71695580662,
+      "ND P7_1_3": 191776970,
+      "ND P7_2": 3104269570,
+      "PARTERNARIATO PER L’INNOVAZIONE": 426743597,
+      "PROCEDURA APERTA": 17682184472338,
+      "PROCEDURA DI GARA": 178563850957,
+      "PROCEDURA NEGOZIATA CON PREVIA INDIZIONE DI GARA (SETTORI SPECIALI)": 1440586333468,
+      "PROCEDURA NEGOZIATA PER AFFIDAMENTI SOTTO SOGLIA": 289271781400,
+      "PROCEDURA NEGOZIATA SENZA PREVIA PUBBLICAZIONE": 3771463562428,
+      "PROCEDURA RISTRETTA": 6837101224268
+    },
+    "amountMeaning": "Somma di importo_lotto > 0 per etichetta; i CIG con importo non positivo restano nel conteggio ma non nel totale euro.",
     "directAward": {
+      "amountEuroCents": 23938909526365,
+      "amountSharePercent": 38.365072,
       "records": 1192083,
       "sharePercent": 81.991075
     },
     "directAwardFamily": {
+      "amountEuroCents": 28720470278896,
+      "amountSharePercent": 46.028116,
       "meaning": "Etichette che iniziano con AFFIDAMENTO DIRETTO; non sono tutte equivalenti.",
       "records": 1220553,
       "sharePercent": 83.949232
     },
     "openProcedure": {
+      "amountEuroCents": 17682184472338,
+      "amountSharePercent": 28.337894,
       "records": 72098,
       "sharePercent": 4.958877
-    }
+    },
+    "totalPositiveAmountEuroCents": 62397665899699
   },
   "referenceYear": 2025,
   "schemaVersion": 1,

--- a/scripts/research/anac_cig_audit.py
+++ b/scripts/research/anac_cig_audit.py
@@ -16,7 +16,7 @@ import sys
 import zipfile
 from collections import Counter
 from dataclasses import dataclass
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from pathlib import Path
 from typing import Iterable, TextIO
 
@@ -126,6 +126,10 @@ def percentage(numerator: int, denominator: int) -> float | None:
     return round((numerator / denominator) * 100, 6)
 
 
+def euro_to_cents(amount: Decimal) -> int:
+    return int((amount * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as source:
@@ -161,12 +165,17 @@ def audit(
 
     counts = Counts()
     choice_counts: Counter[str] = Counter()
+    choice_amount_cents: Counter[str] = Counter()
     exact_amounts: Counter[Decimal] = Counter()
     seen_cigs: set[str] = set()
     all_cigs: set[str] = set()
     active_cigs: set[str] = set()
     observed_months: set[int] = set()
     inputs: list[dict[str, object]] = []
+    total_positive_amount_cents = 0
+    direct_award_amount_cents = 0
+    direct_award_family_amount_cents = 0
+    open_procedure_amount_cents = 0
 
     for path in sorted(paths):
         if not path.is_file():
@@ -264,8 +273,19 @@ def audit(
                 counts.anac_scope_non_direct_above += int(
                     is_anac_scope and not is_direct_family and amount >= UPPER_THRESHOLD
                 )
-                choice_counts[choice or "NON INDICATA"] += 1
+                label = choice or "NON INDICATA"
+                choice_counts[label] += 1
                 exact_amounts[amount] += 1
+                if amount > 0:
+                    cents = euro_to_cents(amount)
+                    choice_amount_cents[label] += cents
+                    total_positive_amount_cents += cents
+                    if is_direct:
+                        direct_award_amount_cents += cents
+                    if is_direct_family:
+                        direct_award_family_amount_cents += cents
+                    if choice == OPEN_PROCEDURE:
+                        open_procedure_amount_cents += cents
         finally:
             stream.close()
             if archive is not None:
@@ -315,17 +335,40 @@ def audit(
             "directAward": {
                 "records": counts.direct_awards,
                 "sharePercent": percentage(counts.direct_awards, counts.rows),
+                "amountEuroCents": direct_award_amount_cents,
+                "amountSharePercent": percentage(
+                    direct_award_amount_cents,
+                    total_positive_amount_cents,
+                ),
             },
             "directAwardFamily": {
                 "records": counts.direct_award_family,
                 "sharePercent": percentage(counts.direct_award_family, counts.rows),
+                "amountEuroCents": direct_award_family_amount_cents,
+                "amountSharePercent": percentage(
+                    direct_award_family_amount_cents,
+                    total_positive_amount_cents,
+                ),
                 "meaning": "Etichette che iniziano con AFFIDAMENTO DIRETTO; non sono tutte equivalenti.",
             },
             "openProcedure": {
                 "records": counts.open_procedures,
                 "sharePercent": percentage(counts.open_procedures, counts.rows),
+                "amountEuroCents": open_procedure_amount_cents,
+                "amountSharePercent": percentage(
+                    open_procedure_amount_cents,
+                    total_positive_amount_cents,
+                ),
             },
             "allLabels": dict(choice_counts.most_common()),
+            "allLabelsAmountEuroCents": {
+                label: choice_amount_cents[label] for label, _ in choice_counts.most_common()
+            },
+            "totalPositiveAmountEuroCents": total_positive_amount_cents,
+            "amountMeaning": (
+                "Somma di importo_lotto > 0 per etichetta; i CIG con importo non positivo "
+                "restano nel conteggio ma non nel totale euro."
+            ),
         },
         "servicesAndSuppliesBelow140000": {
             "records": counts.services_and_supplies_below_threshold,

--- a/src/app/appalti/appalti.module.css
+++ b/src/app/appalti/appalti.module.css
@@ -43,6 +43,27 @@
   align-items: end;
 }
 
+.leadMeasurePair {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.leadMeasure[data-emphasis="value"] {
+  border-top-color: var(--chart-primary);
+}
+
+.barAmount {
+  display: block;
+  margin-top: 2px;
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.barAmount small {
+  font-weight: 500;
+}
+
 .leadCopy p,
 .sectionHeading p,
 .sourcePanel > p,
@@ -362,6 +383,10 @@
   }
 
   .leadMeasure {
+    max-width: 22rem;
+  }
+
+  .leadMeasurePair {
     max-width: 22rem;
   }
 

--- a/src/app/appalti/appalti.module.css
+++ b/src/app/appalti/appalti.module.css
@@ -28,12 +28,21 @@
   border-color: var(--color-neutral-400);
 }
 
-.readingNotice strong {
+.readingNotice strong,
+.asideNotice strong {
   display: inline;
   color: var(--color-text);
   font-size: inherit;
   letter-spacing: normal;
   text-transform: none;
+}
+
+.asideNotice {
+  border-color: var(--color-neutral-400);
+}
+
+.asideNotice .note {
+  margin: var(--space-3) 0 0;
 }
 
 .leadPanel {

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -114,11 +114,10 @@ export default function AppaltiPage() {
       <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="appalti-reading-title">
         <h2 id="appalti-reading-title">Come leggere questi numeri</h2>
         <p>
-          Contare i CIG e sommare <strong>importo_lotto</strong> sono due letture diverse sullo
-          stesso snapshot. Sotto, ogni etichetta mostra quante volte compare e quanto vale in euro
-          dichiarati. La Relazione ANAC sulle procedure da 40.000 € in su resta un perimetro a parte
-          (circa {marketComparison ? percent(marketComparison.byValue) : "n.d."} sul valore di quel
-          mercato).
+          Qui sotto tutto parla dello <strong>stesso snapshot CIG 2025</strong>: conteggio dei CIG e
+          somma di <strong>importo_lotto</strong> (valore dichiarato del lotto). Sono due letture
+          diverse dello stesso file, non due mercati diversi. I grandi numeri in euro della tabella
+          (centinaia di miliardi) sono proprio quella somma.
         </p>
       </section>
 
@@ -129,9 +128,10 @@ export default function AppaltiPage() {
             La voce <strong>AFFIDAMENTO DIRETTO</strong> è l&apos;etichetta più frequente:{" "}
             {share(directAward.records, totalCigs)} dei {integer(totalCigs)} CIG, ma solo{" "}
             {percent(directAward.amountSharePercent ?? 0)} della somma di{" "}
-            <strong>importo_lotto</strong> nello snapshot. La famiglia di etichette che iniziano con
-            “AFFIDAMENTO DIRETTO” arriva a {share(directAwardFamily.records, totalCigs)} dei CIG e a{" "}
-            {percent(directAwardFamily.amountSharePercent ?? 0)} del valore dichiarato.
+            <strong>importo_lotto</strong> nello snapshot
+            ({exactEuro((directAward.amountEuroCents ?? 0) / 100)}). La famiglia di etichette che
+            iniziano con “AFFIDAMENTO DIRETTO” arriva a {share(directAwardFamily.records, totalCigs)}{" "}
+            dei CIG e a {percent(directAwardFamily.amountSharePercent ?? 0)} del valore dichiarato.
           </p>
         </div>
         <div className={styles.leadMeasurePair}>
@@ -149,58 +149,6 @@ export default function AppaltiPage() {
           </div>
         </div>
       </section>
-
-      {marketComparison && marketValueBillion !== null ? (
-        <section className={`panel ${styles.valuePanel}`} aria-labelledby="value-share-title">
-          <div className={styles.sectionHeading}>
-            <div>
-              <h2 id="value-share-title" className="panel-title">
-                Sul valore in euro la storia cambia
-              </h2>
-              <p>
-                Nella Relazione annuale ANAC sul mercato delle procedure da 40.000 € in su, gli
-                affidamenti diretti sono il {percent(marketComparison.byNumber)} del numero e solo il{" "}
-                {percent(marketComparison.byValue)} del valore. È un altro perimetro rispetto alla
-                somma di importo_lotto sui CIG sopra ({percent(directAward.amountSharePercent ?? 0)}{" "}
-                sul valore dello snapshot).
-              </p>
-            </div>
-            <span className="tag tag-neutral">Fonte: Relazione ANAC {marketComparison.year}</span>
-          </div>
-
-          <div className={styles.valuePair} aria-label="Confronto quota sul numero e sul valore">
-            <div className={styles.valueCard}>
-              <span>Quota sul numero</span>
-              <strong>{percent(marketComparison.byNumber)}</strong>
-              <small>
-                {integer(marketComparison.procedureCount)} procedure da 40.000 € in su
-              </small>
-            </div>
-            <div className={styles.valueCard} data-emphasis="value">
-              <span>Quota sul valore</span>
-              <strong>{percent(marketComparison.byValue)}</strong>
-              <small>
-                circa {marketValueBillion.toLocaleString("it-IT", {
-                  maximumFractionDigits: 1,
-                })}{" "}
-                mld € su {marketComparison.totalValueBillion.toLocaleString("it-IT", {
-                  maximumFractionDigits: 1,
-                })}{" "}
-                mld €
-              </small>
-            </div>
-          </div>
-
-          <p className={styles.note}>
-            {marketComparison.caveat}{" "}
-            <a href={marketComparison.sourceUrl} target="_blank" rel="noreferrer">
-              {marketComparison.sourceTitle} ↗
-            </a>
-            {" · "}
-            <Link href="/controlli">Serie e confronti in Controlli →</Link>
-          </p>
-        </section>
-      ) : null}
 
       <section className={`panel ${styles.procedurePanel}`} aria-labelledby="procedure-breakdown-title">
         <div className={styles.sectionHeading}>
@@ -297,6 +245,33 @@ export default function AppaltiPage() {
           </ScrollRegion>
         </details>
       </section>
+
+      {marketComparison && marketValueBillion !== null ? (
+        <section className={`notice scope-notice ${styles.asideNotice}`} aria-labelledby="value-share-title">
+          <h2 id="value-share-title">Non confondere con la Relazione ANAC</h2>
+          <p>
+            I {exactEuro((directAward.amountEuroCents ?? 0) / 100)} e il{" "}
+            {percent(directAward.amountSharePercent ?? 0)} sopra sono la somma di{" "}
+            <strong>importo_lotto</strong> su tutti i CIG dello snapshot. La Relazione annuale ANAC
+            parla invece solo del mercato delle procedure da <strong>40.000 € in su</strong>: lì gli
+            affidamenti diretti sono il {percent(marketComparison.byNumber)} del numero e il{" "}
+            {percent(marketComparison.byValue)} del valore (circa{" "}
+            {marketValueBillion.toLocaleString("it-IT", { maximumFractionDigits: 1 })} mld € su{" "}
+            {marketComparison.totalValueBillion.toLocaleString("it-IT", {
+              maximumFractionDigits: 1,
+            })}{" "}
+            mld €). Non sostituisce i numeri della tabella.
+          </p>
+          <p className={styles.note}>
+            {marketComparison.caveat}{" "}
+            <a href={marketComparison.sourceUrl} target="_blank" rel="noreferrer">
+              {marketComparison.sourceTitle} ↗
+            </a>
+            {" · "}
+            <Link href="/controlli">Serie e confronti in Controlli →</Link>
+          </p>
+        </section>
+      ) : null}
 
       <section className={`panel ${styles.subsetPanel}`} aria-labelledby="subset-title">
         <div className={styles.sectionHeading}>

--- a/src/app/appalti/page.tsx
+++ b/src/app/appalti/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import IntegratedSectionPreview from "@/components/integrated-section-preview";
 import { getProcurementComparisonForYear } from "@/lib/audit-data";
 import { anacCigSnapshot } from "@/lib/anac-cig-snapshot";
-import { exactEuro, integer, longDate, percent } from "@/lib/format";
+import { compactEuro, exactEuro, integer, longDate, percent } from "@/lib/format";
 import styles from "./appalti.module.css";
 import { ScrollRegion } from "./scroll-region";
 
@@ -15,15 +15,32 @@ export const metadata: Metadata = {
 
 const data = anacCigSnapshot;
 const totalCigs = data.population.records;
-const procedureEntries = Object.entries(data.procedureChoice.allLabels)
-  .map(([label, records]) => ({ label, records }))
+const labelAmounts = data.procedureChoice.allLabelsAmountEuroCents;
+const totalAmountCents = data.procedureChoice.totalPositiveAmountEuroCents;
+type ProcedureLabel = keyof typeof labelAmounts;
+const procedureEntries = (
+  Object.entries(data.procedureChoice.allLabels) as Array<[ProcedureLabel, number]>
+)
+  .map(([label, records]) => ({
+    label,
+    records,
+    amountEuroCents: labelAmounts[label],
+  }))
   .sort((left, right) => right.records - left.records);
 const featuredProcedureEntries = procedureEntries.slice(0, 6);
 const otherProcedureEntries = procedureEntries.slice(6);
 const otherProcedureCount = otherProcedureEntries.reduce((sum, row) => sum + row.records, 0);
+const otherProcedureAmount = otherProcedureEntries.reduce(
+  (sum, row) => sum + row.amountEuroCents,
+  0,
+);
 const procedureRows = [
   ...featuredProcedureEntries,
-  { label: `Altre ${otherProcedureEntries.length} etichette`, records: otherProcedureCount },
+  {
+    label: `Altre ${otherProcedureEntries.length} etichette`,
+    records: otherProcedureCount,
+    amountEuroCents: otherProcedureAmount,
+  },
 ];
 
 const directAward = data.procedureChoice.directAward;
@@ -37,8 +54,12 @@ const marketValueBillion =
     ? null
     : (marketComparison.totalValueBillion * marketComparison.byValue) / 100;
 
-function share(records: number, denominator: number): string {
-  return percent((records / denominator) * 100);
+function share(part: number, denominator: number): string {
+  return percent((part / denominator) * 100);
+}
+
+function amountShare(amountEuroCents: number): string {
+  return share(amountEuroCents, totalAmountCents);
 }
 
 const exactAmountRows = Object.entries(data.exactContractAmounts)
@@ -77,14 +98,10 @@ export default function AppaltiPage() {
           <span className="stat-note">{integer(directAward.records)} su {integer(totalCigs)} CIG · quota sul numero di CIG</span>
         </div>
         <div>
-          <span className="stat-label">Affidamenti diretti · sul valore</span>
-          <span className="stat-value">
-            {marketComparison ? percent(marketComparison.byValue) : "Non disponibile"}
-          </span>
+          <span className="stat-label">Affidamento diretto · sul valore CIG</span>
+          <span className="stat-value">{percent(directAward.amountSharePercent ?? 0)}</span>
           <span className="stat-note">
-            {marketComparison
-              ? `Relazione ANAC ${marketComparison.year} · procedure da 40.000 € in su`
-              : "manca la serie ANAC sul valore"}
+            somma di importo_lotto · quota sul totale euro dello snapshot
           </span>
         </div>
         <div>
@@ -97,10 +114,11 @@ export default function AppaltiPage() {
       <section className={`notice scope-notice ${styles.readingNotice}`} aria-labelledby="appalti-reading-title">
         <h2 id="appalti-reading-title">Come leggere questi numeri</h2>
         <p>
-          Contare i CIG e pesare il valore in euro sono due letture diverse. Qui lo snapshot CIG
-          misura quante etichette ricorrono; la Relazione ANAC sul mercato da 40.000 € in su misura
-          anche quanto pesano in euro. Il campo <strong>importo_lotto</strong> è il valore dichiarato
-          del lotto nella banca dati.
+          Contare i CIG e sommare <strong>importo_lotto</strong> sono due letture diverse sullo
+          stesso snapshot. Sotto, ogni etichetta mostra quante volte compare e quanto vale in euro
+          dichiarati. La Relazione ANAC sulle procedure da 40.000 € in su resta un perimetro a parte
+          (circa {marketComparison ? percent(marketComparison.byValue) : "n.d."} sul valore di quel
+          mercato).
         </p>
       </section>
 
@@ -108,16 +126,27 @@ export default function AppaltiPage() {
         <div className={styles.leadCopy}>
           <h2 id="procedure-title" className="panel-title">Le procedure che ricorrono di più</h2>
           <p>
-            La voce <strong>AFFIDAMENTO DIRETTO</strong> è l&apos;etichetta più frequente: rappresenta
-            {" "}{share(directAward.records, totalCigs)} dei {integer(totalCigs)} CIG unici osservati.
-            La famiglia più ampia delle etichette che iniziano con “AFFIDAMENTO DIRETTO” arriva a
-            {" "}{share(directAwardFamily.records, totalCigs)} e raccoglie etichette diverse.
+            La voce <strong>AFFIDAMENTO DIRETTO</strong> è l&apos;etichetta più frequente:{" "}
+            {share(directAward.records, totalCigs)} dei {integer(totalCigs)} CIG, ma solo{" "}
+            {percent(directAward.amountSharePercent ?? 0)} della somma di{" "}
+            <strong>importo_lotto</strong> nello snapshot. La famiglia di etichette che iniziano con
+            “AFFIDAMENTO DIRETTO” arriva a {share(directAwardFamily.records, totalCigs)} dei CIG e a{" "}
+            {percent(directAwardFamily.amountSharePercent ?? 0)} del valore dichiarato.
           </p>
         </div>
-        <div className={styles.leadMeasure}>
-          <span>Etichetta più frequente</span>
-          <strong>{share(directAward.records, totalCigs)}</strong>
-          <small>del totale CIG · denominatore: {integer(totalCigs)}</small>
+        <div className={styles.leadMeasurePair}>
+          <div className={styles.leadMeasure}>
+            <span>Sul numero di CIG</span>
+            <strong>{share(directAward.records, totalCigs)}</strong>
+            <small>etichetta esatta · {integer(directAward.records)} CIG</small>
+          </div>
+          <div className={styles.leadMeasure} data-emphasis="value">
+            <span>Sul valore dichiarato</span>
+            <strong>{percent(directAward.amountSharePercent ?? 0)}</strong>
+            <small>
+              {exactEuro((directAward.amountEuroCents ?? 0) / 100)} · importo_lotto &gt; 0
+            </small>
+          </div>
         </div>
       </section>
 
@@ -131,8 +160,9 @@ export default function AppaltiPage() {
               <p>
                 Nella Relazione annuale ANAC sul mercato delle procedure da 40.000 € in su, gli
                 affidamenti diretti sono il {percent(marketComparison.byNumber)} del numero e solo il{" "}
-                {percent(marketComparison.byValue)} del valore. Non è lo stesso perimetro dei CIG
-                sopra: qui conta quanto pesano i soldi, non quante etichette compaiono.
+                {percent(marketComparison.byValue)} del valore. È un altro perimetro rispetto alla
+                somma di importo_lotto sui CIG sopra ({percent(directAward.amountSharePercent ?? 0)}{" "}
+                sul valore dello snapshot).
               </p>
             </div>
             <span className="tag tag-neutral">Fonte: Relazione ANAC {marketComparison.year}</span>
@@ -180,11 +210,12 @@ export default function AppaltiPage() {
               Le prime sei voci coprono {share(
                 featuredProcedureEntries.reduce((sum, row) => sum + row.records, 0),
                 totalCigs,
-              )} dei CIG. Le altre sono accorpate solo nel grafico e nella tabella equivalente qui
-              sotto; il dettaglio delle 32 etichette resta apribile più avanti.
+              )} dei CIG e {amountShare(
+                featuredProcedureEntries.reduce((sum, row) => sum + row.amountEuroCents, 0),
+              )} del valore dichiarato (importo_lotto &gt; 0). Per ogni riga vedi conteggio e euro.
             </p>
           </div>
-          <span className="tag tag-neutral">Denominatore: tutti i CIG unici 2025</span>
+          <span className="tag tag-neutral">CIG e somma importo_lotto · 2025</span>
         </div>
 
         <ol className={styles.barList} aria-label="Le sei etichette di procedura più frequenti e le altre etichette">
@@ -194,6 +225,10 @@ export default function AppaltiPage() {
                 <span>{row.label}</span>
                 <strong>
                   {integer(row.records)} <small>· {share(row.records, totalCigs)}</small>
+                  <span className={styles.barAmount}>
+                    {compactEuro(row.amountEuroCents / 100)}
+                    <small> · {amountShare(row.amountEuroCents)}</small>
+                  </span>
                 </strong>
               </div>
               <div className={styles.barTrack} aria-hidden="true">
@@ -206,12 +241,16 @@ export default function AppaltiPage() {
 
         <ScrollRegion className="table-scroll" role="region" aria-label="Tabella esatta della distribuzione delle procedure" tabIndex={0}>
           <table className="table">
-            <caption>Le stesse categorie rappresentate nel grafico, con conteggio e quota sul totale dei CIG unici 2025</caption>
+            <caption>
+              Stesse categorie del grafico: conteggio CIG e somma di importo_lotto positivo
+            </caption>
             <thead>
               <tr>
                 <th scope="col">Etichetta</th>
                 <th scope="col" className="num">CIG</th>
-                <th scope="col" className="num">Quota</th>
+                <th scope="col" className="num">Quota CIG</th>
+                <th scope="col" className="num">Valore dichiarato</th>
+                <th scope="col" className="num">Quota valore</th>
               </tr>
             </thead>
             <tbody>
@@ -220,6 +259,8 @@ export default function AppaltiPage() {
                   <th scope="row">{row.label}</th>
                   <td className="num">{integer(row.records)}</td>
                   <td className="num">{share(row.records, totalCigs)}</td>
+                  <td className="num">{exactEuro(row.amountEuroCents / 100)}</td>
+                  <td className="num">{amountShare(row.amountEuroCents)}</td>
                 </tr>
               ))}
             </tbody>
@@ -236,7 +277,9 @@ export default function AppaltiPage() {
                 <tr>
                   <th scope="col">Etichetta originale</th>
                   <th scope="col" className="num">CIG</th>
-                  <th scope="col" className="num">Quota</th>
+                  <th scope="col" className="num">Quota CIG</th>
+                  <th scope="col" className="num">Valore dichiarato</th>
+                  <th scope="col" className="num">Quota valore</th>
                 </tr>
               </thead>
               <tbody>
@@ -245,6 +288,8 @@ export default function AppaltiPage() {
                     <th scope="row">{row.label}</th>
                     <td className="num">{integer(row.records)}</td>
                     <td className="num">{share(row.records, totalCigs)}</td>
+                    <td className="num">{exactEuro(row.amountEuroCents / 100)}</td>
+                    <td className="num">{amountShare(row.amountEuroCents)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/lib/anac-cig-snapshot.ts
+++ b/src/lib/anac-cig-snapshot.ts
@@ -58,6 +58,33 @@ export function assertAnacCigManifest(candidate: typeof rawManifest = rawManifes
   ) {
     throw new Error("Manifest ANAC CIG: aggregati delle procedure incoerenti.");
   }
+  const labelAmounts = candidate.procedureChoice.allLabelsAmountEuroCents;
+  const totalAmount = candidate.procedureChoice.totalPositiveAmountEuroCents;
+  if (
+    typeof totalAmount !== "number" ||
+    totalAmount < 0 ||
+    !labelAmounts ||
+    Object.keys(labelAmounts).length !== Object.keys(candidate.procedureChoice.allLabels).length
+  ) {
+    throw new Error("Manifest ANAC CIG: totali euro per etichetta mancanti o incoerenti.");
+  }
+  const amountSum = Object.values(labelAmounts).reduce((sum, value) => sum + value, 0);
+  if (amountSum !== totalAmount) {
+    throw new Error("Manifest ANAC CIG: la somma degli importi per etichetta non riconcilia.");
+  }
+  if (
+    candidate.procedureChoice.directAward.amountEuroCents !==
+      labelAmounts["AFFIDAMENTO DIRETTO"] ||
+    candidate.procedureChoice.directAward.amountEuroCents >
+      candidate.procedureChoice.directAwardFamily.amountEuroCents ||
+    candidate.procedureChoice.directAwardFamily.amountEuroCents > totalAmount ||
+    candidate.procedureChoice.openProcedure.amountEuroCents > totalAmount
+  ) {
+    throw new Error("Manifest ANAC CIG: aggregati euro delle procedure incoerenti.");
+  }
+  if (Object.values(labelAmounts).some((value) => value < 0)) {
+    throw new Error("Manifest ANAC CIG: importo euro negativo.");
+  }
   if (
     candidate.population.servicesAndSupplies > candidate.population.records ||
     candidate.servicesAndSuppliesBelow140000.records > candidate.population.servicesAndSupplies ||

--- a/tests/anac-cig-snapshot.test.mjs
+++ b/tests/anac-cig-snapshot.test.mjs
@@ -68,4 +68,8 @@ test("ANAC manifest fails closed when page aggregates drift", () => {
   const amountDrift = freshManifest();
   amountDrift.exactContractAmounts["39900"] = -1;
   assert.throws(() => assertAnacCigManifest(amountDrift), /conteggio importo negativo/);
+
+  const labelAmountDrift = freshManifest();
+  labelAmountDrift.procedureChoice.allLabelsAmountEuroCents["AFFIDAMENTO DIRETTO"] += 1;
+  assert.throws(() => assertAnacCigManifest(labelAmountDrift), /somma degli importi/);
 });

--- a/tests/appalti-page.test.mjs
+++ b/tests/appalti-page.test.mjs
@@ -44,6 +44,19 @@ test("appalti page makes the chart/table equivalence and denominator explicit", 
   assert.equal(anacCigSnapshot.provenance.license, "CC BY-SA 4.0");
 });
 
+test("appalti page separates CIG euro sums from the Relazione ANAC perimeter", () => {
+  assert.match(pageSource, /Come leggere questi numeri/);
+  assert.match(pageSource, /stesso snapshot CIG 2025/);
+  assert.match(pageSource, /Non confondere con la Relazione ANAC/);
+  assert.match(pageSource, /Non sostituisce i numeri della tabella/);
+  assert.match(pageSource, /40\.000 € in su/);
+  assert.doesNotMatch(pageSource, /Sul valore in euro la storia cambia/);
+  const tableMarker = pageSource.indexOf("procedure-breakdown-title");
+  const relazioneMarker = pageSource.indexOf("value-share-title");
+  assert.ok(tableMarker >= 0);
+  assert.ok(relazioneMarker > tableMarker);
+});
+
 test("appalti page treats threshold concentrations as screening signals, not findings", () => {
   assert.match(pageSource, /indicano dove guardare\s*\n?\s*meglio negli atti/);
   assert.match(pageSource, /serve a scegliere cosa verificare negli atti/);

--- a/tests/appalti-page.test.mjs
+++ b/tests/appalti-page.test.mjs
@@ -17,24 +17,26 @@ test("appalti page keeps the verified 2025 denominators and scope visible", () =
   assert.equal(anacCigSnapshot.population.records, 1_453_918);
   assert.equal(anacCigSnapshot.population.servicesAndSupplies, 1_290_218);
   assert.equal(anacCigSnapshot.procedureChoice.directAward.records, 1_192_083);
+  assert.equal(anacCigSnapshot.procedureChoice.directAward.amountEuroCents, 23_938_909_526_365);
   assert.equal(anacCigSnapshot.servicesAndSuppliesBelow140000.records, 1_159_940);
   assert.equal(anacCigSnapshot.thresholdBand135000To140000.strictContractRecords, 13_393);
   assert.match(pageSource, /quota sul numero di CIG/);
-  assert.match(pageSource, /Affidamenti diretti · sul valore/);
-  assert.match(pageSource, /getProcurementComparisonForYear/);
-  assert.match(pageSource, /Sul valore in euro la storia cambia/);
-  assert.match(pageSource, /Quota sul valore/);
+  assert.match(pageSource, /Affidamento diretto · sul valore CIG/);
+  assert.match(pageSource, /amountShare\(/);
+  assert.match(pageSource, /Valore dichiarato/);
+  assert.match(pageSource, /Quota valore/);
   assert.match(controlsPageSource, /href="\/appalti"/);
 });
 
 test("appalti page makes the chart/table equivalence and denominator explicit", () => {
   assert.match(pageSource, /Distribuzione delle etichette/);
   assert.match(pageSource, /Tabella esatta della distribuzione/);
-  assert.match(pageSource, /Denominatore: tutti i CIG unici 2025/);
-  assert.match(pageSource, /Quota sul denominatore/);
+  assert.match(pageSource, /CIG e somma importo_lotto/);
+  assert.match(pageSource, /Quota CIG/);
   assert.match(pageSource, /Apri tutte le 32 etichette originali/);
   assert.match(pageSource, /AFFIDAMENTO DIRETTO/);
   assert.match(pageSource, /row\.records \/ totalCigs/);
+  assert.match(pageSource, /row\.amountEuroCents/);
   assert.doesNotMatch(pageSource, /largestProcedureCount/);
   assert.match(pageSource, /ScrollRegion/);
   assert.match(scrollRegionSource, /event\.key === "End"/);
@@ -45,12 +47,12 @@ test("appalti page makes the chart/table equivalence and denominator explicit", 
 test("appalti page treats threshold concentrations as screening signals, not findings", () => {
   assert.match(pageSource, /indicano dove guardare\s*\n?\s*meglio negli atti/);
   assert.match(pageSource, /serve a scegliere cosa verificare negli atti/);
-  assert.match(pageSource, /valore dichiarato\s*\n?\s*del lotto nella banca dati/);
   assert.match(pageSource, /Definizione stretta/);
   assert.match(pageSource, /thresholdBand\.strictContractDefinition/);
   assert.match(pageSource, /135\.000 €/);
   assert.match(stylesSource, /\.detailTable\s*\{[^}]*min-width:\s*0/);
   assert.match(stylesSource, /\.valuePair/);
+  assert.match(stylesSource, /\.barAmount/);
   assert.doesNotMatch(pageSource, /93%|quasi 95%|sprechi accertati|fornitori?\s*:/i);
 });
 

--- a/tests/etl/test_anac_cig_audit.py
+++ b/tests/etl/test_anac_cig_audit.py
@@ -103,6 +103,20 @@ class AnacCigAuditTest(unittest.TestCase):
         self.assertEqual(result["coverage"]["observedMonths"], [1])
         self.assertEqual(result["procedureChoice"]["directAward"]["records"], 2)
         self.assertAlmostEqual(result["procedureChoice"]["directAward"]["sharePercent"], 66.666667)
+        self.assertEqual(result["procedureChoice"]["directAward"]["amountEuroCents"], 28_990_000)
+        self.assertAlmostEqual(
+            result["procedureChoice"]["directAward"]["amountSharePercent"],
+            65.901341,
+        )
+        self.assertEqual(result["procedureChoice"]["totalPositiveAmountEuroCents"], 43_990_000)
+        self.assertEqual(
+            result["procedureChoice"]["allLabelsAmountEuroCents"]["AFFIDAMENTO DIRETTO"],
+            28_990_000,
+        )
+        self.assertEqual(
+            result["procedureChoice"]["allLabelsAmountEuroCents"]["PROCEDURA APERTA"],
+            15_000_000,
+        )
         self.assertEqual(result["servicesAndSuppliesBelow140000"]["records"], 1)
         self.assertEqual(result["thresholdBand135000To140000"]["strictContractRecords"], 1)
         self.assertEqual(result["exactContractAmounts"]["139900"], 1)


### PR DESCRIPTION
## Summary
- Ricalcola lo snapshot ANAC CIG 2025 sommando `importo_lotto` per etichetta di procedura.
- Su `/appalti`, nella distribuzione etichette (barre + tabelle), ogni riga mostra CIG/quota e valore dichiarato/quota valore.
- Affidamento diretto: ~82% dei CIG, ~38% della somma `importo_lotto` nello snapshot (la Relazione ≥40k con il 5,1% resta un perimetro distinto).

## Test plan
- [ ] `/appalti` → sezione Distribuzione: ogni riga ha euro + quota valore
- [ ] Confrontare AFFIDAMENTO DIRETTO ~82% count vs ~38% value
- [ ] `python3 -m unittest tests.etl.test_anac_cig_audit`
- [ ] `node --test tests/appalti-page.test.mjs tests/anac-cig-snapshot.test.mjs`

Made with [Cursor](https://cursor.com)