### PR TITLE
feat(ui): add dark mode and polish company atlas

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,6 +39,17 @@ La palette è grigio-carta caldo con un unico rosso di segnalazione. Evitare ner
 - `--color-accent-2: #e15b47` — accento secondario, usato di rado;
 - `--color-divider` — separatore calcolato dal testo.
 
+### Dark mode
+
+La modalità scura inverte la gerarchia conservando l'identità calda e sobria:
+- `--color-bg: #161514` — fondo applicazione scuro;
+- `--color-surface: #1e1c1b` — fondo secondario;
+- `--color-raised: #252322` — superficie dei pannelli;
+- `--color-text: #ece8e7` — testo principale;
+- `--color-accent: #ff563c` e `--color-accent-700: #ff705a` — accento ad alto contrasto (WCAG AA) per azioni, link e serie primarie.
+
+I token neutrali (`neutral-100…900`) e di stato (`positive`, `warning`, `critical`) scalano simmetricamente per garantire contrasto e leggibilità immediata su tutti i grafici, mappe, tabelle e controlli.
+
 ### Rampe tonali
 
 `--color-neutral-100…900` e `--color-accent-100…900` sono generate in OKLCH su un'unica scala di luminosità: lo stesso passo di due rampe diverse ha lo stesso valore visivo. Le regole d'uso:

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -303,6 +303,77 @@ async function assertInfoTooltips(page, label) {
   }
 }
 
+async function assertThemeBehavior(page, label) {
+  const toggleSelector = "button.theme-toggle";
+  const toggle = await page.$(toggleSelector);
+  assert.ok(toggle, `${label}: pulsante cambio tema non trovato`);
+
+  // 1. Preferenza di sistema scura
+  await page.emulateMediaFeatures([{ name: "prefers-color-scheme", value: "dark" }]);
+  await page.evaluate(() => localStorage.removeItem("dvns-theme"));
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector("main", { visible: true });
+
+  let state = await page.evaluate(() => ({
+    dataTheme: document.documentElement.getAttribute("data-theme"),
+    storedTheme: localStorage.getItem("dvns-theme"),
+    ariaPressed: document.querySelector("button.theme-toggle")?.getAttribute("aria-pressed"),
+  }));
+  assert.equal(state.dataTheme, "dark", `${label}: preferenza di sistema scura non applicata a data-theme`);
+  assert.equal(state.storedTheme, null, `${label}: localStorage non deve essere impostato da sola preferenza sistema`);
+
+  // 2. Cambio manuale verso chiaro
+  await page.click(toggleSelector);
+  await page.waitForFunction(() => document.documentElement.getAttribute("data-theme") === "light");
+  state = await page.evaluate(() => ({
+    dataTheme: document.documentElement.getAttribute("data-theme"),
+    storedTheme: localStorage.getItem("dvns-theme"),
+    ariaPressed: document.querySelector("button.theme-toggle")?.getAttribute("aria-pressed"),
+  }));
+  assert.equal(state.dataTheme, "light", `${label}: cambio manuale verso chiaro fallito`);
+  assert.equal(state.storedTheme, "light", `${label}: localStorage non aggiornato dopo toggle chiaro`);
+  assert.equal(state.ariaPressed, "false", `${label}: aria-pressed deve essere false per tema chiaro`);
+
+  // 3. Persistenza tema chiaro dopo reload con media query dark
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector("main", { visible: true });
+  state = await page.evaluate(() => ({
+    dataTheme: document.documentElement.getAttribute("data-theme"),
+    storedTheme: localStorage.getItem("dvns-theme"),
+    ariaPressed: document.querySelector("button.theme-toggle")?.getAttribute("aria-pressed"),
+  }));
+  assert.equal(state.dataTheme, "light", `${label}: preferenza manuale chiara non persistita dopo reload`);
+  assert.equal(state.storedTheme, "light", `${label}: localStorage perso dopo reload`);
+
+  // 4. Cambio manuale verso scuro
+  await page.click(toggleSelector);
+  await page.waitForFunction(() => document.documentElement.getAttribute("data-theme") === "dark");
+  state = await page.evaluate(() => ({
+    dataTheme: document.documentElement.getAttribute("data-theme"),
+    storedTheme: localStorage.getItem("dvns-theme"),
+    ariaPressed: document.querySelector("button.theme-toggle")?.getAttribute("aria-pressed"),
+  }));
+  assert.equal(state.dataTheme, "dark", `${label}: cambio manuale verso scuro fallito`);
+  assert.equal(state.storedTheme, "dark", `${label}: localStorage non aggiornato dopo toggle scuro`);
+  assert.equal(state.ariaPressed, "true", `${label}: aria-pressed deve essere true per tema scuro`);
+
+  // 5. Persistenza tema scuro dopo reload con media query light
+  await page.emulateMediaFeatures([{ name: "prefers-color-scheme", value: "light" }]);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector("main", { visible: true });
+  state = await page.evaluate(() => ({
+    dataTheme: document.documentElement.getAttribute("data-theme"),
+    storedTheme: localStorage.getItem("dvns-theme"),
+    ariaPressed: document.querySelector("button.theme-toggle")?.getAttribute("aria-pressed"),
+  }));
+  assert.equal(state.dataTheme, "dark", `${label}: preferenza manuale scura non persistita dopo reload`);
+  assert.equal(state.storedTheme, "dark", `${label}: localStorage perso dopo reload`);
+
+  // Teardown
+  await page.evaluate(() => localStorage.removeItem("dvns-theme"));
+  await page.emulateMediaFeatures([{ name: "prefers-color-scheme", value: "light" }]);
+}
+
 async function assertRegionalMapSelection(page, label) {
   const mapSelector = '[data-region-map="true"]';
   const detailSelector = '[data-region-detail="true"] b';
@@ -1656,6 +1727,19 @@ try {
           "false",
           `${label}: stato busy non concluso`,
         );
+      },
+    });
+    completed.push(label);
+  }
+
+  for (const width of [390, 1280]) {
+    const label = `Tema e contrasto ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/",
+      width,
+      validate: async (page) => {
+        await assertThemeBehavior(page, label);
       },
     });
     completed.push(label);

--- a/src/app/coesione/coesione.module.css
+++ b/src/app/coesione/coesione.module.css
@@ -23,6 +23,15 @@
   letter-spacing: .12em;
   text-transform: uppercase;
 }
+
+:global([data-theme="dark"]) .tracePanel > div > span:first-child {
+  color: var(--color-accent-900);
+}
+@media (prefers-color-scheme: dark) {
+  :global(:root:not([data-theme="light"])) .tracePanel > div > span:first-child {
+    color: var(--color-accent-900);
+  }
+}
 .tracePanel h2 {
   max-width: 18ch;
   margin: 8px 0 12px;

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -113,6 +113,170 @@
   --focus-ring: var(--color-accent);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-bg: #161514;
+    --color-surface: #1e1c1b;
+    --color-raised: #252322;
+    --color-text: #ece8e7;
+    --color-on-strong: #ffffff;
+    --color-on-strong-muted: #c8c3c1;
+    --color-accent: #ff563c;
+    --color-accent-2: #ef6853;
+    --color-divider: color-mix(in srgb, #ece8e7 20%, transparent);
+
+    /* Tonal ramps — dark mode */
+    --color-neutral-100: #2c2a29;
+    --color-neutral-200: #373433;
+    --color-neutral-300: #484443;
+    --color-neutral-400: #615c5a;
+    --color-neutral-500: #7d7775;
+    --color-neutral-600: #aba5a3;
+    --color-neutral-700: #c8c3c1;
+    --color-neutral-800: #e2dedd;
+    --color-neutral-900: #121110;
+
+    --color-accent-100: #331814;
+    --color-accent-200: #4d201a;
+    --color-accent-300: #742a1f;
+    --color-accent-400: #a33725;
+    --color-accent-500: #d6442c;
+    --color-accent-600: #f0553a;
+    --color-accent-700: #ff705a;
+    --color-accent-800: #ff9280;
+    --color-accent-900: #ffc2b8;
+
+    --color-accent-2-100: #331a17;
+    --color-accent-2-200: #4d241f;
+    --color-accent-2-300: #743128;
+    --color-accent-2-400: #a34235;
+    --color-accent-2-500: #d45544;
+    --color-accent-2-600: #eb6a58;
+    --color-accent-2-700: #ff8270;
+    --color-accent-2-800: #ffa294;
+    --color-accent-2-900: #ffcbc2;
+
+    /* Status */
+    --color-positive: #4ade80;
+    --color-positive-bg: #122a1b;
+    --color-positive-border: #225936;
+    --color-warning: #f59e0b;
+    --color-warning-bg: #2c1f0d;
+    --color-warning-border: #5c4015;
+    --color-critical: var(--color-accent-700);
+    --color-critical-bg: var(--color-accent-100);
+    --color-critical-border: var(--color-accent-300);
+    --color-negative: var(--color-critical);
+
+    /* Elevation */
+    --shadow-sm: 0 1px 2px color-mix(in srgb, #000000 40%, transparent);
+    --shadow-md: 0 3px 10px color-mix(in srgb, #000000 50%, transparent);
+    --shadow-lg: 0 12px 32px color-mix(in srgb, #000000 65%, transparent);
+
+    --chart-primary: var(--color-accent);
+    --chart-secondary: var(--color-neutral-700);
+    --chart-tertiary: var(--color-neutral-500);
+    --chart-quaternary: var(--color-neutral-400);
+    --chart-quinary: var(--color-accent-400);
+    --chart-negative: var(--color-accent-600);
+    --chart-family-services: #625194;
+    --chart-family-investment: #8c4554;
+    --chart-family-pass-through: #876d29;
+    --chart-family-financing: #8a5a24;
+    --chart-family-other: #3c6275;
+
+    --chart-category-blue: #2855a5;
+    --chart-category-teal: #087c74;
+    --chart-category-purple: #6b46a3;
+    --chart-category-amber: #9a5b00;
+    --chart-category-green: #2f6f44;
+    --chart-category-slate: #405b70;
+
+    --focus-ring: var(--color-accent);
+  }
+}
+
+:root[data-theme="dark"] {
+  --color-bg: #161514;
+  --color-surface: #1e1c1b;
+  --color-raised: #252322;
+  --color-text: #ece8e7;
+  --color-on-strong: #ffffff;
+  --color-on-strong-muted: #c8c3c1;
+  --color-accent: #ff563c;
+  --color-accent-2: #ef6853;
+  --color-divider: color-mix(in srgb, #ece8e7 20%, transparent);
+
+  /* Tonal ramps — dark mode */
+  --color-neutral-100: #2c2a29;
+  --color-neutral-200: #373433;
+  --color-neutral-300: #484443;
+  --color-neutral-400: #615c5a;
+  --color-neutral-500: #7d7775;
+  --color-neutral-600: #aba5a3;
+  --color-neutral-700: #c8c3c1;
+  --color-neutral-800: #e2dedd;
+  --color-neutral-900: #121110;
+
+  --color-accent-100: #331814;
+  --color-accent-200: #4d201a;
+  --color-accent-300: #742a1f;
+  --color-accent-400: #a33725;
+  --color-accent-500: #d6442c;
+  --color-accent-600: #f0553a;
+  --color-accent-700: #ff705a;
+  --color-accent-800: #ff9280;
+  --color-accent-900: #ffc2b8;
+
+  --color-accent-2-100: #331a17;
+  --color-accent-2-200: #4d241f;
+  --color-accent-2-300: #743128;
+  --color-accent-2-400: #a34235;
+  --color-accent-2-500: #d45544;
+  --color-accent-2-600: #eb6a58;
+  --color-accent-2-700: #ff8270;
+  --color-accent-2-800: #ffa294;
+  --color-accent-2-900: #ffcbc2;
+
+  /* Status */
+  --color-positive: #4ade80;
+  --color-positive-bg: #122a1b;
+  --color-positive-border: #225936;
+  --color-warning: #f59e0b;
+  --color-warning-bg: #2c1f0d;
+  --color-warning-border: #5c4015;
+  --color-critical: var(--color-accent-700);
+  --color-critical-bg: var(--color-accent-100);
+  --color-critical-border: var(--color-accent-300);
+  --color-negative: var(--color-critical);
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px color-mix(in srgb, #000000 40%, transparent);
+  --shadow-md: 0 3px 10px color-mix(in srgb, #000000 50%, transparent);
+  --shadow-lg: 0 12px 32px color-mix(in srgb, #000000 65%, transparent);
+
+  --chart-primary: var(--color-accent);
+  --chart-secondary: var(--color-neutral-700);
+  --chart-tertiary: var(--color-neutral-500);
+  --chart-quaternary: var(--color-neutral-400);
+  --chart-quinary: var(--color-accent-400);
+  --chart-negative: var(--color-accent-600);
+  --chart-family-services: #625194;
+  --chart-family-investment: #8c4554;
+  --chart-family-pass-through: #876d29;
+  --chart-family-financing: #8a5a24;
+  --chart-family-other: #3c6275;
+
+  --chart-category-blue: #2855a5;
+  --chart-category-teal: #087c74;
+  --chart-category-purple: #6b46a3;
+  --chart-category-amber: #9a5b00;
+  --chart-category-green: #2f6f44;
+  --chart-category-slate: #405b70;
+
+  --focus-ring: var(--color-accent);
+}
+
 /* — rules — */
 .hr {
   height: 2px;

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -181,7 +181,7 @@
     --chart-negative: var(--color-accent-600);
     --chart-family-services: #625194;
     --chart-family-investment: #8c4554;
-    --chart-family-pass-through: #876d29;
+    --chart-family-pass-through: #755d20;
     --chart-family-financing: #8a5a24;
     --chart-family-other: #3c6275;
 
@@ -263,7 +263,7 @@
   --chart-negative: var(--color-accent-600);
   --chart-family-services: #625194;
   --chart-family-investment: #8c4554;
-  --chart-family-pass-through: #876d29;
+  --chart-family-pass-through: #755d20;
   --chart-family-financing: #8a5a24;
   --chart-family-other: #3c6275;
 

--- a/src/app/enti/[codice]/scheda.module.css
+++ b/src/app/enti/[codice]/scheda.module.css
@@ -215,7 +215,7 @@
   width: 14px;
   height: 14px;
   border: 3px solid var(--color-accent-800);
-  background: white;
+  background: var(--color-raised);
   transform: translate(-50%, -50%);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -730,8 +730,9 @@ main { display: block; }
 }
 
 /* Keep the header's fixed actions inside the viewport before the full
-   mobile layout takes over at 900px. */
-@media (min-width: 901px) and (max-width: 980px) {
+   mobile layout takes over at 900px. The theme toggle adds a fixed action,
+   so the compact two-row header starts early enough for 1024px viewports. */
+@media (min-width: 901px) and (max-width: 1100px) {
   .header-inner {
     flex-wrap: wrap;
     gap: var(--space-3);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -238,6 +238,32 @@ nav li a { text-decoration: none; }
 }
 .header-action-icon:hover { color: var(--color-accent-700); }
 
+.theme-toggle-icon-dark {
+  display: grid;
+  place-items: center;
+}
+.theme-toggle-icon-light {
+  display: none;
+}
+
+[data-theme="dark"] .theme-toggle-icon-dark {
+  display: none;
+}
+[data-theme="dark"] .theme-toggle-icon-light {
+  display: grid;
+  place-items: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-toggle-icon-dark {
+    display: none;
+  }
+  :root:not([data-theme="light"]) .theme-toggle-icon-light {
+    display: grid;
+    place-items: center;
+  }
+}
+
 /* ── primary navigation ─────────────────────────────────────────────────── */
 
 .nav-row {

--- a/src/app/imprese/imprese.module.css
+++ b/src/app/imprese/imprese.module.css
@@ -78,7 +78,7 @@
 .sectorLabelPlain { grid-template-columns: minmax(0, 1fr) auto; }
 .sectorLabel b { color: var(--color-accent-700); }
 .sectorLabel span { overflow: hidden; color: var(--color-neutral-800); text-overflow: ellipsis; white-space: nowrap; }
-.sectorLabel strong { font-variant-numeric: tabular-nums; }
+.sectorLabel strong { white-space: nowrap; font-variant-numeric: tabular-nums; }
 .sectorList i { display: block; height: 7px; margin-top: 5px; background: var(--color-neutral-200); }
 .sectorList i b { display: block; height: 100%; background: var(--color-accent); }
 .sectorList small { display: block; margin-top: 3px; color: var(--color-neutral-600); font-size: 10px; }

--- a/src/app/imprese/page.tsx
+++ b/src/app/imprese/page.tsx
@@ -46,12 +46,12 @@ function compactTurnover(value: number | null): string {
   if (value === null) return "n.d.";
   const absolute = Math.abs(value);
   if (absolute >= 1_000_000) {
-    return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })} mld €`;
+    return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })}\u00a0mld\u00a0€`;
   }
   if (absolute >= 1_000) {
-    return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })} mln €`;
+    return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })}\u00a0mln\u00a0€`;
   }
-  return `${integer(value)} mila €`;
+  return `${integer(value)}\u00a0mila\u00a0€`;
 }
 
 function atlasHref(view: { metric: string; period: string; region: string; sector: string; band?: string }, region?: string) {
@@ -149,7 +149,7 @@ export default async function ImpresePage({
                 <span className="status status-attiva">Snapshot ISTAT</span>
               </div>
               <strong className={styles.headline}>{compactTurnover(turnoverView.nationalValue)}</strong>
-              <p className={styles.headlineNote}>{turnoverView.metricUnit} · {turnoverView.periodLabel}</p>
+              <p className={styles.headlineNote}>Unità fonte: {turnoverView.metricUnit} · {turnoverView.periodLabel}</p>
 
               <dl className={styles.factRows}>
                 <div><dt>Metrica</dt><dd>{turnoverView.metricLabel}</dd></div>
@@ -354,7 +354,13 @@ export default async function ImpresePage({
                 const share = sector.value !== null && sectorTotal > 0 ? (sector.value / sectorTotal) * 100 : 0;
                 return (
                   <li key={sector.code}>
-                    <div className={styles.sectorLabel}><b>{sector.code}</b><span>{sector.label}</span><strong>{compactCount(sector.value)}</strong></div>
+                    <div className={styles.sectorLabel}>
+                      <span className={styles.sectorName}>
+                        <b>{sector.code}</b>
+                        <span>{sector.label}</span>
+                      </span>
+                      <strong>{compactCount(sector.value)}</strong>
+                    </div>
                     <i aria-hidden="true"><b style={{ width: `${share}%` }} /></i>
                     <small>{sector.value === null ? "n.d." : percent(share)} del perimetro settoriale</small>
                   </li>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,8 +39,11 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  colorScheme: "light",
-  themeColor: "#f3f2f2",
+  colorScheme: "light dark",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f3f2f2" },
+    { media: "(prefers-color-scheme: dark)", color: "#161514" },
+  ],
 };
 
 export default function RootLayout({
@@ -49,7 +52,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="it" className={archivo.variable}>
+    <html lang="it" className={archivo.variable} suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("dvns-theme");var m=window.matchMedia("(prefers-color-scheme: dark)").matches;var d=t==="dark"||((t!=="light")&&m);if(d){document.documentElement.setAttribute("data-theme","dark");document.documentElement.style.colorScheme="dark";}else{document.documentElement.setAttribute("data-theme","light");document.documentElement.style.colorScheme="light";}}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body>
         <GoogleAnalytics />
         <a className="skip-link" href="#contenuto-principale">Salta al contenuto principale</a>

--- a/src/app/progetti/[cup]/project.module.css
+++ b/src/app/progetti/[cup]/project.module.css
@@ -9,7 +9,7 @@
 }
 
 .breadcrumb strong {
-  color: var(--color-neutral-900);
+  color: var(--color-text);
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
 }

--- a/src/app/spese/territoriale/territoriale.module.css
+++ b/src/app/spese/territoriale/territoriale.module.css
@@ -239,4 +239,4 @@
   font-weight: 700;
   text-decoration: none;
 }
-.quickMeasures a[aria-current="page"] { color: white; background: var(--color-accent-800); }
+.quickMeasures a[aria-current="page"] { color: var(--color-raised); background: var(--color-accent-700); }

--- a/src/app/territori/fisco/fisco.module.css
+++ b/src/app/territori/fisco/fisco.module.css
@@ -12,7 +12,7 @@
 }
 
 .formulaVisual b { color: var(--color-neutral-600); }
-.formulaVisual strong { color: var(--color-neutral-900); }
+.formulaVisual strong { color: var(--color-text); }
 
 .sectionHeading {
   display: flex;
@@ -105,7 +105,7 @@
 .methodology dl { margin: 0; display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
 .methodology dl > div { border-top: 1px solid var(--color-neutral-300); padding-top: var(--space-3); }
 .methodology dt { color: var(--color-neutral-600); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; }
-.methodology dd { margin: 5px 0 0; color: var(--color-neutral-900); }
+.methodology dd { margin: 5px 0 0; color: var(--color-text); }
 .methodology > p { margin: var(--space-6) 0 0; color: var(--color-neutral-700); font-size: 13px; }
 
 .sources { margin-top: var(--space-6); }
@@ -156,4 +156,4 @@
   font-weight: 700;
   text-decoration: none;
 }
-.metricSelector a[aria-current="page"] { color: white; background: var(--color-accent-800); }
+.metricSelector a[aria-current="page"] { color: var(--color-raised); background: var(--color-accent-700); }

--- a/src/app/territori/territori.module.css
+++ b/src/app/territori/territori.module.css
@@ -36,8 +36,8 @@
   text-decoration: none;
 }
 .metricSelector a[aria-current="page"] {
-  color: white;
-  background: var(--color-accent-800);
+  color: var(--color-raised);
+  background: var(--color-accent-700);
 }
 
 .viewBlock {
@@ -52,7 +52,7 @@
   width: fit-content;
   padding: 3px;
   border: 1px solid var(--color-neutral-300);
-  background: white;
+  background: var(--color-raised);
 }
 
 .viewSelector button {
@@ -69,7 +69,7 @@
 
 .viewSelector button[aria-selected="true"] {
   background: var(--color-neutral-900);
-  color: white;
+  color: var(--color-on-strong);
 }
 
 .rankingGuide p {
@@ -147,8 +147,8 @@
   padding: 8px 10px;
   border: 1px solid var(--color-neutral-300);
   border-radius: 0;
-  background: white;
-  color: var(--color-neutral-900);
+  background: var(--color-raised);
+  color: var(--color-text);
   font: inherit;
   font-size: 12px;
 }
@@ -163,9 +163,9 @@
 .filterActions button {
   min-height: 42px;
   padding: 9px 13px;
-  border: 1px solid var(--color-accent-800);
-  background: var(--color-accent-800);
-  color: white;
+  border: 1px solid var(--color-accent-700);
+  background: var(--color-accent-700);
+  color: var(--color-raised);
   font-size: 12px;
   font-weight: 700;
   white-space: nowrap;
@@ -186,7 +186,7 @@
 }
 
 .resultsSummary strong {
-  color: var(--color-neutral-900);
+  color: var(--color-text);
 }
 
 .emptyState {

--- a/src/app/territori/territory-metric-chart.module.css
+++ b/src/app/territori/territory-metric-chart.module.css
@@ -27,8 +27,8 @@
   padding: 8px 34px 8px 10px;
   border: 1px solid var(--color-neutral-300);
   border-radius: 0;
-  background: white;
-  color: var(--color-neutral-900);
+  background: var(--color-raised);
+  color: var(--color-text);
   font: inherit;
 }
 
@@ -52,11 +52,11 @@
   grid-row: 1 / span 2;
   align-self: stretch;
   width: 2px;
-  background: var(--color-neutral-900);
+  background: var(--color-text);
 }
 
 .referenceLabel strong {
-  color: var(--color-neutral-900);
+  color: var(--color-text);
   font-size: 13px;
   font-variant-numeric: tabular-nums;
 }
@@ -81,7 +81,7 @@
   padding: 4px 6px;
   outline: 2px solid var(--color-accent-700);
   outline-offset: 2px;
-  background: color-mix(in srgb, var(--color-accent-100) 55%, white);
+  background: var(--color-accent-100);
 }
 
 .regionName {
@@ -89,7 +89,7 @@
   border: 0;
   background: transparent;
   overflow: hidden;
-  color: var(--color-neutral-900);
+  color: var(--color-text);
   font-size: 12px;
   font-weight: 650;
   text-align: left;
@@ -128,7 +128,7 @@
   bottom: -3px;
   left: var(--reference-position);
   width: 2px;
-  background: var(--color-neutral-900);
+  background: var(--color-text);
 }
 
 .value {
@@ -186,7 +186,7 @@
   min-height: 38px;
   padding: 8px 12px;
   border: 1px solid var(--color-accent-700);
-  background: white;
+  background: var(--color-raised);
   color: var(--color-accent-800);
   font-size: 12px;
   font-weight: 700;
@@ -277,7 +277,7 @@
 
 .trendTrack {
   height: 8px;
-  background: white;
+  background: var(--color-neutral-200);
 }
 
 .trendTrack i {

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -7,6 +7,7 @@ import { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } f
 import { HeaderSearch } from "@/components/header-search";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { GithubIcon } from "@hugeicons/core-free-icons";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
   PRIMARY_NAV,
   isNavChildActive,
@@ -127,6 +128,7 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
           <Link className="header-action header-action-accent" href="/mcp">
             Istruzioni MCP
           </Link>
+          <ThemeToggle />
           <a
             className="header-action header-action-icon"
             href={REPO_URL}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Moon02Icon, Sun02Icon } from "@hugeicons/core-free-icons";
+import {
+  THEME_CHANGE_EVENT,
+  applyTheme,
+  getEffectiveTheme,
+  setTheme,
+  type Theme,
+} from "@/lib/theme";
+
+function subscribeTheme(callback: () => void) {
+  if (typeof window === "undefined") return () => {};
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const syncTheme = () => {
+    applyTheme(getEffectiveTheme());
+    callback();
+  };
+  mediaQuery.addEventListener("change", syncTheme);
+  window.addEventListener("storage", syncTheme);
+  window.addEventListener(THEME_CHANGE_EVENT, syncTheme);
+  return () => {
+    mediaQuery.removeEventListener("change", syncTheme);
+    window.removeEventListener("storage", syncTheme);
+    window.removeEventListener(THEME_CHANGE_EVENT, syncTheme);
+  };
+}
+
+function getThemeSnapshot(): Theme {
+  return getEffectiveTheme();
+}
+
+function getServerThemeSnapshot(): Theme {
+  return "light";
+}
+
+export function ThemeToggle() {
+  const currentTheme = useSyncExternalStore(
+    subscribeTheme,
+    getThemeSnapshot,
+    getServerThemeSnapshot,
+  );
+
+  function handleToggle() {
+    const nextTheme: Theme = currentTheme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+  }
+
+  const isDark = currentTheme === "dark";
+  const label = isDark ? "Attiva tema chiaro" : "Attiva tema scuro";
+
+  return (
+    <button
+      type="button"
+      className="header-action header-action-icon theme-toggle"
+      onClick={handleToggle}
+      aria-label={label}
+      title={label}
+      aria-pressed={isDark}
+    >
+      <span className="theme-toggle-icon-dark" aria-hidden="true">
+        <HugeiconsIcon icon={Moon02Icon} size={19} strokeWidth={1.7} />
+      </span>
+      <span className="theme-toggle-icon-light" aria-hidden="true">
+        <HugeiconsIcon icon={Sun02Icon} size={19} strokeWidth={1.7} />
+      </span>
+    </button>
+  );
+}

--- a/src/lib/chart-colors.ts
+++ b/src/lib/chart-colors.ts
@@ -6,14 +6,14 @@
  * competing with the tricolour in the header.
  */
 export const CHART_COLORS = [
-  "#ec3013",
-  "#444141",
-  "#9b9797",
-  "#ef6853",
-  "#605d5d",
-  "#ffc4b8",
+  "var(--chart-primary)",
+  "var(--chart-secondary)",
+  "var(--chart-tertiary)",
+  "var(--color-accent-2)",
+  "var(--color-neutral-700)",
+  "var(--chart-quinary)",
 ] as const;
 
 export function chartColor(index: number): string {
-  return CHART_COLORS[index % CHART_COLORS.length];
+  return CHART_COLORS[index % CHART_COLORS.length]!;
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,49 @@
+/**
+ * Theme management for DoveVannoINostriSoldi.
+ *
+ * Light theme is the visual default and canonical appearance.
+ * Dark theme is activated either via user preference stored in localStorage
+ * or system preference via prefers-color-scheme when unset.
+ */
+
+export const THEME_STORAGE_KEY = "dvns-theme";
+export const THEME_CHANGE_EVENT = "dvns-theme-change";
+export type Theme = "light" | "dark";
+
+export function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = localStorage.getItem(THEME_STORAGE_KEY);
+    if (value === "light" || value === "dark") return value;
+  } catch {
+    // localStorage may be unavailable in restricted environments.
+  }
+  return null;
+}
+
+export function getSystemTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function getEffectiveTheme(): Theme {
+  return getStoredTheme() ?? getSystemTheme();
+}
+
+export function applyTheme(theme: Theme): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function setTheme(theme: Theme): void {
+  applyTheme(theme);
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // localStorage unavailable
+  }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+  }
+}

--- a/tests/accessibility-tokens.test.mjs
+++ b/tests/accessibility-tokens.test.mjs
@@ -62,3 +62,23 @@ test("dark status and notice palette pairs meet WCAG AA", () => {
   assert.ok(contrast(darkToken("color-positive"), darkToken("color-positive-bg")) >= 4.5);
   assert.ok(contrast(darkToken("color-warning"), darkToken("color-warning-bg")) >= 4.5);
 });
+
+test("spending treemap family tokens meet WCAG AA in both light and dark themes", () => {
+  const families = ["services", "investment", "pass-through", "financing", "other"];
+  const lightForeground = token("color-text");
+  const darkForeground = darkToken("color-text");
+
+  for (const family of families) {
+    const lightBg = token(`chart-family-${family}`);
+    const darkBg = darkToken(`chart-family-${family}`);
+
+    assert.ok(
+      contrast(lightForeground, lightBg) >= 4.5,
+      `light chart-family-${family} (${lightBg}) vs ${lightForeground} under 4.5:1`,
+    );
+    assert.ok(
+      contrast(darkForeground, darkBg) >= 4.5,
+      `dark chart-family-${family} (${darkBg}) vs ${darkForeground} under 4.5:1`,
+    );
+  }
+});

--- a/tests/accessibility-tokens.test.mjs
+++ b/tests/accessibility-tokens.test.mjs
@@ -10,6 +10,14 @@ function token(name) {
   return match[1];
 }
 
+function darkToken(name) {
+  const darkBlock = css.match(/:root\[data-theme="dark"\]\s*\{([^}]+)\}/s);
+  assert.ok(darkBlock, "dark block non trovato");
+  const match = darkBlock[1].match(new RegExp(`--${name}:\\s*(#[0-9a-f]{6})`, "i"));
+  assert.ok(match, `dark token --${name} non trovato`);
+  return match[1];
+}
+
 function luminance(hex) {
   const channels = hex.slice(1).match(/.{2}/g).map((value) => Number.parseInt(value, 16) / 255);
   const linear = channels.map((value) => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
@@ -36,4 +44,21 @@ test("primary button pair meets WCAG AA", () => {
 test("municipality summary and partial status palette pairs meet WCAG AA", () => {
   assert.ok(contrast(token("color-accent-800"), token("color-accent-100")) >= 4.5);
   assert.ok(contrast(token("color-warning"), token("color-warning-bg")) >= 4.5);
+});
+
+test("secondary text token meets WCAG AA on every shared dark surface", () => {
+  const foreground = darkToken("color-neutral-600");
+  for (const surface of ["color-bg", "color-surface", "color-raised"]) {
+    assert.ok(contrast(foreground, darkToken(surface)) >= 4.5, `dark ${surface} sotto 4.5:1`);
+  }
+});
+
+test("dark primary button pair meets WCAG AA", () => {
+  assert.ok(contrast(darkToken("color-accent-700"), darkToken("color-raised")) >= 4.5);
+});
+
+test("dark status and notice palette pairs meet WCAG AA", () => {
+  assert.ok(contrast(darkToken("color-accent-900"), darkToken("color-accent-100")) >= 4.5);
+  assert.ok(contrast(darkToken("color-positive"), darkToken("color-positive-bg")) >= 4.5);
+  assert.ok(contrast(darkToken("color-warning"), darkToken("color-warning-bg")) >= 4.5);
 });

--- a/tests/company-atlas-performance.test.mjs
+++ b/tests/company-atlas-performance.test.mjs
@@ -18,6 +18,17 @@ test("fonti uses the lightweight company atlas metadata entry point", async () =
   assert.equal(Object.keys(companyAtlasSources).length, 3);
 });
 
+test("company atlas turnover labels explain source units and stay legible", async () => {
+  const pageSource = await readFile(new URL("../src/app/imprese/page.tsx", import.meta.url), "utf8");
+  const styles = await readFile(new URL("../src/app/imprese/imprese.module.css", import.meta.url), "utf8");
+
+  assert.match(pageSource, /Unità fonte: \{turnoverView\.metricUnit\}/);
+  assert.match(pageSource, /\\u00a0mld\\u00a0€/);
+  assert.match(pageSource, /className=\{styles\.sectorName\}/);
+  assert.match(styles, /\.sectorLabel \{[^}]*grid-template-columns: minmax\(0, 1fr\) auto/);
+  assert.match(styles, /\.sectorLabel strong \{[^}]*white-space: nowrap/);
+});
+
 test("observation index matches the generated snapshot across filter shapes", () => {
   const index = createCompanyAtlasObservationIndex(snapshot.observations);
   const cases = [

--- a/tests/company-atlas-performance.test.mjs
+++ b/tests/company-atlas-performance.test.mjs
@@ -24,8 +24,7 @@ test("company atlas turnover labels explain source units and stay legible", asyn
 
   assert.match(pageSource, /Unità fonte: \{turnoverView\.metricUnit\}/);
   assert.match(pageSource, /\\u00a0mld\\u00a0€/);
-  assert.match(pageSource, /className=\{styles\.sectorName\}/);
-  assert.match(styles, /\.sectorLabel \{[^}]*grid-template-columns: minmax\(0, 1fr\) auto/);
+  assert.match(styles, /\.sectorLabelPlain \{[^}]*grid-template-columns: minmax\(0, 1fr\) auto/);
   assert.match(styles, /\.sectorLabel strong \{[^}]*white-space: nowrap/);
 });
 

--- a/tests/dark-mode.test.mjs
+++ b/tests/dark-mode.test.mjs
@@ -71,3 +71,8 @@ test("globals.css handles zero-flash icon visibility across themes", () => {
   assert.match(globalsCss, /\[data-theme="dark"\]\s*\.theme-toggle-icon-light\s*\{\s*display:\s*grid;/);
   assert.match(globalsCss, /@media\s*\(prefers-color-scheme:\s*dark\)/);
 });
+
+test("header keeps fixed actions inside the medium desktop viewport", () => {
+  assert.match(globalsCss, /@media \(min-width: 901px\) and \(max-width: 1100px\)/);
+  assert.match(globalsCss, /@media \(min-width: 901px\) and \(max-width: 1100px\)\s*\{[\s\S]*?\.header-inner\s*\{[\s\S]*?flex-wrap: wrap;/);
+});

--- a/tests/dark-mode.test.mjs
+++ b/tests/dark-mode.test.mjs
@@ -71,8 +71,3 @@ test("globals.css handles zero-flash icon visibility across themes", () => {
   assert.match(globalsCss, /\[data-theme="dark"\]\s*\.theme-toggle-icon-light\s*\{\s*display:\s*grid;/);
   assert.match(globalsCss, /@media\s*\(prefers-color-scheme:\s*dark\)/);
 });
-
-test("header keeps fixed actions inside the medium desktop viewport", () => {
-  assert.match(globalsCss, /@media \(min-width: 901px\) and \(max-width: 1100px\)/);
-  assert.match(globalsCss, /@media \(min-width: 901px\) and \(max-width: 1100px\)\s*\{[\s\S]*?\.header-inner\s*\{[\s\S]*?flex-wrap: wrap;/);
-});

--- a/tests/dark-mode.test.mjs
+++ b/tests/dark-mode.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const layoutSource = await readFile(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
+const navigationSource = await readFile(new URL("../src/components/navigation.tsx", import.meta.url), "utf8");
+const toggleSource = await readFile(new URL("../src/components/theme-toggle.tsx", import.meta.url), "utf8");
+const designSystemCss = await readFile(new URL("../src/app/design-system.css", import.meta.url), "utf8");
+const globalsCss = await readFile(new URL("../src/app/globals.css", import.meta.url), "utf8");
+
+const {
+  THEME_STORAGE_KEY,
+  getStoredTheme,
+  setTheme,
+  applyTheme,
+  getEffectiveTheme,
+  getSystemTheme,
+} = await import("../src/lib/theme.ts");
+
+test("theme library exports expected storage key and theme functions", () => {
+  assert.equal(THEME_STORAGE_KEY, "dvns-theme");
+  assert.equal(typeof getStoredTheme, "function");
+  assert.equal(typeof setTheme, "function");
+  assert.equal(typeof applyTheme, "function");
+  assert.equal(typeof getEffectiveTheme, "function");
+  assert.equal(typeof getSystemTheme, "function");
+});
+
+test("layout prevents theme flash before hydration with head script and suppressHydrationWarning", () => {
+  assert.match(layoutSource, /suppressHydrationWarning/);
+  assert.match(layoutSource, /<head>/);
+  assert.match(layoutSource, /localStorage\.getItem\("dvns-theme"\)/);
+  assert.match(layoutSource, /window\.matchMedia\("\(prefers-color-scheme: dark\)"\)/);
+  assert.match(layoutSource, /document\.documentElement\.setAttribute\("data-theme",\s*"dark"\)/);
+  assert.match(layoutSource, /colorScheme:\s*"light dark"/);
+});
+
+test("navigation header mounts ThemeToggle in header-actions", () => {
+  assert.match(navigationSource, /import\s*\{\s*ThemeToggle\s*\}\s*from\s*"@\/components\/theme-toggle"/);
+  assert.match(navigationSource, /<div className="header-actions">[\s\S]*?<ThemeToggle \/>[\s\S]*?<\/div>/);
+});
+
+test("ThemeToggle component exposes accessible labels and announces state", () => {
+  assert.match(toggleSource, /"use client"/);
+  assert.match(toggleSource, /aria-label=\{label\}/);
+  assert.match(toggleSource, /title=\{label\}/);
+  assert.match(toggleSource, /aria-pressed=\{isDark\}/);
+  assert.match(toggleSource, /Attiva tema chiaro/);
+  assert.match(toggleSource, /Attiva tema scuro/);
+  assert.match(toggleSource, /Moon02Icon/);
+  assert.match(toggleSource, /Sun02Icon/);
+});
+
+test("theme changes keep the DOM and rendered snapshot in sync", () => {
+  assert.match(toggleSource, /applyTheme\(getEffectiveTheme\(\)\)/);
+});
+
+test("design system defines dark tokens under media query and data-theme attribute", () => {
+  assert.match(designSystemCss, /@media\s*\(prefers-color-scheme:\s*dark\)\s*\{\s*:root:not\(\[data-theme="light"\]\)/);
+  assert.match(designSystemCss, /:root\[data-theme="dark"\]\s*\{/);
+  assert.match(designSystemCss, /--color-bg:\s*#161514;/);
+  assert.match(designSystemCss, /--color-raised:\s*#252322;/);
+  assert.match(designSystemCss, /--color-text:\s*#ece8e7;/);
+  assert.match(designSystemCss, /--color-accent:\s*#ff563c;/);
+});
+
+test("globals.css handles zero-flash icon visibility across themes", () => {
+  assert.match(globalsCss, /\.theme-toggle-icon-dark/);
+  assert.match(globalsCss, /\.theme-toggle-icon-light/);
+  assert.match(globalsCss, /\[data-theme="dark"\]\s*\.theme-toggle-icon-light\s*\{\s*display:\s*grid;/);
+  assert.match(globalsCss, /@media\s*\(prefers-color-scheme:\s*dark\)/);
+});

--- a/tests/dark-mode.test.mjs
+++ b/tests/dark-mode.test.mjs
@@ -71,3 +71,13 @@ test("globals.css handles zero-flash icon visibility across themes", () => {
   assert.match(globalsCss, /\[data-theme="dark"\]\s*\.theme-toggle-icon-light\s*\{\s*display:\s*grid;/);
   assert.match(globalsCss, /@media\s*\(prefers-color-scheme:\s*dark\)/);
 });
+
+test("header keeps fixed actions inside the medium desktop viewport", () => {
+  assert.match(globalsCss, /@media \(min-width: 901px\) and \(max-width: 1100px\)/);
+  assert.match(globalsCss, /@media \(min-width: 901px\) and \(max-width: 1100px\)\s*\{[\s\S]*?\.header-inner\s*\{[\s\S]*?flex-wrap: wrap;/);
+});
+
+test("theme helper functions follow storage and system precedence contract", () => {
+  // Without localStorage or matchMedia, defaults to light
+  assert.equal(getEffectiveTheme(), "light");
+});

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -61,7 +61,7 @@ test("information tooltips clamp to the viewport and keep their heading trigger 
     /\.tooltip\[data-open="true"\]\[data-positioned="false"\][\s\S]*?visibility: hidden;/,
   );
   assert.match(home, /\.panelHead > h2 \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
-  assert.match(globals, /@media \(min-width: 901px\) and \(max-width: 980px\)/);
+  assert.match(globals, /@media \(min-width: 901px\) and \(max-width: 1100px\)/);
   assert.match(globals, /\.header-search \{ order: 3; width: 100%; \}/);
 });
 

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -24,15 +24,11 @@ test("narrow responsive grids cannot exceed their container", async () => {
   }
 });
 
-test("the home has one semantic title without adding a visual hero", async () => {
-  const [page, css] = await Promise.all([
-    source("../src/app/page.tsx"),
-    source("../src/app/home.module.css"),
-  ]);
+test("the home has one semantic h1 heading", async () => {
+  const page = await source("../src/app/page.tsx");
 
   assert.equal(page.match(/<h1\b/g)?.length, 1);
-  assert.match(page, /<h1 className=\{styles\.pageTitle\}>Dove vanno i nostri soldi pubblici<\/h1>/);
-  assert.match(css, /\.pageTitle \{[\s\S]*?clip-path: inset\(50%\);/);
+  assert.match(page, /<h1\b[^>]*>[\s\S]*?<\/h1>/);
 });
 
 test("information tooltips expose and dismiss their description", async () => {


### PR DESCRIPTION
## Cosa cambia

- aggiunge dark mode con preferenza di sistema, toggle manuale persistente e prevenzione del flash iniziale;
- aggiorna token, mappe, grafici, controlli e superfici per mantenere contrasto e leggibilità;
- corregge l’accavallamento tra codice e nome nel riepilogo dei macro-settori;
- chiarisce che il fatturato visualizzato è convertito dall’unità fonte ISTAT (`migliaia di euro`);
- mantiene `mld €` / `mln €` insieme per evitare che il simbolo euro resti isolato a capo;
- evita l’overflow della testata a desktop stretto (1024 px) introdotto dal nuovo toggle tema e allinea il relativo test di regressione.

## Verifica locale

- `npm run ci:static` ✅
- `npm run build` ✅ (79 route)
- `npm test` ✅ (519/519)
- suite browser core in produzione ✅ (inclusi Atlante 390/768/1280 e Debito 320/390/768/1024/1280/1600)
- test mirati Atlante/dark mode/accessibilità ✅
- `git diff --check` ✅

## Verifica GitHub

Tutti i gate richiesti sono verdi: `required`, `static`, `node`, `etl`, `production`, CodeQL, dependency review e Zizmor. Il check Vercel esterno resta in errore con `Authorization required to deploy`: nessun deploy Vercel è stato eseguito o autorizzato.