### PR TITLE
feat(coesione): perimetro dell archivio nel catalogo asili

### DIFF
--- a/src/app/coesione/asili/page.tsx
+++ b/src/app/coesione/asili/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Form from "next/form";
 import Link from "next/link";
-import { compactEuro, integer } from "@/lib/format";
+import { compactEuro, integer, longDate } from "@/lib/format";
 import {
   PnrrChildcareQueryError,
   pnrrChildcareData,
@@ -103,7 +103,18 @@ export default async function PnrrChildcareCatalog({ searchParams }: { searchPar
         {error ? <p className={styles.error} role="alert">{error}</p> : null}
       </section>
 
-      <div className={styles.statRail} aria-label="Copertura del tracciato">
+      <p className={styles.archiveScope}>
+        <strong>Intero archivio: {integer(pnrrChildcareMeta.coverage.uniqueProjects)} CUP</strong>
+        <span aria-hidden="true"> · </span>
+        misura {pnrrChildcareMeta.submeasure.code}
+        <span aria-hidden="true"> · </span>
+        dati al {longDate(pnrrChildcareMeta.referenceDate)}
+        <span aria-hidden="true"> · </span>
+        <a href={pnrrChildcareMeta.source.landingUrl} target="_blank" rel="noreferrer">
+          Fonte Italia Domani ↗
+        </a>
+      </p>
+      <div className={styles.statRail} aria-label="Copertura dell’intero archivio">
         <div><strong>{compactEuro(pnrrChildcareMeta.totals.pnrrFundingCents / 100)}</strong><span>finanziamento PNRR registrato</span></div>
         <div><strong>{integer(pnrrChildcareMeta.coverage.tenderRows)}</strong><span>gare collegate</span></div>
         <div><strong>{integer(pnrrChildcareMeta.coverage.awardeeRows)}</strong><span>righe aggiudicatario</span></div>

--- a/src/app/coesione/asili/pnrr-asili.module.css
+++ b/src/app/coesione/asili/pnrr-asili.module.css
@@ -79,6 +79,13 @@
   font-weight: 700;
 }
 
+.archiveScope {
+  max-width: 80ch;
+  margin: 0 0 var(--space-3);
+  color: var(--color-neutral-700);
+  font-size: 12px;
+}
+
 .statRail {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -302,6 +309,10 @@
 
   .cardMetrics {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .card {
+    min-height: auto;
   }
 }
 

--- a/tests/pnrr-childcare-ui.test.mjs
+++ b/tests/pnrr-childcare-ui.test.mjs
@@ -11,6 +11,10 @@ test("PNRR catalog is server-rendered, searchable, and semantically cautious", a
   assert.match(page, /finanziamento PNRR registrato/i);
   assert.match(page, /pista documentale su CUP, finanziamenti, gare e aggiudicatari/i);
   assert.match(page, /non contiene i pagamenti ReGiS/i);
+  assert.match(page, /Intero archivio:[\s\S]*?coverage\.uniqueProjects/);
+  assert.match(page, /submeasure\.code/);
+  assert.match(page, /longDate\(pnrrChildcareMeta\.referenceDate\)/);
+  assert.match(page, /pnrrChildcareMeta\.source\.landingUrl/);
   assert.equal(page.match(/<h1\b/g)?.length, 1);
   assert.match(page, /aria-label="Pagine dei risultati"/);
   assert.doesNotMatch(page, /heroMetric|kicker|01 ·|02 ·/);
@@ -34,6 +38,7 @@ test("PNRR layouts collapse every major grid on narrow screens", async () => {
     source("../src/app/progetti/[cup]/project.module.css"),
   ]);
   assert.match(catalogCss, /@media \(max-width: 650px\)[\s\S]*?grid-template-columns: 1fr;/);
+  assert.match(catalogCss, /@media \(max-width: 650px\)[\s\S]*?\.card \{[\s\S]*?min-height: auto;/);
   assert.match(projectCss, /@media \(max-width: 620px\)[\s\S]*?\.flowGrid \{[\s\S]*?grid-template-columns: 1fr;/);
   assert.match(projectCss, /overflow-wrap:\s+anywhere/);
 });


### PR DESCRIPTION
## Base / head

- Base: `main` (`39e7e9c`)
- Head: `feat/asili-archivio-perimetro`

## Scope

- Riga di perimetro sopra la rail di statistiche del catalogo PNRR asili: dimensione dell archivio completo (CUP), misura, data di riferimento e fonte ufficiale.
- `aria-label` della rail allineato al perimetro dichiarato.
- `.card` senza altezza minima sotto 650px: le schede corte non lasciano spazi vuoti su mobile.
- Contratti UI estesi in `tests/pnrr-childcare-ui.test.mjs`.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| La rail mostrava gare, aggiudicatari e Comuni senza dichiarare il denominatore dell archivio | "Intero archivio: N CUP · misura · dati al … · fonte" | Il lettore deve poter distinguere l archivio completo dai risultati filtrati, come da principi editoriali del progetto (perimetro e fonte accanto ai KPI) |
| `.card { min-height: 330px }` anche su mobile | `min-height: auto` sotto 650px | Altezze forzate riempiono di vuoto le schede sui telefoni |

## Verifica

- `node --experimental-strip-types --test tests/pnrr-childcare-ui.test.mjs` → 4/4
- `npm run typecheck` → OK
- `npx eslint` sui file toccati → OK

Nota: recupera il contenuto ancora valido dalla PR #69 (stack UI del 22/08); i campi esistono già nel meta generato (`uniqueProjects`, `referenceDate`, `submeasure`, `source.landingUrl`).