### PR TITLE
fix(mcp): accetta il trasporto anche su /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Server [Model Context Protocol](https://modelcontextprotocol.io/) pubblico, sola
 https://www.dovevannoinostrisoldi.com/api/mcp
 ```
 
-In locale: `http://localhost:3000/api/mcp`. Pagina catalogo: [/mcp](https://www.dovevannoinostrisoldi.com/mcp).
+In locale: `http://localhost:3000/api/mcp`. Pagina catalogo: [/mcp](https://www.dovevannoinostrisoldi.com/mcp). Per evitare errori di configurazione, `POST /mcp` e `OPTIONS /mcp` sono alias compatibili dell'endpoint canonico; `GET /mcp` resta la pagina informativa.
 
 Strumenti principali: `list_datasets`, `query_dataset`.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -7,7 +7,7 @@ Il server MCP espone i dati pubblici già disponibili nel portale attraverso un 
 La prima interfaccia testuale deterministica del portale è documentata separatamente in
 [ASSISTENTE.md](ASSISTENTE.md): non è un provider LLM e non inoltra prompt al server MCP.
 
-L'endpoint Streamable HTTP è `/api/mcp`. L'implementazione usa l'SDK TypeScript ufficiale e mantiene compatibilità stateless con i client MCP della generazione precedente.
+L'endpoint Streamable HTTP canonico è `/api/mcp`. `POST /mcp` e `OPTIONS /mcp` sono alias compatibili, mentre `GET /mcp` resta la pagina di presentazione: un client configurato con il percorso breve non riceve quindi un 405. L'implementazione usa l'SDK TypeScript ufficiale e mantiene compatibilità stateless con i client MCP della generazione precedente.
 
 Le procedure per collegare l'endpoint esistente a Manufact, ChatGPT e Claude, insieme a starter
 prompt e casi di review, sono in [MCP_DISTRIBUTION.md](MCP_DISTRIBUTION.md). L'endpoint canonico non

--- a/scripts/ci/run-production-gates.sh
+++ b/scripts/ci/run-production-gates.sh
@@ -13,6 +13,11 @@ READY_TIMEOUT="${READY_TIMEOUT:-90}"
 READY_PATH="/territori/irpef"
 BASE_URL="http://${NEXT_HOST}:${NEXT_PORT}"
 
+# Next may represent an internal rewrite through `localhost` even when the
+# production-gate server is bound to 127.0.0.1. Keep browser CORS fail-closed
+# while explicitly allowing only this run-owned loopback origin.
+export MCP_ALLOWED_ORIGINS="${MCP_ALLOWED_ORIGINS:-$BASE_URL}"
+
 server_pid=""
 cleanup() {
   if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
@@ -64,7 +69,11 @@ npm run test:mcp:http
 echo "::endgroup::"
 
 echo "::group::MCP local load test"
-npm run test:mcp:load -- --requests 60 --concurrency 10 --p95-ms 3000
+npm run test:mcp:load -- \
+  --url "${BASE_URL}/api/mcp" \
+  --requests 60 \
+  --concurrency 10 \
+  --p95-ms 3000
 echo "::endgroup::"
 
 echo "::group::Browser core suite"

--- a/scripts/mcp_http_smoke.mjs
+++ b/scripts/mcp_http_smoke.mjs
@@ -36,8 +36,13 @@ async function waitForServer() {
   throw new Error(`Server non pronto: ${lastError instanceof Error ? lastError.message : "errore"}`);
 }
 
-async function mcpRequest(body, headers = {}) {
-  const response = await fetch(new URL("/api/mcp", baseUrl), {
+async function mcpRequest(
+  body,
+  headers = {},
+  pathname = "/api/mcp",
+  expectedContentType = /(?:application\/json|text\/event-stream)/,
+) {
+  const response = await fetch(new URL(pathname, baseUrl), {
     method: "POST",
     headers: {
       Accept: "application/json, text/event-stream",
@@ -49,7 +54,10 @@ async function mcpRequest(body, headers = {}) {
   });
   const text = await responseText(response, `MCP ${body.method}`);
   assert.equal(response.status, 200, text.slice(0, 500));
+  assert.match(response.headers.get("content-type") ?? "", expectedContentType);
   assert.equal(response.headers.get("cache-control"), "private, no-store");
+  assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(response.url, new URL(pathname, baseUrl).href, "MCP alias must not redirect");
   return text;
 }
 
@@ -61,6 +69,62 @@ const pageResponse = await fetch(new URL("/territori/irpef", baseUrl), {
 const page = await responseText(pageResponse, "pagina IRPEF");
 assert.equal(pageResponse.status, 200);
 assert.match(page, /Imposta netta dichiarata/i);
+
+const mcpPageResponse = await fetch(new URL("/mcp", baseUrl), {
+  signal: AbortSignal.timeout(10_000),
+});
+const mcpPage = await responseText(mcpPageResponse, "pagina MCP");
+assert.equal(mcpPageResponse.status, 200);
+assert.match(mcpPageResponse.headers.get("content-type") ?? "", /text\/html/);
+assert.match(mcpPage, /Endpoint Streamable HTTP/i);
+assert.match(mcpPage, /\/api\/mcp/);
+
+const sseGetResponse = await fetch(new URL("/mcp", baseUrl), {
+  headers: { Accept: "text/event-stream" },
+  signal: AbortSignal.timeout(10_000),
+});
+assert.equal(sseGetResponse.status, 405);
+assert.equal(sseGetResponse.headers.get("allow"), "POST, OPTIONS");
+assert.equal(sseGetResponse.headers.get("cache-control"), "private, no-store");
+assert.match(sseGetResponse.headers.get("content-type") ?? "", /application\/json/);
+
+const allowedPreflight = await fetch(new URL("/mcp", baseUrl), {
+  method: "OPTIONS",
+  headers: {
+    Origin: baseUrl.origin,
+    "Access-Control-Request-Method": "POST",
+    "Access-Control-Request-Headers": "content-type,mcp-protocol-version",
+  },
+  signal: AbortSignal.timeout(10_000),
+});
+assert.equal(allowedPreflight.status, 204);
+assert.equal(allowedPreflight.headers.get("cache-control"), "private, no-store");
+assert.equal(allowedPreflight.headers.get("access-control-allow-origin"), baseUrl.origin);
+assert.match(allowedPreflight.headers.get("access-control-allow-methods") ?? "", /POST/);
+assert.match(
+  allowedPreflight.headers.get("access-control-allow-headers") ?? "",
+  /MCP-Protocol-Version/i,
+);
+
+const rejectedPreflight = await fetch(new URL("/mcp", baseUrl), {
+  method: "OPTIONS",
+  headers: { Origin: "https://attacker.invalid" },
+  signal: AbortSignal.timeout(10_000),
+});
+assert.equal(rejectedPreflight.status, 403);
+assert.equal(rejectedPreflight.headers.get("access-control-allow-origin"), null);
+
+const oversizedAlias = await fetch(new URL("/mcp", baseUrl), {
+  method: "POST",
+  headers: {
+    Accept: "application/json, text/event-stream",
+    "Content-Type": "application/json",
+  },
+  body: "x".repeat(1_000_001),
+  signal: AbortSignal.timeout(10_000),
+});
+assert.equal(oversizedAlias.status, 413);
+assert.equal(oversizedAlias.headers.get("cache-control"), "private, no-store");
 
 const apiResponse = await fetch(new URL("/api/territori/irpef?anno=2024&livello=regione", baseUrl), {
   signal: AbortSignal.timeout(10_000),
@@ -81,6 +145,15 @@ assert.match(pnrrApi, /"cup":"B11B21001610005"/);
 const legacyTools = await mcpRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
 assert.match(legacyTools, /list_datasets/);
 assert.match(legacyTools, /query_dataset/);
+
+const compatibilityTools = await mcpRequest(
+  { jsonrpc: "2.0", id: 11, method: "tools/list" },
+  {},
+  "/mcp",
+  /text\/event-stream/,
+);
+assert.match(compatibilityTools, /list_datasets/);
+assert.match(compatibilityTools, /query_dataset/);
 
 const legacyDataset = await mcpRequest({
   jsonrpc: "2.0",
@@ -151,6 +224,19 @@ const modernDiscovery = await mcpRequest(
 assert.match(modernDiscovery, /2026-07-28/);
 assert.match(modernDiscovery, /"resultType":"complete"/);
 
+const compatibilityDiscovery = await mcpRequest(
+  {
+    jsonrpc: "2.0",
+    id: 31,
+    method: "server/discover",
+    params: { _meta: meta },
+  },
+  { "MCP-Protocol-Version": "2026-07-28", "MCP-Method": "server/discover" },
+  "/mcp",
+);
+assert.match(compatibilityDiscovery, /2026-07-28/);
+assert.match(compatibilityDiscovery, /"resultType":"complete"/);
+
 const modernDataset = await mcpRequest(
   {
     jsonrpc: "2.0",
@@ -181,11 +267,17 @@ console.log(JSON.stringify({
   baseUrl: baseUrl.origin,
   checks: [
     "page",
+    "mcp-page",
+    "mcp-sse-get",
     "api",
+    "mcp-alias-preflight",
+    "mcp-alias-security",
     "legacy-tools",
+    "compatibility-tools",
     "legacy-query",
     "integrated-query",
     "modern-discovery",
+    "compatibility-modern-discovery",
     "modern-query",
   ],
 }));

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -46,13 +46,20 @@ function normalizedOrigin(value: string): string | null {
 }
 
 function allowedOrigins(request: Request): Set<string> {
+  const requestUrl = new URL(request.url);
+  const requestHost = normalizedHost(request.headers.get("host") ?? "");
+  const validatedHostOrigin = requestHost && requestHostAllowed(request)
+    ? `${requestUrl.protocol}//${requestHost}`
+    : null;
   const configured = (process.env.MCP_ALLOWED_ORIGINS ?? "")
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean)
     .map(normalizedOrigin)
     .filter((value): value is string => value !== null);
-  return new Set([new URL(request.url).origin, ...configured]);
+  return new Set([requestUrl.origin, validatedHostOrigin, ...configured].filter(
+    (value): value is string => value !== null,
+  ));
 }
 
 function normalizedHost(value: string): string | null {
@@ -173,4 +180,14 @@ export function OPTIONS(request: Request) {
   );
   response.headers.set("Access-Control-Max-Age", "600");
   return secureResponse(response, request);
+}
+
+export function GET(request: Request) {
+  const rejected = validateRequest(request);
+  if (rejected) return secureResponse(rejected, request);
+
+  return secureResponse(Response.json(
+    { error: "Questo server MCP usa Streamable HTTP tramite POST" },
+    { status: 405, headers: { Allow: "POST, OPTIONS" } },
+  ), request);
 }

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -24,8 +24,11 @@ export default function McpPage() {
         <h2 id="endpoint-title">Endpoint Streamable HTTP</h2>
         <McpEndpoint />
         <p>
-          Aggiungi questo indirizzo come server MCP remoto nel client compatibile. Il catalogo è
-          disponibile anche come risorsa <code>dvns://datasets</code>.
+          Copia l&apos;indirizzo qui sopra nel client MCP: è un endpoint tecnico e non una pagina da
+          aprire nel browser. Il catalogo è
+          disponibile anche come risorsa <code>dvns://datasets</code>. L&apos;indirizzo breve di
+          questa pagina, <code>/mcp</code>, accetta comunque le richieste MCP per compatibilità:
+          non è necessario indovinare un percorso diverso.
         </p>
       </section>
 

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -87,7 +87,7 @@ export function Navigation() {
 
         <div className="header-actions">
           <Link className="header-action header-action-accent" href="/mcp">
-            MCP
+            Istruzioni MCP
           </Link>
           <a
             className="header-action header-action-icon"

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -75,7 +75,7 @@ export function SiteFooter({ latestTerritorialCheckLabel }: SiteFooterProps) {
           Codice su GitHub ↗
         </a>
         <Link className="footer-link" href="/mcp">
-          MCP
+          Istruzioni MCP
         </Link>
       </div>
       <div className="footer-row">

--- a/src/lib/site-navigation.ts
+++ b/src/lib/site-navigation.ts
@@ -170,7 +170,7 @@ export const SITE_MAP_GROUPS: readonly { title: string; links: readonly NavLink[
     title: "Strumenti",
     links: [
       { href: "/assistente", label: "Assistente" },
-      { href: "/mcp", label: "MCP" },
+      { href: "/mcp", label: "Istruzioni MCP" },
       { href: "/supporto", label: "Supporto" },
       { href: "/supporter", label: "Chi ci sostiene" },
     ],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server.js";
+import { NextResponse } from "next/server.js";
+
+const MCP_TRANSPORT_METHODS = new Set(["POST", "OPTIONS"]);
+
+export function proxy(request: NextRequest) {
+  const acceptsEventStream = request.headers
+    .get("accept")
+    ?.toLocaleLowerCase("en-US")
+    .split(",")
+    .some((value) => value.trim().split(";", 1)[0] === "text/event-stream") ?? false;
+  const isTransportRequest = MCP_TRANSPORT_METHODS.has(request.method)
+    || (request.method === "GET" && acceptsEventStream);
+
+  if (request.nextUrl.pathname !== "/mcp" || !isTransportRequest) {
+    return NextResponse.next();
+  }
+
+  const endpointUrl = new URL(request.url);
+  endpointUrl.pathname = "/api/mcp";
+  return NextResponse.rewrite(endpointUrl);
+}
+
+export const config = {
+  matcher: "/mcp",
+};

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import proxyTesting from "next/experimental/testing/server.js";
+import { NextRequest } from "next/server.js";
+import { config, proxy } from "../src/proxy.ts";
+
+const { getRewrittenUrl, isRewrite } = proxyTesting;
+
+test("MCP compatibility proxy is scoped to the exact public presentation path", () => {
+  assert.deepEqual(config, { matcher: "/mcp" });
+});
+
+test("MCP compatibility proxy rewrites POST and OPTIONS to the canonical endpoint", async () => {
+  for (const method of ["POST", "OPTIONS"]) {
+    const response = await proxy(new NextRequest("https://example.test/mcp?client=test", { method }));
+    assert.equal(isRewrite(response), true, method);
+    assert.equal(getRewrittenUrl(response), "https://example.test/api/mcp?client=test", method);
+  }
+
+  const eventStreamGet = await proxy(new NextRequest("https://example.test/mcp", {
+    method: "GET",
+    headers: { Accept: "application/json, text/event-stream" },
+  }));
+  assert.equal(isRewrite(eventStreamGet), true);
+  assert.equal(getRewrittenUrl(eventStreamGet), "https://example.test/api/mcp");
+});
+
+test("MCP compatibility proxy preserves the human-facing page for safe methods", async () => {
+  for (const [method, headers] of [
+    ["GET", { Accept: "text/html" }],
+    ["HEAD", {}],
+    ["PUT", {}],
+  ]) {
+    const response = await proxy(new NextRequest("https://example.test/mcp", { method, headers }));
+    assert.equal(isRewrite(response), false, method);
+    assert.equal(response.headers.get("x-middleware-next"), "1", method);
+  }
+
+  const subpath = await proxy(new NextRequest("https://example.test/mcp/extra", { method: "POST" }));
+  assert.equal(isRewrite(subpath), false);
+  assert.equal(subpath.headers.get("x-middleware-next"), "1");
+});

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -6,7 +6,7 @@ process.env.MCP_ALLOWED_HOSTS = [process.env.MCP_ALLOWED_HOSTS, "example.test"]
   .filter(Boolean)
   .join(",");
 
-const { OPTIONS, POST } = await import("../src/app/api/mcp/route.ts");
+const { GET, OPTIONS, POST } = await import("../src/app/api/mcp/route.ts");
 const loader = await import("../src/lib/integrated-sources.ts");
 
 const requestBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
@@ -57,6 +57,30 @@ test("MCP endpoint answers browser preflight only for an allowed origin", async 
   }));
   assert.equal(rejected.status, 403);
   assert.equal(rejected.headers.get("access-control-allow-origin"), null);
+});
+
+test("MCP endpoint preserves CORS across an internal same-origin rewrite", () => {
+  const response = OPTIONS(new Request("http://localhost:3210/api/mcp", {
+    method: "OPTIONS",
+    headers: {
+      Host: "127.0.0.1:3210",
+      Origin: "http://127.0.0.1:3210",
+      "Access-Control-Request-Method": "POST",
+    },
+  }));
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("access-control-allow-origin"), "http://127.0.0.1:3210");
+});
+
+test("MCP endpoint rejects optional SSE GET without returning cacheable HTML", async () => {
+  const response = GET(new Request("https://example.test/api/mcp", {
+    headers: { Accept: "text/event-stream" },
+  }));
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "POST, OPTIONS");
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+  assert.equal(response.headers.get("content-type"), "application/json");
+  assert.match(await response.text(), /Streamable HTTP tramite POST/);
 });
 
 test("MCP endpoint enforces an explicit host allowlist", async () => {


### PR DESCRIPTION
## Problema

Il sito pubblica /mcp come pagina di istruzioni, ma un client che usa quel percorso riceve 405 al POST. La route canonica /api/mcp funziona correttamente, quindi il problema è di discovery e compatibilità del percorso pubblico.

## Soluzione

- conserva /api/mcp come endpoint canonico;
- riscrive internamente POST e OPTIONS da /mcp verso la route canonica, senza redirect e senza duplicare il server;
- mantiene GET /mcp come pagina HTML;
- restituisce un 405 JSON non cacheabile ai vecchi GET SSE;
- preserva Host/Origin, CORS, limite corpo, no-store e controlli di sicurezza;
- rende la navigazione esplicita con la label Istruzioni MCP;
- estende lo smoke HTTP a alias legacy e 2026, CORS, body cap e assenza di redirect.

## Verifica

- build Next.js: PASS, 78 pagine e Proxy rilevato;
- ci:static: PASS;
- test mirati MCP/navigation: 41/41 PASS;
- suite completa: 476/482 nel sandbox; i sei casi falliti sono stati rieseguiti con rete e loopback autorizzati, 59/60 PASS, con l'unico timeout OpenBDAP poi PASS isolato;
- doctor skill DVNS: PASS;
- browser mcp-access desktop e mobile: PASS;
- wire protocol sulla build rebased: PASS per pagina, GET SSE, CORS, sicurezza, alias legacy, discovery 2026 e query canoniche.

Dopo il deploy va verificato live che il precedente 405 pubblico cacheato da Vercel non sia più servito.