### PR TITLE
feat(supporter): acknowledge Buy Me a Coffee donors

### DIFF
--- a/src/app/supporter/page.tsx
+++ b/src/app/supporter/page.tsx
@@ -27,16 +27,21 @@ export default function SupportersPage() {
           <a href={BUY_ME_A_COFFEE_URL} target="_blank" rel="noreferrer">
             Buy Me a Coffee
           </a>{" "}
-          aiuta a pagare compute e hosting. Il contributo resta volontario e non influenza i dati
-          pubblicati.
+          aiuta a pagare compute e hosting. Elenco aggiornato dai contributi pubblici ricevuti
+          finora ({INDIVIDUAL_SUPPORTERS.length} nomi, inclusi i sostegni anonimi aggregati). Il
+          contributo resta volontario e non influenza i dati pubblicati.
         </p>
         <ul>
           {INDIVIDUAL_SUPPORTERS.map((supporter) => (
-            <li key={supporter.href}>
+            <li key={supporter.name}>
               <strong>
-                <a href={supporter.href} target="_blank" rel="noreferrer">
-                  {supporter.name}
-                </a>
+                {supporter.href ? (
+                  <a href={supporter.href} target="_blank" rel="noreferrer">
+                    {supporter.name}
+                  </a>
+                ) : (
+                  supporter.name
+                )}
               </strong>
               {": "}
               {supporter.contribution}
@@ -51,14 +56,16 @@ export default function SupportersPage() {
       </section>
 
       {SITE_SUPPORTERS.map((supporter) => (
-        <section className="panel" key={supporter.href}>
+        <section className="panel" key={supporter.href ?? supporter.name}>
           <h2 className="panel-title">{supporter.name}</h2>
           <p>{supporter.contribution}</p>
-          <p>
-            <a href={supporter.href} target="_blank" rel="noreferrer">
-              {new URL(supporter.href).hostname} ↗
-            </a>
-          </p>
+          {supporter.href ? (
+            <p>
+              <a href={supporter.href} target="_blank" rel="noreferrer">
+                {new URL(supporter.href).hostname} ↗
+              </a>
+            </p>
+          ) : null}
         </section>
       ))}
     </main>

--- a/src/lib/supporters.ts
+++ b/src/lib/supporters.ts
@@ -1,16 +1,79 @@
 export type SiteSupporter = Readonly<{
   name: string;
-  href: string;
+  /** Public profile when known; omit for anonymous or name-only acknowledgements. */
+  href?: string;
   contribution: string;
 }>;
 
-/** Individual donors acknowledged publicly (e.g. Buy Me a Coffee). */
+/**
+ * Individual donors acknowledged publicly from Buy Me a Coffee.
+ * Aggregated by display name; anonymous gifts stay under “Someone”.
+ * Ordered by first public support (oldest first).
+ */
 export const INDIVIDUAL_SUPPORTERS: readonly SiteSupporter[] = [
   {
     name: "Clodo76",
     href: "https://github.com/Clodo76",
     contribution:
-      "Primo sostegno su Buy Me a Coffee per aiutare a coprire compute e hosting del progetto.",
+      "Primo sostegno su Buy Me a Coffee: 500 ai compute. «Progetto meritevole».",
+  },
+  {
+    name: "giuseppe russo",
+    contribution: "Sostegno su Buy Me a Coffee (10 ai compute).",
+  },
+  {
+    name: "chochoichoy",
+    contribution:
+      "Sostegno su Buy Me a Coffee (10 ai compute). «grazie per portare avanti questo progetto!»",
+  },
+  {
+    name: "Francesco Cecchetti",
+    contribution: "Sostegno su Buy Me a Coffee (10 ai compute). «avanti così»",
+  },
+  {
+    name: "Crisnulli",
+    contribution: "Sostegno su Buy Me a Coffee (10 ai compute).",
+  },
+  {
+    name: "scacciavillani",
+    contribution: "Sostegno su Buy Me a Coffee (5 ai compute).",
+  },
+  {
+    name: "HyDrogu",
+    contribution:
+      "Sostegno su Buy Me a Coffee (10 ai compute). «Complimenti ragazzi, continuate così»",
+  },
+  {
+    name: "Marco rossi",
+    contribution: "Sostegno su Buy Me a Coffee (10 ai compute). «Bel lavoro! Complimenti»",
+  },
+  {
+    name: "Nicole",
+    contribution: "Sostegno su Buy Me a Coffee (10 ai compute). «Ottimo lavoro! Continuate così»",
+  },
+  {
+    name: "Luca Celati",
+    contribution: "Sostegno su Buy Me a Coffee (5 ai compute).",
+  },
+  {
+    name: "Aldo Colamartino",
+    contribution:
+      "Sostegno su Buy Me a Coffee (5 ai compute). «Accountability, accountability e trasparenza ci vogliono.»",
+  },
+  {
+    name: "MrPolitano",
+    contribution:
+      "Sostegno su Buy Me a Coffee (5 ai compute). «È l'inizio del cambiamento. Forza ragazzi e grazie»",
+  },
+  {
+    name: "herr_man",
+    contribution:
+      "Sostegno su Buy Me a Coffee (5 ai compute). «bravi coder mi fate un po' invidia :)»",
+  },
+  {
+    name: "Someone",
+    contribution:
+      "Sostegni anonimi su Buy Me a Coffee (3 ai compute in totale).",
   },
 ];
 

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -117,9 +117,17 @@ test("supporters page lists the current acknowledgements", async () => {
   assert.match(supporters, /INDIVIDUAL_SUPPORTERS/);
   assert.match(supporters, /Clodo76/);
   assert.match(supporters, /github\.com\/Clodo76/);
+  assert.match(supporters, /500 ai compute/);
+  assert.match(supporters, /Aldo Colamartino/);
+  assert.match(supporters, /Francesco Cecchetti/);
+  assert.match(supporters, /HyDrogu/);
+  assert.match(supporters, /chochoichoy/);
+  assert.match(supporters, /Sostegni anonimi/);
   assert.match(page, /SITE_SUPPORTERS/);
   assert.match(page, /INDIVIDUAL_SUPPORTERS/);
   assert.match(page, /BUY_ME_A_COFFEE_URL/);
+  assert.match(page, /supporter\.href \?/);
+  assert.match(page, /contributi pubblici ricevuti/);
   assert.match(footer, /href="\/supporter"/);
   assert.match(footer, /BUY_ME_A_COFFEE_URL/);
   assert.match(footer, /Buy me an AI compute/);


### PR DESCRIPTION
## Summary
- Aggiorna `/supporter` con i contributi pubblici ricevuti su Buy Me a Coffee (inclusi anonimi aggregati).
- Branch basato sull’attuale `main` (dopo #123 e #106).

## Test plan
- [ ] Controllare `/supporter`: elenco donatori e sezioni Regolo / Manto / Italian Builders
- [ ] Verificare link Clodo76 → GitHub e CTA Buy Me a Coffee
- [ ] `node --test tests/site-navigation.test.mjs`


Made with [Cursor](https://cursor.com)