### PR TITLE
fix(openbdap): gestisci le indisponibilità temporanee dei CSV

### DIFF
--- a/src/lib/bdap-payments.ts
+++ b/src/lib/bdap-payments.ts
@@ -3,6 +3,10 @@ import {
   parseDelimitedRecords,
   type DelimitedRecord,
 } from "@/lib/data/delimited";
+import {
+  isOpenBdapCsvConversionError,
+  OpenBdapUnavailableError,
+} from "@/lib/data/openbdap-response";
 import { fetchOfficialSource } from "@/lib/data/source-fetch";
 import {
   assertOpenBdapComponentTotal,
@@ -325,7 +329,7 @@ function normalizePackage(
     notes,
     referenceYear: period.year,
     metadataModified: text(pkg.metadata_modified),
-    csvUrl: `${BDAP_DUMP}/${packageId}.csv`,
+    csvUrl: `${BDAP_DUMP}/${packageId}.csv?download=1`,
     apiUrl: `${BDAP_ACTION}/package_show?id=${encodeURIComponent(packageId)}`,
   };
 
@@ -591,11 +595,17 @@ async function fetchDatasetRows(
   }
 
   const contentType = response.headers.get("content-type") ?? "";
+  const payload = decodePublicDataText(await response.arrayBuffer());
   if (!contentType.toLowerCase().includes("csv")) {
+    if (isOpenBdapCsvConversionError(payload)) {
+      throw new OpenBdapUnavailableError(
+        "OpenBDAP non ha reso disponibile il CSV per il dataset richiesto",
+      );
+    }
     throw new Error("OpenBDAP non ha restituito un CSV per il dataset richiesto");
   }
 
-  const rows = parseDelimitedRecords(decodePublicDataText(await response.arrayBuffer()));
+  const rows = parseDelimitedRecords(payload);
   if (rows.length === 0) throw new Error("Dataset OpenBDAP vuoto");
   return rows;
 }

--- a/src/lib/data/openbdap-response.ts
+++ b/src/lib/data/openbdap-response.ts
@@ -1,0 +1,23 @@
+import { SourceFetchError } from "@/lib/data/source-fetch";
+
+export class OpenBdapUnavailableError extends SourceFetchError {
+  constructor(message: string) {
+    super(message, "openbdap");
+    this.name = "OpenBdapUnavailableError";
+  }
+}
+
+export function isOpenBdapCsvConversionError(payload: string): boolean {
+  try {
+    const parsed = JSON.parse(payload) as {
+      success?: unknown;
+      error?: { message?: unknown };
+    };
+    const message = parsed.error?.message;
+    return parsed.success === false
+      && typeof message === "string"
+      && /^Cannot convert data to csv(?:\. Attachment not found)?$/i.test(message.trim());
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/ssn-national-history.ts
+++ b/src/lib/ssn-national-history.ts
@@ -1,4 +1,8 @@
 import { decodePublicDataText, parseDelimitedRows, type DelimitedRecord } from "@/lib/data/delimited";
+import {
+  isOpenBdapCsvConversionError,
+  OpenBdapUnavailableError,
+} from "@/lib/data/openbdap-response";
 import { fetchOfficialSource } from "@/lib/data/source-fetch";
 import { SSN_CCE_METRICS, type SsnCceMetricId, type SsnCceValues } from "@/lib/data/ssn-cce-contract";
 
@@ -401,6 +405,11 @@ async function fetchNationalYear(
   const payload = await withAbort(response.arrayBuffer(), signal);
   const textPayload = decodePublicDataText(payload);
   // A 200 JSON error from the dump endpoint must never be parsed as a partial dataset.
+  if (isOpenBdapCsvConversionError(textPayload)) {
+    throw new OpenBdapUnavailableError(
+      `OpenBDAP non ha reso disponibile il CSV per l'anno ${pkg.year}`,
+    );
+  }
   if (textPayload.trimStart().startsWith("{") || textPayload.trimStart().startsWith("[")) {
     throw new Error(`OpenBDAP ha restituito un errore JSON invece del CSV per l'anno ${pkg.year}`);
   }

--- a/tests/bdap-release-contract.test.mjs
+++ b/tests/bdap-release-contract.test.mjs
@@ -32,6 +32,7 @@ test("OpenBDAP annual release is an explicit consuntivo with no month", () => {
   assert.equal(dataset?.referenceYear, 2025);
   assert.equal(dataset?.referenceMonth, null);
   assert.equal(dataset?.productCode, "PBS_SPE_RND_MISS_001");
+  assert.equal(dataset?.csvUrl, `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/${packageId}.csv?download=1`);
 });
 
 test("OpenBDAP monthly release keeps its reference month", () => {
@@ -49,6 +50,7 @@ test("OpenBDAP monthly release keeps its reference month", () => {
   assert.equal(dataset?.referenceYear, 2025);
   assert.equal(dataset?.referenceMonth, 12);
   assert.equal(dataset?.productCode, "PBS_SPE_M12_MISS_001");
+  assert.equal(dataset?.csvUrl, `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/${packageId}.csv?download=1`);
 });
 
 test("OpenBDAP release validation rejects code, title, and perimeter drift", () => {
@@ -219,6 +221,60 @@ test("annual OpenBDAP queries prefer consuntivo and monthly queries stay monthly
       () => getStateSpendingSnapshot({ year: 2025, month: 12 }),
       /mese della riga NOVEMBRE non coincide con il rilascio DICEMBRE/,
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenBDAP payments classify the known conversion outage and preserve the download query", async () => {
+  const originalFetch = globalThis.fetch;
+  const dumpUrls = [];
+  const dimensions = new Map([
+    ["PBS_SPE_RND_MISS_001", ["Pagamenti Bilancio dello Stato per Missione Consuntivo", "PBS_SPE_RND_MISS_001"]],
+    ["PBS_SPE_RND_MISAM_001", ["Pagamenti Bilancio dello Stato per Missione Amministrazione Consuntivo", "PBS_SPE_RND_MISAM_001"]],
+    ["PBS_SPE_RND_AMCE2_001", ["Pagamenti Bilancio dello Stato per Amministrazione Classificazione Economica II livello Consuntivo", "PBS_SPE_RND_AMCE2_001"]],
+  ]);
+
+  globalThis.fetch = async (input) => {
+    const url = new URL(input.toString());
+    if (url.pathname.endsWith("/package_search")) {
+      const code = url.searchParams.get("q");
+      const dimension = dimensions.get(code);
+      assert.ok(dimension, code);
+      const id = `12345678-1234-4abc-8def-${String([...dimensions.keys()].indexOf(code) + 1).padStart(12, "0")}`;
+      return new Response(JSON.stringify({
+        success: true,
+        result: {
+          results: [fixture({
+            id,
+            title: `2025 - ${dimension[0]}`,
+            code: dimension[1],
+            scope: "pagamenti Bilancio dello Stato per l'esercizio finanziario di riferimento",
+          })],
+        },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    dumpUrls.push(url);
+    return new Response(JSON.stringify({
+      success: false,
+      error: { message: "Cannot convert data to csv" },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    await assert.rejects(
+      getStateSpendingSnapshot({ year: 2025 }),
+      (error) => error?.name === "OpenBdapUnavailableError",
+    );
+    assert.ok(dumpUrls.length > 0);
+    assert.ok(dumpUrls.every((url) => url.searchParams.get("download") === "1"));
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/helpers/live-openbdap.mjs
+++ b/tests/helpers/live-openbdap.mjs
@@ -12,9 +12,8 @@
  * timeout chain.
  *
  * `runLiveOpenBdap` wraps a live assertion body: it probes first, then runs
- * the body, and if the body throws a `SourceFetchError` (OpenBDAP answered the
- * probe but flaked during the heavy data fetch) the test is skipped instead of
- * failing. Real assertion failures propagate normally.
+ * the body, and skips only an explicit OpenBDAP outage, network error, timeout,
+ * or abort. Configuration and data-contract failures propagate normally.
  */
 
 const BDAP_ACTION = "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action";
@@ -37,9 +36,13 @@ export async function isOpenBdapReachable({ timeoutMs = 8_000 } = {}) {
   }
 }
 
-function isTransientSourceError(error) {
-  if (error?.name === "SourceFetchError") return true;
+export function isTransientSourceError(error) {
+  if (error?.name === "OpenBdapUnavailableError") return true;
   if (error?.name === "AbortError" || error?.name === "TimeoutError") return true;
+  if (error?.name === "SourceFetchError") {
+    return /^Errore di rete verso openbdap\b/.test(error?.message ?? "")
+      || /^Impossibile interrogare la fonte openbdap\b/.test(error?.message ?? "");
+  }
   return false;
 }
 

--- a/tests/openbdap-response.test.mjs
+++ b/tests/openbdap-response.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+import { isTransientSourceError } from "./helpers/live-openbdap.mjs";
+
+const {
+  isOpenBdapCsvConversionError,
+  OpenBdapUnavailableError,
+} = await import("../src/lib/data/openbdap-response.ts");
+const { SourceFetchError } = await import("../src/lib/data/source-fetch.ts");
+
+test("recognizes only the known OpenBDAP CSV conversion outage", () => {
+  assert.equal(
+    isOpenBdapCsvConversionError(JSON.stringify({
+      success: false,
+      error: { message: "Cannot convert data to csv" },
+    })),
+    true,
+  );
+  assert.equal(
+    isOpenBdapCsvConversionError(JSON.stringify({
+      success: false,
+      error: { message: "Cannot convert data to csv. Attachment not found" },
+    })),
+    true,
+  );
+});
+
+test("does not hide unknown JSON, schema drift, or non-JSON responses", () => {
+  assert.equal(isOpenBdapCsvConversionError('{"error":{"message":"Schema changed"}}'), false);
+  assert.equal(
+    isOpenBdapCsvConversionError('{"success":true,"error":{"message":"Cannot convert data to csv"}}'),
+    false,
+  );
+  assert.equal(isOpenBdapCsvConversionError('{"success":true,"result":[]}'), false);
+  assert.equal(isOpenBdapCsvConversionError("Anno;Importo\n2024;1"), false);
+  assert.equal(isOpenBdapCsvConversionError("<html>maintenance</html>"), false);
+});
+
+test("live checks skip only explicit OpenBDAP outages and network failures", () => {
+  assert.equal(isTransientSourceError(new OpenBdapUnavailableError("CSV non disponibile")), true);
+  assert.equal(
+    isTransientSourceError(new SourceFetchError("Errore di rete verso openbdap dopo 2 tentativo/i", "openbdap")),
+    true,
+  );
+  assert.equal(isTransientSourceError(Object.assign(new Error("timeout"), { name: "TimeoutError" })), true);
+});
+
+test("live checks do not hide source configuration or data-contract failures", () => {
+  assert.equal(
+    isTransientSourceError(new SourceFetchError("Host non consentito per la fonte openbdap", "openbdap")),
+    false,
+  );
+  assert.equal(isTransientSourceError(new Error("Header CSV divergente")), false);
+  assert.equal(isTransientSourceError(new Error("Anno incoerente")), false);
+});

--- a/tests/ssn-national-history.test.mjs
+++ b/tests/ssn-national-history.test.mjs
@@ -204,7 +204,13 @@ function delayed(ms, signal) {
   });
 }
 
-function stubHistoryFetch({ delayMs = 0, jsonYear = null, trailingDelimiter = false, missingLicenseIdYear = null } = {}) {
+function stubHistoryFetch({
+  conversionErrorYear = null,
+  delayMs = 0,
+  jsonYear = null,
+  missingLicenseIdYear = null,
+  trailingDelimiter = false,
+} = {}) {
   const packages = [...SSN_NATIONAL_HISTORY_YEARS].map(packageResult);
   if (missingLicenseIdYear !== null) {
     const packageToMutate = packages.find((candidate) => candidate.name.endsWith(`_${missingLicenseIdYear}`));
@@ -231,6 +237,15 @@ function stubHistoryFetch({ delayMs = 0, jsonYear = null, trailingDelimiter = fa
       const pkg = packages.find((candidate) => candidate.id === packageId);
       assert.ok(pkg, `package ${packageId}`);
       const year = Number(pkg.name.slice(-4));
+      if (year === conversionErrorYear) {
+        return new Response(JSON.stringify({
+          success: false,
+          error: { message: "Cannot convert data to csv" },
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
       if (year === jsonYear) {
         return new Response(JSON.stringify({ error: "Attachment not found" }), {
           status: 200,
@@ -309,6 +324,21 @@ test("SSN national history rejects a 200 JSON error returned by the CSV dump", a
     await assert.rejects(
       getSsnNationalHistory({ deadlineMs: 2_000 }),
       /errore JSON invece del CSV.*2018/i,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("SSN national history classifies only the known conversion outage as unavailable", async () => {
+  const originalFetch = globalThis.fetch;
+  const stub = stubHistoryFetch({ conversionErrorYear: 2018 });
+  globalThis.fetch = stub.fetchStub;
+  try {
+    await assert.rejects(
+      getSsnNationalHistory({ deadlineMs: 2_000 }),
+      (error) => error?.name === "OpenBdapUnavailableError"
+        && /CSV.*2018/i.test(error.message),
     );
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Cosa cambia

- usa il parametro ufficiale `?download=1` per i dump CSV dei pagamenti dello Stato;
- riconosce soltanto l'errore OpenBDAP noto `Cannot convert data to csv` come indisponibilità temporanea;
- mantiene bloccanti JSON sconosciuti, drift di schema e configurazioni errate;
- restringe gli skip dei test live a timeout, rete e indisponibilità OpenBDAP esplicita.

## Perché

OpenBDAP può rispondere `HTTP 200 application/json` al posto del CSV. Questo ha bloccato la CI della PR #159, anche se quella PR non modifica i dati OpenBDAP. Senza `?download=1`, inoltre, il percorso runtime dei pagamenti usa un URL oggi non valido.

## Verifica

- `npm run ci:static` — PASS
- `npm run test:node` — 531 pass, 1 skip, 0 fail
- `npm run build` — PASS, 80 pagine
- test mirati OpenBDAP — 35 pass, 3 live skip nell'ambiente isolato
- verifica live diretta del payload di errore ufficiale — riprodotta

La PR non modifica i contratti dei dati e non rilassa le verifiche di schema.
