### PR TITLE
fix(mcp): endpoint pubblico canonico nel riquadro di copia

### DIFF
--- a/src/components/mcp-endpoint.tsx
+++ b/src/components/mcp-endpoint.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "@/app/mcp/mcp.module.css";
 import { PUBLIC_MCP_ENDPOINT } from "@/lib/site";
 
@@ -42,18 +42,12 @@ function useClipboardFeedback(value: string, enabled = true) {
 }
 
 export function McpEndpoint() {
-  const origin = useSyncExternalStore(
-    () => () => undefined,
-    () => window.location.origin,
-    () => "",
-  );
-  const endpoint = `${origin}/api/mcp`;
-  const { copy, status } = useClipboardFeedback(endpoint, Boolean(origin));
+  const { copy, status } = useClipboardFeedback(PUBLIC_MCP_ENDPOINT);
 
   return (
     <div className={styles.endpointRow}>
-      <code>{endpoint}</code>
-      <button className="btn" type="button" onClick={copy} disabled={!origin}>
+      <code>{PUBLIC_MCP_ENDPOINT}</code>
+      <button className="btn" type="button" onClick={copy}>
         {status === "copied" ? "Copiato" : status === "error" ? "Copia non riuscita" : "Copia endpoint"}
       </button>
       <span className={styles.srStatus} role="status" aria-live="polite">

--- a/tests/mcp_distribution.test.mjs
+++ b/tests/mcp_distribution.test.mjs
@@ -48,4 +48,6 @@ test("distribution pages and docs keep one canonical MCP endpoint", async () => 
   assert.match(combined, /saldo CPT resta un saldo contabile territorializzato/i);
   assert.match(combined, /spreco, frode o qualità del servizio/i);
   assert.doesNotMatch(combined, /già (?:pubblicat[oa]|disponibile) (?:su|in) (?:ChatGPT|Claude|Manufact)/i);
+  assert.doesNotMatch(files[4], /window\.location\.origin|useSyncExternalStore/);
+  assert.match(files[4], /<code>\{PUBLIC_MCP_ENDPOINT\}<\/code>/);
 });


### PR DESCRIPTION
## Base / head

- Base: `main` (`39e7e9c`)
- Head: `fix/mcp-canonical-endpoint`

## Scope

- Riquadro "Copia endpoint" su `/mcp` e prompt per agenti mostrano lo stesso endpoint pubblico canonico (`PUBLIC_MCP_ENDPOINT`).
- Rimossa la lettura lato client di `window.location.origin` (hack `useSyncExternalStore`): meno codice, nessun endpoint ambiguo su anteprime.
- Contratto di distribuzione esteso in `tests/mcp_distribution.test.mjs`.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| `<code>{origin}/api/mcp</code>` con origin dal browser | `<code>{PUBLIC_MCP_ENDPOINT}</code>` | Su deploy di anteprima il riquadro mostrava un endpoint non raggiungibile pubblicamente, in contraddizione col prompt e con `docs/MCP_DISTRIBUTION.md` |
| `disabled={!origin}` sul bottone | sempre attivo | L endpoint canonico è una costante: nessuno stato da attendere |
| `useSyncExternalStore` per leggere l origin | rimosso | Codice morto dopo la canonizzazione |

## Verifica

- `node --experimental-strip-types --test tests/mcp_distribution.test.mjs` → 2/2
- `npm run typecheck` → OK
- `npx eslint` sui file toccati → OK

Nota: recupera il fix ancora valido dalla PR #73 (stack UI del 22/08); le parti cosmetiche (kicker, indici decorativi) non sono state riportate perché aree ripensate in `main`.