### PR TITLE
fix(etl): rendi la verifica offline degli artefatti indipendente dalla piattaforma

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# The repository is authored with LF. Without this file a Windows checkout runs
+# under Git's default core.autocrlf=true and rewrites every tracked text file to
+# CRLF, which breaks the byte-level guarantees this project is built on.
+
+* text=auto eol=lf
+
+# Verified artifacts: Git must never rewrite these bytes in either direction.
+# Their sha256 and byte size are part of the published provenance, so a line
+# ending conversion turns a valid snapshot into a failed reconciliation.
+/data/source-ledger/** -text
+/src/data/generated/** -text
+
+*.gz binary
+*.ico binary
+*.jpg binary
+*.png binary
+*.pem -text

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -355,7 +355,7 @@ def detect_unregistered_files(registry: dict) -> list[str]:
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             for fname in filenames:
                 full = Path(dirpath) / fname
-                rel = str(full.relative_to(ROOT))
+                rel = full.relative_to(ROOT).as_posix()
                 if rel in registered:
                     continue
 

--- a/scripts/etl/integrated_curated_datasets.py
+++ b/scripts/etl/integrated_curated_datasets.py
@@ -2557,7 +2557,7 @@ def build_artifacts(*, spec_path: Path, source_root: Path, catalog_path: Path, r
         "schemaVersion": 1, "generatedAt": spec["generatedAt"], "complete": True,
         "totals": totals, "catalogSha256": sha256_bytes(catalog_payload),
         "artifactSha256": {
-            str(Path(path).relative_to(ROOT)): sha256_bytes(payload)
+            Path(path).relative_to(ROOT).as_posix(): sha256_bytes(payload)
             for path, payload in sorted(artifacts.items())
         },
     }
@@ -2603,10 +2603,10 @@ def check_artifacts(artifacts: dict[str, bytes]) -> None:
         try:
             actual = path.read_bytes()
         except OSError:
-            mismatches.append(f"mancante: {path.relative_to(ROOT)}")
+            mismatches.append(f"mancante: {path.relative_to(ROOT).as_posix()}")
             continue
         if actual != expected:
-            mismatches.append(f"divergente: {path.relative_to(ROOT)}")
+            mismatches.append(f"divergente: {path.relative_to(ROOT).as_posix()}")
     if mismatches:
         raise DatasetBuildError("artefatti non riproducibili:\n" + "\n".join(mismatches))
 
@@ -2801,7 +2801,7 @@ def check_committed(
     if actual_rows_paths != expected_rows_paths or actual_receipt_paths != expected_receipt_paths:
         raise DatasetBuildError("artefatti extra, inattesi, stale o mancanti nelle directory dataset")
     artifact_hashes = require_dict(proof.get("artifactSha256"), "proof.artifactSha256")
-    expected_keys = {str(path.relative_to(ROOT)) for path in expected_paths}
+    expected_keys = {path.relative_to(ROOT).as_posix() for path in expected_paths}
     if set(artifact_hashes) != expected_keys:
         raise DatasetBuildError("insieme artefatti nel proof divergente")
 
@@ -2966,7 +2966,7 @@ def check_committed(
     if proof.get("totals") != totals:
         raise DatasetBuildError("totali proof/catalogo divergenti")
     for path in expected_paths:
-        relative = str(path.relative_to(ROOT))
+        relative = path.relative_to(ROOT).as_posix()
         if path in expected_rows_paths:
             payload = read_bounded_regular_file(
                 path,

--- a/scripts/etl/istat_regions_account.py
+++ b/scripts/etl/istat_regions_account.py
@@ -213,7 +213,7 @@ def build_snapshot(payload: bytes, acquired_at: str) -> tuple[dict, dict]:
         "asset": {"bytes": len(payload), "sha256": hashlib.sha256(payload).hexdigest()},
         "spendingWorkbook": {"path": SPENDING_FILE, "bytes": len(spending), "sha256": hashlib.sha256(spending).hexdigest()},
         "transformation": {"version": 1, "description": "Esclusi i tre fogli aggregati; letti solo gli impegni dei sei Titoli e riconciliati con il totale ufficiale per 22 amministrazioni."},
-        "dataArtifact": {"path": str(DATA_PATH.relative_to(ROOT)), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
+        "dataArtifact": {"path": DATA_PATH.relative_to(ROOT).as_posix(), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
     }
     return data, meta
 

--- a/scripts/etl/pcm_financial_account.py
+++ b/scripts/etl/pcm_financial_account.py
@@ -296,7 +296,7 @@ def build_snapshot(payload: bytes, source_url: str, acquired_at: str) -> tuple[d
             "headers": len(EXPECTED_HEADERS),
         },
         "dataArtifact": {
-            "path": str(DATA_PATH.relative_to(ROOT)),
+            "path": DATA_PATH.relative_to(ROOT).as_posix(),
             "bytes": len(data_bytes),
             "sha256": hashlib.sha256(data_bytes).hexdigest(),
         },

--- a/scripts/etl/rgs_ministries_account.py
+++ b/scripts/etl/rgs_ministries_account.py
@@ -260,7 +260,7 @@ def build_snapshot(payload: bytes, acquired_at: str) -> tuple[dict, dict]:
         },
         "asset": {"bytes": len(payload), "sha256": hashlib.sha256(payload).hexdigest(), "encoding": "cp1252", "delimiter": ";"},
         "transformation": {"version": 1, "description": "41 colonne validate; 5.395 righe riconciliate e aggregate per Ministero e missione senza mescolare CP, RS e CS."},
-        "dataArtifact": {"path": str(DATA_PATH.relative_to(ROOT)), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
+        "dataArtifact": {"path": DATA_PATH.relative_to(ROOT).as_posix(), "bytes": len(data_bytes), "sha256": hashlib.sha256(data_bytes).hexdigest()},
     }
     return data, meta
 

--- a/tests/etl/test_integrated_curated_datasets.py
+++ b/tests/etl/test_integrated_curated_datasets.py
@@ -1868,7 +1868,7 @@ class IntegratedCuratedDatasetsTests(unittest.TestCase):
         proof = json.loads(self.proof_path.read_text(encoding="utf-8"))
         proof["catalogSha256"] = sha256(self.catalog_path.read_bytes())
         for path in (rows_path, receipt_path, self.catalog_path):
-            relative = str(path.relative_to(self.repository))
+            relative = path.relative_to(self.repository).as_posix()
             proof["artifactSha256"][relative] = sha256(path.read_bytes())
         self.proof_path.write_bytes(ETL.canonical_json(proof))
 
@@ -1888,7 +1888,7 @@ class IntegratedCuratedDatasetsTests(unittest.TestCase):
         self.catalog_path.write_bytes(ETL.canonical_json(catalog))
         proof = json.loads(self.proof_path.read_text(encoding="utf-8"))
         proof["catalogSha256"] = sha256(self.catalog_path.read_bytes())
-        proof["artifactSha256"][str(self.catalog_path.relative_to(self.repository))] = sha256(
+        proof["artifactSha256"][self.catalog_path.relative_to(self.repository).as_posix()] = sha256(
             self.catalog_path.read_bytes()
         )
         self.proof_path.write_bytes(ETL.canonical_json(proof))
@@ -1913,6 +1913,28 @@ class IntegratedCuratedDatasetsTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ETL.DatasetBuildError, "extra|inatteso|stale"):
             self.check()
+
+    def test_proof_keys_use_posix_separators_not_host_backslashes(self) -> None:
+        from pathlib import PureWindowsPath
+
+        windows_key = str(PureWindowsPath("src") / "data" / "generated" / "catalog.json")
+        posix_key = (PureWindowsPath("src") / "data" / "generated" / "catalog.json").as_posix()
+        self.assertEqual(windows_key, r"src\data\generated\catalog.json")
+        self.assertEqual(posix_key, "src/data/generated/catalog.json")
+        self.assertNotEqual(windows_key, posix_key)
+
+        payload = (
+            "name|private_id|amount|source|note\n"
+            "Alpha||1|https://example.gov.it/atto/1|note\n"
+        ).encode("utf-8")
+        self.write_fixture(payload, rows=1)
+        self.build()
+        proof = json.loads(self.proof_path.read_text(encoding="utf-8"))
+        self.assertGreater(len(proof["artifactSha256"]), 0)
+        for key in proof["artifactSha256"]:
+            self.assertNotIn("\\", key, f"chiave proof non canonica: {key!r}")
+            self.assertEqual(key, key.replace("\\", "/"))
+            self.assertEqual(key, Path(key).as_posix())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Completa #134 sul `main` attuale: i percorsi nei proof e nei sidecar usano `as_posix()`, e `.gitattributes` impedisce a Git di riscrivere in CRLF gli artefatti verificati.
- Include la patch di #135 (`danielemeanti23`) e i nits della review: i test costruiscono le chiavi proof con `.as_posix()`, più un test mirato sui separatori Windows (`PureWindowsPath`) e sulle chiavi emesse dal build.
- Su POSIX il comportamento resta identico bit per bit; nessun artefatto committato cambia.

Chiude #134. Sostituisce #135 (fork non riallineato, CHANGES_REQUESTED).

## Test plan
- [x] `python3 -m unittest tests.etl.test_integrated_curated_datasets` (51 test)
- [x] test ISTAT / PCM / RGS account
- [ ] CI required checks su questa PR
- [ ] Dopo il merge: chiudere #135 come superseded


Made with [Cursor](https://cursor.com)