### PR TITLE
fix(stato): scala le barre dei canali di pagamento sul massimo reale

### DIFF
--- a/src/app/stato/amministrazioni/[codice]/page.tsx
+++ b/src/app/stato/amministrazioni/[codice]/page.tsx
@@ -57,7 +57,7 @@ function SourceRow({ dataset }: { dataset: BdapDataset }) {
 }
 
 function AdministrationDashboard({ data }: { data: StateAdministrationSpending }) {
-  const maxPaymentMethod = data.paymentMethods[0]?.value ?? 0;
+  const maxPaymentMethod = Math.max(...data.paymentMethods.map((method) => method.value), 0);
   const identity = data.administration.identity;
   const isConsuntivo = data.period.releaseKind === "consuntivo";
   const totalPaidField = isConsuntivo ? "Totale pagato" : "Totale Pagato";
@@ -229,7 +229,7 @@ function AdministrationDashboard({ data }: { data: StateAdministrationSpending }
       <section className={styles.section}>
         <div className={styles.sectionHeader}>
           <div><h2>Canali di pagamento</h2></div>
-          <p>Le modalità comprese da RGS nel totale pagato, ordinate dalla maggiore.</p>
+          <p>Le modalità comprese da RGS nel totale pagato. La barra più lunga corrisponde al canale con il totale maggiore.</p>
         </div>
         <div className={styles.methodList}>
           {data.paymentMethods.map((method) => {
@@ -238,7 +238,7 @@ function AdministrationDashboard({ data }: { data: StateAdministrationSpending }
               <div className={styles.methodRow} key={method.code ?? method.label}>
                 <span>{method.label}</span>
                 <div className={styles.methodTrack} aria-hidden="true">
-                  <i style={{ width: `${Math.min(width, 100)}%` }} />
+                  <i style={{ width: `${width}%` }} />
                 </div>
                 <strong>{compactEuro(method.value)}</strong>
               </div>

--- a/src/app/stato/page.tsx
+++ b/src/app/stato/page.tsx
@@ -123,7 +123,7 @@ function StatePeriodSelector({ isConsuntivo }: { isConsuntivo: boolean }) {
 }
 
 function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
-  const maxPaymentMethod = snapshot.paymentMethods[0]?.value ?? 0;
+  const maxPaymentMethod = Math.max(...snapshot.paymentMethods.map((method) => method.value), 0);
   const sourceUpdatedAt = snapshot.sources.mission.metadataModified;
   const isConsuntivo = snapshot.period.releaseKind === "consuntivo";
   const totalPaidField = isConsuntivo ? "Totale pagato" : "Totale Pagato";
@@ -369,7 +369,7 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
               <div className={styles.methodRow} key={method.code ?? method.label}>
                 <span>{method.label}</span>
                 <div className={styles.methodTrack} aria-hidden="true">
-                  <i style={{ width: `${Math.min(width, 100)}%` }} />
+                  <i style={{ width: `${width}%` }} />
                 </div>
                 <strong>{compactEuro(method.value)}</strong>
               </div>

--- a/tests/state-page-ui.test.mjs
+++ b/tests/state-page-ui.test.mjs
@@ -4,6 +4,10 @@ import test from "node:test";
 
 const page = await readFile(new URL("../src/app/stato/page.tsx", import.meta.url), "utf8");
 const css = await readFile(new URL("../src/app/stato/stato.module.css", import.meta.url), "utf8");
+const administrationPage = await readFile(
+  new URL("../src/app/stato/amministrazioni/[codice]/page.tsx", import.meta.url),
+  "utf8",
+);
 
 test("state page reads the Next 16 searchParams promise and fails closed", () => {
   assert.match(page, /searchParams: Promise<\{ anno\?: string \| string\[\] \}>/);
@@ -32,4 +36,11 @@ test("state period controls preserve keyboard-sized targets on narrow screens", 
   assert.match(css, /\.periodSelector a,\s*\.separationLink \{[\s\S]*?min-height: 44px;/);
   assert.match(css, /@media \(max-width: 720px\)[\s\S]*?\.periodSelector \{\s*display: block;/);
   assert.match(css, /\.periodSelector a\[aria-current="page"\]/);
+});
+
+test("state payment bars scale against the true series maximum", () => {
+  assert.match(page, /Math\.max\(\.\.\.snapshot\.paymentMethods\.map\(\(method\) => method\.value\), 0\)/);
+  assert.match(administrationPage, /Math\.max\(\.\.\.data\.paymentMethods\.map\(\(method\) => method\.value\), 0\)/);
+  assert.doesNotMatch(page, /paymentMethods\[0\]/);
+  assert.doesNotMatch(administrationPage, /paymentMethods\[0\]/);
 });


### PR DESCRIPTION
## Base / head

- Base: `main` (`39e7e9c`)
- Head: `fix/stato-payment-method-max`

## Scope

- Le barre dei canali di pagamento in `/stato` e `/stato/amministrazioni/[codice]` si scalano sul **massimo reale della serie** (`Math.max`), non più sulla prima voce.
- Rimozione del clamp `Math.min(width, 100)` divenuto morto: con il massimo corretto la larghezza resta in [0, 100] per costruzione.
- La copy del dettaglio amministrazione descrive la scala reale.
- Contratto statico aggiunto in `tests/state-page-ui.test.mjs`.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| `paymentMethods[0]?.value` usato come massimo | `Math.max(...values, 0)` | `paymentMethodsForRows` restituisce l ordine di contratto (Erario primo), non ordinato per valore: se un altro canale supera Erario, la barra più lunga sforava il 100% e la promessa della copy non reggeva |
| `Math.min(width, 100)` a valle | larghezza diretta | Con il massimo reale il clamp è irraggiungibile; il codice morto fuorviava |
| "ordinate dalla maggiore" su `/stato/amministrazioni/[codice]` | descrizione della scala reale | L array non è ordinato per valore |

## Verifica

- `node --experimental-strip-types --test tests/state-page-ui.test.mjs` → 5/5
- `npm run typecheck` → OK
- `npx eslint` sui file toccati → OK

Nota: recupera il fix ancora valido dalla PR #64 (stack UI del 22/08), adattato al `main` attuale senza gli attributi e2e dello stack (l harness browser è cambiato con #98).