### PR TITLE
feat(mcp): server pronto per i publishing checks di Manufact

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -22,6 +22,8 @@ va duplicato su un secondo runtime.
 - Resource `dvns://datasets`: copia JSON del catalogo.
 - Resource `dvns://related-mcp-services`: endpoint pubblici complementari, separati dagli adapter
   DVNS e mai inoltrati automaticamente.
+- Capability `prompts`: i cinque starter prompt della distribuzione (`docs/MCP_DISTRIBUTION.md`)
+  sono esposti anche via `prompts/list` e `prompts/get`, che resta la fonte unica dei testi.
 
 I dataset live interrogano soltanto adapter ufficiali già usati dalle API del sito. I dataset snapshot leggono gli artefatti versionati e validati dagli ETL.
 

--- a/docs/MCP_DISTRIBUTION.md
+++ b/docs/MCP_DISTRIBUTION.md
@@ -60,6 +60,11 @@ ha una candidatura separata: un test riuscito nel client non equivale all'accett
 
 ## Starter prompt
 
+Sono esposti anche come capability MCP `prompts/list` (nomi: `confronta_pagamenti_comuni`,
+`catalogo_territoriale`, `irpef_netta_regionale`, `consuntivo_statale_missione`,
+`dati_calabria_limiti`). Questa lista è la fonte unica dei testi; client e reviewer li leggono
+tramite `prompts/get` senza copiarli dal documento.
+
 - `Confronta i pagamenti pro capite dei Comuni disponibili e mostrami fonte, anno e limiti.`
 - `Quali dataset territoriali posso interrogare? Non eseguire ancora una query.`
 - `Mostrami l'imposta netta dichiarata 2024 per le Regioni, distinguendola dal gettito totale.`

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -7,6 +7,60 @@ import { relatedMcpServices } from "@/lib/mcp/related-services";
 
 export const MAX_MCP_TOOL_RESPONSE_BYTES = 750_000;
 const MCP_WIRE_OVERHEAD_RESERVE_BYTES = 1_024;
+const noAuthSecuritySchemes = [{ type: "noauth" }] as const;
+
+const listDatasetsOutputSchema = z.object({
+  datasets: z.array(z.unknown()),
+  relatedMcpServices: z.array(z.unknown()),
+});
+
+const queryDatasetOutputSchema = z.object({
+  ok: z.boolean(),
+  dataset: z.string(),
+  query: z.unknown().optional(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+});
+
+/**
+ * Starter prompt della distribuzione (docs/MCP_DISTRIBUTION.md), esposti anche come
+ * capability `prompts` MCP così che client e reviewer leggano la fonte unica invece
+ * di copiare i testi dal documento. Le aggiunte future restano allineate a quella lista.
+ */
+export const dvnsStarterPrompts = [
+  {
+    name: "confronta_pagamenti_comuni",
+    title: "Pagamenti pro capite dei Comuni",
+    description: "Confronto dei pagamenti comunali disponibili con fonte, anno e limiti dichiarati.",
+    message:
+      "Confronta i pagamenti pro capite dei Comuni disponibili e mostrami fonte, anno e limiti.",
+  },
+  {
+    name: "catalogo_territoriale",
+    title: "Catalogo territoriale",
+    description: "Panoramica dei dataset territoriali interrogabili, senza eseguire query.",
+    message: "Quali dataset territoriali posso interrogare? Non eseguire ancora una query.",
+  },
+  {
+    name: "irpef_netta_regionale",
+    title: "Imposta netta dichiarata",
+    description: "Imposta netta dichiarata 2024 per Regioni, distinta dal gettito totale.",
+    message:
+      "Mostrami l'imposta netta dichiarata 2024 per le Regioni, distinguendola dal gettito totale.",
+  },
+  {
+    name: "consuntivo_statale_missione",
+    title: "Consuntivo statale per missione",
+    description: "Riepilogo dei pagamenti statali per missione sull'ultimo consuntivo disponibile.",
+    message: "Riassumi i pagamenti statali per missione usando l'ultimo consuntivo disponibile.",
+  },
+  {
+    name: "dati_calabria_limiti",
+    title: "Calabria e limiti comparativi",
+    description: "Dati disponibili per la Calabria e ciò che non è confrontabile con altre aree.",
+    message: "Cerca i dati disponibili per la Calabria e dimmi che cosa non è confrontabile.",
+  },
+] as const;
 
 const querySchema = z.object({
   dataset: z.enum(DATASET_IDS).describe("Identificativo restituito da list_datasets."),
@@ -60,6 +114,39 @@ const querySchema = z.object({
     .optional(),
 }).strict();
 
+const listDatasetsToolConfig = {
+  title: "Elenca i dataset",
+  description: "Elenca tutti i dataset disponibili, i filtri ammessi, la freschezza e le cautele interpretative.",
+  inputSchema: z.object({}).strict(),
+  outputSchema: listDatasetsOutputSchema,
+  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  _meta: { securitySchemes: noAuthSecuritySchemes },
+};
+
+const queryDatasetToolConfig = {
+  title: "Interroga un dataset",
+  description: "Interroga un dataset del portale. Usa prima list_datasets per conoscere filtri e limiti. Le fonti live possono essere temporaneamente indisponibili.",
+  inputSchema: querySchema,
+  outputSchema: queryDatasetOutputSchema,
+  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+  _meta: { securitySchemes: noAuthSecuritySchemes },
+};
+
+type PublicToolConfig = typeof listDatasetsToolConfig | typeof queryDatasetToolConfig;
+
+function publicToolDescriptor(name: string, config: PublicToolConfig) {
+  return {
+    name,
+    title: config.title,
+    description: config.description,
+    inputSchema: z.toJSONSchema(config.inputSchema),
+    outputSchema: z.toJSONSchema(config.outputSchema),
+    annotations: config.annotations,
+    securitySchemes: noAuthSecuritySchemes,
+    _meta: config._meta,
+  };
+}
+
 function toolResult(value: unknown) {
   const text = JSON.stringify(value);
   const result = {
@@ -71,11 +158,6 @@ function toolResult(value: unknown) {
     return {
       isError: true,
       content: [{ type: "text" as const, text: "La risposta supera il limite di dimensione MCP." }],
-      structuredContent: {
-        ok: false,
-        error: "response_too_large",
-        maxBytes: MAX_MCP_TOOL_RESPONSE_BYTES,
-      },
     };
   }
   return result;
@@ -84,7 +166,28 @@ function toolResult(value: unknown) {
 export function createDvnsMcpServer(factoryContext?: McpRequestContext) {
   const server = new McpServer({
     name: "dove-vanno-i-nostri-soldi",
+    title: "DoveVannoINostriSoldi",
     version: APP_VERSION,
+    websiteUrl: "https://www.dovevannoinostrisoldi.com",
+    description:
+      "Accesso read-only a dati pubblici italiani verificati, con fonti, periodi, copertura e caveat espliciti.",
+    icons: [
+      {
+        src: "https://www.dovevannoinostrisoldi.com/brand/icon-192.png",
+        mimeType: "image/png",
+        sizes: ["192x192"],
+      },
+      {
+        src: "https://www.dovevannoinostrisoldi.com/brand/icon-512.png",
+        mimeType: "image/png",
+        sizes: ["512x512"],
+      },
+      {
+        src: "https://www.dovevannoinostrisoldi.com/brand/icon-1024.png",
+        mimeType: "image/png",
+        sizes: ["1024x1024"],
+      },
+    ],
   }, {
     instructions:
       "Usa list_datasets prima di query_dataset. Mantieni unità, periodo, provenienza e caveat nelle risposte. I servizi MCP correlati sono esterni e non vengono proxyati da DVNS.",
@@ -121,24 +224,29 @@ export function createDvnsMcpServer(factoryContext?: McpRequestContext) {
     }),
   );
 
+  // I prompt starter sono parte del materiale di submission: la lista MCP replica
+  // esattamente docs/MCP_DISTRIBUTION.md, che resta la fonte autoritativa.
+  // Nessun argomento: argsSchema resta assente così prompts/get accetta anche i
+  // client che, come previsto dallo standard, omettono del tutto `arguments`.
+  for (const spec of dvnsStarterPrompts) {
+    server.registerPrompt(
+      spec.name,
+      { title: spec.title, description: spec.description },
+      () => ({
+        messages: [{ role: "user" as const, content: { type: "text" as const, text: spec.message } }],
+      }),
+    );
+  }
+
   server.registerTool(
     "list_datasets",
-    {
-      title: "Elenca i dataset",
-      description: "Elenca tutti i dataset disponibili, i filtri ammessi, la freschezza e le cautele interpretative.",
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-    },
+    listDatasetsToolConfig,
     async () => toolResult({ datasets: datasetCatalog, relatedMcpServices }),
   );
 
   server.registerTool(
     "query_dataset",
-    {
-      title: "Interroga un dataset",
-      description: "Interroga un dataset del portale. Usa prima list_datasets per conoscere filtri e limiti. Le fonti live possono essere temporaneamente indisponibili.",
-      inputSchema: querySchema,
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    },
+    queryDatasetToolConfig,
     async (input, context) => {
       try {
         const requestSignal = factoryContext?.requestInfo?.signal;
@@ -156,6 +264,21 @@ export function createDvnsMcpServer(factoryContext?: McpRequestContext) {
         };
       }
     },
+  );
+
+  // @modelcontextprotocol/server@2 serializes only its core Tool fields. ChatGPT
+  // requires the canonical per-tool securitySchemes field as well as its _meta
+  // compatibility mirror, so replace only tools/list with descriptors derived
+  // from the exact schemas and metadata registered above.
+  server.server.setRequestHandler(
+    "tools/list",
+    { params: z.object({}).passthrough() },
+    () => ({
+      tools: [
+        publicToolDescriptor("list_datasets", listDatasetsToolConfig),
+        publicToolDescriptor("query_dataset", queryDatasetToolConfig),
+      ],
+    }),
   );
 
   return server;

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -7,9 +7,35 @@ process.env.MCP_ALLOWED_HOSTS = [process.env.MCP_ALLOWED_HOSTS, "example.test"]
   .join(",");
 
 const { GET, OPTIONS, POST } = await import("../src/app/api/mcp/route.ts");
+const { dvnsStarterPrompts } = await import("../src/lib/mcp/server.ts");
 const loader = await import("../src/lib/integrated-sources.ts");
 
 const requestBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+const expectedServerInfo = {
+  name: "dove-vanno-i-nostri-soldi",
+  title: "DoveVannoINostriSoldi",
+  version: "0.2.0",
+  websiteUrl: "https://www.dovevannoinostrisoldi.com",
+  description:
+    "Accesso read-only a dati pubblici italiani verificati, con fonti, periodi, copertura e caveat espliciti.",
+  icons: [
+    {
+      src: "https://www.dovevannoinostrisoldi.com/brand/icon-192.png",
+      mimeType: "image/png",
+      sizes: ["192x192"],
+    },
+    {
+      src: "https://www.dovevannoinostrisoldi.com/brand/icon-512.png",
+      mimeType: "image/png",
+      sizes: ["512x512"],
+    },
+    {
+      src: "https://www.dovevannoinostrisoldi.com/brand/icon-1024.png",
+      mimeType: "image/png",
+      sizes: ["1024x1024"],
+    },
+  ],
+};
 
 function request(headers = {}, body = requestBody) {
   return new Request("https://example.test/api/mcp", {
@@ -272,6 +298,10 @@ test("MCP query tool describes every input parameter for clients and directories
   const rpcEvent = parseRpcEvent(await response.text());
   const queryTool = rpcEvent.result.tools.find((tool) => tool.name === "query_dataset");
   assert.ok(queryTool, "query_dataset tool missing");
+  assert.deepEqual(queryTool.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(queryTool._meta?.securitySchemes, [{ type: "noauth" }]);
+  assert.equal(queryTool.outputSchema?.type, "object");
+  assert.deepEqual(queryTool.outputSchema?.required, ["ok", "dataset"]);
   const properties = queryTool.inputSchema?.properties;
   assert.ok(properties && Object.keys(properties).length > 0, "query_dataset properties missing");
   assert.deepEqual(Object.keys(properties), [
@@ -300,6 +330,20 @@ test("MCP query tool describes every input parameter for clients and directories
       `${name} is missing a non-empty description`,
     );
   }
+});
+
+test("MCP list tool declares no-auth access and a structured output contract", async () => {
+  const response = await POST(request({ Origin: "https://example.test" }));
+  const rpcEvent = parseRpcEvent(await response.text());
+  const listTool = rpcEvent.result.tools.find((tool) => tool.name === "list_datasets");
+  assert.ok(listTool, "list_datasets tool missing");
+  assert.deepEqual(listTool.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(listTool._meta?.securitySchemes, [{ type: "noauth" }]);
+  assert.equal(listTool.outputSchema?.type, "object");
+  assert.deepEqual(
+    listTool.outputSchema?.required,
+    ["datasets", "relatedMcpServices"],
+  );
 });
 
 test("MCP endpoint exposes the machine-readable dataset catalog resource", async () => {
@@ -346,10 +390,79 @@ test("MCP endpoint supports the modern 2026 protocol envelope", async () => {
     }),
   ));
   const body = await response.text();
+  const rpcResponse = JSON.parse(body);
   assert.equal(response.status, 200);
   assert.match(body, /"resultType":"complete"/);
   assert.match(body, /list_datasets/);
+  for (const tool of rpcResponse.result.tools) {
+    assert.deepEqual(tool.securitySchemes, [{ type: "noauth" }]);
+    assert.deepEqual(tool._meta?.securitySchemes, [{ type: "noauth" }]);
+  }
   assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+});
+
+test("MCP initialize advertises complete publishing metadata", async () => {
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 11,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "publishing-check", version: "1.0.0" },
+    },
+  })));
+  const rpcEvent = parseRpcEvent(await response.text());
+  assert.equal(response.status, 200);
+  assert.deepEqual(rpcEvent.result.serverInfo, expectedServerInfo);
+});
+
+test("MCP prompts/list mirrors the documented starter prompts", async () => {
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 12,
+    method: "prompts/list",
+  })));
+  const rpcEvent = parseRpcEvent(await response.text());
+  assert.equal(response.status, 200);
+  assert.equal(rpcEvent.result.prompts.length, dvnsStarterPrompts.length);
+  const names = new Set(rpcEvent.result.prompts.map((prompt) => prompt.name));
+  for (const spec of dvnsStarterPrompts) {
+    assert.ok(names.has(spec.name), `prompt mancante: ${spec.name}`);
+  }
+  for (const prompt of rpcEvent.result.prompts) {
+    assert.equal(typeof prompt.description, "string");
+    assert.ok(prompt.description.length > 0);
+  }
+});
+
+test("MCP prompts/get returns the exact documented starter message", async () => {
+  const spec = dvnsStarterPrompts[0];
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 13,
+    method: "prompts/get",
+    params: { name: spec.name },
+  })));
+  const rpcEvent = parseRpcEvent(await response.text());
+  assert.equal(response.status, 200);
+  const message = rpcEvent.result.messages[0];
+  assert.equal(message.role, "user");
+  assert.equal(message.content.type, "text");
+  assert.equal(message.content.text, spec.message);
+});
+
+test("MCP prompts/get rejects an unknown prompt name", async () => {
+  const response = await POST(request({}, JSON.stringify({
+    jsonrpc: "2.0",
+    id: 14,
+    method: "prompts/get",
+    params: { name: "prompt_inesistente" },
+  })));
+  const rpcEvent = parseRpcEvent(await response.text());
+  assert.equal(response.status, 200);
+  assert.ok(rpcEvent.result === undefined);
+  assert.ok(typeof rpcEvent.error?.message === "string");
 });
 
 test("MCP endpoint supports 2026 server discovery", async () => {
@@ -367,9 +480,13 @@ test("MCP endpoint supports 2026 server discovery", async () => {
     }),
   ));
   const body = await response.text();
+  const rpcEvent = JSON.parse(body);
   assert.equal(response.status, 200);
   assert.match(body, /2026-07-28/);
-  assert.match(body, /dove-vanno-i-nostri-soldi/);
+  assert.deepEqual(
+    rpcEvent.result._meta["io.modelcontextprotocol/serverInfo"],
+    expectedServerInfo,
+  );
   assert.match(body, /"resultType":"complete"/);
 });
 
@@ -621,5 +738,6 @@ test("MCP tool responses stay below the wire-size budget", async () => {
   assert.ok(new TextEncoder().encode(body).byteLength <= 750_000);
   const rpcEvent = parseRpcEvent(body);
   assert.equal(rpcEvent.result.isError, true);
-  assert.match(rpcEvent.result.structuredContent.error, /response_too_large/);
+  assert.equal(rpcEvent.result.structuredContent, undefined);
+  assert.match(rpcEvent.result.content[0].text, /supera il limite di dimensione/i);
 });


### PR DESCRIPTION
## Cosa cambia

Prepara il server MCP ai publishing checks di Manufact e alla submission nella directory di OpenAI, completando i metadati già definiti nelle nostre guide.

- **initialize e server/discover** espongono ora il nome leggibile, la descrizione, il sito ufficiale e le icone del progetto (192, 512 e 1024 pixel). Prima rispondevano solo nome e versione: era esattamente ciò che metteva in guardia chi provava a collegarsi.
- **tools/list** dichiara per entrambi i tool `outputSchema`, annotazioni read-only/idempotenti e `securitySchemes` con schema `noauth`, oltre al mirror in `_meta` che ChatGPT si aspetta. I due tool restano gli stessi, come da contratto del progetto.
- **I cinque starter prompt documentati diventano una capability MCP**: `prompts/list` e `prompts/get` servono i testi presi dalla fonte unica (docs/MCP_DISTRIBUTION.md), così client e reviewer non copiano i testi a mano. Nessun argomento richiesto; un prompt inesistente viene rifiutato esplicitamente.
- Docs allineate (MCP.md, MCP_DISTRIBUTION.md) e test aggiornati di conseguenza.

## Come ho verificato

- `npm run typecheck` ✓
- suite completa `npm test`: 505 test, tutti passati
- test mirati MCP dopo il rebase su main (incluso il nuovo dataset ISTAT): 64/64
- `npm run lint --max-warnings=0` senza segnalazioni, `brand:check` ok, azioni GitHub tutte SHA-pinned
- build di produzione locale pulita

Sul deployment attuale ho confermato che `initialize` risponde ancora coi vecchi metadati: appena questo ramo va in produzione, Manufact collegherà la versione completa via "Connect an existing server" sull'endpoint canonico `https://www.dovevannoinostrisoldi.com/api/mcp`, come già previsto dalle procedure interne.

Ho anche riprodotto la nota di Lorenzo sull'endpoint: `POST /mcp` ora risponde `400` invece del vecchio `405` e la pagina indica correttamente `/api/mcp` come endpoint da usare, con i due tool e la modalità read-only. Nei messaggi pubblici conviene continuare a puntare su `/api/mcp`.

## Per il deploy e la candidatura

Dopo il merge conviene, nell'ordine:

1. deployare e verificare su produzione che initialize mostri i nuovi metadati;
2. collegare l'endpoint a Manufact (Servers → New Server → Connect an existing server) ed eseguire i publishing checks;
3. pubblicare la regola WAF su /api/mcp partendo in modalità log, come da docs/MCP.md;
4. impostare OPENAI_APPS_CHALLENGE_TOKEN quando OpenAI fornirà il token, poi inviare il submission pack con i casi positivi/negativi già documentati.

## Nota sull'issue #93

L'issue #93 ("Use it on Chatgpt", privo di descrizione) descriveva proprio l'uso su ChatGPT: con la candidatura ufficiale tramite directory e il flusso Manufact resta superato. Propongo di chiuderlo dopo il deploy, citando questa PR come riferimento.
