### PR TITLE
fix(etl): rendi la verifica offline degli artefatti indipendente dalla piattaforma

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# The repository is authored with LF. Without this file a Windows checkout runs
+# under Git's default core.autocrlf=true and rewrites every tracked text file to
+# CRLF, which breaks the byte-level guarantees this project is built on.
+
+* text=auto eol=lf
+
+# Verified artifacts: Git must never rewrite these bytes in either direction.
+# Their sha256 and byte size are part of the published provenance, so a line
+# ending conversion turns a valid snapshot into a failed reconciliation.
+/data/source-ledger/** -text
+/src/data/generated/** -text
+
+*.gz binary
+*.ico binary
+*.jpg binary
+*.png binary
+*.pem -text

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -355,7 +355,7 @@ def detect_unregistered_files(registry: dict) -> list[str]:
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             for fname in filenames:
                 full = Path(dirpath) / fname
-                rel = str(full.relative_to(ROOT))
+                rel = full.relative_to(ROOT).as_posix()
                 if rel in registered:
                     continue
 

--- a/scripts/etl/integrated_curated_datasets.py
+++ b/scripts/etl/integrated_curated_datasets.py
@@ -2557,7 +2557,7 @@ def build_artifacts(*, spec_path: Path, source_root: Path, catalog_path: Path, r
         "schemaVersion": 1, "generatedAt": spec["generatedAt"], "complete": True,
         "totals": totals, "catalogSha256": sha256_bytes(catalog_payload),
         "artifactSha256": {
-            str(Path(path).relative_to(ROOT)): sha256_bytes(payload)
+            Path(path).relative_to(ROOT).as_posix(): sha256_bytes(payload)
             for path, payload in sorted(artifacts.items())
         },
     }
@@ -2603,10 +2603,10 @@ def check_artifacts(artifacts: dict[str, bytes]) -> None:
         try:
             actual = path.read_bytes()
         except OSError:
-            mismatches.append(f"mancante: {path.relative_to(ROOT)}")
+            mismatches.append(f"mancante: {path.relative_to(ROOT).as_posix()}")
             continue
         if actual != expected:
-            mismatches.append(f"divergente: {path.relative_to(ROOT)}")
+            mismatches.append(f"divergente: {path.relative_to(ROOT).as_posix()}")
     if mismatches:
         raise DatasetBuildError("artefatti non riproducibili:\n" + "\n".join(mismatches))
 
@@ -2801,7 +2801,7 @@ def check_committed(
     if actual_rows_paths != expected_rows_paths or actual_receipt_paths != expected_receipt_paths:
         raise DatasetBuildError("artefatti extra, inattesi, stale o mancanti nelle directory dataset")
     artifact_hashes = require_dict(proof.get("artifactSha256"), "proof.artifactSha256")
-    expected_keys = {str(path.relative_to(ROOT)) for path in expected_paths}
+    expected_keys = {path.relative_to(ROOT).as_posix() for path in expected_paths}
     if set(artifact_hashes) != expected_keys:
         raise DatasetBuildError("insieme artefatti nel proof divergente")
 
@@ -2966,7 +2966,7 @@ def check_committed(
     if proof.get("totals") != totals:
         raise DatasetBuildError("totali proof/catalogo divergenti")
     for path in expected_paths:
-        relative = str(path.relative_to(ROOT))
+        relative = path.relative_to(ROOT).as_posix()
         if path in expected_rows_paths:
             payload = read_bounded_regular_file(
                 path,

--- a/scripts/etl/istat_regions_account.py
+++ b/scripts/etl/istat_regions_account.py
@@ -213,7 +213,7 @@ def build_snapshot(payload: bytes, acquired_at: str) -> tuple[dict, dict]:
         "asset": {"bytes": len(payload), "sha256": hashlib.sha256(payload).hexdigest()},
         "spendingWorkbook": {"path": SPENDING_FILE, "bytes": len(spending), "sha256": hashlib.sha256(spending).hexdigest()},
         "transformation": {"version": 1, "description": "Esclusi i tre fogli aggregati; letti solo gli impegni dei sei Titoli e riconciliati con il totale ufficiale per 22 amministrazioni."},
-        "dataArtifact": {"path": str(DATA_PATH.relative_to(ROOT)), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
+        "dataArtifact": {"path": DATA_PATH.relative_to(ROOT).as_posix(), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
     }
     return data, meta
 

--- a/scripts/etl/pcm_financial_account.py
+++ b/scripts/etl/pcm_financial_account.py
@@ -296,7 +296,7 @@ def build_snapshot(payload: bytes, source_url: str, acquired_at: str) -> tuple[d
             "headers": len(EXPECTED_HEADERS),
         },
         "dataArtifact": {
-            "path": str(DATA_PATH.relative_to(ROOT)),
+            "path": DATA_PATH.relative_to(ROOT).as_posix(),
             "bytes": len(data_bytes),
             "sha256": hashlib.sha256(data_bytes).hexdigest(),
         },

--- a/scripts/etl/rgs_ministries_account.py
+++ b/scripts/etl/rgs_ministries_account.py
@@ -260,7 +260,7 @@ def build_snapshot(payload: bytes, acquired_at: str) -> tuple[dict, dict]:
         },
         "asset": {"bytes": len(payload), "sha256": hashlib.sha256(payload).hexdigest(), "encoding": "cp1252", "delimiter": ";"},
         "transformation": {"version": 1, "description": "41 colonne validate; 5.395 righe riconciliate e aggregate per Ministero e missione senza mescolare CP, RS e CS."},
-        "dataArtifact": {"path": str(DATA_PATH.relative_to(ROOT)), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
+        "dataArtifact": {"path": DATA_PATH.relative_to(ROOT).as_posix(), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
     }
     return data, meta
 


### PR DESCRIPTION
## Cosa cambia

I percorsi relativi che finiscono nei proof e nei metadati pubblicati sono
prodotti con `str(path.relative_to(ROOT))`, quindi usano il separatore
dell'host. Su un checkout non-POSIX `check_committed` confronta
`src\data\generated\...` con le chiavi `src/data/generated/...` del proof e
termina sempre con `insieme artefatti nel proof divergente`, anche su un
corpus intatto. `as_posix()` fissa una sola forma canonica.

Gli stessi punti in `istat_regions_account.py`, `pcm_financial_account.py` e
`rgs_ministries_account.py` scrivono il percorso dentro il sidecar dei
metadati: senza questa modifica uno snapshot rigenerato altrove entrerebbe in
repo con un percorso non canonico.

`.gitattributes` chiude il secondo lato dello stesso problema: senza, un
checkout con il `core.autocrlf=true` di default riscrive in CRLF anche gli
artefatti verificati, e sha256 e byte-size delle ricevute non tornano più.

Chiude parte di #134.

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [x] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [x] `npm test`, test ETL Python, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

Prima: `python scripts/etl/integrated_curated_datasets.py check` →
`DatasetBuildError: insieme artefatti nel proof divergente` (exit 1).
Dopo: `{"action": "check", "sourceRequired": false, "status": "ok"}` (exit 0).

`git add --renormalize .` non produce **alcuna** modifica nell'indice: su
Linux il comportamento è identico bit per bit, `.gitattributes` corregge solo
cosa arriva nel worktree.

### Dati pubblici

- [x] Nessun artefatto committato cambia: `as_posix()` e `str()` coincidono su POSIX.

## Limiti e prove non eseguite

Verificato su Windows 10 con Python 3.12.4 e Node 24. Non ho potuto eseguire i
gate browser e Lighthouse (richiedono `next start` su 127.0.0.1:3000) né i
workflow di refresh, che contattano le fonti ufficiali.
