### PR TITLE
fix(imprese): etichette ISTAT senza overlap

### DIFF
--- a/src/app/imprese/imprese.module.css
+++ b/src/app/imprese/imprese.module.css
@@ -74,7 +74,8 @@
 
 .sectorList { display: flex; flex-direction: column; gap: 12px; margin: 0; padding: 0; list-style: none; }
 .sectorList li { min-width: 0; }
-.sectorLabel { display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; align-items: baseline; gap: 5px; font-size: 12px; }
+.sectorLabel { display: grid; grid-template-columns: max-content minmax(0, 1fr) auto; align-items: baseline; gap: 5px; font-size: 12px; }
+.sectorLabelPlain { grid-template-columns: minmax(0, 1fr) auto; }
 .sectorLabel b { color: var(--color-accent-700); }
 .sectorLabel span { overflow: hidden; color: var(--color-neutral-800); text-overflow: ellipsis; white-space: nowrap; }
 .sectorLabel strong { font-variant-numeric: tabular-nums; }

--- a/src/app/imprese/page.tsx
+++ b/src/app/imprese/page.tsx
@@ -172,8 +172,7 @@ export default async function ImpresePage({
                   const share = sector.value !== null && sectorTotal > 0 ? (sector.value / sectorTotal) * 100 : 0;
                   return (
                     <li key={sector.code}>
-                      <div className={styles.sectorLabel}>
-                        <b>{sector.code}</b>
+                      <div className={`${styles.sectorLabel} ${styles.sectorLabelPlain}`}>
                         <span>{sector.label}</span>
                         <strong>{compactTurnover(sector.value)}</strong>
                       </div>

--- a/src/components/company-atlas-filters.tsx
+++ b/src/components/company-atlas-filters.tsx
@@ -6,6 +6,12 @@ import styles from "./company-atlas-filters.module.css";
 
 type SelectOption = Readonly<{ id: string; label: string }>;
 
+function sectorChoiceLabel(id: string, label: string) {
+  if (id.toLowerCase() === "all") return label;
+  if (id.localeCompare(label, "it", { sensitivity: "accent" }) === 0) return label;
+  return `${id} · ${label}`;
+}
+
 type CompanyAtlasFiltersProps = Readonly<{
   filters: Required<Pick<AtlasFilters, "metric" | "period" | "region" | "sector" | "band">>;
   metrics: SelectOption[];
@@ -95,7 +101,7 @@ export function CompanyAtlasFilters({
             <option value="all">Tutti i settori</option>
             {sectors.filter((option) => option.id.toLowerCase() !== "all").map((option) => (
               <option key={option.id} value={option.id}>
-                {option.id === "all" ? option.label : `${option.id} · ${option.label}`}
+                {sectorChoiceLabel(option.id, option.label)}
               </option>
             ))}
           </select>

--- a/tests/istat-enterprise-turnover.test.mjs
+++ b/tests/istat-enterprise-turnover.test.mjs
@@ -188,6 +188,18 @@ test("getIstatTurnoverView builds compliant view for dashboard", () => {
   assert.equal(campaniaView.selectedRegion?.value, 216_750_478);
 });
 
+test("turnover sector list shows the ISTAT label once, without the 22px ATECO code column", async () => {
+  const pageSource = await readFile(new URL("../src/app/imprese/page.tsx", import.meta.url), "utf8");
+  const turnoverBlock = pageSource.slice(
+    pageSource.indexOf("isTurnover"),
+    pageSource.indexOf("const view = getCompanyAtlasView"),
+  );
+
+  assert.match(turnoverBlock, /sectorLabelPlain/);
+  assert.doesNotMatch(turnoverBlock, /<b>\{sector\.code\}<\/b>/);
+  assert.match(turnoverBlock, /\{sector\.label\}/);
+});
+
 test("fonti lists the lightweight ISTAT turnover source next to the camera sources", async () => {
   const pageSource = await readFile(new URL("../src/app/fonti/page.tsx", import.meta.url), "utf8");
 


### PR DESCRIPTION
## Summary
- Su `/imprese?metric=turnover` i codici `INDUSTRIA`/`SERVIZI` stavano in una colonna da 22px pensata per le lettere ATECO e coprivano l'etichetta.
- La lista mostra solo la label (Industria, Servizi); il filtro non ripete più `INDUSTRIA · Industria`.

## Test plan
- [x] Aprire `/imprese?metric=turnover`: due righe senza testo sovrapposto
- [x] Dropdown macro-settore: Industria / Servizi
- [x] `/imprese` camerale: ancora `G · Commercio...`

Made with [Cursor](https://cursor.com)