### PR TITLE
fix(mcp): query_dataset openWorldHint false per publishing checks

### DIFF
--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -128,7 +128,10 @@ const queryDatasetToolConfig = {
   description: "Interroga un dataset del portale. Usa prima list_datasets per conoscere filtri e limiti. Le fonti live possono essere temporaneamente indisponibili.",
   inputSchema: querySchema,
   outputSchema: queryDatasetOutputSchema,
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+  // Tool di sola lettura su fonti interne: openWorldHint resta false perché non
+  // modifichiamo stato visibile su internet né inviamo dati a terze parti
+  // (checklist Manufact tool-hints-present: readOnlyHint true richiede openWorldHint false).
+  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   _meta: { securitySchemes: noAuthSecuritySchemes },
 };
 

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -346,6 +346,22 @@ test("MCP list tool declares no-auth access and a structured output contract", a
   );
 });
 
+test("MCP tools declare consistent read-only annotations (Manufact tool-hints-present)", async () => {
+  const response = await POST(request({ Origin: "https://example.test" }));
+  const rpcEvent = parseRpcEvent(await response.text());
+  for (const name of ["list_datasets", "query_dataset"]) {
+    const tool = rpcEvent.result.tools.find((entry) => entry.name === name);
+    assert.ok(tool, `${name} tool missing`);
+    assert.equal(tool.annotations?.readOnlyHint, true, `${name} must remain read-only`);
+    assert.equal(
+      tool.annotations?.openWorldHint,
+      false,
+      `${name} reads internal sources only: openWorldHint true contradicts readOnlyHint`,
+    );
+    assert.equal(tool.annotations?.destructiveHint, false, `${name} must not be destructive`);
+  }
+});
+
 test("MCP endpoint exposes the machine-readable dataset catalog resource", async () => {
   const response = await POST(request({}, JSON.stringify({
     jsonrpc: "2.0",


### PR DESCRIPTION
## Cosa cambia

La publishing checklist Manufact segnala 1 errore (tool-hints-present): `query_dataset` dichiara `openWorldHint: true` insieme a `readOnlyHint: true` — contraddizione, perché una lettura non modifica stato esterno.

- `src/lib/mcp/server.ts`: `query_dataset` ora dichiara `readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false` (allineato a `list_datasets` e alla semantica reale: sola lettura su fonti interne).
- `tests/mcp-route.test.mjs`: nuovo test di regressione che verifica l'invariante delle annotazioni su entrambi i tool.

## Validazione

- `node --test tests/mcp-route.test.mjs`: tutti verdi, incluso il nuovo test.
- `npm run typecheck`: OK.
