### PR TITLE
test: salta i test live OpenBDAP quando la fonte non è raggiungibile

### DIFF
--- a/tests/helpers/live-openbdap.mjs
+++ b/tests/helpers/live-openbdap.mjs
@@ -1,0 +1,31 @@
+/**
+ * Live OpenBDAP integration tests reconcile the data contracts against the
+ * real published series. OpenBDAP can be intermittently unreachable
+ * (maintenance windows, rate limiting, transient network errors), which turns
+ * a valuable live check into a flaky CI gate: a single failed request among
+ * the sequential discovery+fetch chain fails the whole `node` job and blocks
+ * every open PR for a reason that has nothing to do with the data contract.
+ *
+ * `isOpenBdapReachable` probes the lightest CKAN endpoint the live tests rely
+ * on (`package_search?rows=1`) with a short, independent timeout. The live
+ * tests call it at the top of their body and `context.skip()` when it returns
+ * false, so an outage is reported as a skip instead of a failure.
+ */
+
+const BDAP_ACTION = "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action";
+
+export async function isOpenBdapReachable({ timeoutMs = 8_000 } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(
+      `${BDAP_ACTION}/package_search?rows=1`,
+      { method: "GET", signal: controller.signal, redirect: "error" },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/ssn-national-history.test.mjs
+++ b/tests/ssn-national-history.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
+import { isOpenBdapReachable } from "./helpers/live-openbdap.mjs";
 
 const { SSN_NATIONAL_HISTORY_YEARS, getSsnNationalHistory, nationalValuesFromRows } = await import(
   "../src/lib/ssn-national-history.ts"
@@ -20,7 +21,11 @@ test(
   // 13 sequential live OpenBDAP CSV fetches (one discovery call plus one per year); can take
   // a couple of minutes under retry per the openbdap source policy.
   { timeout: 300_000 },
-  async () => {
+  async (context) => {
+    if (!(await isOpenBdapReachable())) {
+      context.skip("OpenBDAP non raggiungibile — test live saltato");
+      return;
+    }
     const history = await getSsnNationalHistory();
     assert.equal(history.years.length, 13);
     assert.deepEqual(history.years.map((entry) => entry.year), [...SSN_NATIONAL_HISTORY_YEARS]);
@@ -338,11 +343,15 @@ test("SSN national history accepts OpenBDAP CSVs with one empty trailing delimit
   }
 });
 
-test("openbdap_ssn_storico_nazionale MCP dataset rejects filters and stays within the response budget", async () => {
+test("openbdap_ssn_storico_nazionale MCP dataset rejects filters and stays within the response budget", async (context) => {
   await assert.rejects(
     queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale", year: 2024 }),
     /Filtri non supportati/,
   );
+  if (!(await isOpenBdapReachable())) {
+    context.skip("OpenBDAP non raggiungibile — test live saltato");
+    return;
+  }
   const result = await queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale" });
   assert.equal(result.years.length, 13);
   assert.ok(JSON.stringify(result).length < 750 * 1024);

--- a/tests/state-spending-legislature.test.mjs
+++ b/tests/state-spending-legislature.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
+import { isOpenBdapReachable } from "./helpers/live-openbdap.mjs";
 
 const { LEGISLATURES, getLegislatureSpendingCycles, fullYearsWithinLegislature } = await import(
   "../src/lib/state-spending-legislature.ts"
@@ -93,7 +94,11 @@ test(
   // up to ~30s under retry per the openbdap source policy (15s timeout, 1 retry), so this needs
   // real headroom rather than the 120s default.
   { timeout: 300_000 },
-  async () => {
+  async (context) => {
+    if (!(await isOpenBdapReachable())) {
+      context.skip("OpenBDAP non raggiungibile — test live saltato");
+      return;
+    }
     const cycles = await getLegislatureSpendingCycles();
     assert.equal(cycles.length, LEGISLATURES.length);
 
@@ -131,11 +136,15 @@ test(
   },
 );
 
-test("openbdap_spesa_legislature MCP dataset rejects any filter and exposes the same cycles", async () => {
+test("openbdap_spesa_legislature MCP dataset rejects any filter and exposes the same cycles", async (context) => {
   await assert.rejects(
     queryPublicDataset({ dataset: "openbdap_spesa_legislature", year: 2024 }),
     /Filtri non supportati/,
   );
+  if (!(await isOpenBdapReachable())) {
+    context.skip("OpenBDAP non raggiungibile — test live saltato");
+    return;
+  }
   const result = await queryPublicDataset({ dataset: "openbdap_spesa_legislature" });
   assert.equal(result.cycles.length, LEGISLATURES.length);
   assert.ok(JSON.stringify(result).length < 750 * 1024);


### PR DESCRIPTION
## Base / head

- Base: `main` (`39e7e9c`)
- Head: `fix/live-openbdap-skip-when-unreachable`

## Scope

I test di riconciliazione live (`spesa per legislatura`, `storico SSN`, `budget risposta MCP`) interrogano OpenBDAP in CI. Quando la fonte è intermittente (manutenzione, rate limit, errori transitori), un solo fallimento nella catena sequenziale di fetch fa fallire tutto il job `node` e blocca ogni PR aperta per un motivo estraneo al contratto dati.

Un probe leggero (`package_search?rows=1`, timeout 8s indipendente) viene chiamato all inizio dei test live: se OpenBDAP non risponde, `context.skip()` riporta l out-age come skip invece che come failure.

- Nuovo helper `tests/helpers/live-openbdap.mjs` con `isOpenBdapReachable()`.
- 3 test live in `state-spending-legislature.test.mjs` (2) e `ssn-national-history.test.mjs` (2, di cui 1 con anche la parte di contratto che resta sempre attiva) usano `context.skip()` quando il probe fallisce.
- Complementare a #136 (che stubba `fetch` per il budget test con dati sintetici): questo PR gestisce i test live intenzionali che #136 non copre.

## Before | After | Why

| Before | After | Why |
| --- | --- | --- |
| Test live falliscono con `SourceFetchError` quando OpenBDAP è down | `context.skip("OpenBDAP non raggiungibile")` | Un outage esterno non deve bloccare PR non correlate |
| La parte di contratto (reject filtri) veniva saltata insieme alla parte live | La parte di contratto resta sempre attiva; solo la parte live salta | Il contratto è verificato anche offline |

## Verifica

- `npm run typecheck` → OK
- `npx eslint` sui file toccati → OK
- Con `DVNS_OFFLINE_GUARD=1` (offline guard attivo): 28 test, 24 pass, **0 fail, 4 skip** ✓
- Senza offline guard (OpenBDAP raggiungibile): 9/9 pass in legislature (test live girano) ✓

Nota: risolve la flakiness CI che bloccava #139-142 (e ogni altra PR basata su main).