### PR TITLE
test: rendi la suite Node eseguibile fuori da CI e togli una dipendenza di rete

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,9 @@ git diff --check
 ```
 
 `ci:static` esegue lint, typecheck, design:check e brand:check insieme.
+Se il tuo interprete Python non si chiama `python3`, indicalo con `PYTHON`
+(per esempio `PYTHON=python npm run test:node`): i test che attraversano il
+confine ETL usano quel nome, il default resta `python3`.
 I test browser e Lighthouse richiedono un server `next start` attivo su
 `127.0.0.1:3000`; vedi `scripts/ci/run-production-gates.sh` per l'orchestrazione
 completa usata dalla CI.

--- a/tests/consulenti-contract.test.mjs
+++ b/tests/consulenti-contract.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { PYTHON_BIN } from "./helpers/python.mjs";
 import { assertConsulentiSnapshot } from "../src/lib/data/consulenti-contract.ts";
 
 const snapshotPath = new URL(
@@ -79,7 +80,7 @@ test("Consulenti Pubblici ETL converts decimal amounts to integer cents", () => 
   );
 
   const generated = spawnSync(
-    "python3",
+    PYTHON_BIN,
     ["scripts/etl/consulenti_snapshot.py", "--input", input, "--output", output],
     { encoding: "utf8" },
   );
@@ -89,7 +90,7 @@ test("Consulenti Pubblici ETL converts decimal amounts to integer cents", () => 
   assert.equal(snapshot.employeeAppointments[0].paidCents, 1001);
 
   const checked = spawnSync(
-    "python3",
+    PYTHON_BIN,
     ["scripts/etl/consulenti_snapshot.py", "--check", "--output", output],
     { encoding: "utf8" },
   );

--- a/tests/helpers/python.mjs
+++ b/tests/helpers/python.mjs
@@ -1,0 +1,8 @@
+/*
+ * The ETL bridge tests shell out to the Python toolchain. On Windows the
+ * interpreter is normally installed as `python`, so a hardcoded `python3`
+ * turns every one of those tests into a spawn failure that reads like a
+ * broken data contract instead of a missing binary. PYTHON lets a contributor
+ * name the interpreter; CI keeps the documented default.
+ */
+export const PYTHON_BIN = process.env.PYTHON?.trim() || "python3";

--- a/tests/integrated-curated-datasets.test.mjs
+++ b/tests/integrated-curated-datasets.test.mjs
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import test from "node:test";
+import { PYTHON_BIN } from "./helpers/python.mjs";
 
 
 const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
@@ -547,7 +548,7 @@ test("the committed curated corpus has an exact, closed artifact and row ledger"
 
 test("the committed curated corpus passes source-free verification", () => {
   const result = spawnSync(
-    "python3",
+    PYTHON_BIN,
     ["scripts/etl/integrated_curated_datasets.py", "check"],
     { cwd: repositoryRoot, encoding: "utf8" },
   );

--- a/tests/mef-irpef.test.mjs
+++ b/tests/mef-irpef.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
-import { extname, join, relative } from "node:path";
+import { extname, join, relative, sep } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import "./helpers/register-ts-alias.mjs";
@@ -219,7 +219,10 @@ test("the full municipal artifact stays behind the server query boundary", async
       matches.push(relative(repositoryRoot, file));
     }
   }
-  assert.deepEqual(matches.map((path) => path.replace(/^.*?src\//, "src/")).sort(), [
+  // relative() yields the platform separator; the expected identity is a repository
+  // path, so compare on one canonical form instead of the host's.
+  const repositoryPaths = matches.map((path) => path.split(sep).join("/"));
+  assert.deepEqual(repositoryPaths.map((path) => path.replace(/^.*?src\//, "src/")).sort(), [
     "src/lib/mef-irpef-snapshot.ts",
   ]);
   const snapshotSource = await readFile(

--- a/tests/mef-participations.test.mjs
+++ b/tests/mef-participations.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { PYTHON_BIN } from "./helpers/python.mjs";
 import snapshot from "../src/data/generated/mef-participations-overview.json" with { type: "json" };
 
 const script = fileURLToPath(new URL("../scripts/etl/mef_participations_snapshot.py", import.meta.url));
@@ -23,7 +24,7 @@ function runFixture(values, headers = requiredHeaders) {
   const input = join(directory, "input.csv");
   const output = join(directory, "output.json");
   writeFileSync(input, `${headers.join(";")}\n${headers.map((header) => values[header] ?? "").join(";")}\n`);
-  const result = spawnSync("python3", [
+  const result = spawnSync(PYTHON_BIN, [
     script,
     "--input", input,
     "--reference-year", "2030",

--- a/tests/opencivitas-contract.test.mjs
+++ b/tests/opencivitas-contract.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { X509Certificate } from "node:crypto";
 import test from "node:test";
+import { PYTHON_BIN } from "./helpers/python.mjs";
 import { assertOpenCivitasSnapshot } from "../src/lib/data/opencivitas-contract.ts";
 
 const snapshotPath = new URL("../src/data/generated/opencivitas-2022.json", import.meta.url);
@@ -49,7 +50,7 @@ test("OpenCivitas keeps source anomaly warnings and nullable assessments", () =>
 });
 
 test("OpenCivitas ETL validates the committed snapshot offline", () => {
-  const checked = spawnSync("python3", ["scripts/etl/opencivitas_snapshot.py", "--check"], {
+  const checked = spawnSync(PYTHON_BIN, ["scripts/etl/opencivitas_snapshot.py", "--check"], {
     encoding: "utf8",
   });
   assert.equal(checked.status, 0, checked.stderr);

--- a/tests/siope-etl-ranking.test.mjs
+++ b/tests/siope-etl-ranking.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import test from "node:test";
+import { PYTHON_BIN } from "./helpers/python.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -18,7 +19,7 @@ test("SIOPE ETL ranks a low-volume municipality first per capita", async () => {
     "by_value, by_per_capita = municipality_rankings(items, 3)",
     "print(json.dumps({'value': [x['name'] for x in by_value], 'perCapita': [x['name'] for x in by_per_capita], 'sentinel': parse_population('00000001'), 'valid': parse_population('00000125')}))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const result = JSON.parse(stdout);
@@ -51,7 +52,7 @@ test("SIOPE ETL resolves official provinces and rejects unknown province codes",
     "        rejected = False",
     "    print(json.dumps({'province': province, 'count': count, 'rejected': rejected}))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const result = JSON.parse(stdout);
@@ -73,7 +74,7 @@ test("SIOPE registry validity is evaluated against the requested year", async ()
     "    active_2027, _, count_2027 = load_municipalities(archive, {'CF1': 'Piemonte'}, 2027)",
     "    print(json.dumps({'active2026': sorted(active_2026), 'active2027': sorted(active_2027), 'count2026': count_2026, 'count2027': count_2027}))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   assert.deepEqual(JSON.parse(stdout), {
@@ -101,7 +102,7 @@ test("SIOPE ETL builds resident-weighted distribution from the full municipal in
     "result = build_distribution(rows=rows, year=2026, latest_month=8, observed_at='2026-08-21T00:00:00+00:00', validators=validators)",
     "print(json.dumps(result))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const result = JSON.parse(stdout);
@@ -164,7 +165,7 @@ test("SIOPE ETL keeps an IPA-unmatched municipality national but not geographic"
     "    result = build_snapshot(year=2026, movements_zip=movements, registry_zip=registry, ipa_path=ipa, validators=validators)",
     "    print(json.dumps({'snapshot': result}))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const { snapshot } = JSON.parse(stdout);
@@ -200,7 +201,7 @@ test("SIOPE distribution does not fabricate a share for a zero denominator", asy
     "result = build_distribution(rows=rows, year=2025, latest_month=12, observed_at='2026-08-21T00:00:00+00:00', validators=validators)",
     "print(json.dumps(result))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const result = JSON.parse(stdout);
@@ -226,7 +227,7 @@ test("SIOPE distribution rejects fake provenance and inconsistent title componen
     "        errors.append(str(error))",
     "print(json.dumps(errors))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const errors = JSON.parse(stdout);
@@ -260,7 +261,7 @@ test("SIOPE refresh skip includes upstream ETag when it is available", async () 
     "  no_etag = is_unchanged(path, 2026, validators)",
     "print(json.dumps({'same': same, 'drift': drift, 'noEtag': no_etag}))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   assert.deepEqual(JSON.parse(stdout), { same: true, drift: false, noEtag: true });

--- a/tests/siope-snapshot.test.mjs
+++ b/tests/siope-snapshot.test.mjs
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 import test from "node:test";
+import { PYTHON_BIN } from "./helpers/python.mjs";
 import "./helpers/register-ts-alias.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -31,7 +32,7 @@ test("distribution keeps an explicit region-null municipality national but not r
     "result = build_distribution(rows=rows, year=2026, latest_month=8, observed_at='2026-08-21T00:00:00+00:00', validators=validators)",
     "print(json.dumps(result))",
   ].join("\n");
-  const { stdout } = await execFileAsync("python3", ["-c", code], {
+  const { stdout } = await execFileAsync(PYTHON_BIN, ["-c", code], {
     cwd: new URL("..", import.meta.url),
   });
   const result = JSON.parse(stdout);

--- a/tests/ssn-national-history.test.mjs
+++ b/tests/ssn-national-history.test.mjs
@@ -341,14 +341,22 @@ test("SSN national history accepts OpenBDAP CSVs with one empty trailing delimit
   }
 });
 
-test("openbdap_ssn_storico_nazionale MCP dataset rejects filters and stays within the response budget", async (context) => {
+test("openbdap_ssn_storico_nazionale MCP dataset rejects filters and stays within the response budget", async () => {
   await assert.rejects(
     queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale", year: 2024 }),
     /Filtri non supportati/,
   );
-  await runLiveOpenBdap(context, async () => {
+  // Every other case in this file serves the history from a stub. Without one
+  // the assertion depends on OpenBDAP answering, which makes a local run fail
+  // for a reason that has nothing to do with the dataset contract.
+  const originalFetch = globalThis.fetch;
+  const stub = stubHistoryFetch();
+  globalThis.fetch = stub.fetchStub;
+  try {
     const result = await queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale" });
     assert.equal(result.years.length, 13);
     assert.ok(JSON.stringify(result).length < 750 * 1024);
-  });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });


### PR DESCRIPTION
## Cosa cambia

Tre dettagli impediscono di riprodurre `npm test` fuori da un ambiente POSIX,
e producono errori che si leggono come contratti dati rotti invece che come
problemi di ambiente:

- sei file lanciano l'interprete come `python3`, che su Windows normalmente non
  esiste: nove test ETL falliscono con ENOENT e l'assertion visibile è
  `null !== 0`. `PYTHON` permette di nominare l'interprete, il default
  documentato resta `python3`;
- `tests/mef-irpef.test.mjs` confronta percorsi normalizzando solo `/`, mentre
  `relative()` restituisce il separatore dell'host;
- il test sul budget di risposta di `openbdap_ssn_storico_nazionale` non stubba
  `globalThis.fetch`, a differenza di ogni altro caso dello stesso file, quindi
  interroga davvero OpenBDAP. Il test riguarda il contratto del dataset, non la
  disponibilità della fonte: con lo stub già presente nel file passa da 30,4 s
  (e fallisce quando la fonte non risponde) a 69 ms. Il test dichiaratamente
  live più sopra nel file resta invariato.

Chiude parte di #134.

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [x] `npm test`, typecheck, lint e design check passano.
- [x] Ho verificato `git diff --check`.

Nessun test cambia semantica: il file `tests/helpers/python.mjs` risolve solo
il nome dell'eseguibile, e il default è quello di prima.

### API e MCP

- [x] La superficie MCP non cambia; cambia solo come il test la alimenta.
- [x] Il caso live intenzionale (`{ timeout: 300_000 }`) resta live.

## Limiti e prove non eseguite

Verificato su Windows 10 con Python 3.12.4 e Node 24. Non ho eseguito i gate
browser e Lighthouse né i workflow di refresh.
