### PR TITLE
fix: geografie ISTAT ruotate e cold start IRPEF

### DIFF
--- a/src/lib/mef-irpef-snapshot.ts
+++ b/src/lib/mef-irpef-snapshot.ts
@@ -250,14 +250,12 @@ function normalizedSearch(value: string): string {
     .trim();
 }
 
+const italianNameCollator = new Intl.Collator("it-IT", { sensitivity: "base" });
+
 function compareRecords(left: InternalRecord, right: InternalRecord): number {
-  const nameOrder = left.sortKey.localeCompare(
-    right.sortKey,
-    "it-IT",
-    { sensitivity: "base" },
-  );
+  const nameOrder = italianNameCollator.compare(left.sortKey, right.sortKey);
   if (nameOrder !== 0) return nameOrder;
-  return left.territory.code.localeCompare(right.territory.code, "en");
+  return left.territory.code < right.territory.code ? -1 : left.territory.code > right.territory.code ? 1 : 0;
 }
 
 function toReportedMeasure(measure: MefIrpefAggregateMeasure): ReportedMeasure {

--- a/src/lib/municipality-geography.ts
+++ b/src/lib/municipality-geography.ts
@@ -174,8 +174,18 @@ function italianIstatNameCandidates(istatName: string): string[] {
     const trimmed = part.trim();
     if (trimmed) candidates.push(trimmed);
     const hyphen = trimmed.lastIndexOf("-");
-    if (hyphen >= 8) candidates.push(trimmed.slice(0, hyphen).trim());
+    if (hyphen >= 3 && trimmed.length - hyphen - 1 >= 3) {
+      candidates.push(trimmed.slice(0, hyphen).trim());
+    }
   }
+  return candidates;
+}
+
+function siopeNameCandidates(siopeName: string): string[] {
+  const normalized = normalizeMunicipalityName(siopeName);
+  const candidates = [normalized];
+  const epithet = normalized.match(/^(.*)\s-\s[A-Z0-9]+$/);
+  if (epithet?.[1]) candidates.push(epithet[1].trim());
   return candidates;
 }
 
@@ -184,7 +194,7 @@ function compactedNamesAgree(left: string, right: string): boolean {
   const delta = left.length - right.length;
   if (delta > 1 || delta < -1) {
     const [shorter, longer] = left.length < right.length ? [left, right] : [right, left];
-    return shorter.length >= 10 && longer.startsWith(shorter);
+    return shorter.length >= 8 && longer.startsWith(shorter);
   }
   const [a, b] = left.length <= right.length ? [left, right] : [right, left];
   let i = 0;
@@ -214,11 +224,11 @@ function compactedNamesAgree(left: string, right: string): boolean {
  * still identifies the same municipality; otherwise the join must fail closed.
  */
 export function municipalityNamesAgree(siopeName: string, istatName: string): boolean {
-  const left = compactMunicipalityName(siopeName);
-  if (!left) return false;
-  return italianIstatNameCandidates(istatName).some((candidate) =>
-    compactedNamesAgree(left, compactMunicipalityName(candidate)),
-  );
+  const istatCandidates = italianIstatNameCandidates(istatName).map(compactMunicipalityName);
+  return siopeNameCandidates(siopeName).some((candidate) => {
+    const left = compactMunicipalityName(candidate);
+    return Boolean(left) && istatCandidates.some((right) => compactedNamesAgree(left, right));
+  });
 }
 
 export function getMunicipalityGeographyByTaxCodeIfNameAgrees(

--- a/src/lib/municipality-geography.ts
+++ b/src/lib/municipality-geography.ts
@@ -150,6 +150,87 @@ export function getMunicipalityGeographyByTaxCode(year: number, taxCode: string)
   return record && row ? unpack(year, record.referenceDate, row) : null;
 }
 
+function normalizeMunicipalityName(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleUpperCase("it-IT")
+    .replace(/^COMUNE\s+(DI|DEL|DELLA|DELLO|DEI|DEGLI|DELLE)\s+/u, "")
+    .replace(/\s+CAPITALE$/u, "")
+    .replace(/[''`´]/g, "")
+    .replace(/[^A-Z0-9/-]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function compactMunicipalityName(name: string): string {
+  return normalizeMunicipalityName(name).replace(/[ /-]/g, "");
+}
+
+function italianIstatNameCandidates(istatName: string): string[] {
+  const normalized = normalizeMunicipalityName(istatName);
+  const candidates = [normalized];
+  for (const part of normalized.split("/")) {
+    const trimmed = part.trim();
+    if (trimmed) candidates.push(trimmed);
+    const hyphen = trimmed.lastIndexOf("-");
+    if (hyphen >= 8) candidates.push(trimmed.slice(0, hyphen).trim());
+  }
+  return candidates;
+}
+
+function compactedNamesAgree(left: string, right: string): boolean {
+  if (left === right) return true;
+  const delta = left.length - right.length;
+  if (delta > 1 || delta < -1) {
+    const [shorter, longer] = left.length < right.length ? [left, right] : [right, left];
+    return shorter.length >= 10 && longer.startsWith(shorter);
+  }
+  const [a, b] = left.length <= right.length ? [left, right] : [right, left];
+  let i = 0;
+  let j = 0;
+  let edits = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      i += 1;
+      j += 1;
+      continue;
+    }
+    edits += 1;
+    if (edits > 1) return false;
+    if (a.length === b.length) {
+      i += 1;
+      j += 1;
+    } else {
+      j += 1;
+    }
+  }
+  return edits + (b.length - j) <= 1;
+}
+
+/**
+ * ISTAT SITUAS report 61 has a known COD_COM_FISCALE rotation in the Fermo
+ * and Salerno clusters. A tax-code hit is usable only when the SIOPE name
+ * still identifies the same municipality; otherwise the join must fail closed.
+ */
+export function municipalityNamesAgree(siopeName: string, istatName: string): boolean {
+  const left = compactMunicipalityName(siopeName);
+  if (!left) return false;
+  return italianIstatNameCandidates(istatName).some((candidate) =>
+    compactedNamesAgree(left, compactMunicipalityName(candidate)),
+  );
+}
+
+export function getMunicipalityGeographyByTaxCodeIfNameAgrees(
+  year: number,
+  taxCode: string,
+  siopeName: string,
+): MunicipalityGeography | null {
+  const geography = getMunicipalityGeographyByTaxCode(year, taxCode);
+  if (!geography || !municipalityNamesAgree(siopeName, geography.name)) return null;
+  return geography;
+}
+
 export function eurosPerSquareKilometreCents(
   amountCents: number | null,
   surfaceSquareMetres: number | null,

--- a/src/lib/siope-municipality-detail.ts
+++ b/src/lib/siope-municipality-detail.ts
@@ -7,7 +7,7 @@ import { partialMonthOf } from "@/lib/siope-calendar";
 import { getSiopeMunicipalSnapshot } from "@/lib/siope-snapshot";
 import {
   eurosPerSquareKilometreCents,
-  getMunicipalityGeographyByTaxCode,
+  getMunicipalityGeographyByTaxCodeIfNameAgrees,
   type MunicipalityGeography,
 } from "@/lib/municipality-geography";
 
@@ -208,7 +208,7 @@ export function getSiopeMunicipalityDetail(rawTaxCode: string): SiopeMunicipalit
     region: identity[4],
     years: artifacts.map((artifact): SiopeMunicipalityYear => {
       const row = rowsByYearAndTaxCode.get(artifact.year)?.get(taxCode);
-      const geography = getMunicipalityGeographyByTaxCode(artifact.year, taxCode);
+      const geography = getMunicipalityGeographyByTaxCodeIfNameAgrees(artifact.year, taxCode, identity[2]);
       if (!row) {
         return {
           year: artifact.year,
@@ -287,7 +287,7 @@ export function getSiopeMunicipalityPeerCoverage(year: number): SiopeMunicipalit
   let withMovementsAndGeography = 0;
   for (const row of artifact.rows) {
     const hasMovements = row[6] !== null;
-    const geography = getMunicipalityGeographyByTaxCode(year, row[0]);
+    const geography = getMunicipalityGeographyByTaxCodeIfNameAgrees(year, row[0], row[2]);
     const hasGeography = geography !== null;
     if (hasMovements) withMovements += 1;
     if (hasGeography) withGeography += 1;
@@ -309,7 +309,7 @@ export function getSiopeMunicipalityPeerObservations(year: number): readonly Sio
   const artifact = artifacts.find((item) => item.year === year);
   if (!artifact) return [];
   return artifact.rows.flatMap((row) => {
-    const geography = getMunicipalityGeographyByTaxCode(year, row[0]);
+    const geography = getMunicipalityGeographyByTaxCodeIfNameAgrees(year, row[0], row[2]);
     const perSquareKmCents = eurosPerSquareKilometreCents(
       row[6],
       geography?.surfaceSquareMetres ?? null,

--- a/tests/municipality-geography.test.mjs
+++ b/tests/municipality-geography.test.mjs
@@ -8,8 +8,10 @@ const {
   eurosPerSquareKilometreCents,
   getMunicipalityGeographyByIstatCode,
   getMunicipalityGeographyByTaxCode,
+  getMunicipalityGeographyByTaxCodeIfNameAgrees,
   getRegionGeography,
   municipalityGeographyRows,
+  municipalityNamesAgree,
 } = await import("../src/lib/municipality-geography.ts");
 
 test("ISTAT geography snapshot has complete annual municipality coverage", () => {
@@ -56,4 +58,62 @@ test("regional geography reconciles municipality denominators", () => {
   assert.equal(region.municipalities, municipalityGeographyRows(2023).filter((row) => row.regionCode === "18").length);
   assert.ok(region.surfaceSquareKilometres > 15_000);
   assert.ok(region.densityPerSquareKilometre > 100);
+});
+
+test("municipality name agreement keeps spelling and bilingual variants, not swapped comunes", () => {
+  assert.equal(municipalityNamesAgree("COMUNE DI BENEVENTO", "Benevento"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI BOLZANO", "Bolzano/Bozen"), true);
+  assert.equal(municipalityNamesAgree("ROMA CAPITALE", "Roma"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI POIANA MAGGIORE", "Pojana Maggiore"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI CASSANO ALLO IONIO", "Cassano all'Ionio"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI DUINO-AURISINA", "Duino Aurisina-Devin Nabrežina"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI VALLECROSIA AL MARE", "Vallecrosia"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI MONTEGRANARO", "Monte San Pietrangeli"), false);
+  assert.equal(municipalityNamesAgree("COMUNE DI MONTEFORTINO", "Monte Rinaldo"), false);
+  assert.equal(municipalityNamesAgree("COMUNE DI CASTIGLIONE DEL GENOVESI", "San Mango Piemonte"), false);
+});
+
+const ISTAT_TAX_CODE_ROTATION_SIOPE_NAMES = new Set([
+  "COMUNE DI MONTEFALCONE APPENNINO",
+  "COMUNE DI MONTEFORTINO",
+  "COMUNE DI MONTE GIBERTO",
+  "COMUNE DI MONTEGIORGIO",
+  "COMUNE DI MONTEGRANARO",
+  "COMUNE DI MONTELEONE DI FERMO",
+  "COMUNE DI MONTELPARO",
+  "COMUNE DI MONTE RINALDO",
+  "COMUNE DI MONTERUBBIANO",
+  "COMUNE DI MONTE SAN PIETRANGELI",
+  "COMUNE DI MONTE URANO",
+  "COMUNE DI MONTE VIDON COMBATTE",
+  "COMUNE DI MONTE VIDON CORRADO",
+  "COMUNE DI CASTIGLIONE DEL GENOVESI",
+  "COMUNE DI SAN MANGO PIEMONTE",
+]);
+
+test("SIOPE↔ISTAT geography join fails closed on the known COD_COM_FISCALE rotation", async () => {
+  const { getSiopeMunicipalityDetail } = await import("../src/lib/siope-municipality-detail.ts");
+  const detail2025 = (await import("../src/data/generated/siope-municipal-detail-2025.json", { with: { type: "json" } })).default;
+
+  const benevento = getMunicipalityGeographyByTaxCodeIfNameAgrees(2026, "00074270620", "COMUNE DI BENEVENTO");
+  assert.ok(benevento);
+  assert.equal(benevento.istatCode, "062008");
+
+  const rotated = detail2025.municipalities.filter((row) => ISTAT_TAX_CODE_ROTATION_SIOPE_NAMES.has(row[2]));
+  assert.equal(rotated.length, 15);
+
+  for (const [taxCode, , siopeName] of rotated) {
+    const mismatched = getMunicipalityGeographyByTaxCode(2025, taxCode);
+    assert.ok(mismatched, `ISTAT still indexes ${taxCode}`);
+    assert.notEqual(mismatched.name.toLocaleUpperCase("it-IT"), siopeName.replace(/^COMUNE DI /u, ""));
+    assert.equal(municipalityNamesAgree(siopeName, mismatched.name), false);
+    assert.equal(getMunicipalityGeographyByTaxCodeIfNameAgrees(2025, taxCode, siopeName), null);
+
+    const detail = getSiopeMunicipalityDetail(taxCode);
+    assert.ok(detail);
+    assert.ok(
+      detail.years.every((year) => year.geography === null && year.perSquareKmCents === null),
+      `${siopeName} must not publish a km² figure from the swapped ISTAT tax code`,
+    );
+  }
 });

--- a/tests/municipality-geography.test.mjs
+++ b/tests/municipality-geography.test.mjs
@@ -68,6 +68,9 @@ test("municipality name agreement keeps spelling and bilingual variants, not swa
   assert.equal(municipalityNamesAgree("COMUNE DI CASSANO ALLO IONIO", "Cassano all'Ionio"), true);
   assert.equal(municipalityNamesAgree("COMUNE DI DUINO-AURISINA", "Duino Aurisina-Devin Nabrežina"), true);
   assert.equal(municipalityNamesAgree("COMUNE DI VALLECROSIA AL MARE", "Vallecrosia"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI SGONICO", "Sgonico-Zgonik"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI MURISENGO MONFERRATO", "Murisengo"), true);
+  assert.equal(municipalityNamesAgree("COMUNE DI TRIPI - ABAKAINON", "Tripi"), true);
   assert.equal(municipalityNamesAgree("COMUNE DI MONTEGRANARO", "Monte San Pietrangeli"), false);
   assert.equal(municipalityNamesAgree("COMUNE DI MONTEFORTINO", "Monte Rinaldo"), false);
   assert.equal(municipalityNamesAgree("COMUNE DI CASTIGLIONE DEL GENOVESI", "San Mango Piemonte"), false);


### PR DESCRIPTION
## Summary
- Closes #151: il join SIOPE↔ISTAT per codice fiscale non pubblica più superficie/€/km² quando il nome ISTAT è di un altro Comune (rotazione `COD_COM_FISCALE` su 15 Comuni di Fermo e Salerno). Varianti grafiche e bilingui restano valide.
- Closes #150: l'ordinamento IRPEF riusa un `Intl.Collator` di modulo invece di ricostruirlo a ogni `localeCompare`.

## Test plan
- [ ] `/enti` di Montegranaro / Montefortino: km² e pari geografici assenti, non numeri di un altro Comune
- [ ] Benevento, Bolzano, Roma Capitale, Cassano allo Ionio: geografia ancora presente
- [ ] `/territori/irpef` e `GET /api/territori/irpef` rispondono; ordine alfabetico invariato

Made with [Cursor](https://cursor.com)