### PR TITLE
fix(controlli): rivela lo scorrimento laterale delle tabelle larghe

### DIFF
--- a/src/app/controlli/controlli.module.css
+++ b/src/app/controlli/controlli.module.css
@@ -520,6 +520,10 @@
   max-width: 100ch;
 }
 
+.tableHint {
+  display: none;
+}
+
 @media (max-width: 620px) {
   .yearFilter {
     align-items: flex-start;
@@ -537,6 +541,15 @@
   }
 
   .signalValue { font-size: 27px; }
+
+  .tableHint {
+    display: block;
+    margin: var(--space-3) 0 var(--space-2);
+    color: var(--color-neutral-700);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
   .breakdown li {
     grid-template-columns: minmax(0, 1fr) 112px;
   }

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -348,58 +348,65 @@ export default async function ControlsPage({ searchParams }: PageProps) {
           </div>
 
           {topSpendingOutliers.length > 0 ? (
-            <div
-              className={"table-scroll " + styles.outlierTable}
-              role="region"
-              aria-label="Screening derivato dei Comuni oltre la soglia regionale"
-              tabIndex={0}
-            >
-              <table className="table">
-                <caption>
-                  {topSpendingOutliers.length} di {integer(spendingOutliers.pagination.total)}
-                  {" "}risultati dello screening, ordinati per distanza dalla soglia per facilitare
-                  la lettura · OpenCivitas {openCivitasSnapshot.referenceYear}
-                </caption>
-                <thead>
-                  <tr>
-                    <th scope="col">Comune</th>
-                    <th scope="col">Provincia · Regione</th>
-                    <th scope="col" className="num">Differenza per abitante</th>
-                    <th scope="col" className="num">Popolazione implicita</th>
-                    <th scope="col">Distanza dalla soglia</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {topSpendingOutliers.map((outlier) => (
-                    <tr key={outlier.istatCode}>
-                      <th scope="row">
-                        {municipalityName(outlier.name)}
-                        <small>{outlier.istatCode}</small>
-                      </th>
-                      <td>
-                        {municipalityName(outlier.province)} · {municipalityName(outlier.region)}
-                      </td>
-                      <td className="num">
-                        {signedEuroFromCents(outlier.differencePerCapitaCents)}
-                        <small>{outlier.direction === "sopra" ? "sopra" : "sotto"} la soglia</small>
-                      </td>
-                      <td className="num">
-                        {outlier.impliedPopulation === null
-                          ? "non disponibile"
-                          : "~" + integer(outlier.impliedPopulation)}
-                        <small>{populationBandLabels[outlier.populationBand]}</small>
-                      </td>
-                      <td>
-                        {outlier.excessMultiple === null
-                          ? "IQR = 0"
-                          : number.format(outlier.excessMultiple) + " × IQR"}
-                        <small>{signedEuroFromCents(outlier.distanceBeyondFenceCents)} oltre</small>
-                      </td>
+            <>
+              <p className={styles.tableHint} id="outlier-table-hint">
+                Scorri lateralmente per differenza, popolazione e distanza dalla soglia. Da
+                tastiera usa Freccia sinistra e Freccia destra.
+              </p>
+              <div
+                className={"table-scroll " + styles.outlierTable}
+                role="region"
+                aria-label="Screening derivato dei Comuni oltre la soglia regionale"
+                aria-describedby="outlier-table-hint"
+                tabIndex={0}
+              >
+                <table className="table">
+                  <caption>
+                    {topSpendingOutliers.length} di {integer(spendingOutliers.pagination.total)}
+                    {" "}risultati dello screening, ordinati per distanza dalla soglia per facilitare
+                    la lettura · OpenCivitas {openCivitasSnapshot.referenceYear}
+                  </caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Comune</th>
+                      <th scope="col">Provincia · Regione</th>
+                      <th scope="col" className="num">Differenza per abitante</th>
+                      <th scope="col" className="num">Popolazione implicita</th>
+                      <th scope="col">Distanza dalla soglia</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  </thead>
+                  <tbody>
+                    {topSpendingOutliers.map((outlier) => (
+                      <tr key={outlier.istatCode}>
+                        <th scope="row">
+                          {municipalityName(outlier.name)}
+                          <small>{outlier.istatCode}</small>
+                        </th>
+                        <td>
+                          {municipalityName(outlier.province)} · {municipalityName(outlier.region)}
+                        </td>
+                        <td className="num">
+                          {signedEuroFromCents(outlier.differencePerCapitaCents)}
+                          <small>{outlier.direction === "sopra" ? "sopra" : "sotto"} la soglia</small>
+                        </td>
+                        <td className="num">
+                          {outlier.impliedPopulation === null
+                            ? "non disponibile"
+                            : "~" + integer(outlier.impliedPopulation)}
+                          <small>{populationBandLabels[outlier.populationBand]}</small>
+                        </td>
+                        <td>
+                          {outlier.excessMultiple === null
+                            ? "IQR = 0"
+                            : number.format(outlier.excessMultiple) + " × IQR"}
+                          <small>{signedEuroFromCents(outlier.distanceBeyondFenceCents)} oltre</small>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
           ) : (
             <p className={styles.note}>Nessun valore supera la soglia con i dati attuali.</p>
           )}
@@ -413,7 +420,10 @@ export default async function ControlsPage({ searchParams }: PageProps) {
               ricostruzioni totale ÷ per abitante. Resta una stima implicita, distinta da un
               dato demografico ISTAT.
             </p>
-            <div className={"table-scroll " + styles.outlierTable} role="region" aria-label="Controllo di sensibilità per fascia di popolazione" tabIndex={0}>
+            <p className={styles.tableHint} id="sensitivity-table-hint">
+              Scorri lateralmente per coorti, Comuni valutati e valori oltre soglia.
+            </p>
+            <div className={"table-scroll " + styles.outlierTable} role="region" aria-label="Controllo di sensibilità per fascia di popolazione" aria-describedby="sensitivity-table-hint" tabIndex={0}>
               <table className="table">
                 <caption>Controllo di sensibilità del metodo per fascia di popolazione implicita</caption>
                 <thead>
@@ -507,10 +517,14 @@ export default async function ControlsPage({ searchParams }: PageProps) {
           </div>
         )}
 
+        <p className={styles.tableHint} id="procurement-table-hint">
+          Scorri lateralmente per quote sul numero, valore e fonte.
+        </p>
         <div
           className={`table-scroll ${styles.procurementTable}`}
           role="region"
           aria-label="Serie annuale degli affidamenti diretti ANAC"
+          aria-describedby="procurement-table-hint"
           tabIndex={0}
         >
           <table className="table">
@@ -656,10 +670,14 @@ export default async function ControlsPage({ searchParams }: PageProps) {
             </p>
             <details className={styles.scenarioMethod}>
               <summary>Vedi formula e ipotesi</summary>
+              <p className={styles.tableHint} id="scenario-table-hint">
+                Scorri lateralmente per confrontare tutte le basi del modello.
+              </p>
               <div
                 className="table-scroll"
                 role="region"
                 aria-label="Ipotesi percentuali dei tre scenari"
+                aria-describedby="scenario-table-hint"
                 tabIndex={0}
               >
                 <table className="table">

--- a/src/app/partecipazioni/page.tsx
+++ b/src/app/partecipazioni/page.tsx
@@ -115,7 +115,11 @@ export default function ParticipationsPage() {
 
       <section className="panel">
         <h2 className="panel-title">Organizzazioni dichiarate da più amministrazioni</h2>
-        <div className="table-scroll" role="region" aria-label="Organizzazioni partecipate da più amministrazioni" tabIndex={0}>
+        <p className={styles.tableHint} id="participations-table-hint">
+          Scorri lateralmente per codice fiscale e numero di amministrazioni. Da tastiera usa
+          Freccia sinistra e Freccia destra.
+        </p>
+        <div className="table-scroll" role="region" aria-label="Organizzazioni partecipate da più amministrazioni" aria-describedby="participations-table-hint" tabIndex={0}>
           <table className="table">
             <thead>
               <tr>

--- a/src/app/partecipazioni/partecipazioni.module.css
+++ b/src/app/partecipazioni/partecipazioni.module.css
@@ -96,3 +96,17 @@
   color: var(--color-neutral-600);
   max-width: 100ch;
 }
+
+.tableHint {
+  display: none;
+}
+
+@media (max-width: 620px) {
+  .tableHint {
+    display: block;
+    margin: 0 0 var(--space-2);
+    color: var(--color-neutral-700);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+}

--- a/tests/ui-contracts.test.mjs
+++ b/tests/ui-contracts.test.mjs
@@ -39,6 +39,14 @@ const controlsCss = await readFile(
   new URL("../src/app/controlli/controlli.module.css", import.meta.url),
   "utf8",
 );
+const participationsPage = await readFile(
+  new URL("../src/app/partecipazioni/page.tsx", import.meta.url),
+  "utf8",
+);
+const participationsCss = await readFile(
+  new URL("../src/app/partecipazioni/partecipazioni.module.css", import.meta.url),
+  "utf8",
+);
 
 test("the fiscal formula has one explicit screen-reader relationship", () => {
   const accessibleFormula =
@@ -132,4 +140,17 @@ test("the spending analysis explains the share without turning it into a merit r
   assert.match(spendingCss, /\.analysis \{/);
   assert.match(spendingCss, /@media \(max-width: 620px\)[\s\S]*?\.quantiles \{/);
   assert.match(spendingCss, /@media \(max-width: 420px\)[\s\S]*?table-layout: fixed/);
+});
+
+test("wide oversight tables disclose horizontal scrolling on mobile", () => {
+  assert.equal(controlsPage.match(/className=\{styles\.tableHint\}/g)?.length, 4);
+  assert.match(controlsPage, /aria-describedby="outlier-table-hint"/);
+  assert.match(controlsPage, /aria-describedby="sensitivity-table-hint"/);
+  assert.match(controlsPage, /aria-describedby="procurement-table-hint"/);
+  assert.match(controlsPage, /aria-describedby="scenario-table-hint"/);
+  assert.match(controlsCss, /\.tableHint \{\s*display: none;/);
+  assert.match(controlsCss, /@media \(max-width: 620px\)[\s\S]*?\.tableHint \{[\s\S]*?display: block;/);
+  assert.match(participationsPage, /aria-describedby="participations-table-hint"/);
+  assert.match(participationsPage, /Freccia sinistra e Freccia destra/);
+  assert.match(participationsCss, /@media \(max-width: 620px\)[\s\S]*?\.tableHint \{[\s\S]*?display: block;/);
 });


### PR DESCRIPTION
## Base / head

- Base: `main` (`39e7e9c`)
- Head: `fix/controlli-scroll-disclosure`

## Scope

- Le 4 regioni tabella scrollabili di `/controlli` (screening soglie, sensibilità per fascia, affidamenti ANAC, ipotesi scenari) e la tabella di `/partecipazioni` dichiarano la continuazione orizzontale.
- Hint visibile solo ≤620px, collegato alla regione con `aria-describedby`; istruzioni tastiera (Freccia sinistra/destra) sulle tabelle focalizzabili.
- Solo markup e CSS: nessun cambio a dati, ordine o contenuti.
- Contratto aggiunto in `tests/ui-contracts.test.mjs`.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| Continuazione laterale implicita (colonne fuori vista su mobile senza avviso) | Hint mobile + relazione esplicita con la regione scrollabile | WCAG: le regioni scrollabili devono essere annunciate; il lettore mobile deve sapere che ci sono altre colonne |
| Nessuna istruzione tastiera | "Da tastiera usa Freccia sinistra e Freccia destra" | Le regioni hanno tabIndex=0: le istruzioni rendono il gesto scopribile |

## Verifica

- `node --experimental-strip-types --test tests/ui-contracts.test.mjs` → 7/7
- `npm run typecheck` → OK
- `npx eslint` sui file toccati → OK

Nota: recupera il pattern ancora valido dalla PR #70 (stack UI del 22/08), adattato alla pagina `/controlli` riscritta da #119.