### PR TITLE
Riorganizza la homepage attorno all'esplorazione territoriale

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -319,6 +319,27 @@ async function assertRegionalMapSelection(page, label) {
   );
   assert.equal(regionPaths.length, 20, `${label}: la mappa deve esporre 20 regioni`);
 
+  const metricCases = [
+    ["total", "Pagamenti comunali totali, per regione", / pagati$/],
+    ["municipalities", "Comuni inclusi nei dati SIOPE, per regione", / Comuni inclusi$/],
+    ["per-capita", "Pagamenti comunali per abitante coperto, per regione", / per abitante coperto$/],
+  ];
+  for (const [metric, expectedTitle, expectedValue] of metricCases) {
+    const selector = `[data-region-metric="${metric}"]`;
+    await page.click(selector);
+    await page.waitForFunction(
+      (metricSelector) => document.querySelector(metricSelector)?.getAttribute("aria-pressed") === "true",
+      { timeout: 2_000 },
+      selector,
+    );
+    const metricState = await page.$eval(mapSelector, (map) => ({
+      firstRegionLabel: map.querySelector('path[role="button"]')?.getAttribute("aria-label") ?? "",
+      title: map.querySelector("title")?.textContent ?? "",
+    }));
+    assert.equal(metricState.title, expectedTitle, `${label}: titolo errato per ${metric}`);
+    assert.match(metricState.firstRegionLabel, expectedValue, `${label}: valore errato per ${metric}`);
+  }
+
   const lombardia = await page.$(`${mapSelector} path[aria-label^="Lombardia:"]`);
   const veneto = await page.$(`${mapSelector} path[aria-label^="Veneto:"]`);
   assert.ok(lombardia, `${label}: percorso Lombardia assente`);
@@ -401,7 +422,7 @@ async function assertSpendingComposition(page, label, width) {
       visualDisplay: visual ? getComputedStyle(visual).display : null,
       visualHeight: visual?.getBoundingClientRect().height ?? 0,
       hasMetadata: /Denominatore:.*Fonte:/s.test(root.textContent ?? ""),
-      compositionBeforeMap: Boolean(map && (root.compareDocumentPosition(map) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      mapBeforeComposition: Boolean(map && (map.compareDocumentPosition(root) & Node.DOCUMENT_POSITION_FOLLOWING)),
       mapBeforeMunicipalities: Boolean(
         map && municipalityHeading && (map.compareDocumentPosition(municipalityHeading) & Node.DOCUMENT_POSITION_FOLLOWING)
       ),
@@ -410,7 +431,7 @@ async function assertSpendingComposition(page, label, width) {
   }, width);
   assert.equal(state.legendButtons, 5, `${label}: macro-voci inattese`);
   assert.equal(state.hasMetadata, true, `${label}: periodo/perimetro/fonte non vicini`);
-  assert.equal(state.compositionBeforeMap, true, `${label}: composizione dopo la mappa nel DOM`);
+  assert.equal(state.mapBeforeComposition, true, `${label}: la mappa non precede la composizione nel DOM`);
   assert.equal(state.mapBeforeMunicipalities, true, `${label}: classifica Comuni anticipa la mappa`);
   assert.equal(state.visualDisplay === "none", state.shouldCollapse, `${label}: fallback mobile incoerente`);
   if (!state.shouldCollapse) assert.ok(state.visualHeight >= 250, `${label}: geometria treemap non riservata`);

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -1,127 +1,110 @@
-/*
- * The home dashboard keeps one reading rail, one geographic canvas and one
- * detail rail. DOM order survives when the rails collapse.
- */
-
 .dashboard {
-  display: grid;
-  grid-template-columns: 360px minmax(0, 1fr) 300px;
-  align-items: start;
-  gap: var(--space-4);
-  padding-block: var(--space-4) 0;
-}
-
-.pageTitle {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
-.column {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  min-width: 0;
+  padding-block: var(--space-5) 0;
 }
+
+.pageIntro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+.pageIntro h1 { margin: 0; font-size: 30px; }
+.pageIntro p { margin: 6px 0 0; color: var(--color-neutral-700); }
+
+.atlasPanel { padding-bottom: var(--space-3); }
 
 .panelHead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-2);
-  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
 }
 .panelHead :global(.panel-title),
-.panelHead > h2 {
-  flex: 1 1 auto;
-  min-width: 0;
-  margin-bottom: 0;
-}
+.panelHead > h2,
+.panelHead > div { min-width: 0; }
+.panelHead :global(.panel-title),
+.panelHead > h2 { flex: 1 1 auto; margin-bottom: 0; }
+.panelHead > div > :global(.panel-title) { margin-bottom: 2px; }
+.panelHead p { margin: 0; font-size: 12px; color: var(--color-neutral-600); }
+.headNote { flex: none; font-size: 11px; color: var(--color-neutral-600); }
 
-.headNote {
-  font-size: 12px;
+.nationalSummary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--color-neutral-300);
+}
+.nationalSummary > div {
+  min-width: 0;
+  padding: 12px 14px;
+  border-right: 1px solid var(--color-neutral-300);
+}
+.nationalSummary > div:last-child { border-right: 0; }
+.nationalSummary span,
+.nationalSummary strong,
+.nationalSummary small { display: block; }
+.nationalSummary span {
+  font-size: 10px;
+  letter-spacing: .07em;
+  text-transform: uppercase;
   color: var(--color-neutral-600);
 }
-
-/* ── headline block ─────────────────────────────────────────────────────── */
-
-.freshness {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  margin: var(--space-3) 0 0;
-  font-size: 12px;
-  color: var(--color-neutral-700);
-}
-.freshness i {
-  width: 7px;
-  height: 7px;
-  flex: none;
-  background: var(--color-accent);
-}
-
-.headline {
-  display: block;
-  margin-top: var(--space-2);
+.nationalSummary strong {
+  margin-top: 4px;
   font-family: var(--font-heading);
-  font-size: 38px;
+  font-size: 20px;
   font-weight: var(--font-heading-weight);
-  letter-spacing: -.03em;
-  line-height: 1.05;
   font-variant-numeric: tabular-nums;
 }
+.nationalSummary small { margin-top: 2px; font-size: 11px; color: var(--color-neutral-600); }
 
-.headlineNote {
-  margin: 6px 0 0;
-  font-size: 13px;
-  color: var(--color-neutral-700);
+.attribution { margin: var(--space-3) 0 0; font-size: 11px; color: var(--color-neutral-600); }
+
+.insightGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.08fr);
+  gap: var(--space-4);
+  align-items: stretch;
 }
 
-.factRows {
-  margin: var(--space-3) 0 0;
-}
-.factRows > div {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 7px 0;
-  border-top: 1px solid var(--color-neutral-200);
-  font-size: 12.5px;
-}
-.factRows dt { color: var(--color-neutral-700); }
-.factRows dd {
+.panelAction { margin-top: var(--space-3); }
+
+.monthPanel { display: flex; flex-direction: column; }
+.monthChartScroll { display: flex; flex: 1; width: 100%; overflow-x: auto; }
+.monthChart {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(56px, 1fr));
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 620px;
+  min-height: 420px;
   margin: 0;
-  font-weight: 600;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.rule {
-  height: 1px;
-  border: 0;
-  margin: var(--space-4) 0;
-  background: var(--color-neutral-300);
-}
-
-.spendingDetailsLink {
-  min-height: 44px;
-  margin-top: var(--space-3);
-}
-
-/* ── ranked municipalities ──────────────────────────────────────────────── */
-
-.rankList {
-  margin: 0;
-  padding: 0;
+  padding: var(--space-3) 0 0;
   list-style: none;
 }
+.monthChart li {
+  display: grid;
+  grid-template-rows: 20px minmax(230px, 1fr) 24px;
+  align-items: end;
+  min-width: 0;
+  text-align: center;
+}
+.monthChart li > b { font-size: 11px; font-variant-numeric: tabular-nums; }
+.monthChart li > i {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  height: 100%;
+  border-bottom: 1px solid var(--color-neutral-400);
+}
+.monthChart li > i > span { display: block; width: min(34px, 64%); background: var(--color-accent-700); }
+.monthChart li > span { padding-top: 5px; overflow: hidden; font-size: 11px; text-overflow: ellipsis; }
+.running { background: var(--color-neutral-500) !important; }
+
+.rankList { margin: 0; padding: 0; list-style: none; }
 .rankList li {
   display: flex;
   align-items: baseline;
@@ -130,196 +113,65 @@
   border-bottom: 1px solid var(--color-neutral-200);
   font-size: 13px;
 }
-.rankList li > span {
-  flex: none;
-  width: 14px;
-  font-size: 11px;
-  color: var(--color-neutral-600);
-  font-variant-numeric: tabular-nums;
-}
-.rankList strong {
-  flex: 1;
-  min-width: 0;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.rankList strong small {
-  display: block;
-  margin-top: 2px;
-  overflow: hidden;
-  color: var(--color-neutral-600);
-  font-size: 11px;
-  font-weight: 400;
-  text-overflow: ellipsis;
-}
-.rankList b {
-  flex: none;
-  font-variant-numeric: tabular-nums;
-}
+.rankList li > span { flex: none; width: 14px; color: var(--color-neutral-600); font-size: 11px; }
+.rankList strong { flex: 1; min-width: 0; font-weight: 500; }
+.rankList strong small { display: block; margin-top: 2px; color: var(--color-neutral-600); font-size: 11px; font-weight: 400; }
+.rankList b { flex: none; font-variant-numeric: tabular-nums; }
 
-/* ── map side statistics ────────────────────────────────────────────────── */
-
-.mapStats {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.mapStats > div {
-  padding: 12px 14px;
-  background: var(--color-neutral-100);
-  border: 1px solid var(--color-neutral-200);
-}
-.mapStats span {
-  display: block;
-  font-size: 10px;
-  letter-spacing: .07em;
-  text-transform: uppercase;
-  color: var(--color-neutral-600);
-}
-.mapStats strong {
-  display: block;
-  margin: 6px 0 4px;
-  font-family: var(--font-heading);
-  font-size: 21px;
-  font-weight: var(--font-heading-weight);
-  letter-spacing: -.02em;
-  font-variant-numeric: tabular-nums;
-}
-.mapStats small {
-  display: block;
-  font-size: 12px;
-  color: var(--color-neutral-600);
-}
-
-.attribution {
-  margin: var(--space-3) 0 0;
-  font-size: 11px;
-  color: var(--color-neutral-600);
-}
-
-/* ── month bars ─────────────────────────────────────────────────────────── */
-
-.monthList {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-}
-.monthList li {
+.supportGrid {
   display: grid;
-  grid-template-columns: 62px minmax(0, 1fr) 38px;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-4);
+  align-items: start;
 }
-.monthList li > span { color: var(--color-neutral-700); }
-.monthList li > i {
-  display: block;
-  height: 10px;
-  background: var(--color-neutral-200);
-}
-.monthList li > i > b {
-  display: block;
-  height: 100%;
-  background: var(--color-accent);
-}
-.monthList li > b {
-  text-align: right;
-  font-weight: 600;
-}
-.running { background: var(--color-neutral-500) !important; }
 
-/* ── source cards ───────────────────────────────────────────────────────── */
-
-.sourceList {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-}
-.sourceList article + article {
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--color-neutral-200);
-}
-.sourceList header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
+.sourceList { display: flex; flex-direction: column; gap: var(--space-3); }
+.sourceList article + article { padding-top: var(--space-3); border-top: 1px solid var(--color-neutral-200); }
+.sourceList header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); }
 .sourceList strong { font-size: 13px; }
 .sourceList dl { margin: var(--space-2) 0 0; }
-.sourceList dl > div {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 4px 0;
-  font-size: 12px;
-}
-.sourceList dt { color: var(--color-neutral-600); }
-.sourceList dd { margin: 0; text-align: right; }
+.sourceList dl > div,
+.factRows > div { display: flex; justify-content: space-between; gap: 10px; padding: 6px 0; font-size: 12px; }
+.sourceList dt,
+.factRows dt { color: var(--color-neutral-600); }
+.sourceList dd,
+.factRows dd { margin: 0; text-align: right; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-/* ── ratio bar ──────────────────────────────────────────────────────────── */
+.factRows { margin: 0; }
+.factRows > div { border-top: 1px solid var(--color-neutral-200); }
 
-.ratioHead {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  margin-top: var(--space-3);
-  font-size: 12px;
-}
+.ratioHead { display: flex; justify-content: space-between; gap: 10px; margin-top: var(--space-3); font-size: 12px; }
 .ratioHead b { font-variant-numeric: tabular-nums; }
+.ratioTrack { height: 10px; margin-top: 6px; background: var(--color-neutral-200); }
+.ratioTrack i { display: block; height: 100%; background: var(--color-accent); }
 
-.ratioTrack {
-  height: 10px;
-  margin-top: 6px;
-  background: var(--color-neutral-200);
-}
-.ratioTrack i {
-  display: block;
-  height: 100%;
-  background: var(--color-accent);
-}
+.note { margin: var(--space-3) 0; font-size: 12px; color: var(--color-neutral-600); }
+.readingNotice { display: grid; grid-template-columns: 180px minmax(0, 1fr); align-items: start; gap: var(--space-4); }
+.readingNotice p { margin: 0; }
 
-.note {
-  margin: var(--space-3) 0 0;
-  font-size: 12px;
-  color: var(--color-neutral-600);
+@media (max-width: 1240px) {
+  .supportGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
-.readingNote {
-  margin: 0 0 var(--space-3);
-  font-size: 13px;
-  color: var(--color-neutral-800);
+@media (max-width: 980px) {
+  .pageIntro { align-items: flex-start; flex-direction: column; gap: var(--space-3); }
+  .insightGrid { grid-template-columns: minmax(0, 1fr); }
+  .monthChartScroll { flex: none; }
+  .monthChart { min-height: 300px; }
+  .nationalSummary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .nationalSummary > div:nth-child(2) { border-right: 0; }
+  .nationalSummary > div:nth-child(-n + 2) { border-bottom: 1px solid var(--color-neutral-300); }
 }
 
-/* ── responsive ─────────────────────────────────────────────────────────── */
-
-@media (max-width: 1320px) {
-  .dashboard { grid-template-columns: 360px minmax(0, 1fr); }
-  /* The right-hand rail becomes a full-width band of cards under the board. */
-  .dashboard > .column:last-child {
-    grid-column: 1 / -1;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    align-items: start;
-  }
+@media (max-width: 680px) {
+  .dashboard { padding-block-start: var(--space-4); }
+  .pageIntro h1 { font-size: 24px; }
+  .supportGrid { grid-template-columns: minmax(0, 1fr); }
+  .readingNotice { grid-template-columns: minmax(0, 1fr); gap: var(--space-2); }
 }
 
-@media (max-width: 900px) {
-  .dashboard { grid-template-columns: minmax(0, 1fr); }
-  .dashboard > .column:last-child { grid-column: auto; }
-}
-
-@media (max-width: 620px) {
-  .headline { font-size: 32px; }
-  .mapStats { display: grid; grid-template-columns: 1fr 1fr; }
-  .monthList li { grid-template-columns: 58px minmax(0, 1fr) 36px; }
-}
-
-@media (max-width: 420px) {
-  .mapStats { grid-template-columns: 1fr; }
+@media (max-width: 460px) {
+  .nationalSummary { grid-template-columns: minmax(0, 1fr); }
+  .nationalSummary > div { border-right: 0; border-bottom: 1px solid var(--color-neutral-300); }
+  .nationalSummary > div:last-child { border-bottom: 0; }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,10 +15,7 @@ import {
 } from "@/lib/format";
 import { municipalityName } from "@/lib/municipality-name";
 import { openCoesioneSnapshot as cohesion } from "@/lib/opencoesione-snapshot";
-import {
-  HOME_SPENDING_BUCKETS,
-  PASS_THROUGH_TITLE_CODE,
-} from "@/lib/siope-titles";
+import { HOME_SPENDING_BUCKETS } from "@/lib/siope-titles";
 import {
   availableSiopeYears,
   completedMonths,
@@ -51,99 +48,104 @@ export default async function HomePage({
   const siope = getSiopeMunicipalSnapshot(year);
   const monthLabel = siope.latestMonthLabel.toLocaleLowerCase("it-IT");
   const period = `da gennaio a ${monthLabel} ${siope.year}`;
-
-  const passThrough =
-    siope.titles.find((title) => title.code === PASS_THROUGH_TITLE_CODE)?.value ?? 0;
-  const netPayments = siope.totalPaid - passThrough;
-
   const runningMonth = partialMonth(siope);
   const settledMonths = completedMonths(siope);
-  const completedAverage =
-    settledMonths.length > 0
-      ? settledMonths.reduce((sum, point) => sum + point.flow, 0) / settledMonths.length
-      : 0;
   const lastCompleted = settledMonths[settledMonths.length - 1] ?? null;
 
   const valueByCode = new Map(siope.titles.map((title) => [title.code, title.value]));
-  const buckets = HOME_SPENDING_BUCKETS.map((bucket, index) => {
-    const value = bucket.codes.reduce((sum, code) => sum + (valueByCode.get(code) ?? 0), 0);
-    return {
-      ...bucket,
-      id: bucket.codes.join("-"),
-      value,
-      family: COMPOSITION_FAMILIES[index],
-    };
-  });
+  const buckets = HOME_SPENDING_BUCKETS.map((bucket, index) => ({
+    ...bucket,
+    id: bucket.codes.join("-"),
+    value: bucket.codes.reduce((sum, code) => sum + (valueByCode.get(code) ?? 0), 0),
+    family: COMPOSITION_FAMILIES[index],
+  }));
 
   const topRegions = regionsByPerCapita(siope).slice(0, 6);
   const topMunicipalities = municipalitiesByPerCapita(siope).slice(0, 5);
-  /* One unit for the absolute-value comparison column. */
   const topRegionScale = topRegions[0]?.value ?? 0;
   const maxFlow = Math.max(...siope.monthly.map((point) => point.flow), 0);
 
   const cohesionForYear = cohesion.annualSeries.find((point) => point.year === year) ?? null;
   const cohesionPaid = (cohesionForYear?.paymentsCents ?? 0) / 100;
   const cohesionCommitted = (cohesionForYear?.commitmentsCents ?? 0) / 100;
-  const cohesionRatio =
-    cohesionCommitted > 0 ? (cohesionPaid / cohesionCommitted) * 100 : 0;
+  const cohesionRatio = cohesionCommitted > 0 ? (cohesionPaid / cohesionCommitted) * 100 : 0;
   const procurement = getProcurementComparisonForYear(year);
 
   return (
     <main className={`shell ${styles.dashboard}`}>
-      <h1 className={styles.pageTitle}>Dove vanno i nostri soldi pubblici</h1>
-      <div className={styles.column}>
-        <section className="panel">
+      <header className={styles.pageIntro}>
+        <div>
+          <h1>Esplora i pagamenti dei Comuni</h1>
+          <p>Parti da un territorio, poi verifica importi, periodo e fonte.</p>
+        </div>
+        <PeriodSelector activeYear={year} years={availableSiopeYears} pathname="/" />
+      </header>
+
+      <section className={`panel ${styles.atlasPanel}`} aria-labelledby="atlas-title">
+        <div className={styles.panelHead}>
+          <h2 className="panel-title" id="atlas-title">Pagamenti comunali, regione per regione</h2>
+          <InfoTooltip id="cash-payments-tip" label="Che cosa sono i pagamenti di cassa?">
+            Uscite di cassa registrate dai Comuni, mese per mese. Restano fuori Stato centrale,
+            Regioni e sanità.
+          </InfoTooltip>
+        </div>
+
+        <ItalyRegionsMap
+          regions={siope.regions}
+          period={period}
+          detailsHref={`/territori?anno=${year}`}
+          summary={
+            <div className={styles.nationalSummary} aria-label="Quadro nazionale dei pagamenti comunali">
+              <div>
+                <span>Totale nel periodo</span>
+                <strong>{compactEuro(siope.totalPaid)}</strong>
+                <small>pagamenti di cassa dei Comuni</small>
+              </div>
+              <div>
+                <span>In media per abitante</span>
+                <strong>{siope.nationalPerCapita === null ? "n.d." : exactEuro(siope.nationalPerCapita)}</strong>
+                <small>su {integer(siope.populationCovered)} persone</small>
+              </div>
+              <div>
+                <span>Comuni inclusi</span>
+                <strong>{integer(siope.coverage.withMovements)}</strong>
+                <small>su {integer(siope.coverage.activeSiopeMunicipalities)} validi nel periodo</small>
+              </div>
+              <div>
+                <span>Fonte</span>
+                <strong>SIOPE</strong>
+                <small>Aggiornato al {longDate(siope.source.siopeMovementsLastModified)}</small>
+              </div>
+            </div>
+          }
+        />
+
+        <p className={styles.attribution}>
+          Confini amministrativi: <a href="https://www.istat.it/storage/cartografia/confini_amministrativi/generalizzati/2026/Limiti01012026_g.zip" target="_blank" rel="noreferrer">ISTAT, 1 gennaio 2026</a>, geometria semplificata dai dati ufficiali e mantenuta nelle proporzioni originali.
+        </p>
+      </section>
+
+      <div className={styles.insightGrid}>
+        <section className="panel" aria-labelledby="composition-title">
           <div className={styles.panelHead}>
-            <h2 className="panel-title">Pagamenti effettuati dai Comuni</h2>
-            <InfoTooltip id="cash-payments-tip" label="Che cosa sono i pagamenti di cassa?">
-              Uscite di cassa registrate dai Comuni, mese per mese. Il totale riguarda i Comuni;
-              restano fuori Stato centrale, Regioni e sanità.
-            </InfoTooltip>
-          </div>
-
-          <p className={styles.freshness}>
-            <i aria-hidden="true" />
-            Dati aggiornati al {longDate(siope.source.siopeMovementsLastModified)}
-          </p>
-
-          <strong className={styles.headline}>{compactEuro(siope.totalPaid)}</strong>
-          <p className={styles.headlineNote}>
-            Da gennaio a {monthLabel} {siope.year}, in tutta Italia
-          </p>
-
-          <dl className={styles.factRows}>
             <div>
-              <dt>In media per abitante</dt>
-              <dd>
-                {siope.nationalPerCapita === null
-                  ? "n.d."
-                  : exactEuro(siope.nationalPerCapita)}
-              </dd>
+              <h2 className="panel-title" id="composition-title">Per cosa</h2>
+              <p>Composizione del totale pagato</p>
             </div>
-            <div>
-              <dt>Pagamenti al netto delle partite di giro</dt>
-              <dd>{compactEuro(netPayments)}</dd>
-            </div>
-            <div>
-              <dt>Media dei mesi completi</dt>
-              <dd>{compactEuro(completedAverage)}</dd>
-            </div>
-          </dl>
-
-          <hr className={styles.rule} />
-
-          <div className={styles.panelHead}>
-            <h2 className="panel-title">Come si compone il totale</h2>
           </div>
           <SpendingComposition
-            state={{ kind: "ready", totalEuro: siope.totalPaid, items: buckets.map((bucket) => ({
-              id: bucket.id,
-              label: bucket.name,
-              valueEuro: bucket.value,
-              explanation: bucket.explanation,
-              family: bucket.family,
-            })) }}
-            period={`Da gennaio a ${siope.latestMonthLabel.toLocaleLowerCase("it-IT")} ${siope.year}`}
+            state={{
+              kind: "ready",
+              totalEuro: siope.totalPaid,
+              items: buckets.map((bucket) => ({
+                id: bucket.id,
+                label: bucket.name,
+                valueEuro: bucket.value,
+                explanation: bucket.explanation,
+                family: bucket.family,
+              })),
+            }}
+            period={`Da gennaio a ${monthLabel} ${siope.year}`}
             scope="Pagamenti di cassa dei Comuni in tutta Italia"
             denominator="totale dei pagamenti SIOPE dei Comuni nel periodo"
             source={{
@@ -152,216 +154,116 @@ export default async function HomePage({
               observedAt: longDate(siope.source.observedAt),
             }}
           />
-          <Link
-            className={`btn btn-block ${styles.spendingDetailsLink}`}
-            href={`/spese?anno=${year}`}
-          >
+          <Link className={`btn btn-block ${styles.panelAction}`} href={`/spese?anno=${year}`}>
             Vedi il dettaglio delle voci
           </Link>
         </section>
 
-      </div>
-
-      <div className={styles.column}>
-        <section className="panel">
+        <section className={`panel ${styles.monthPanel}`} aria-labelledby="monthly-title">
           <div className={styles.panelHead}>
-            <h2 className="panel-title">Dove si spende di più, regione per regione</h2>
-            <PeriodSelector activeYear={year} years={availableSiopeYears} pathname="/" />
+            <div>
+              <h2 className="panel-title" id="monthly-title">Quando</h2>
+              <p>Pagamenti mese per mese · miliardi di €</p>
+            </div>
+            <span className={styles.headNote}>Totale nel periodo: {compactEuro(siope.totalPaid)}</span>
           </div>
-
-          <ItalyRegionsMap
-            regions={siope.regions}
-            period={period}
-            aside={
-              <div className={styles.mapStats}>
-                <div>
-                  <span>Da gennaio a {monthLabel}</span>
-                  <strong>{compactEuro(siope.totalPaid)}</strong>
-                  <small>
-                    totale nazionale dei Comuni · {compactEuro(siope.coverage.paymentsWithoutRegion)}
-                    {" "}senza Regione IPA non mappati
-                  </small>
-                </div>
-                <div>
-                  <span>Ultimo mese completo</span>
-                  <strong>{lastCompleted ? compactEuro(lastCompleted.flow) : "n.d."}</strong>
-                  <small>
-                    {lastCompleted
-                      ? `${lastCompleted.label.toLocaleLowerCase("it-IT")} ${siope.year}`
-                      : "nessun mese chiuso"}
-                  </small>
-                </div>
-                <div>
-                  <span>In media per abitante</span>
-                  <strong>
-                    {siope.nationalPerCapita === null
-                      ? "n.d."
-                      : exactEuro(siope.nationalPerCapita)}
-                  </strong>
-                  <small>su {integer(siope.populationCovered)} persone</small>
-                </div>
-                <div>
-                  <span>Comuni inclusi</span>
-                  <strong>{integer(siope.coverage.withMovements)}</strong>
-                  <small>
-                    su {integer(siope.coverage.activeSiopeMunicipalities)} validi nel periodo
-                  </small>
-                </div>
-              </div>
-            }
-          />
-
-          <p className={styles.attribution}>
-            Confini amministrativi a fini statistici:{" "}
-            <a
-              href="https://www.istat.it/storage/cartografia/confini_amministrativi/generalizzati/2026/Limiti01012026_g.zip"
-              target="_blank"
-              rel="noreferrer"
-            >
-              ISTAT, 1 gennaio 2026
-            </a>
-            ,{" "}
-            <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">
-              CC BY 4.0
-            </a>
-            , geometria semplificata.
-          </p>
-        </section>
-
-        <section className="panel">
-          <div className={styles.panelHead}>
-            <h2 className="panel-title">Le regioni con più pagamenti per abitante</h2>
-            <span className={styles.headNote}>Comuni con sede nella regione</span>
+          <div className={styles.monthChartScroll} role="region" aria-label="Pagamenti mensili" tabIndex={0}>
+            <ul className={styles.monthChart}>
+              {siope.monthly.map((point) => {
+                const running = point.month === runningMonth;
+                return (
+                  <li key={point.month}>
+                    <b>{billions(point.flow)}</b>
+                    <i aria-hidden="true">
+                      <span
+                        className={running ? styles.running : undefined}
+                        style={{ height: maxFlow > 0 ? `${(point.flow / maxFlow) * 100}%` : "0%" }}
+                      />
+                    </i>
+                    <span>{point.label}{running ? "*" : ""}</span>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-          <div className="table-scroll" role="region" aria-label="Regioni ordinate per pagamenti pro capite" tabIndex={0}>
-            <table className="table">
-              <thead>
-                <tr>
-                  <th scope="col">Regione</th>
-                  <th scope="col" className="num">Per abitante</th>
-                  <th scope="col" className="num">Totale pagato</th>
-                </tr>
-              </thead>
-              <tbody>
-                {topRegions.map((region) => (
-                  <tr key={region.region}>
-                    <th scope="row">{region.region}</th>
-                    <td className="num">
-                      {region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}
-                    </td>
-                    <td className="num">{compactEuroLike(region.value, topRegionScale)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <Link className="btn btn-block" href={`/territori?anno=${year}`}>
-            Vedi tutte le regioni
-          </Link>
-        </section>
-      </div>
-
-      <div className={styles.column}>
-        <section className="panel">
-          <div className={styles.panelHead}>
-            <h2 className="panel-title">Mese per mese</h2>
-            <span className={styles.headNote}>miliardi di €</span>
-          </div>
-          <ul className={styles.monthList}>
-            {siope.monthly.map((point) => {
-              const running = point.month === runningMonth;
-              return (
-                <li key={point.month}>
-                  <span>{point.label}</span>
-                  <i aria-hidden="true">
-                    <b
-                      className={running ? styles.running : undefined}
-                      style={{ width: maxFlow > 0 ? `${(point.flow / maxFlow) * 100}%` : "0%" }}
-                    />
-                  </i>
-                  <b className="num-tabular">{billions(point.flow)}</b>
-                </li>
-              );
-            })}
-          </ul>
           {runningMonth === null ? (
             <p className={styles.note}>Anno chiuso: tutti i mesi sono definitivi.</p>
           ) : (
             <p className={styles.note}>
-              {siope.latestMonthLabel} è ancora in corso: il numero salirà.
+              * {siope.latestMonthLabel} è ancora in corso. L’ultimo mese completo è {lastCompleted?.label.toLocaleLowerCase("it-IT") ?? "non disponibile"}.
             </p>
           )}
         </section>
+      </div>
 
+      <section className="panel" aria-labelledby="regional-ranking-title">
+        <div className={styles.panelHead}>
+          <h2 className="panel-title" id="regional-ranking-title">Le regioni con più pagamenti per abitante</h2>
+          <span className={styles.headNote}>Comuni con sede nella regione</span>
+        </div>
+        <div className="table-scroll" role="region" aria-label="Regioni ordinate per pagamenti pro capite" tabIndex={0}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th scope="col">Regione</th>
+                <th scope="col" className="num">Per abitante</th>
+                <th scope="col" className="num">Totale pagato</th>
+                <th scope="col" className="num">Popolazione coperta</th>
+                <th scope="col" className="num">Comuni inclusi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topRegions.map((region) => (
+                <tr key={region.region}>
+                  <th scope="row">{region.region}</th>
+                  <td className="num">{region.perCapita === null ? "n.d." : exactEuro(region.perCapita)}</td>
+                  <td className="num">{compactEuroLike(region.value, topRegionScale)}</td>
+                  <td className="num">{region.population === null ? "n.d." : integer(region.population)}</td>
+                  <td className="num">{integer(region.municipalities)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <Link className="btn btn-block" href={`/territori?anno=${year}`}>Vedi tutte le regioni</Link>
+      </section>
+
+      <div className={styles.supportGrid}>
         <section className="panel">
-          <h2 className="panel-title">
-            I {topMunicipalities.length} Comuni con più pagamenti per abitante
-          </h2>
+          <h2 className="panel-title">I {topMunicipalities.length} Comuni con più pagamenti per abitante</h2>
           <ol className={styles.rankList}>
             {topMunicipalities.map((municipality, index) => (
               <li key={municipality.codiceFiscale}>
                 <span>{index + 1}</span>
                 <strong>
                   {municipalityName(municipality.name)}
-                  <small>
-                    {municipality.population === null
-                      ? "popolazione non disponibile"
-                      : `${integer(municipality.population)} abitanti`}
-                  </small>
+                  <small>{municipality.population === null ? "popolazione non disponibile" : `${integer(municipality.population)} abitanti`}</small>
                 </strong>
                 <b>{exactEuro(municipality.perCapita ?? 0)}</b>
               </li>
             ))}
           </ol>
-          <p className={styles.note}>
-            Confronto pro capite; il totale resta nel dettaglio territoriale.
-          </p>
-          <Link className="btn btn-block" href={`/territori?anno=${year}`}>
-            Vedi il confronto territoriale
-          </Link>
+          <p className={styles.note}>Confronto pro capite: un valore alto non indica da solo uno spreco.</p>
+          <Link className="btn btn-block" href={`/territori?anno=${year}`}>Vedi il confronto territoriale</Link>
         </section>
 
         <section className="panel">
           <h2 className="panel-title">Da dove arrivano i numeri</h2>
           <div className={styles.sourceList}>
             <article>
-              <header>
-                <strong>SIOPE · pagamenti dei Comuni</strong>
-                <span className="status status-attiva">Attiva</span>
-              </header>
+              <header><strong>SIOPE · pagamenti dei Comuni</strong><span className="status status-attiva">Attiva</span></header>
               <dl>
-                <div>
-                  <dt>Dati fino a</dt>
-                  <dd>
-                    {monthLabel} {siope.year}
-                  </dd>
-                </div>
-                <div>
-                  <dt>File pubblicato il</dt>
-                  <dd>{longDate(siope.source.siopeMovementsLastModified)}</dd>
-                </div>
-                <div>
-                  <dt>Scaricato da noi</dt>
-                  <dd>{longDate(siope.source.observedAt)}</dd>
-                </div>
+                <div><dt>Dati fino a</dt><dd>{monthLabel} {siope.year}</dd></div>
+                <div><dt>File pubblicato il</dt><dd>{longDate(siope.source.siopeMovementsLastModified)}</dd></div>
+                <div><dt>Scaricato da noi</dt><dd>{longDate(siope.source.observedAt)}</dd></div>
               </dl>
             </article>
             <article>
-              <header>
-                <strong>IPA · registro degli enti</strong>
-                <span className="status status-attiva">Attiva</span>
-              </header>
-              <dl>
-                <div>
-                  <dt>Aggiornato il</dt>
-                  <dd>{longDate(siope.source.ipaLastModified)}</dd>
-                </div>
-              </dl>
+              <header><strong>IPA · registro degli enti</strong><span className="status status-attiva">Attiva</span></header>
+              <dl><div><dt>Aggiornato il</dt><dd>{longDate(siope.source.ipaLastModified)}</dd></div></dl>
             </article>
           </div>
-          <Link className="btn btn-block" href="/fonti">
-            Vedi tutte le fonti
-          </Link>
+          <Link className="btn btn-block" href="/fonti">Vedi tutte le fonti</Link>
         </section>
 
         <section className="panel">
@@ -369,33 +271,15 @@ export default async function HomePage({
           {cohesionForYear ? (
             <>
               <dl className={styles.factRows}>
-                <div>
-                  <dt>Impegni registrati entro il {year}</dt>
-                  <dd>{compactEuro(cohesionCommitted)}</dd>
-                </div>
-                <div>
-                  <dt>Pagamenti registrati entro il {year}</dt>
-                  <dd>{compactEuro(cohesionPaid)}</dd>
-                </div>
+                <div><dt>Impegni registrati entro il {year}</dt><dd>{compactEuro(cohesionCommitted)}</dd></div>
+                <div><dt>Pagamenti registrati entro il {year}</dt><dd>{compactEuro(cohesionPaid)}</dd></div>
               </dl>
-              <div className={styles.ratioHead}>
-                <span>Pagamenti sugli impegni</span>
-                <b>{percent(cohesionRatio)}</b>
-              </div>
-              <div className={styles.ratioTrack} aria-hidden="true">
-                <i style={{ width: `${Math.min(cohesionRatio, 100)}%` }} />
-              </div>
-              <p className={styles.note}>
-                Serie cumulata al {year}, nello snapshot aggiornato al {longDate(cohesion.referenceDate)}.
-                Un pagamento non prova che il progetto sia finito.
-              </p>
+              <div className={styles.ratioHead}><span>Pagamenti sugli impegni</span><b>{percent(cohesionRatio)}</b></div>
+              <div className={styles.ratioTrack} aria-hidden="true"><i style={{ width: `${Math.min(cohesionRatio, 100)}%` }} /></div>
+              <p className={styles.note}>Serie cumulata aggiornata al {longDate(cohesion.referenceDate)}. Un pagamento non prova che il progetto sia finito.</p>
             </>
-          ) : (
-            <p className={styles.note}>La serie OpenCoesione non contiene dati per il {year}.</p>
-          )}
-          <Link className="btn btn-block" href="/coesione">
-            Vai ai fondi
-          </Link>
+          ) : <p className={styles.note}>La serie OpenCoesione non contiene dati per il {year}.</p>}
+          <Link className="btn btn-block" href="/coesione">Vai ai fondi</Link>
         </section>
 
         <section className="panel">
@@ -404,39 +288,22 @@ export default async function HomePage({
             <>
               <dl className={styles.factRows}>
                 <div>
-                  <dt>Valore degli affidamenti diretti nel {procurement.year}</dt>
-                  <dd>{((procurement.totalValueBillion * procurement.byValue) / 100).toLocaleString("it-IT", {
-                    maximumFractionDigits: 1,
-                  })} mld €</dd>
+                  <dt>Affidamenti diretti nel {procurement.year}</dt>
+                  <dd>{((procurement.totalValueBillion * procurement.byValue) / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })} mld €</dd>
                 </div>
-                <div>
-                  <dt>Quota sul valore dei contratti</dt>
-                  <dd>{percent(procurement.byValue)}</dd>
-                </div>
+                <div><dt>Quota sul valore dei contratti</dt><dd>{percent(procurement.byValue)}</dd></div>
               </dl>
-              <p className={styles.note}>
-                Relazione ANAC sul {procurement.year}. Segnale da approfondire con le fonti ufficiali.
-              </p>
+              <p className={styles.note}>Relazione ANAC sul {procurement.year}. È un segnale da approfondire, non una prova di illecito.</p>
             </>
-          ) : (
-            <p className={styles.note}>
-              La relazione ANAC completa sul {year} arriverà quando sarà pubblicata.
-            </p>
-          )}
-          <Link className="btn btn-block" href="/controlli">
-            Vai ai controlli
-          </Link>
-        </section>
-
-        <section className="panel panel-accent">
-          <h2 className="panel-title">Come leggere questi numeri</h2>
-          <p className={styles.readingNote}>
-            Qui vedi i pagamenti dei Comuni. Una cifra alta va letta con abitanti e con i servizi
-            che quel Comune gestisce.
-          </p>
-          <Link href="/metodologia">Come leggiamo i dati →</Link>
+          ) : <p className={styles.note}>La relazione ANAC completa sul {year} arriverà quando sarà pubblicata.</p>}
+          <Link className="btn btn-block" href="/controlli">Vai ai controlli</Link>
         </section>
       </div>
+
+      <section className={`notice ${styles.readingNotice}`} aria-labelledby="reading-title">
+        <strong id="reading-title">Prima di confrontare</strong>
+        <p>Qui vedi pagamenti di cassa dei Comuni. Abitanti, servizi gestiti e perimetro contabile cambiano il significato del confronto. <Link href="/metodologia">Leggi il metodo →</Link></p>
+      </section>
     </main>
   );
 }

--- a/src/components/italy-regions-map.module.css
+++ b/src/components/italy-regions-map.module.css
@@ -1,22 +1,99 @@
 .layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 220px;
+  grid-template-columns: minmax(0, 1fr) 300px;
   gap: var(--space-4);
-  align-items: start;
+  align-items: stretch;
 }
 
-.mapColumn { min-width: 0; }
+.controls {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(300px, .72fr) minmax(320px, 1fr);
+  gap: var(--space-3);
+}
 
-.asideColumn { min-width: 0; }
+.metricControl,
+.regionSelector {
+  min-width: 0;
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.metricControl legend,
+.regionSelector > span {
+  display: block;
+  padding: 0;
+  margin-bottom: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-700);
+}
+
+.metricControl > div {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--color-neutral-400);
+}
+
+.metricControl button {
+  min-width: 0;
+  min-height: 44px;
+  padding: 8px 10px;
+  color: var(--color-neutral-700);
+  background: var(--color-raised);
+  border: 0;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+}
+.metricControl button + button { border-left: 1px solid var(--color-neutral-300); }
+.metricControl button:hover { color: var(--color-text); background: var(--color-neutral-200); }
+.metricControl button[aria-pressed="true"] { color: var(--color-raised); background: var(--color-accent-700); }
+.metricControl button[aria-pressed="true"]:hover { background: var(--color-accent-800); }
+
+.regionSelector select {
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 12px;
+  color: var(--color-text);
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-400);
+  font-size: 13px;
+}
+
+.mapColumn {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mapHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 2px 0 var(--space-2);
+}
+.mapHeading strong {
+  font-family: var(--font-heading);
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.mapHeading span { font-size: 11px; color: var(--color-neutral-600); }
 
 .map {
   display: block;
   width: 100%;
-  max-height: 520px;
+  height: 500px;
+  max-height: 54vh;
+  min-height: 390px;
 }
 
-/* A mid-grey outline, not white: two pale neighbours must still read as two
-   regions, and every border has to survive against the palest step. */
 .region {
   stroke: var(--color-neutral-500);
   stroke-width: 1;
@@ -33,8 +110,6 @@
   outline: none;
 }
 
-/* SVG paints sibling paths in document order. Draw the active outlines again
-   after all fills so a later region can never cover a hovered border. */
 .outline {
   fill: none;
   stroke: var(--color-text);
@@ -48,9 +123,6 @@
 .selectedOutline { stroke-width: 2.5; }
 .selectedOutline.hoverOutline { stroke-width: 3; }
 
-/* One sequential ramp, read as intensity rather than as five categories. It
-   starts at accent-200 rather than accent-100: the first step has to be
-   distinguishable from the white panel behind the map. */
 .level0 { fill: var(--color-accent-200); background: var(--color-accent-200); }
 .level1 { fill: var(--color-accent-300); background: var(--color-accent-300); }
 .level2 { fill: var(--color-accent-400); background: var(--color-accent-400); }
@@ -61,13 +133,14 @@
 .legend {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 2px;
-  margin-top: var(--space-3);
+  margin-top: var(--space-2);
   font-size: 11px;
   color: var(--color-neutral-600);
 }
 .legend i {
-  width: 26px;
+  width: 30px;
   height: 10px;
   flex: none;
   border: 1px solid var(--color-neutral-400);
@@ -76,52 +149,57 @@
 .legendEnd:first-child { margin-right: var(--space-2); }
 .legendEnd:last-child { margin-left: var(--space-2); }
 
-.mobileSelector { display: none; }
-
 .geoNote {
   margin: var(--space-2) 0 0;
   font-size: 11px;
   color: var(--color-neutral-600);
 }
 
-/* The reading row under the map: hover/focus previews until a click or an
-   explicit keyboard selection fixes the region. */
-.detail {
-  grid-column: 1 / -1;
-  display: grid;
-  grid-template-columns: minmax(140px, 1.4fr) repeat(5, minmax(84px, 1fr));
-  align-items: center;
-  gap: var(--space-3);
-  margin-top: var(--space-3);
-  padding: 10px 14px;
-  background: var(--color-neutral-100);
-  border: 1px solid var(--color-neutral-400);
+.summary {
+  margin-top: auto;
+  padding-top: var(--space-4);
 }
-.detail b {
-  font-family: var(--font-heading);
-  font-size: 14px;
-  font-weight: var(--font-heading-weight);
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.detail span {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+
+.inspector {
   min-width: 0;
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.25;
-  font-variant-numeric: tabular-nums;
+  padding: var(--space-4);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
 }
-.detail small {
+.inspectorLabel {
+  display: block;
   font-size: 10px;
-  font-weight: 400;
-  line-height: 1.2;
-  letter-spacing: .07em;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-700);
+}
+.inspector > b {
+  display: block;
+  margin-top: var(--space-3);
+  font-family: var(--font-heading);
+  font-size: 26px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: -.02em;
+}
+.inspector dl { margin: var(--space-4) 0; }
+.inspector dl > div {
+  padding: 11px 0;
+  border-top: 1px solid var(--color-neutral-300);
+}
+.inspector dt {
+  font-size: 10px;
+  letter-spacing: .06em;
   text-transform: uppercase;
   color: var(--color-neutral-600);
 }
+.inspector dd {
+  margin: 4px 0 0;
+  font-size: 16px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.inspector dl > div:nth-child(n + 3) dd { font-size: 13px; font-weight: 600; }
 
 .srOnly {
   position: absolute;
@@ -135,37 +213,25 @@
   border: 0;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1050px) {
   .layout { grid-template-columns: minmax(0, 1fr); }
-  .detail { grid-template-columns: repeat(3, minmax(84px, 1fr)); }
-  .detail b { grid-column: 1 / -1; }
+  .controls { grid-column: auto; }
+  .map { max-height: 500px; }
+  .inspector dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .inspector dl > div { padding-right: var(--space-3); }
 }
 
 @media (max-width: 760px) {
-  .map { max-height: 440px; }
+  .controls { grid-template-columns: minmax(0, 1fr); }
+  .mapHeading { align-items: flex-start; flex-direction: column; gap: 2px; }
+  .map { height: 420px; min-height: 340px; }
   .legendEnd { display: none; }
-  .legend { justify-content: center; }
-
-  .mobileSelector {
-    display: grid;
-    gap: 6px;
-    margin-top: var(--space-3);
-    font-size: 12px;
-    color: var(--color-neutral-700);
-  }
-  .mobileSelector select {
-    width: 100%;
-    min-height: 44px;
-    padding: 0 12px;
-    border: 1px solid var(--color-neutral-400);
-    background: var(--color-raised);
-    color: var(--color-text);
-    font-size: 14px;
-  }
+  .inspector dl { grid-template-columns: minmax(0, 1fr); }
 }
 
 @media (max-width: 480px) {
-  .detail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .metricControl button { padding-inline: 5px; font-size: 11px; }
+  .map { height: 360px; min-height: 300px; }
 }
 
 @media (hover: none) {
@@ -174,5 +240,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .region { transition: none; }
+  .region,
+  .metricControl button { transition: none; }
 }

--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ITALY_REGIONS_VIEWBOX,
@@ -13,10 +14,56 @@ import {
 import { compactEuro, exactEuro, integer } from "@/lib/format";
 import styles from "./italy-regions-map.module.css";
 
+type RegionalMetricDefinition = {
+  label: string;
+  title: string;
+  legendLabel: string;
+  legendEnds: readonly [string, string];
+  value: (region: SiopeRegionPoint | undefined) => number | null;
+  format: (value: number) => string;
+  ariaSuffix: string;
+};
+
+const regionalMetrics = {
+  "per-capita": {
+    label: "Per abitante",
+    title: "Pagamenti comunali per abitante coperto, per regione",
+    legendLabel: "Scala dei pagamenti per abitante coperto",
+    legendEnds: ["Meno per abitante", "Più per abitante"],
+    value: (region) => region?.perCapita ?? null,
+    format: exactEuro,
+    ariaSuffix: "per abitante coperto",
+  },
+  total: {
+    label: "Totale pagato",
+    title: "Pagamenti comunali totali, per regione",
+    legendLabel: "Scala dei pagamenti totali",
+    legendEnds: ["Totale minore", "Totale maggiore"],
+    value: (region) => region?.value ?? null,
+    format: compactEuro,
+    ariaSuffix: "pagati",
+  },
+  municipalities: {
+    label: "Comuni inclusi",
+    title: "Comuni inclusi nei dati SIOPE, per regione",
+    legendLabel: "Scala del numero di Comuni inclusi",
+    legendEnds: ["Meno Comuni", "Più Comuni"],
+    value: (region) => region?.municipalities ?? null,
+    format: integer,
+    ariaSuffix: "Comuni inclusi",
+  },
+} satisfies Record<string, RegionalMetricDefinition>;
+
+type RegionalMetric = keyof typeof regionalMetrics;
+
 const italianRegionCollator = new Intl.Collator("it");
 const regionOptions = Object.entries(REGION_NAME_BY_ISTAT_CODE).sort(([, left], [, right]) =>
   italianRegionCollator.compare(left, right),
 );
+const regionalMetricEntries = Object.entries(regionalMetrics) as Array<
+  [RegionalMetric, RegionalMetricDefinition]
+>;
+const navigableRegionCodes: string[] = italyRegionGeometry.map(({ code }) => code);
 
 function quantile(values: number[], fraction: number): number {
   const index = Math.min(values.length - 1, Math.floor(values.length * fraction));
@@ -26,13 +73,15 @@ function quantile(values: number[], fraction: number): number {
 export function ItalyRegionsMap({
   regions,
   period,
-  aside,
+  summary,
+  detailsHref,
 }: {
   regions: SiopeRegionPoint[];
   period: string;
-  /** National figures shown beside the map; owned by the page, not the map. */
-  aside?: React.ReactNode;
+  summary?: React.ReactNode;
+  detailsHref: string;
 }) {
+  const [metric, setMetric] = useState<RegionalMetric>("per-capita");
   const [selectedCode, setSelectedCode] = useState("03");
   const [hoveredCode, setHoveredCode] = useState<string | null>(null);
   const [focusedCode, setFocusedCode] = useState<string | null>(null);
@@ -40,17 +89,15 @@ export function ItalyRegionsMap({
   const [automaticSelection, setAutomaticSelection] = useState<"ip" | null>(null);
   const userSelected = useRef(false);
   const regionPathRefs = useRef(new Map<string, SVGPathElement>());
-  const { byCode, thresholds } = useMemo(() => {
-    const mapped = regionDataByIstatCode(regions);
+  const byCode = useMemo(() => regionDataByIstatCode(regions), [regions]);
+  const metricDefinition = regionalMetrics[metric];
+  const thresholds = useMemo(() => {
     const values = regions
-      .map((region) => region.perCapita)
+      .map(metricDefinition.value)
       .filter((value): value is number => value !== null)
       .sort((left, right) => left - right);
-    return {
-      byCode: mapped,
-      thresholds: [0.2, 0.4, 0.6, 0.8].map((fraction) => quantile(values, fraction)),
-    };
-  }, [regions]);
+    return [0.2, 0.4, 0.6, 0.8].map((fraction) => quantile(values, fraction));
+  }, [metricDefinition, regions]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -97,7 +144,6 @@ export function ItalyRegionsMap({
 
   const displayedCode = selectionLocked ? selectedCode : hoveredCode ?? selectedCode;
   const selected = byCode.get(displayedCode);
-  const navigableCodes: string[] = italyRegionGeometry.map(({ code }) => code);
   const outlinedCodes = [selectedCode, hoveredCode].filter(
     (code, index, codes): code is string => code !== null && codes.indexOf(code) === index,
   );
@@ -109,21 +155,21 @@ export function ItalyRegionsMap({
       return;
     }
 
-    const currentIndex = navigableCodes.indexOf(code);
+    const currentIndex = navigableRegionCodes.indexOf(code);
     let nextIndex: number | null = null;
     if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-      nextIndex = (currentIndex + 1) % navigableCodes.length;
+      nextIndex = (currentIndex + 1) % navigableRegionCodes.length;
     } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-      nextIndex = (currentIndex - 1 + navigableCodes.length) % navigableCodes.length;
+      nextIndex = (currentIndex - 1 + navigableRegionCodes.length) % navigableRegionCodes.length;
     } else if (event.key === "Home") {
       nextIndex = 0;
     } else if (event.key === "End") {
-      nextIndex = navigableCodes.length - 1;
+      nextIndex = navigableRegionCodes.length - 1;
     }
 
     if (nextIndex === null) return;
     event.preventDefault();
-    const nextCode = navigableCodes[nextIndex];
+    const nextCode = navigableRegionCodes[nextIndex];
     setFocusedCode(nextCode);
     previewRegion(nextCode);
     regionPathRefs.current.get(nextCode)?.focus();
@@ -131,31 +177,68 @@ export function ItalyRegionsMap({
 
   function level(value: number | null): number | null {
     if (value === null) return null;
-    return thresholds.findIndex((threshold) => value <= threshold) === -1
-      ? thresholds.length
-      : thresholds.findIndex((threshold) => value <= threshold);
+    const matchingIndex = thresholds.findIndex((threshold) => value <= threshold);
+    return matchingIndex === -1 ? thresholds.length : matchingIndex;
   }
 
   return (
     <div className={styles.layout}>
+      <div className={styles.controls}>
+        <fieldset className={styles.metricControl}>
+          <legend>Misura</legend>
+          <div>
+            {regionalMetricEntries.map(([value, definition]) => (
+              <button
+                type="button"
+                key={value}
+                data-region-metric={value}
+                aria-pressed={metric === value}
+                onClick={() => setMetric(value)}
+              >
+                {definition.label}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className={styles.regionSelector}>
+          <span>Territorio</span>
+          <select
+            data-region-selector="true"
+            value={selectedCode}
+            onChange={(event) => selectRegion(event.target.value)}
+          >
+            {regionOptions.map(([code, name]) => (
+              <option value={code} key={code}>{name}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
       <div className={styles.mapColumn}>
+        <div className={styles.mapHeading}>
+          <strong>{metricDefinition.title}</strong>
+          <span>{period}</span>
+        </div>
         <svg
           className={styles.map}
           viewBox={ITALY_REGIONS_VIEWBOX}
+          preserveAspectRatio="xMidYMid meet"
           role="group"
           data-region-map="true"
           aria-labelledby="regional-map-title regional-map-description"
         >
-          <title id="regional-map-title">Pagamenti comunali per abitante coperto, per regione</title>
+          <title id="regional-map-title">{metricDefinition.title}</title>
           <desc id="regional-map-description">
-            Mappa regionale colorata in base ai pagamenti di cassa SIOPE dei Comuni. Usa Tab per
-            entrare nella mappa e i tasti freccia per esplorare le regioni. Passa sopra una regione
-            per un’anteprima; fai clic o premi Invio per fissarla nel pannello accanto.
+            Mappa regionale colorata in base alla misura selezionata. Usa Tab per entrare nella
+            mappa e i tasti freccia per esplorare le regioni. Passa sopra una regione per
+            un’anteprima; fai clic o premi Invio per fissarla nel pannello accanto.
           </desc>
           {italyRegionGeometry.map((geometry) => {
             const region = byCode.get(geometry.code);
-            const colorLevel = level(region?.perCapita ?? null);
-            const selected = selectedCode === geometry.code;
+            const value = metricDefinition.value(region);
+            const colorLevel = level(value);
+            const selectedRegion = selectedCode === geometry.code;
             const focusable = (focusedCode ?? selectedCode) === geometry.code;
             const hovered = hoveredCode === geometry.code;
             return (
@@ -171,14 +254,14 @@ export function ItalyRegionsMap({
                 }`}
                 tabIndex={focusable ? 0 : -1}
                 role="button"
-                aria-pressed={selected}
+                aria-pressed={selectedRegion}
                 aria-label={`${REGION_NAME_BY_ISTAT_CODE[geometry.code]}: ${
-                  region?.perCapita === null || region?.perCapita === undefined
+                  value === null
                     ? "dato non disponibile"
-                    : `${exactEuro(region.perCapita)} per abitante coperto`
+                    : `${metricDefinition.format(value)} ${metricDefinition.ariaSuffix}`
                 }`}
                 data-hovered={hovered ? "true" : undefined}
-                data-selected={selected ? "true" : undefined}
+                data-selected={selectedRegion ? "true" : undefined}
                 onPointerEnter={() => previewRegion(geometry.code)}
                 onPointerLeave={() => clearPreview(geometry.code)}
                 onFocus={() => {
@@ -211,18 +294,23 @@ export function ItalyRegionsMap({
           })}
         </svg>
 
-        <label className={styles.mobileSelector}>
-          <span>Scegli una regione</span>
-          <select
-            data-region-selector="true"
-            value={selectedCode}
-            onChange={(event) => selectRegion(event.target.value)}
-          >
-            {regionOptions.map(([code, name]) => (
-              <option value={code} key={code}>{name}</option>
-            ))}
-          </select>
-        </label>
+        <div className={styles.legend} aria-label={metricDefinition.legendLabel}>
+          <span className={styles.legendEnd}>{metricDefinition.legendEnds[0]}</span>
+          {[0, 1, 2, 3, 4].map((index) => (
+            <i
+              key={index}
+              className={styles[`level${index}`]}
+              title={
+                index === 0
+                  ? `fino a ${metricDefinition.format(thresholds[0])}`
+                  : index === 4
+                    ? `oltre ${metricDefinition.format(thresholds[3])}`
+                    : `da ${metricDefinition.format(thresholds[index - 1])} a ${metricDefinition.format(thresholds[index])}`
+              }
+            />
+          ))}
+          <span className={styles.legendEnd}>{metricDefinition.legendEnds[1]}</span>
+        </div>
 
         {automaticSelection ? (
           <p className={styles.geoNote}>
@@ -231,50 +319,36 @@ export function ItalyRegionsMap({
           </p>
         ) : null}
 
-        <div className={styles.legend} aria-label="Scala dei pagamenti pro capite">
-          <span className={styles.legendEnd}>Meno spesa per abitante</span>
-          {[0, 1, 2, 3, 4].map((index) => (
-            <i
-              key={index}
-              className={styles[`level${index}`]}
-              title={
-                index === 0
-                  ? `fino a ${integer(thresholds[0])} €`
-                  : index === 4
-                    ? `oltre ${integer(thresholds[3])} €`
-                    : `da ${integer(thresholds[index - 1])} a ${integer(thresholds[index])} €`
-              }
-            />
-          ))}
-          <span className={styles.legendEnd}>Più spesa per abitante</span>
-        </div>
+        {summary ? <div className={styles.summary}>{summary}</div> : null}
       </div>
 
-      {aside ? <div className={styles.asideColumn}>{aside}</div> : null}
-
-      <div className={styles.detail} data-region-detail="true" aria-live="polite">
+      <aside className={styles.inspector} data-region-detail="true" aria-live="polite">
+        <span className={styles.inspectorLabel}>Regione selezionata</span>
         <b>{selected?.region ?? "Dato non disponibile"}</b>
-        <span>
-          <small>Totale</small>
-          {selected ? compactEuro(selected.value) : "n.d."}
-        </span>
-        <span>
-          <small>Per abitante</small>
-          {selected?.perCapita === null || !selected ? "n.d." : exactEuro(selected.perCapita)}
-        </span>
-        <span>
-          <small>Abitanti</small>
-          {selected?.population == null ? "n.d." : integer(selected.population)}
-        </span>
-        <span>
-          <small>Comuni</small>
-          {selected ? integer(selected.municipalities) : "n.d."}
-        </span>
-        <span>
-          <small>Periodo</small>
-          {period}
-        </span>
-      </div>
+        <dl>
+          <div>
+            <dt>Per abitante</dt>
+            <dd>{selected?.perCapita === null || !selected ? "n.d." : exactEuro(selected.perCapita)}</dd>
+          </div>
+          <div>
+            <dt>Totale pagato</dt>
+            <dd>{selected ? compactEuro(selected.value) : "n.d."}</dd>
+          </div>
+          <div>
+            <dt>Popolazione coperta</dt>
+            <dd>{selected?.population == null ? "n.d." : integer(selected.population)}</dd>
+          </div>
+          <div>
+            <dt>Comuni inclusi</dt>
+            <dd>{selected ? integer(selected.municipalities) : "n.d."}</dd>
+          </div>
+          <div>
+            <dt>Periodo</dt>
+            <dd>{period}</dd>
+          </div>
+        </dl>
+        <Link className="btn btn-block" href={detailsHref}>Vedi il confronto completo</Link>
+      </aside>
 
       <div className={styles.srOnly}>
         <table>
@@ -283,7 +357,7 @@ export function ItalyRegionsMap({
           <tbody>
             {regions.map((region) => (
               <tr key={region.region}>
-                <th>{region.region}</th>
+                <th scope="row">{region.region}</th>
                 <td>{exactEuro(region.value)}</td>
                 <td>{region.perCapita === null ? "Non disponibile" : exactEuro(region.perCapita)}</td>
                 <td>{integer(region.municipalities)}</td>

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -24,15 +24,16 @@ test("narrow responsive grids cannot exceed their container", async () => {
   }
 });
 
-test("the home has one semantic title without adding a visual hero", async () => {
+test("the home exposes one visible title for the territorial explorer", async () => {
   const [page, css] = await Promise.all([
     source("../src/app/page.tsx"),
     source("../src/app/home.module.css"),
   ]);
 
   assert.equal(page.match(/<h1\b/g)?.length, 1);
-  assert.match(page, /<h1 className=\{styles\.pageTitle\}>Dove vanno i nostri soldi pubblici<\/h1>/);
-  assert.match(css, /\.pageTitle \{[\s\S]*?clip-path: inset\(50%\);/);
+  assert.match(page, /<h1>Esplora i pagamenti dei Comuni<\/h1>/);
+  assert.match(css, /\.pageIntro h1 \{[^}]*font-size: 30px;/);
+  assert.doesNotMatch(css, /\.pageTitle \{[\s\S]*?clip-path: inset\(50%\);/);
 });
 
 test("information tooltips expose and dismiss their description", async () => {
@@ -60,7 +61,8 @@ test("information tooltips clamp to the viewport and keep their heading trigger 
     tooltipCss,
     /\.tooltip\[data-open="true"\]\[data-positioned="false"\][\s\S]*?visibility: hidden;/,
   );
-  assert.match(home, /\.panelHead > h2 \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
+  assert.match(home, /\.panelHead > h2,[\s\S]*?\.panelHead > div \{ min-width: 0; \}/);
+  assert.match(home, /\.panelHead > h2 \{ flex: 1 1 auto;/);
   assert.match(globals, /@media \(min-width: 901px\) and \(max-width: 980px\)/);
   assert.match(globals, /\.header-search \{ order: 3; width: 100%; \}/);
 });


### PR DESCRIPTION
## Perché

La homepage precedente esponeva molte informazioni corrette, ma distribuiva il percorso principale tra tre colonne strette e pannelli con pari peso visivo. La nuova versione mantiene colori, tipografia, pattern e fonti del progetto, ma organizza la pagina intorno al compito più frequente: esplorare i pagamenti dei Comuni partendo dal territorio.

## Cosa cambia

- introduce un titolo visibile e una breve istruzione d'uso;
- mette anno, misura, territorio, mappa e dettaglio regionale nello stesso flusso;
- conserva la geometria ISTAT dell'Italia e amplia lo spazio della mappa;
- permette di leggere la mappa per abitante, totale pagato o Comuni inclusi;
- affianca al territorio selezionato valori, periodo e collegamento al confronto completo;
- presenta composizione e andamento mensile come risposte consecutive a “Per cosa” e “Quando”;
- amplia la tabella regionale con totale, popolazione e copertura comunale;
- raccoglie gli approfondimenti secondari dopo il percorso principale;
- linearizza i contenuti su mobile senza nascondere dati o controlli;
- rimuove duplicazioni nel componente mappa tramite una sola configurazione delle metriche.

## Ambito della PR upstream

Il branch parte direttamente da `Italian-Builders-Org/main` e contiene un solo commit. Il diff è limitato a sei file della homepage, del componente mappa e dei relativi test; non include snapshot o aggiornamenti dati specifici del fork.

## Perché la navigazione è migliore

1. L'utente capisce subito cosa può fare nella pagina.
2. I controlli precedono il risultato che modificano.
3. La selezione del territorio è disponibile anche senza interagire con l'SVG.
4. Le tre misure usano lo stesso modello di interazione e la stessa legenda contestuale.
5. La regione scelta resta visibile in un pannello stabile, separato dal quadro nazionale.
6. Il link “Vedi il confronto completo” mantiene anno e contesto.
7. Le informazioni principali seguono l'ordine territorio → destinazione → tempo → confronto.
8. Le tabelle espongono gli stessi numeri anche a chi non usa la visualizzazione grafica.
9. Su schermi stretti i controlli mantengono target utilizzabili e non producono overflow orizzontale.
10. Fonti, periodo, perimetro e cautele restano vicini ai numeri a cui si riferiscono.

## Verifiche eseguite

- `npm ci` — completato, 0 vulnerabilità note;
- `npm run ci:static` — lint, typecheck, design e brand check verdi;
- `npm run test:node` — 500/500 test;
- `npm run test:etl` — 272/272 test;
- `npm run test:snapshots` — 16 controlli standalone e working tree invariato;
- `npm run build` — build Next.js 16.3.1 riuscita, 79 pagine statiche;
- `bash scripts/ci/run-production-gates.sh` — browser core, 21 rotte editoriali, MCP smoke e load test verdi;
- viewport browser: 320, 390, 768, 901, 1024, 1280 e 1600 px, inclusa equivalenza zoom 200%;
- Lighthouse, mediana di 3 run: Performance 97%, Accessibility 100%, Best Practices 100%, SEO 100%, CLS 0.000, TBT 5 ms;
- verifica isolata della skill su catalogo, fonti, RGS, hub e MCP: PASS desktop e mobile;
- link interni della homepage risolti a rotte esistenti; link ufficiali ISTAT e SIOPE verificati con risposta HTTP 200;
- `git diff --check` — nessun errore.

## Note

I test locali sono stati eseguiti con Node 22.22.3; il repository richiede 22.23.2 tramite `.nvmrc`. La CI usa la versione dichiarata e costituisce il controllo finale su quel runtime. Non sono stati cambiati colori, pattern di brand o contratti dati pubblici.
