### PR TITLE
test: catch transient SourceFetchError nei test live OpenBDAP

### DIFF
--- a/tests/helpers/live-openbdap.mjs
+++ b/tests/helpers/live-openbdap.mjs
@@ -7,12 +7,19 @@
  * every open PR for a reason that has nothing to do with the data contract.
  *
  * `isOpenBdapReachable` probes the lightest CKAN endpoint the live tests rely
- * on (`package_search?rows=1`) with a short, independent timeout. The live
- * tests call it at the top of their body and `context.skip()` when it returns
- * false, so an outage is reported as a skip instead of a failure.
+ * on (`package_search?rows=1`) with a short, independent timeout. When the
+ * probe fails the live call is skipped immediately, avoiding a multi-minute
+ * timeout chain.
+ *
+ * `runLiveOpenBdap` wraps a live assertion body: it probes first, then runs
+ * the body, and if the body throws a `SourceFetchError` (OpenBDAP answered the
+ * probe but flaked during the heavy data fetch) the test is skipped instead of
+ * failing. Real assertion failures propagate normally.
  */
 
 const BDAP_ACTION = "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action";
+
+const SKIP_REASON = "OpenBDAP non raggiungibile — test live saltato";
 
 export async function isOpenBdapReachable({ timeoutMs = 8_000 } = {}) {
   const controller = new AbortController();
@@ -27,5 +34,31 @@ export async function isOpenBdapReachable({ timeoutMs = 8_000 } = {}) {
     return false;
   } finally {
     clearTimeout(timer);
+  }
+}
+
+function isTransientSourceError(error) {
+  if (error?.name === "SourceFetchError") return true;
+  if (error?.name === "AbortError" || error?.name === "TimeoutError") return true;
+  return false;
+}
+
+/**
+ * Runs a live OpenBDAP assertion. Skips the test when the source is unreachable
+ * (probe or during the call); real assertion failures still propagate.
+ */
+export async function runLiveOpenBdap(context, body) {
+  if (!(await isOpenBdapReachable())) {
+    context.skip(SKIP_REASON);
+    return;
+  }
+  try {
+    return await body();
+  } catch (error) {
+    if (isTransientSourceError(error)) {
+      context.skip(SKIP_REASON);
+      return;
+    }
+    throw error;
   }
 }

--- a/tests/ssn-national-history.test.mjs
+++ b/tests/ssn-national-history.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
-import { isOpenBdapReachable } from "./helpers/live-openbdap.mjs";
+import { runLiveOpenBdap } from "./helpers/live-openbdap.mjs";
 
 const { SSN_NATIONAL_HISTORY_YEARS, getSsnNationalHistory, nationalValuesFromRows } = await import(
   "../src/lib/ssn-national-history.ts"
@@ -22,34 +22,32 @@ test(
   // a couple of minutes under retry per the openbdap source policy.
   { timeout: 300_000 },
   async (context) => {
-    if (!(await isOpenBdapReachable())) {
-      context.skip("OpenBDAP non raggiungibile — test live saltato");
-      return;
-    }
-    const history = await getSsnNationalHistory();
-    assert.equal(history.years.length, 13);
-    assert.deepEqual(history.years.map((entry) => entry.year), [...SSN_NATIONAL_HISTORY_YEARS]);
+    await runLiveOpenBdap(context, async () => {
+      const history = await getSsnNationalHistory();
+      assert.equal(history.years.length, 13);
+      assert.deepEqual(history.years.map((entry) => entry.year), [...SSN_NATIONAL_HISTORY_YEARS]);
 
-    const year2024 = history.years.find((entry) => entry.year === 2024);
-    assert.ok(year2024);
-    // Must match the independently locked, hash-verified 2024 snapshot exactly: same source,
-    // same metrics, same unit (cents) — not a second, potentially drifting computation.
-    assert.deepEqual(year2024.values, ssnCceSnapshot.national.values);
+      const year2024 = history.years.find((entry) => entry.year === 2024);
+      assert.ok(year2024);
+      // Must match the independently locked, hash-verified 2024 snapshot exactly: same source,
+      // same metrics, same unit (cents) — not a second, potentially drifting computation.
+      assert.deepEqual(year2024.values, ssnCceSnapshot.national.values);
 
-    // Values must be integers (cents), not floats with rounding artifacts from a naive
-    // euro * 100 conversion.
-    for (const entry of history.years) {
-      for (const value of Object.values(entry.values)) {
-        assert.ok(Number.isSafeInteger(value), `${entry.year}: ${value} non è un intero sicuro`);
-        assert.ok(value > 0, `${entry.year}: valore non positivo`);
+      // Values must be integers (cents), not floats with rounding artifacts from a naive
+      // euro * 100 conversion.
+      for (const entry of history.years) {
+        for (const value of Object.values(entry.values)) {
+          assert.ok(Number.isSafeInteger(value), `${entry.year}: ${value} non è un intero sicuro`);
+          assert.ok(value > 0, `${entry.year}: valore non positivo`);
+        }
       }
-    }
 
-    // The known 2020-2021 rise in externally contracted healthcare work services should be
-    // visible in the raw series (it is not asserted as caused by anything, only that the
-    // adapter surfaces the real published numbers instead of a flattened trend).
-    const byYear = new Map(history.years.map((entry) => [entry.year, entry.values]));
-    assert.ok(byYear.get(2020).healthcareWorkServices > byYear.get(2019).healthcareWorkServices);
+      // The known 2020-2021 rise in externally contracted healthcare work services should be
+      // visible in the raw series (it is not asserted as caused by anything, only that the
+      // adapter surfaces the real published numbers instead of a flattened trend).
+      const byYear = new Map(history.years.map((entry) => [entry.year, entry.values]));
+      assert.ok(byYear.get(2020).healthcareWorkServices > byYear.get(2019).healthcareWorkServices);
+    });
   },
 );
 
@@ -348,11 +346,9 @@ test("openbdap_ssn_storico_nazionale MCP dataset rejects filters and stays withi
     queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale", year: 2024 }),
     /Filtri non supportati/,
   );
-  if (!(await isOpenBdapReachable())) {
-    context.skip("OpenBDAP non raggiungibile — test live saltato");
-    return;
-  }
-  const result = await queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale" });
-  assert.equal(result.years.length, 13);
-  assert.ok(JSON.stringify(result).length < 750 * 1024);
+  await runLiveOpenBdap(context, async () => {
+    const result = await queryPublicDataset({ dataset: "openbdap_ssn_storico_nazionale" });
+    assert.equal(result.years.length, 13);
+    assert.ok(JSON.stringify(result).length < 750 * 1024);
+  });
 });

--- a/tests/state-spending-legislature.test.mjs
+++ b/tests/state-spending-legislature.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
-import { isOpenBdapReachable } from "./helpers/live-openbdap.mjs";
+import { runLiveOpenBdap } from "./helpers/live-openbdap.mjs";
 
 const { LEGISLATURES, getLegislatureSpendingCycles, fullYearsWithinLegislature } = await import(
   "../src/lib/state-spending-legislature.ts"
@@ -95,44 +95,42 @@ test(
   // real headroom rather than the 120s default.
   { timeout: 300_000 },
   async (context) => {
-    if (!(await isOpenBdapReachable())) {
-      context.skip("OpenBDAP non raggiungibile — test live saltato");
-      return;
-    }
-    const cycles = await getLegislatureSpendingCycles();
-    assert.equal(cycles.length, LEGISLATURES.length);
+    await runLiveOpenBdap(context, async () => {
+      const cycles = await getLegislatureSpendingCycles();
+      assert.equal(cycles.length, LEGISLATURES.length);
 
-    const seventeenth = cycles.find((cycle) => cycle.legislature.number === "XVII");
-    assert.ok(seventeenth);
-    assert.deepEqual(
-      seventeenth.years.map((entry) => entry.year),
-      [2014, 2015, 2016, 2017],
-    );
-    assert.equal(seventeenth.preElectionYear.year, 2017);
-    assert.ok(seventeenth.years.every((entry) => entry.totalPaid > 0));
-    assert.ok(
-      seventeenth.years.every((entry) => entry.extraordinaryContext === null),
-      "il 2014-2017 non deve avere un contesto straordinario dichiarato",
-    );
+      const seventeenth = cycles.find((cycle) => cycle.legislature.number === "XVII");
+      assert.ok(seventeenth);
+      assert.deepEqual(
+        seventeenth.years.map((entry) => entry.year),
+        [2014, 2015, 2016, 2017],
+      );
+      assert.equal(seventeenth.preElectionYear.year, 2017);
+      assert.ok(seventeenth.years.every((entry) => entry.totalPaid > 0));
+      assert.ok(
+        seventeenth.years.every((entry) => entry.extraordinaryContext === null),
+        "il 2014-2017 non deve avere un contesto straordinario dichiarato",
+      );
 
-    const eighteenth = cycles.find((cycle) => cycle.legislature.number === "XVIII");
-    assert.ok(eighteenth);
-    assert.deepEqual(
-      eighteenth.years.map((entry) => entry.year),
-      [2019, 2020, 2021],
-    );
-    assert.equal(eighteenth.preElectionYear.year, 2021);
-    // The pre-election year for XVIII is a COVID year: the module must say so explicitly
-    // instead of silently folding it into "otherYearsAverage" as if it were ordinary.
-    assert.match(eighteenth.preElectionYear.extraordinaryContext ?? "", /COVID/);
-    assert.match(eighteenth.preElectionYear.extraordinaryContext ?? "", /non (è|e) isolat/i);
+      const eighteenth = cycles.find((cycle) => cycle.legislature.number === "XVIII");
+      assert.ok(eighteenth);
+      assert.deepEqual(
+        eighteenth.years.map((entry) => entry.year),
+        [2019, 2020, 2021],
+      );
+      assert.equal(eighteenth.preElectionYear.year, 2021);
+      // The pre-election year for XVIII is a COVID year: the module must say so explicitly
+      // instead of silently folding it into "otherYearsAverage" as if it were ordinary.
+      assert.match(eighteenth.preElectionYear.extraordinaryContext ?? "", /COVID/);
+      assert.match(eighteenth.preElectionYear.extraordinaryContext ?? "", /non (è|e) isolat/i);
 
-    const nineteenth = cycles.find((cycle) => cycle.legislature.number === "XIX");
-    assert.ok(nineteenth);
-    assert.deepEqual(nineteenth.years, []);
-    assert.equal(nineteenth.preElectionYear, null);
-    assert.equal(nineteenth.otherYearsAverage, null);
-    assert.equal(nineteenth.differenceFromAverage, null);
+      const nineteenth = cycles.find((cycle) => cycle.legislature.number === "XIX");
+      assert.ok(nineteenth);
+      assert.deepEqual(nineteenth.years, []);
+      assert.equal(nineteenth.preElectionYear, null);
+      assert.equal(nineteenth.otherYearsAverage, null);
+      assert.equal(nineteenth.differenceFromAverage, null);
+    });
   },
 );
 
@@ -141,11 +139,9 @@ test("openbdap_spesa_legislature MCP dataset rejects any filter and exposes the 
     queryPublicDataset({ dataset: "openbdap_spesa_legislature", year: 2024 }),
     /Filtri non supportati/,
   );
-  if (!(await isOpenBdapReachable())) {
-    context.skip("OpenBDAP non raggiungibile — test live saltato");
-    return;
-  }
-  const result = await queryPublicDataset({ dataset: "openbdap_spesa_legislature" });
-  assert.equal(result.cycles.length, LEGISLATURES.length);
-  assert.ok(JSON.stringify(result).length < 750 * 1024);
+  await runLiveOpenBdap(context, async () => {
+    const result = await queryPublicDataset({ dataset: "openbdap_spesa_legislature" });
+    assert.equal(result.cycles.length, LEGISLATURES.length);
+    assert.ok(JSON.stringify(result).length < 750 * 1024);
+  });
 });


### PR DESCRIPTION
## Base / head

- Base: `main` (`45a7e09` — include già #144)
- Head: `fix/live-openbdap-catch-transient`

## Scope

Follow-up a #144. Il probe di #144 gestisce il caso in cui OpenBDAP è completamente down, ma non il caso in cui il probe leggero (`package_search?rows=1`) risponde e la chiamata dati pesante flaka dopo: il test fallisce comunque con `SourceFetchError`.

`runLiveOpenBdap(context, body)` avvolge il body del test live:
1. Probe prima (fast bail-out quando OpenBDAP è completamente down)
2. Se il body lancia `SourceFetchError` o `AbortError`/`TimeoutError` (OpenBDAP ha risposto al probe ma flaka sul fetch pesante) → `context.skip()` invece di fail
3. I real assertion failure propagano normalmente

I test di puro contratto (reject filtri) restano sempre attivi, fuori dal wrapper.

## Before | After | Why

| Before (#144) | After | Why |
| --- | --- | --- |
| Probe only: se il probe succeed e la chiamata fallisce → fail | Probe + catch: SourceFetchError nel body → skip | OpenBDAP può rispondere al probe leggero e flakare sul fetch sequenziale pesante (7-13 chiamate CSV) |
| `isOpenBdapReachable()` + `context.skip()` manuale in ogni test | `runLiveOpenBdap(context, body)` centralizzato | Meno duplicazione, logica di skip in un solo posto |

## Verifica

- `npm run typecheck` → OK
- `npx eslint` sui file toccati → OK
- Offline guard (`DVNS_OFFLINE_GUARD=1`): 28 test, 24 pass, **0 fail, 4 skip** ✓
- Catch path verificato: body che lancia `SourceFetchError` → skip ✓
- Real assertion failure → propaga ✓