### PR TITLE
Simulatore Legge di Bilancio per missione

### DIFF
--- a/docs/SIMULATORE_LEGGE_BILANCIO.md
+++ b/docs/SIMULATORE_LEGGE_BILANCIO.md
@@ -1,0 +1,73 @@
+# Simulatore Legge di Bilancio
+
+La pagina [/stato/simulatore](/stato/simulatore) mostra la variazione anno su anno dello
+stanziamento **pubblicato** per missione nelle ultime Leggi di Bilancio confrontabili, e lascia
+all'utente costruire uno scenario ipotetico a partire da quel dato reale. Lo scenario è sempre
+disegnato in modo visivamente distinto dal dato osservato (trama a righe, non colore pieno) e mai
+presentato come proiezione ufficiale, in linea con il vincolo permanente di prodotto "nessun valore
+economico simulato presentato come reale".
+
+## Fonti
+
+- **Stanziamento**: RGS/OpenBDAP, dataset `LBF_SPE_CRU_AMPMA_001` — "Legge di Bilancio Pubblicata ·
+  Serie storica · Spese per Amministrazione, Missione, Programma e Macroaggregato". Licenza
+  Creative Commons Attribution (CC-BY), dichiarata dal catalogo CKAN OpenBDAP. A differenza dei
+  prodotti "Rendiconto" (`src/lib/bdap-payments.ts`), che pubblicano un pacchetto CKAN per anno,
+  questo prodotto pubblica un **unico pacchetto** con l'intera serie storica in una sola risorsa
+  CSV; l'adapter (`src/lib/bdap-legge-bilancio.ts`) lo scopre via `package_search` e ne verifica
+  titolo e codice prodotto prima di leggerlo.
+- Il valore mostrato è il campo ufficiale **"Legge di Bilancio CP A1"**: lo stanziamento di
+  competenza (accrual) del primo anno, così come lo pubblica la Legge di Bilancio di quell'anno
+  stesso. Non è un valore di cassa (CS) né uno dei due anni successivi che la stessa legge
+  prevede in via previsionale (A2, A3).
+
+## Metodo
+
+Per ogni anno e missione, l'adapter somma il campo "Legge di Bilancio CP A1" su tutte le
+amministrazioni e i macroaggregati che riportano sotto quella missione. Il delta anno su anno è
+puramente aritmetico:
+
+```text
+differenza = stanziamento(anno) - stanziamento(anno precedente)
+variazione% = differenza / stanziamento(anno precedente) * 100
+```
+
+La finestra servita di default è le **ultime 6** Leggi di Bilancio comparabili (parametro
+`years`/`anni`, tra 2 e 20). "Comparabili" ha un vincolo verificato dal vivo sul CSV: la
+tassonomia delle missioni RGS è stata riscritta nel 2017 (es. "Diritti sociali politiche sociali e
+famiglia" → "Diritti sociali, politiche sociali e famiglia"); confrontare un'etichetta pre-2017 con
+la sua versione rinominata tratterebbe silenziosamente due stringhe distinte come una serie
+continua. L'adapter quindi non serve mai anni precedenti al 2017 (`MIN_STABLE_MISSION_YEAR`), e
+mostra solo le missioni presenti con lo stesso nome in **tutti** gli anni della finestra richiesta,
+per evitare di disegnare uno zero falso dove OpenBDAP semplicemente non ha pubblicato quella riga.
+
+## Cosa questo simulatore non dimostra
+
+- **Non individua le misure della manovra**: un fondo, un bonus o un'aliquota nominati nel testo
+  di legge richiedono una lettura riga per riga da fonti come UPB o Corte dei Conti, un lavoro
+  editoriale distinto e fuori scope qui. Questo simulatore mostra solo la variazione dello
+  stanziamento a livello di missione.
+- **Non è un pagamento osservato**: "Legge di Bilancio CP A1" è lo stanziamento enacted
+  (autorizzazione di competenza), non la spesa effettivamente pagata durante l'anno. Per la spesa
+  pagata vedi [/stato](/stato) (consuntivo/mensile) e [/stato/legislature](/stato/legislature)
+  (consuntivo annuale per legislatura).
+- **La missione "Debito pubblico" è dominata dal rimborso lordo del debito**: il macroaggregato
+  "RIMBORSO DEL DEBITO PUBBLICO" ricompare in più missioni ma pesa in particolare su questa,
+  rendendo le sue variazioni anno su anno guidate soprattutto dal calendario di rifinanziamento,
+  non da scelte di policy dell'anno.
+- **Copre solo missioni con nome stabile dal 2017**: gli anni 2003-2016 esistono nel dataset RGS
+  ma restano fuori dalla serie servita per il motivo di rinomina spiegato sopra.
+- **Lo scenario ipotetico non è una previsione**: è un'operazione aritmetica (percentuale scelta
+  dall'utente applicata all'ultimo stanziamento reale), mai un annuncio, una previsione di governo
+  o un dato OpenBDAP.
+
+## Superfici
+
+- `GET /api/spese/stato/legge-bilancio`, parametro opzionale `anni` (intero, 2-20; default 6).
+- MCP: `query_dataset` con `dataset=openbdap_legge_bilancio_storico`, filtro opzionale `years`.
+- UI: [/stato/simulatore](/stato/simulatore), collegata da [/stato](/stato).
+
+## Riferimenti
+
+- [OpenBDAP RGS](https://bdap-opendata.rgs.mef.gov.it)
+- [Catalogo del dataset](https://bdap-opendata.rgs.mef.gov.it/content/legge-di-bilancio-pubblicata-serie-storica-spese-amministrazione-missione-programma-1)

--- a/src/app/api/spese/stato/legge-bilancio/route.ts
+++ b/src/app/api/spese/stato/legge-bilancio/route.ts
@@ -1,0 +1,64 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { BudgetLawInvalidWindowError, getBudgetLawMissionSeries } from "@/lib/bdap-legge-bilancio";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_PARAMS = new Set(["anni"]);
+
+class InvalidQueryError extends Error {}
+
+function windowYearsParam(request: NextRequest): number | undefined {
+  for (const key of request.nextUrl.searchParams.keys()) {
+    if (!ALLOWED_PARAMS.has(key)) throw new InvalidQueryError(`Parametro non supportato: ${key}.`);
+  }
+  const values = request.nextUrl.searchParams.getAll("anni");
+  if (values.length === 0) return undefined;
+  if (values.length > 1) throw new InvalidQueryError("Il parametro anni non può essere ripetuto.");
+  if (!/^\d+$/.test(values[0])) throw new InvalidQueryError("Il parametro anni deve essere un intero.");
+  return Number(values[0]);
+}
+
+export async function GET(request: NextRequest) {
+  let windowYears: number | undefined;
+  try {
+    windowYears = windowYearsParam(request);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Richiesta non valida." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const series = await getBudgetLawMissionSeries({ windowYears });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        source: {
+          owner: "Ragioneria Generale dello Stato",
+          platform: "OpenBDAP",
+          semantics: "stanziamento-competenza-legge-bilancio",
+        },
+        ...series,
+      },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=21600",
+        },
+      },
+    );
+  } catch (error) {
+    const status = error instanceof BudgetLawInvalidWindowError ? 400 : 503;
+    return NextResponse.json(
+      {
+        ok: false,
+        source: "RGS / OpenBDAP",
+        observedAt: new Date().toISOString(),
+        error: error instanceof Error ? error.message : "Errore sconosciuto",
+      },
+      { status },
+    );
+  }
+}

--- a/src/app/stato/page.tsx
+++ b/src/app/stato/page.tsx
@@ -434,6 +434,16 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
           <Link href="/stato/legislature">Apri il confronto →</Link>
         </p>
       </div>
+
+      <div className="notice">
+        <strong>Simulatore Legge di Bilancio</strong>
+        <p>
+          Variazione anno su anno dello stanziamento pubblicato per missione nelle ultime Leggi
+          di Bilancio, con uno scenario ipotetico che puoi costruire tu, sempre distinto dal dato
+          reale.{" "}
+          <Link href="/stato/simulatore">Apri il simulatore →</Link>
+        </p>
+      </div>
     </>
   );
 }

--- a/src/app/stato/simulatore/SimulatoreClient.tsx
+++ b/src/app/stato/simulatore/SimulatoreClient.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { MissionEnactedAllocation } from "@/lib/bdap-legge-bilancio";
+import { ChartDataTable } from "@/components/charts/chart-data-table";
+import styles from "./simulatore.module.css";
+
+const exactEuro = new Intl.NumberFormat("it-IT", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+  useGrouping: "always",
+});
+
+function compactEuro(value: number): string {
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000_000) {
+    return `${(value / 1_000_000_000).toLocaleString("it-IT", { maximumFractionDigits: 1 })} mld €`;
+  }
+  if (absolute >= 1_000_000) {
+    return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 1 })} mln €`;
+  }
+  return exactEuro.format(value);
+}
+
+function signedPercent(value: number): string {
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toLocaleString("it-IT", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`;
+}
+
+const SLIDER_MIN = -50;
+const SLIDER_MAX = 50;
+const SLIDER_STEP = 1;
+
+type ChartPoint = {
+  year: number;
+  observedAmountEur: number;
+  hypotheticalAmountEur: number | null;
+};
+
+function ScenarioTooltip({
+  active,
+  payload,
+  isLatestYear,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartPoint }>;
+  isLatestYear: (year: number) => boolean;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+
+  return (
+    <div className={styles.tooltip}>
+      <strong>{point.year}</strong>
+      <span>
+        Stanziamento pubblicato <b>{exactEuro.format(point.observedAmountEur)}</b>
+      </span>
+      {isLatestYear(point.year) && point.hypotheticalAmountEur !== null ? (
+        <span className={styles.tooltipHypothetical}>
+          Scenario ipotetico (non reale) <b>{exactEuro.format(point.hypotheticalAmountEur)}</b>
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function SimulatoreClient({
+  years,
+  missions,
+  allocations,
+}: {
+  years: number[];
+  missions: string[];
+  allocations: MissionEnactedAllocation[];
+}) {
+  const patternId = useId();
+  const [selectedMission, setSelectedMission] = useState(missions[0] ?? "");
+  const [sliderPct, setSliderPct] = useState(0);
+
+  const series = useMemo(
+    () =>
+      allocations
+        .filter((allocation) => allocation.mission === selectedMission)
+        .sort((left, right) => left.year - right.year),
+    [allocations, selectedMission],
+  );
+
+  const latest = series.at(-1) ?? null;
+  const previous = series.length > 1 ? series.at(-2)! : null;
+  const hypotheticalAmountEur = latest ? latest.amountEur * (1 + sliderPct / 100) : null;
+
+  const chartData: ChartPoint[] = series.map((point) => ({
+    year: point.year,
+    observedAmountEur: point.amountEur,
+    hypotheticalAmountEur: point.year === latest?.year ? hypotheticalAmountEur : null,
+  }));
+
+  const realDeltaPct = previous && previous.amountEur !== 0
+    ? ((latest!.amountEur - previous.amountEur) / previous.amountEur) * 100
+    : null;
+  const scenarioVsRealPct = latest && latest.amountEur !== 0 && hypotheticalAmountEur !== null
+    ? ((hypotheticalAmountEur - latest.amountEur) / latest.amountEur) * 100
+    : null;
+
+  if (missions.length === 0 || !latest) {
+    return (
+      <div className={styles.errorState} role="alert">
+        <strong>Nessuna missione disponibile in questa finestra di anni.</strong>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.simulator}>
+      <div className={styles.controls}>
+        <label className={styles.controlField}>
+          <span>Missione</span>
+          <select
+            className="input"
+            value={selectedMission}
+            onChange={(event) => setSelectedMission(event.target.value)}
+          >
+            {missions.map((mission) => (
+              <option key={mission} value={mission}>
+                {mission}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.controlField}>
+          <span>
+            Scenario ipotetico sull&apos;ultimo stanziamento ({latest.year}):{" "}
+            <b className={styles.sliderValue}>{signedPercent(sliderPct)}</b>
+          </span>
+          <input
+            className={styles.slider}
+            type="range"
+            min={SLIDER_MIN}
+            max={SLIDER_MAX}
+            step={SLIDER_STEP}
+            value={sliderPct}
+            onChange={(event) => setSliderPct(Number(event.target.value))}
+            aria-label={`Variazione ipotetica percentuale sullo stanziamento ${latest.year} di ${selectedMission}`}
+            aria-valuetext={signedPercent(sliderPct)}
+          />
+        </label>
+
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={() => setSliderPct(0)}
+          disabled={sliderPct === 0}
+        >
+          Azzera scenario
+        </button>
+      </div>
+
+      <figure className={styles.figure}>
+        <div className={styles.figureHeader}>
+          <div>
+            <span>STANZIAMENTO PUBBLICATO · LEGGE DI BILANCIO</span>
+            <h2>{selectedMission}</h2>
+          </div>
+          <b>{years[0]}-{years.at(-1)}</b>
+        </div>
+
+        <div
+          className={styles.chart}
+          role="img"
+          aria-label={`Stanziamento pubblicato per la missione ${selectedMission} dal ${years[0]} al ${years.at(-1)}, con lo scenario ipotetico impostato a ${signedPercent(sliderPct)} sull'ultimo anno`}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={{ top: 12, right: 16, bottom: 0, left: 4 }} accessibilityLayer>
+              <defs>
+                <pattern
+                  id={patternId}
+                  patternUnits="userSpaceOnUse"
+                  width="6"
+                  height="6"
+                  patternTransform="rotate(45)"
+                >
+                  <rect width="6" height="6" fill="var(--color-accent-100)" />
+                  <line x1="0" y1="0" x2="0" y2="6" stroke="var(--color-accent-600)" strokeWidth="2" />
+                </pattern>
+              </defs>
+              <CartesianGrid vertical={false} stroke="var(--color-neutral-300)" />
+              <XAxis
+                dataKey="year"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+              />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                width={72}
+                tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+                tickFormatter={compactEuro}
+              />
+              <Tooltip
+                animationDuration={120}
+                cursor={{ fill: "var(--color-neutral-100)" }}
+                content={<ScenarioTooltip isLatestYear={(year) => year === latest.year} />}
+              />
+              <Bar
+                dataKey="observedAmountEur"
+                name="Stanziamento pubblicato"
+                fill="var(--chart-primary)"
+                radius={0}
+                isAnimationActive={false}
+              />
+              <Bar
+                dataKey="hypotheticalAmountEur"
+                name="Scenario ipotetico (non reale)"
+                fill={`url(#${patternId})`}
+                stroke="var(--color-accent-600)"
+                strokeWidth={1.5}
+                strokeDasharray="4 2"
+                radius={0}
+                isAnimationActive={false}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className={styles.legend} aria-hidden="true">
+          <span><i className={styles.legendObserved} /> Stanziamento pubblicato (dato osservato)</span>
+          <span><i className={styles.legendHypothetical} /> Scenario ipotetico (non reale, costruito da te)</span>
+        </div>
+
+        <figcaption>
+          Ogni barra piena è lo stanziamento di competenza pubblicato dalla Legge di Bilancio per il
+          primo anno (campo RGS &laquo;Legge di Bilancio CP A1&raquo;), sommato su tutte le
+          amministrazioni. La barra a righe sull&apos;ultimo anno è la tua ipotesi, non un dato
+          osservato.
+        </figcaption>
+
+        <ChartDataTable
+          label={`Stanziamento pubblicato e scenario ipotetico per ${selectedMission}`}
+          columns={["Stanziamento pubblicato", "Scenario ipotetico (non reale)"]}
+          rows={chartData.map((point) => ({
+            label: String(point.year),
+            values: [
+              exactEuro.format(point.observedAmountEur),
+              point.hypotheticalAmountEur === null ? "non disponibile" : exactEuro.format(point.hypotheticalAmountEur),
+            ],
+          }))}
+        />
+      </figure>
+
+      <div className={styles.readout}>
+        <div className={styles.readoutItem}>
+          <span>Variazione reale, ultimo anno vs precedente</span>
+          <strong>{realDeltaPct === null ? "non calcolabile" : signedPercent(realDeltaPct)}</strong>
+          <small>
+            {previous
+              ? `${exactEuro.format(previous.amountEur)} (${previous.year}) → ${exactEuro.format(latest.amountEur)} (${latest.year})`
+              : "Serve almeno un anno precedente nella finestra mostrata."}
+          </small>
+        </div>
+        <div className={`${styles.readoutItem} ${styles.readoutHypothetical}`}>
+          <span>Scenario ipotetico vs stanziamento reale {latest.year}</span>
+          <strong>{scenarioVsRealPct === null ? "non calcolabile" : signedPercent(scenarioVsRealPct)}</strong>
+          <small>
+            {hypotheticalAmountEur === null
+              ? "non disponibile"
+              : `${exactEuro.format(latest.amountEur)} → ${exactEuro.format(hypotheticalAmountEur)}, un'ipotesi tua`}
+          </small>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stato/simulatore/page.tsx
+++ b/src/app/stato/simulatore/page.tsx
@@ -1,0 +1,137 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { longDate } from "@/lib/format";
+import {
+  DEFAULT_BUDGET_LAW_WINDOW_YEARS,
+  getBudgetLawMissionSeries,
+  type BudgetLawMissionSeries,
+} from "@/lib/bdap-legge-bilancio";
+import { SimulatoreClient } from "./SimulatoreClient";
+import styles from "./simulatore.module.css";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Simulatore Legge di Bilancio",
+  description:
+    "Variazione anno su anno dello stanziamento pubblicato per missione nelle ultime Leggi di Bilancio, con uno scenario ipotetico costruito dall'utente.",
+};
+
+export default async function SimulatoreLeggeBilancioPage() {
+  let series: BudgetLawMissionSeries | null = null;
+  let errorMessage: string | null = null;
+
+  try {
+    series = await getBudgetLawMissionSeries({
+      windowYears: DEFAULT_BUDGET_LAW_WINDOW_YEARS,
+      signal: AbortSignal.timeout(8_000),
+    });
+  } catch (error) {
+    errorMessage = error instanceof Error ? error.message : "Errore sconosciuto";
+  }
+
+  return (
+    <main className="shell page">
+      <nav className={styles.breadcrumb} aria-label="Percorso">
+        <Link href="/">Home</Link>
+        <span>→</span>
+        <Link href="/stato">Spese dello Stato</Link>
+        <span>→</span>
+        <span>Simulatore Legge di Bilancio</span>
+      </nav>
+
+      <header className="page-intro">
+        <h1>Simulatore Legge di Bilancio</h1>
+        <p>
+          Lo stanziamento di competenza pubblicato dalla Legge di Bilancio per ciascuna missione,
+          anno su anno, così come lo pubblica RGS/OpenBDAP. Puoi costruire uno scenario ipotetico
+          a partire da quel dato reale.
+        </p>
+      </header>
+
+      <div className="notice warning-notice">
+        <strong>Nessun valore simulato è un dato reale</strong>
+        <p>
+          Lo scenario che costruisci con lo slider qui sotto è un&apos;ipotesi tua, non una
+          proiezione ufficiale né un annuncio di governo: nel grafico e nella tabella è sempre
+          disegnato con una trama a righe e marcato &laquo;ipotesi&raquo;, mai come lo stanziamento
+          osservato. Il dato osservato è solo lo stanziamento <em>enacted</em> pubblicato dalla
+          Legge di Bilancio (competenza, primo anno): non è né una misura della manovra (un fondo,
+          un bonus, un&apos;aliquota nominati nel testo di legge) né un pagamento realmente
+          effettuato.
+        </p>
+      </div>
+
+      {series ? (
+        <SimulatoreClient
+          years={series.years}
+          missions={series.missions}
+          allocations={series.allocations}
+        />
+      ) : (
+        <div className={styles.errorState} role="alert">
+          <strong>Dati OpenBDAP non raggiungibili in questo momento.</strong>
+          <p>Non mostriamo una serie dimostrativa al posto del dato mancante. Dettaglio: {errorMessage ?? "non disponibile"}.</p>
+        </div>
+      )}
+
+      {series ? (
+        <div className={styles.provenance}>
+          <h2>Fonte e provenienza</h2>
+          <dl>
+            <div>
+              <dt>Fonte</dt>
+              <dd>Ragioneria Generale dello Stato (RGS) · OpenBDAP</dd>
+            </div>
+            <div>
+              <dt>Dataset</dt>
+              <dd>{series.dataset.title}</dd>
+            </div>
+            <div>
+              <dt>Licenza</dt>
+              <dd>{series.dataset.license ?? "non dichiarata dal catalogo"}</dd>
+            </div>
+            <div>
+              <dt>Catalogo aggiornato il</dt>
+              <dd>{longDate(series.dataset.metadataModified)}</dd>
+            </div>
+            <div>
+              <dt>Acquisito il</dt>
+              <dd>{longDate(series.observedAt)}</dd>
+            </div>
+            <div>
+              <dt>Copertura mostrata</dt>
+              <dd>
+                {series.years[0]}-{series.years.at(-1)} (la tassonomia delle missioni è stabile solo
+                dal {series.minStableMissionYear}: gli anni precedenti non sono confrontabili e restano fuori)
+              </dd>
+            </div>
+          </dl>
+          <p className={styles.provenanceLinks}>
+            <a href={series.dataset.csvUrl} target="_blank" rel="noreferrer">
+              Scarica il CSV RGS ↗
+            </a>
+            {" · "}
+            <a href={series.dataset.apiUrl} target="_blank" rel="noreferrer">
+              Apri il pacchetto sul catalogo OpenBDAP ↗
+            </a>
+          </p>
+        </div>
+      ) : null}
+
+      <div className="notice">
+        <strong>Cosa questo simulatore non dimostra</strong>
+        <p>
+          Non individua una misura specifica della manovra (un fondo, un bonus, un&apos;aliquota
+          nominati nel testo di legge): quella lettura riga per riga richiede fonti come UPB o
+          Corte dei Conti e non è quello che facciamo qui. Il valore osservato è lo stanziamento
+          enacted, non un pagamento: per la spesa effettivamente pagata vedi{" "}
+          <Link href="/stato">Spese dello Stato</Link> e{" "}
+          <Link href="/stato/legislature">Spesa per legislatura</Link>. La missione &laquo;Debito
+          pubblico&raquo; include il rimborso lordo del debito, che ne domina l&apos;importo
+          indipendentemente dalle scelte di policy dell&apos;anno.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/stato/simulatore/simulatore.module.css
+++ b/src/app/stato/simulatore/simulatore.module.css
@@ -1,0 +1,295 @@
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: var(--space-6);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.breadcrumb a:hover {
+  color: var(--color-accent-700);
+}
+
+.errorState {
+  margin-top: var(--space-6);
+  padding: 30px 0;
+  border-top: 1px solid var(--color-critical-bg);
+  border-bottom: 1px solid var(--color-critical-bg);
+}
+
+.errorState strong {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-size: 17px;
+}
+
+.errorState p {
+  max-width: 760px;
+  margin: 0;
+  color: var(--color-text);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.provenance {
+  margin-top: var(--space-8);
+  padding: var(--space-5);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.provenance h2 {
+  margin: 0 0 var(--space-4);
+  font-size: 15px;
+}
+
+.provenance dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+  margin: 0;
+}
+
+.provenance dt {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.provenance dd {
+  margin: 4px 0 0;
+  color: var(--color-text);
+  font-size: 13px;
+}
+
+.provenanceLinks {
+  margin: var(--space-4) 0 0;
+  font-size: 13px;
+}
+
+.simulator {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  margin-top: var(--space-6);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.controlField {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 240px;
+  flex: 1 1 240px;
+}
+
+.controlField > span {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.sliderValue {
+  color: var(--color-accent-700);
+  font-variant-numeric: tabular-nums;
+}
+
+.slider {
+  width: 100%;
+  min-height: 44px;
+  accent-color: var(--color-accent);
+}
+
+.figure {
+  min-width: 0;
+  margin: 0;
+  padding: 22px;
+  border: 1px solid var(--color-neutral-200);
+  background: var(--color-neutral-100);
+}
+
+.figureHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
+}
+
+.figureHeader span,
+.figureHeader b {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 730;
+  letter-spacing: .07em;
+}
+
+.figureHeader span {
+  text-transform: uppercase;
+}
+
+.figureHeader h2 {
+  margin: 5px 0 0;
+  color: var(--color-text);
+  font-size: 17px;
+  font-weight: 610;
+  letter-spacing: -.018em;
+}
+
+.figureHeader b {
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+
+.chart {
+  width: 100%;
+  height: 380px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+  font-size: 12px;
+  color: var(--color-neutral-700);
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend i {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-sm);
+}
+
+.legendObserved {
+  background: var(--chart-primary);
+}
+
+.legendHypothetical {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--color-accent-100),
+    var(--color-accent-100) 2px,
+    var(--color-accent-600) 2px,
+    var(--color-accent-600) 4px
+  );
+  border: 1px dashed var(--color-accent-600);
+}
+
+.figure figcaption {
+  max-width: 720px;
+  margin-top: var(--space-3);
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.58;
+}
+
+.tooltip {
+  max-width: 300px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-neutral-100);
+  background: var(--color-text);
+  box-shadow: var(--shadow-md);
+}
+
+.tooltip span,
+.tooltip strong,
+.tooltip b {
+  display: block;
+}
+
+.tooltip span {
+  margin-top: 4px;
+  color: var(--color-neutral-400);
+  font-size: 11px;
+  font-weight: 690;
+}
+
+.tooltip b {
+  margin-top: 2px;
+  color: var(--color-raised);
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.tooltipHypothetical b {
+  color: var(--color-accent-300);
+}
+
+.readout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-4);
+}
+
+.readoutItem {
+  padding: var(--space-4);
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.readoutItem span {
+  display: block;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.readoutItem strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 22px;
+  font-variant-numeric: tabular-nums;
+}
+
+.readoutItem small {
+  display: block;
+  margin-top: 6px;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+}
+
+.readoutHypothetical {
+  border-color: var(--color-accent-300);
+  background: var(--color-accent-100);
+}
+
+.readoutHypothetical strong {
+  color: var(--color-accent-700);
+}
+
+@media (max-width: 700px) {
+  .figure {
+    padding: 18px 10px;
+  }
+
+  .chart {
+    height: 320px;
+  }
+
+  .controls {
+    padding: var(--space-4);
+  }
+}

--- a/src/lib/bdap-legge-bilancio.ts
+++ b/src/lib/bdap-legge-bilancio.ts
@@ -1,0 +1,383 @@
+import {
+  decodePublicDataText,
+  parseDelimitedRecords,
+  type DelimitedRecord,
+} from "@/lib/data/delimited";
+import { fetchOfficialSource } from "@/lib/data/source-fetch";
+import { parseOpenBdapAmount } from "@/lib/data/bdap-payment-contract";
+
+const BDAP_BASE = "https://bdap-opendata.rgs.mef.gov.it";
+const BDAP_ACTION = `${BDAP_BASE}/SpodCkanApi/api/3/action`;
+const BDAP_DUMP = `${BDAP_BASE}/SpodCkanApi/api/3/datastore/dump`;
+
+/** RGS product code for "Legge di Bilancio Pubblicata - Serie storica - Spese per
+ * Amministrazione Missione Programma Macroaggregato". Verified live against
+ * package_search: this product publishes one CKAN package with the full
+ * historical series in a single resource, unlike the Rendiconto payment
+ * products (bdap-payments.ts) which publish one package per year. */
+const PRODUCT_CODE = "LBF_SPE_CRU_AMPMA_001";
+const EXPECTED_TITLE =
+  "Legge di Bilancio Pubblicata - Serie storica - Spese per Amministrazione Missione Programma Macroaggregato";
+
+/**
+ * The RGS mission taxonomy was reworded in 2017 (e.g. "Diritti sociali
+ * politiche sociali e famiglia" became "Diritti sociali, politiche sociali e
+ * famiglia"): verified live, every one of the 34 missions has exactly one
+ * stable label for every year from 2017 onward, but several have a second,
+ * differently-punctuated label for 2008-2016. Comparing across the rename
+ * would silently treat two distinct strings as a continuous series, so the
+ * adapter only ever serves years from this floor.
+ */
+export const MIN_STABLE_MISSION_YEAR = 2017;
+
+export const DEFAULT_BUDGET_LAW_WINDOW_YEARS = 6;
+const MIN_BUDGET_LAW_WINDOW_YEARS = 2;
+const MAX_BUDGET_LAW_WINDOW_YEARS = 20;
+
+/** Column holding the enacted competenza (accrual) appropriation for the
+ * budget year itself, as published by that year's Legge di Bilancio — the
+ * first of the three rolling years the law also forecasts (A2, A3). This is
+ * what "stanziamento pubblicato" means throughout this module. */
+const ENACTED_AMOUNT_FIELD = "Legge di Bilancio CP A1";
+
+export type CkanPackage = {
+  id?: unknown;
+  name?: unknown;
+  title?: unknown;
+  notes?: unknown;
+  metadata_modified?: unknown;
+  license_title?: unknown;
+};
+
+type PackageSearchResponse = {
+  success?: boolean;
+  result?: {
+    results?: CkanPackage[];
+  };
+};
+
+export type BudgetLawMissionDataset = {
+  packageId: string;
+  name: string;
+  title: string;
+  notes: string;
+  metadataModified: string | null;
+  license: string | null;
+  csvUrl: string;
+  apiUrl: string;
+};
+
+export type MissionEnactedAllocation = {
+  year: number;
+  mission: string;
+  /** Sum of "Legge di Bilancio CP A1" across every amministrazione and
+   * macroaggregato reporting under this mission in this year. Euro, not cents. */
+  amountEur: number;
+};
+
+export type MissionYearOverYearDelta = {
+  mission: string;
+  fromYear: number;
+  toYear: number;
+  fromAmountEur: number;
+  toAmountEur: number;
+  deltaEur: number;
+  /** null when fromAmountEur is 0: a percentage change from zero is undefined. */
+  deltaPct: number | null;
+};
+
+export type BudgetLawMissionSeries = {
+  dataset: BudgetLawMissionDataset;
+  minStableMissionYear: number;
+  /** Years actually served, ascending; a subset of the requested window when
+   * OpenBDAP has not yet published that many stable years. */
+  years: number[];
+  /** Mission labels present in every one of `years` — a mission published for
+   * some but not all served years is left out rather than shown with a false zero. */
+  missions: string[];
+  /** One entry per (year, mission) pair, covering `years` × `missions`. */
+  allocations: MissionEnactedAllocation[];
+  /** Consecutive-year deltas for each mission in `missions`. */
+  yearOverYearDeltas: MissionYearOverYearDelta[];
+  observedAt: string;
+};
+
+export class BudgetLawDatasetUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BudgetLawDatasetUnavailableError";
+  }
+}
+
+export class BudgetLawWindowUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BudgetLawWindowUnavailableError";
+  }
+}
+
+export class BudgetLawInvalidWindowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BudgetLawInvalidWindowError";
+  }
+}
+
+function text(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const cleaned = value.trim();
+  return cleaned ? cleaned : null;
+}
+
+function uuid(value: unknown): string | null {
+  const candidate = text(value);
+  if (
+    !candidate ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(candidate)
+  ) {
+    return null;
+  }
+  return candidate;
+}
+
+function required(record: DelimitedRecord, key: string): string {
+  const value = record[key]?.trim();
+  if (!value) throw new Error(`OpenBDAP: campo obbligatorio mancante: ${key}`);
+  return value;
+}
+
+/**
+ * Validates one CKAN package against the exact product-code + title contract
+ * for this dataset. Exported so the guard can be unit tested against
+ * synthetic packages without depending on the live catalog.
+ */
+export function normalizeBudgetLawPackage(pkg: CkanPackage): BudgetLawMissionDataset | null {
+  const packageId = uuid(pkg.id);
+  const name = text(pkg.name);
+  const title = text(pkg.title);
+  const notes = text(pkg.notes);
+  if (!packageId || !name || !title || !notes) return null;
+  if (title !== EXPECTED_TITLE) return null;
+
+  const escapedCode = PRODUCT_CODE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if ((notes.match(new RegExp(`\\[${escapedCode}\\]`, "g"))?.length ?? 0) !== 1) {
+    return null;
+  }
+
+  return {
+    packageId,
+    name,
+    title,
+    notes,
+    metadataModified: text(pkg.metadata_modified),
+    license: text(pkg.license_title),
+    csvUrl: `${BDAP_DUMP}/${packageId}.csv`,
+    apiUrl: `${BDAP_ACTION}/package_show?id=${encodeURIComponent(packageId)}`,
+  };
+}
+
+export async function discoverBudgetLawMissionDataset(
+  signal?: AbortSignal,
+): Promise<BudgetLawMissionDataset> {
+  const url = `${BDAP_ACTION}/package_search?${new URLSearchParams({
+    q: PRODUCT_CODE,
+    rows: "20",
+  }).toString()}`;
+  const response = await fetchOfficialSource("openbdap", url, {
+    kind: "discovery",
+    signal,
+    headers: { Accept: "application/json" },
+    tags: [`product:${PRODUCT_CODE}`],
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenBDAP package_search HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as PackageSearchResponse;
+  if (!payload.success || !Array.isArray(payload.result?.results)) {
+    throw new Error("Risposta package_search OpenBDAP non valida");
+  }
+
+  const matches = payload.result.results
+    .map((pkg) => normalizeBudgetLawPackage(pkg))
+    .filter((dataset): dataset is BudgetLawMissionDataset => dataset !== null);
+
+  if (matches.length === 0) {
+    throw new BudgetLawDatasetUnavailableError(
+      "OpenBDAP non pubblica più il dataset Legge di Bilancio per Amministrazione, Missione, Programma e Macroaggregato con questo codice prodotto.",
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      "OpenBDAP ha restituito più pacchetti per il prodotto Legge di Bilancio AMPMA: serve un identificativo univoco.",
+    );
+  }
+  return matches[0];
+}
+
+async function fetchDatasetRows(
+  dataset: BudgetLawMissionDataset,
+  signal?: AbortSignal,
+): Promise<DelimitedRecord[]> {
+  const response = await fetchOfficialSource("openbdap", dataset.csvUrl, {
+    kind: "data",
+    signal,
+    headers: { Accept: "text/csv" },
+    tags: [`dataset:${dataset.packageId}`, "product:legge-bilancio-ampma"],
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenBDAP CSV HTTP ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("csv")) {
+    throw new Error("OpenBDAP non ha restituito un CSV per il dataset Legge di Bilancio");
+  }
+
+  const rows = parseDelimitedRecords(decodePublicDataText(await response.arrayBuffer()));
+  if (rows.length === 0) throw new Error("Dataset OpenBDAP Legge di Bilancio vuoto");
+  return rows;
+}
+
+type RawAllocationRow = {
+  year: number;
+  mission: string;
+  amountEur: number;
+};
+
+/**
+ * Parses one CSV record, or returns null for rows outside this module's
+ * scope: pre-2008 rows never had a Missione classification at all (the
+ * mission-program budget structure was introduced in 2008), and those are
+ * not the same absence as a zero appropriation.
+ */
+function parseAllocationRow(record: DelimitedRecord): RawAllocationRow | null {
+  const yearRaw = record["Esercizio Finanziario"]?.trim();
+  const mission = record["Missione"]?.trim();
+  if (!yearRaw || !mission) return null;
+
+  const year = Number.parseInt(yearRaw, 10);
+  if (!Number.isInteger(year) || !/^\d{4}$/.test(yearRaw)) {
+    throw new Error(`OpenBDAP: anno non valido nel campo Esercizio Finanziario: ${yearRaw}`);
+  }
+  required(record, "Amministrazione");
+  const amountEur = parseOpenBdapAmount(record[ENACTED_AMOUNT_FIELD], ENACTED_AMOUNT_FIELD);
+
+  return { year, mission, amountEur };
+}
+
+/**
+ * Computes the descriptive year-over-year change for one mission between two
+ * of its enacted allocations. Pure and exported so the arithmetic (including
+ * the zero-base guard) can be unit tested without a live fetch.
+ */
+export function missionYearOverYearDelta(
+  from: MissionEnactedAllocation,
+  to: MissionEnactedAllocation,
+): MissionYearOverYearDelta {
+  if (from.mission !== to.mission) {
+    throw new Error("Il delta anno su anno richiede due stanziamenti della stessa missione");
+  }
+  const deltaEur = to.amountEur - from.amountEur;
+  return {
+    mission: from.mission,
+    fromYear: from.year,
+    toYear: to.year,
+    fromAmountEur: from.amountEur,
+    toAmountEur: to.amountEur,
+    deltaEur,
+    deltaPct: from.amountEur !== 0 ? (deltaEur / from.amountEur) * 100 : null,
+  };
+}
+
+/**
+ * Reads the full OpenBDAP AMPMA historical series once, aggregates the
+ * enacted competenza appropriation (CP A1) per year and mission across every
+ * amministrazione and macroaggregato, and returns the most recent stable
+ * window plus its consecutive year-over-year deltas per mission.
+ *
+ * "Enacted appropriation" is not "actual payment": this reads what each
+ * Legge di Bilancio set aside, not what OpenBDAP's Rendiconto consuntivo
+ * later recorded as paid (bdap-payments.ts / /stato/legislature).
+ */
+export async function getBudgetLawMissionSeries(
+  options: { windowYears?: number; signal?: AbortSignal } = {},
+): Promise<BudgetLawMissionSeries> {
+  const requestedWindow = options.windowYears ?? DEFAULT_BUDGET_LAW_WINDOW_YEARS;
+  if (
+    !Number.isInteger(requestedWindow) ||
+    requestedWindow < MIN_BUDGET_LAW_WINDOW_YEARS ||
+    requestedWindow > MAX_BUDGET_LAW_WINDOW_YEARS
+  ) {
+    throw new BudgetLawInvalidWindowError(
+      `Finestra di anni non valida per la Legge di Bilancio: deve essere tra ${MIN_BUDGET_LAW_WINDOW_YEARS} e ${MAX_BUDGET_LAW_WINDOW_YEARS}`,
+    );
+  }
+
+  const dataset = await discoverBudgetLawMissionDataset(options.signal);
+  const records = await fetchDatasetRows(dataset, options.signal);
+
+  const totalsByYearMission = new Map<string, number>();
+  const missionsByYear = new Map<number, Set<string>>();
+
+  for (const record of records) {
+    const row = parseAllocationRow(record);
+    if (!row || row.year < MIN_STABLE_MISSION_YEAR) continue;
+
+    const key = `${row.year}::${row.mission}`;
+    totalsByYearMission.set(key, (totalsByYearMission.get(key) ?? 0) + row.amountEur);
+
+    const missionsForYear = missionsByYear.get(row.year) ?? new Set<string>();
+    missionsForYear.add(row.mission);
+    missionsByYear.set(row.year, missionsForYear);
+  }
+
+  const availableYears = [...missionsByYear.keys()].sort((left, right) => left - right);
+  if (availableYears.length < MIN_BUDGET_LAW_WINDOW_YEARS) {
+    throw new BudgetLawWindowUnavailableError(
+      `OpenBDAP non pubblica ancora almeno ${MIN_BUDGET_LAW_WINDOW_YEARS} Leggi di Bilancio confrontabili dal ${MIN_STABLE_MISSION_YEAR} in poi.`,
+    );
+  }
+
+  const years = availableYears.slice(-Math.min(requestedWindow, availableYears.length));
+  const firstYearMissions = missionsByYear.get(years[0]) ?? new Set<string>();
+  const missions = [...firstYearMissions]
+    .filter((mission) => years.every((year) => missionsByYear.get(year)?.has(mission)))
+    .sort((left, right) => left.localeCompare(right, "it-IT"));
+
+  const amountFor = (year: number, mission: string): number =>
+    totalsByYearMission.get(`${year}::${mission}`) ?? 0;
+
+  const allocations: MissionEnactedAllocation[] = [];
+  for (const year of years) {
+    for (const mission of missions) {
+      allocations.push({ year, mission, amountEur: amountFor(year, mission) });
+    }
+  }
+
+  const yearOverYearDeltas: MissionYearOverYearDelta[] = [];
+  for (const mission of missions) {
+    for (let index = 1; index < years.length; index += 1) {
+      const fromYear = years[index - 1];
+      const toYear = years[index];
+      yearOverYearDeltas.push(
+        missionYearOverYearDelta(
+          { year: fromYear, mission, amountEur: amountFor(fromYear, mission) },
+          { year: toYear, mission, amountEur: amountFor(toYear, mission) },
+        ),
+      );
+    }
+  }
+
+  return {
+    dataset,
+    minStableMissionYear: MIN_STABLE_MISSION_YEAR,
+    years,
+    missions,
+    allocations,
+    yearOverYearDeltas,
+    observedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/mcp/catalog.ts
+++ b/src/lib/mcp/catalog.ts
@@ -12,6 +12,7 @@ export const DATASET_IDS = [
   "openbdap_ssn_conto_economico",
   "openbdap_ssn_storico_nazionale",
   "openbdap_spesa_legislature",
+  "openbdap_legge_bilancio_storico",
   "opencivitas_fabbisogni",
   "opencoesione_progetti",
   "pnrr_asili",
@@ -58,6 +59,7 @@ export type DatasetQuery = {
   period?: string;
   sector?: string;
   band?: string;
+  years?: number;
   limit?: number;
   offset?: number;
   cursor?: string;
@@ -96,6 +98,7 @@ const exampleQueries = {
   openbdap_ssn_conto_economico: { dataset: "openbdap_ssn_conto_economico", year: 2024, region: "Calabria", limit: 20 },
   openbdap_ssn_storico_nazionale: { dataset: "openbdap_ssn_storico_nazionale" },
   openbdap_spesa_legislature: { dataset: "openbdap_spesa_legislature" },
+  openbdap_legge_bilancio_storico: { dataset: "openbdap_legge_bilancio_storico", years: 6 },
   opencivitas_fabbisogni: { dataset: "opencivitas_fabbisogni", region: "CALABRIA", limit: 20 },
   opencoesione_progetti: { dataset: "opencoesione_progetti" },
   pnrr_asili: { dataset: "pnrr_asili", region: "Lazio", limit: 20 },
@@ -168,6 +171,7 @@ const datasetDescriptors: DatasetDescriptorInput[] = [
   { id: "openbdap_ssn_conto_economico", title: "Conto Economico degli enti del SSN", summary: "Consuntivo 2024 OpenBDAP con aggregato nazionale, aggregati regionali e dettaglio di 232 enti; costo del personale, acquisti di servizi e voci ufficiali di consulenze, collaborazioni, interinale e altre prestazioni di lavoro.", sourceIds: ["openbdap"], freshness: "snapshot", filters: ["year", "region", "code", "limit", "offset"], caveat: "Il nazionale e le Regioni provengono da dataset ufficiali distinti dal dettaglio enti; le 21 righe codeSsn=999 non sono esposte per evitare doppio conteggio. Le voci sono categorie contabili: non equivalgono a gettonisti, cooperative, organico o pagamenti di cassa e non consentono classifiche di efficienza o inferenze sulla qualità sanitaria." },
   { id: "openbdap_ssn_storico_nazionale", title: "Serie storica nazionale del Conto Economico SSN", summary: "Costi della produzione, personale, prestazioni di lavoro e acquisti di servizi a livello nazionale, dal 2012 al 2024.", sourceIds: ["openbdap"], freshness: "live", filters: [], caveat: "Solo livello nazionale: il dettaglio regionale e per ente resta disponibile soltanto per il 2024 in openbdap_ssn_conto_economico. Voci di competenza economica, non pagamenti di cassa; non identificano gettonisti, cooperative o organico e non permettono classifiche di efficienza tra anni o Regioni." },
   { id: "openbdap_spesa_legislature", title: "Spesa dello Stato per legislatura", summary: "Confronto descrittivo tra l'anno pre-elettorale e la media degli altri anni completi di ogni legislatura, sulla spesa OpenBDAP RGS per missione (2014-2025).", sourceIds: ["openbdap"], freshness: "live", filters: [], caveat: "Confronto puramente descrittivo, non un test di significatività statistica: due sole legislature complete osservate, la spesa statale cresce anche per motivi non elettorali (trend, inflazione) e il 2020-2021 include la spesa emergenziale COVID-19, dichiarata esplicitamente. Non implica causalità né intento elettorale, non copre spesa comunale, regionale o europea." },
+  { id: "openbdap_legge_bilancio_storico", title: "Legge di Bilancio per missione, serie storica", summary: "Stanziamento di competenza pubblicato dalla Legge di Bilancio per missione, ultime leggi di bilancio confrontabili (dal 2017), con variazione anno su anno.", sourceIds: ["openbdap"], freshness: "live", filters: ["years"], caveat: "È lo stanziamento enacted pubblicato dalla Legge di Bilancio (competenza, primo anno), non le misure della manovra né un pagamento osservato: non isola un fondo, un bonus o un'aliquota specifici, per cui serve la lettura editoriale di UPB o Corte dei Conti. Copre solo missioni con nome stabile dal 2017 (prima di allora la tassonomia è stata rinominata) e include il rimborso lordo del debito pubblico, che domina la missione Debito pubblico indipendentemente dalle scelte di policy dell'anno." },
   { id: "opencivitas_fabbisogni", title: "Fabbisogni e servizi comunali", summary: "Spesa storica, spesa standard e livelli dei servizi dei Comuni coperti da OpenCivitas.", sourceIds: ["opencivitas"], freshness: "snapshot", filters: ["year", "region", "code", "limit", "offset"], caveat: "La differenza dalla spesa standard non è una misura automatica di spreco." },
   { id: "opencoesione_progetti", title: "OpenCoesione", summary: "Aggregati nazionali su costo pubblico, pagamenti, temi, natura e stato dei progetti.", sourceIds: ["opencoesione"], freshness: "snapshot", filters: [], caveat: "Il rapporto pagamenti/costo non misura il completamento o la qualità dei progetti." },
   { id: "pnrr_asili", title: "PNRR asili e prima infanzia", summary: "Progetti Italia Domani per CUP, localizzazioni, finanziamenti, gare e aggiudicatari.", sourceIds: ["italiadomani"], freshness: "snapshot", filters: ["cup", "query", "region", "province", "limit", "offset"], caveat: "Il finanziamento PNRR non è un pagamento osservato; gare e aggiudicazioni sono livelli distinti." },

--- a/src/lib/mcp/datasets.ts
+++ b/src/lib/mcp/datasets.ts
@@ -169,6 +169,12 @@ export async function queryPublicDataset(
       const { getLegislatureSpendingCycles } = await import("@/lib/state-spending-legislature");
       return jsonSafe({ cycles: await getLegislatureSpendingCycles({ signal: options.signal }) });
     }
+    case "openbdap_legge_bilancio_storico": {
+      const { getBudgetLawMissionSeries } = await import("@/lib/bdap-legge-bilancio");
+      return jsonSafe(
+        await getBudgetLawMissionSeries({ windowYears: query.years, signal: options.signal }),
+      );
+    }
     case "opencivitas_fabbisogni": {
       const { openCivitasSnapshot } = await import("@/lib/opencivitas-snapshot");
       if (query.year && query.year !== openCivitasSnapshot.referenceYear) {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -49,6 +49,9 @@ const querySchema = z.object({
   band: z.string().max(30)
     .describe("Codice della fascia di valore della produzione, solo per il dataset che la dichiara.")
     .optional(),
+  years: z.number().int().min(2).max(20)
+    .describe("Numero di Leggi di Bilancio più recenti da restituire, da 2 a 20, solo per il dataset che lo dichiara.")
+    .optional(),
   limit: z.number().int().min(1).max(100)
     .describe("Numero massimo di record da restituire, da 1 a 100, solo per dataset che supportano limit.")
     .optional(),

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -71,7 +71,7 @@ export const publicSources: PublicSource[] = [
     coverage: "Pagamenti dello Stato, opere pubbliche per CUP e Conto Economico SSN 2024",
     format: "CKAN API · OData · CSV · open data",
     url: "https://bdap-opendata.rgs.mef.gov.it/content/api",
-    note: "Connettore attivo: pagamenti dello Stato, dataset MOP e snapshot del Conto Economico consuntivo 2024 degli enti SSN con voci contabili, costi del personale e servizi.",
+    note: "Connettore attivo: pagamenti dello Stato, dataset MOP, snapshot del Conto Economico consuntivo 2024 degli enti SSN con voci contabili, costi del personale e servizi, e serie storica dello stanziamento enacted per missione della Legge di Bilancio (dal 2017, tassonomia stabile).",
     joinKeys: ["CUP", "codice fiscale titolare", "codice ente RGS"],
   },
   {

--- a/tests/bdap-legge-bilancio.test.mjs
+++ b/tests/bdap-legge-bilancio.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const {
+  BudgetLawDatasetUnavailableError,
+  BudgetLawInvalidWindowError,
+  BudgetLawWindowUnavailableError,
+  discoverBudgetLawMissionDataset,
+  getBudgetLawMissionSeries,
+  MIN_STABLE_MISSION_YEAR,
+  missionYearOverYearDelta,
+  normalizeBudgetLawPackage,
+} = await import("../src/lib/bdap-legge-bilancio.ts");
+const { queryPublicDataset } = await import("../src/lib/mcp/datasets.ts");
+
+const packageId = "e0be9f03-134b-446d-8e6c-cb5c14ddc11c";
+const EXPECTED_TITLE =
+  "Legge di Bilancio Pubblicata - Serie storica - Spese per Amministrazione Missione Programma Macroaggregato";
+const PRODUCT_CODE = "LBF_SPE_CRU_AMPMA_001";
+
+function packageFixture(overrides = {}) {
+  return {
+    id: packageId,
+    name: "legge_di_bilancio_pubblicata_serie_storica_spese_per_amministrazione_missione_programma_macroaggregato_new",
+    title: EXPECTED_TITLE,
+    notes: `Prodotto contenente la serie storica dei dati della Legge di Bilancio Spese aggregati per Amministrazione Missione Programma Macroaggregato - [${PRODUCT_CODE}]`,
+    metadata_modified: "2026-01-02T17:37:34.000000",
+    license_title: "Creative Commons Attribution",
+    ...overrides,
+  };
+}
+
+const CSV_HEADER = [
+  "Esercizio Finanziario",
+  "Stato di Previsione",
+  "Amministrazione",
+  "Missione",
+  "Programma",
+  "Unità di voto 1° Livello",
+  "Unità di voto 2° Livello",
+  "Unità di voto 3° Livello",
+  "Macroaggregato",
+  "Legge di Bilancio CP A1",
+  "Legge di Bilancio CP A2",
+  "Legge di Bilancio CP A3",
+  "Legge di Bilancio CS A1",
+  "Legge di Bilancio CS A2",
+  "Legge di Bilancio CS A3",
+].join(";");
+
+function csvRow({ year, admin, mission, macro, cpA1 }) {
+  return [year, admin, `AMMINISTRAZIONE ${admin}`, mission, "", "", "", "", macro, cpA1, cpA1, cpA1, cpA1, cpA1, cpA1]
+    .map((value) => `"${value}"`)
+    .join(";");
+}
+
+const FIXTURE_ROWS = [
+  // Pre-2017: mission taxonomy not yet stable, must be excluded entirely.
+  csvRow({ year: 2016, admin: "01", mission: "Istruzione vecchia denominazione", macro: "FUNZIONAMENTO", cpA1: "999" }),
+  // 2022
+  csvRow({ year: 2022, admin: "01", mission: "Istruzione", macro: "FUNZIONAMENTO", cpA1: "1000" }),
+  csvRow({ year: 2022, admin: "02", mission: "Istruzione", macro: "INTERVENTI", cpA1: "500" }),
+  csvRow({ year: 2022, admin: "01", mission: "Difesa", macro: "FUNZIONAMENTO", cpA1: "2000" }),
+  // 2023
+  csvRow({ year: 2023, admin: "01", mission: "Istruzione", macro: "FUNZIONAMENTO", cpA1: "1100" }),
+  csvRow({ year: 2023, admin: "02", mission: "Istruzione", macro: "INTERVENTI", cpA1: "600" }),
+  csvRow({ year: 2023, admin: "01", mission: "Difesa", macro: "FUNZIONAMENTO", cpA1: "2100" }),
+  // 2024: Difesa is missing this year on purpose.
+  csvRow({ year: 2024, admin: "01", mission: "Istruzione", macro: "FUNZIONAMENTO", cpA1: "1200" }),
+  csvRow({ year: 2024, admin: "02", mission: "Istruzione", macro: "INTERVENTI", cpA1: "700" }),
+];
+
+const FIXTURE_CSV = [CSV_HEADER, ...FIXTURE_ROWS].join("\n");
+
+function installFetch(csv) {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(input.toString());
+    calls.push(url.toString());
+    if (url.pathname.endsWith("/package_search")) {
+      assert.equal(url.searchParams.get("q"), PRODUCT_CODE);
+      return new Response(JSON.stringify({ success: true, result: { results: [packageFixture()] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname.endsWith(`${packageId}.csv`)) {
+      return new Response(csv, { status: 200, headers: { "content-type": "text/csv" } });
+    }
+    throw new Error(`URL non atteso nel test: ${url.toString()}`);
+  };
+  return { calls, restore: () => { globalThis.fetch = originalFetch; } };
+}
+
+test("normalizeBudgetLawPackage accepts the exact product-code and title contract", () => {
+  const dataset = normalizeBudgetLawPackage(packageFixture());
+  assert.ok(dataset);
+  assert.equal(dataset.packageId, packageId);
+  assert.equal(dataset.title, EXPECTED_TITLE);
+  assert.equal(dataset.license, "Creative Commons Attribution");
+  assert.equal(dataset.csvUrl, `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/${packageId}.csv`);
+  assert.match(dataset.apiUrl, /package_show\?id=/);
+});
+
+test("normalizeBudgetLawPackage rejects title drift, missing code, and duplicated code", () => {
+  assert.equal(normalizeBudgetLawPackage(packageFixture({ title: "Titolo diverso" })), null);
+  assert.equal(
+    normalizeBudgetLawPackage(packageFixture({ notes: "Nessun codice prodotto qui" })),
+    null,
+  );
+  assert.equal(
+    normalizeBudgetLawPackage(
+      packageFixture({ notes: `[${PRODUCT_CODE}] duplicato [${PRODUCT_CODE}]` }),
+    ),
+    null,
+  );
+  assert.equal(normalizeBudgetLawPackage(packageFixture({ id: "not-a-uuid" })), null);
+});
+
+test("missionYearOverYearDelta computes the arithmetic delta and guards a zero base", () => {
+  const delta = missionYearOverYearDelta(
+    { year: 2022, mission: "Istruzione", amountEur: 1500 },
+    { year: 2023, mission: "Istruzione", amountEur: 1700 },
+  );
+  assert.equal(delta.deltaEur, 200);
+  assert.ok(Math.abs(delta.deltaPct - (200 / 1500) * 100) < 1e-9);
+
+  const zeroBase = missionYearOverYearDelta(
+    { year: 2022, mission: "Istruzione", amountEur: 0 },
+    { year: 2023, mission: "Istruzione", amountEur: 500 },
+  );
+  assert.equal(zeroBase.deltaPct, null);
+
+  assert.throws(
+    () =>
+      missionYearOverYearDelta(
+        { year: 2022, mission: "Istruzione", amountEur: 100 },
+        { year: 2023, mission: "Difesa", amountEur: 100 },
+      ),
+    /stessa missione/,
+  );
+});
+
+test("discoverBudgetLawMissionDataset rejects zero and multiple matches", async () => {
+  const empty = installFetch(FIXTURE_CSV);
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ success: true, result: { results: [] } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  await assert.rejects(discoverBudgetLawMissionDataset(), BudgetLawDatasetUnavailableError);
+  empty.restore();
+
+  const duplicated = installFetch(FIXTURE_CSV);
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        result: { results: [packageFixture(), packageFixture({ id: "12345678-1234-4abc-8def-1234567890ab" })] },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  await assert.rejects(discoverBudgetLawMissionDataset(), /più pacchetti/);
+  duplicated.restore();
+});
+
+test("getBudgetLawMissionSeries aggregates per mission, skips pre-2017 rows, and drops missions absent from any served year", async () => {
+  const fetchMock = installFetch(FIXTURE_CSV);
+  try {
+    const series = await getBudgetLawMissionSeries();
+    assert.equal(series.minStableMissionYear, MIN_STABLE_MISSION_YEAR);
+    assert.deepEqual(series.years, [2022, 2023, 2024]);
+    // Difesa is missing in 2024, so it must not appear even though it exists in 2022/2023.
+    assert.deepEqual(series.missions, ["Istruzione"]);
+
+    const byYear = new Map(series.allocations.map((row) => [row.year, row.amountEur]));
+    assert.equal(byYear.get(2022), 1500);
+    assert.equal(byYear.get(2023), 1700);
+    assert.equal(byYear.get(2024), 1900);
+
+    assert.equal(series.yearOverYearDeltas.length, 2);
+    const [firstDelta, secondDelta] = series.yearOverYearDeltas;
+    assert.equal(firstDelta.fromYear, 2022);
+    assert.equal(firstDelta.toYear, 2023);
+    assert.equal(firstDelta.deltaEur, 200);
+    assert.equal(secondDelta.fromYear, 2023);
+    assert.equal(secondDelta.toYear, 2024);
+    assert.equal(secondDelta.deltaEur, 200);
+
+    assert.ok(fetchMock.calls.some((call) => call.includes("package_search")));
+    assert.ok(fetchMock.calls.some((call) => call.includes(`${packageId}.csv`)));
+  } finally {
+    fetchMock.restore();
+  }
+});
+
+test("getBudgetLawMissionSeries honours a smaller requested window", async () => {
+  const fetchMock = installFetch(FIXTURE_CSV);
+  try {
+    const series = await getBudgetLawMissionSeries({ windowYears: 2 });
+    assert.deepEqual(series.years, [2023, 2024]);
+  } finally {
+    fetchMock.restore();
+  }
+});
+
+test("getBudgetLawMissionSeries rejects a window outside [2, 20] before fetching", async () => {
+  const fetchMock = installFetch(FIXTURE_CSV);
+  fetchMock.restore();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("non deve fare fetch con una finestra non valida");
+  };
+  try {
+    await assert.rejects(getBudgetLawMissionSeries({ windowYears: 1 }), BudgetLawInvalidWindowError);
+    await assert.rejects(getBudgetLawMissionSeries({ windowYears: 21 }), BudgetLawInvalidWindowError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getBudgetLawMissionSeries throws when fewer than two comparable years are published", async () => {
+  const singleYearCsv = [
+    CSV_HEADER,
+    csvRow({ year: 2017, admin: "01", mission: "Istruzione", macro: "FUNZIONAMENTO", cpA1: "100" }),
+  ].join("\n");
+  const fetchMock = installFetch(singleYearCsv);
+  try {
+    await assert.rejects(getBudgetLawMissionSeries(), BudgetLawWindowUnavailableError);
+  } finally {
+    fetchMock.restore();
+  }
+});
+
+test("openbdap_legge_bilancio_storico MCP dataset rejects unsupported filters and exposes the series", async () => {
+  const fetchMock = installFetch(FIXTURE_CSV);
+  try {
+    await assert.rejects(
+      queryPublicDataset({ dataset: "openbdap_legge_bilancio_storico", code: "x" }),
+      /Filtri non supportati/,
+    );
+    const result = await queryPublicDataset({ dataset: "openbdap_legge_bilancio_storico", years: 2 });
+    assert.deepEqual(result.years, [2023, 2024]);
+    assert.deepEqual(result.missions, ["Istruzione"]);
+  } finally {
+    fetchMock.restore();
+  }
+});


### PR DESCRIPTION
## Cosa aggiunge

Nuova pagina `/stato/simulatore`: mostra la variazione anno su anno dello
stanziamento **pubblicato** (competenza, primo anno) dalla Legge di
Bilancio per missione, e lascia all'utente costruire uno scenario
ipotetico a partire da quei dati reali. Lo scenario è sempre disegnato
con una trama a righe distinta dal dato osservato e mai come proiezione
ufficiale, in linea con il vincolo permanente di `PRODUCT.md`: *"nessun
valore economico simulato presentato come reale"*.

## Fonte

RGS/OpenBDAP, dataset `LBF_SPE_CRU_AMPMA_001` — "Legge di Bilancio
Pubblicata · Serie storica · Spese per Amministrazione, Missione,
Programma e Macroaggregato" (CC BY). Verificato dal vivo via
`package_search` prima di scrivere l'adapter:

- a differenza dei prodotti "Rendiconto" (`bdap-payments.ts`), che
  pubblicano un pacchetto CKAN per anno, questo prodotto pubblica **un
  unico pacchetto** con l'intera serie storica in una sola risorsa CSV;
- il campo usato è `Legge di Bilancio CP A1` (stanziamento di competenza
  del primo anno, così come pubblicato dalla legge di quell'anno);
- la tassonomia delle 34 missioni RGS è stata **rinominata nel 2017**
  (es. "Diritti sociali politiche sociali e famiglia" → "Diritti
  sociali, politiche sociali e famiglia"): verificato sull'intero CSV
  che ogni missione ha un'etichetta stabile solo dal 2017 in poi, quindi
  l'adapter non serve mai anni precedenti e mostra solo le missioni
  presenti con lo stesso nome in tutti gli anni della finestra.

## Cosa NON fa

Non individua le misure della manovra (un fondo, un bonus, un'aliquota
nominati nel testo di legge): quella lettura riga per riga richiede
fonti come UPB o Corte dei Conti ed è dichiarata esplicitamente fuori
scope in UI e in `docs/SIMULATORE_LEGGE_BILANCIO.md`.

## File

- `src/lib/bdap-legge-bilancio.ts` — adapter (discovery, aggregazione
  per missione, delta anno su anno).
- `src/lib/mcp/catalog.ts`, `datasets.ts`, `server.ts` — nuovo dataset
  MCP `openbdap_legge_bilancio_storico` con filtro `years`.
- `src/app/api/spese/stato/legge-bilancio/route.ts` — route API.
- `src/app/stato/simulatore/` — pagina server + componente client
  (selezione missione, slider di variazione, grafico Recharts con due
  serie visivamente distinte, tabella dati accessibile).
- `docs/SIMULATORE_LEGGE_BILANCIO.md` — fonti, metodo, limiti.
- `tests/bdap-legge-bilancio.test.mjs` — test dell'adapter e del
  dataset MCP.
- Collegata da `/stato`; nota `openbdap` aggiornata in `src/lib/sources.ts`.

## Verifica eseguita

- `npm run lint` → verde (0 warning)
- `npm run typecheck` → verde
- `npm run design:check` → verde
- `npm test` → 517 test, 515 pass; i 2 fallimenti (`OpenCivitas ETL
  validates the committed snapshot offline`, un flake di rete su un test
  SSN) sono preesistenti e non toccano i file di questa PR — il primo è
  un bug di compatibilità Python locale (`zip(strict=True)` richiede
  Python ≥3.10, ambiente di test qui su 3.9.6) in
  `scripts/etl/opencivitas_snapshot.py`, non modificato da questa PR.
- `npm run build` → verde, entrambe le nuove route compaiono come
  dinamiche.
- Verifica manuale con `npm run dev`: pagina `/stato/simulatore`,
  `GET /api/spese/stato/legge-bilancio?anni=4` e il tool MCP
  `query_dataset` con `dataset=openbdap_legge_bilancio_storico`
  restituiscono dati reali da OpenBDAP.

🤖 Generato con [Claude Code](https://claude.com/claude-code)