### PR TITLE
fix(security): estendi HSTS a un anno

### DIFF
--- a/tests/mef-irpef-ui.test.mjs
+++ b/tests/mef-irpef-ui.test.mjs
@@ -61,9 +61,25 @@ test("the production deployment advertises HTTPS and a security contact", async 
     source("../public/.well-known/security.txt"),
   ]);
 
-  assert.match(vercel, /Strict-Transport-Security/);
-  assert.match(vercel, /max-age=86400/);
-  assert.doesNotMatch(vercel, /preload/);
+  const vercelConfig = JSON.parse(vercel);
+  const catchAllRules = vercelConfig.headers.filter((rule) => rule.source === "/(.*)");
+  assert.equal(catchAllRules.length, 1);
+
+  const allHstsEntries = vercelConfig.headers.flatMap((rule) =>
+    rule.headers.filter((header) => header.key.toLowerCase() === "strict-transport-security"),
+  );
+  assert.equal(allHstsEntries.length, 1);
+
+  const hstsEntries = catchAllRules[0].headers.filter(
+    (header) => header.key.toLowerCase() === "strict-transport-security",
+  );
+  assert.equal(hstsEntries.length, 1);
+  assert.deepEqual(hstsEntries[0], {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000",
+  });
+  assert.doesNotMatch(hstsEntries[0].value, /includeSubDomains/i);
+  assert.doesNotMatch(hstsEntries[0].value, /preload/i);
   assert.match(vercel, /X-Content-Type-Options/);
   assert.match(securityTxt, /Italian-Builders-Org\/DoveVannoINostriSoldi\/issues/);
   assert.match(securityTxt, /Expires: 2027-08-24T00:00:00.000Z/);

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Strict-Transport-Security", "value": "max-age=86400" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },


### PR DESCRIPTION
## Cosa cambia

- porta `Strict-Transport-Security` da 1 giorno a 1 anno;
- mantiene volutamente esclusi `includeSubDomains` e `preload`;
- rende il test più preciso: una sola regola globale e un solo header HSTS.

Header finale:

```text
Strict-Transport-Security: max-age=31536000
```

## Verifica

- `node --test tests/mef-irpef-ui.test.mjs`: 5/5 PASS
- `git diff --check`: PASS
- worktree pulita e commit basato su `0304b76435f58ff362e0d2ff6843fb9d43610651`

## Coordinamento

La PR #164 modifica anch'essa `tests/mef-irpef-ui.test.mjs`, ma non `vercel.json`. Questa PR va integrata per prima; la #164 dovrà poi ribasarsi conservando entrambe le serie di asserzioni.

Dopo il deploy va verificato live che l'header sia presente sulla risposta HTTPS dello stesso commit.
