### PR TITLE
fix(ci): ignora le ricerche annullate intenzionalmente

### DIFF
--- a/scripts/browser/harness.mjs
+++ b/scripts/browser/harness.mjs
@@ -131,10 +131,23 @@ export async function waitForServer(
   throw new Error(`Server non pronto entro ${timeoutMs / 1_000}s: ${detail}`);
 }
 
-// Filters request failures that are expected Next.js behaviour and do not
-// affect the rendered route (cancelled speculative RSC prefetches and optional
-// location lookups). Kept identical to the previous core-suite semantics.
-function relevantRequestFailure(request) {
+// Filters request failures that are expected client behaviour and do not
+// affect the rendered route: cancelled speculative RSC prefetches, optional
+// location lookups, and superseded debounced searches.
+export function isExpectedAbortedSearchRequest({
+  errorText,
+  resourceType,
+  requestUrl,
+  baseOrigin,
+}) {
+  if (errorText !== "net::ERR_ABORTED" || resourceType !== "fetch") return false;
+
+  const url = new URL(requestUrl);
+  const isSearchEndpoint = url.pathname === "/api/enti" || url.pathname === "/api/search";
+  return url.origin === baseOrigin && isSearchEndpoint && Boolean(url.searchParams.get("q")?.trim());
+}
+
+function relevantRequestFailure(request, baseOrigin) {
   const failure = request.failure();
   const resourceType = request.resourceType();
   const requestUrl = request.url();
@@ -149,7 +162,13 @@ function relevantRequestFailure(request) {
     failure.errorText === "net::ERR_ABORTED" &&
     resourceType === "fetch" &&
     new URL(requestUrl).pathname === "/api/location";
-  if (cancelledNextPrefetch || cancelledLocationLookup) return null;
+  const cancelledSearchLookup = isExpectedAbortedSearchRequest({
+    errorText: failure.errorText,
+    resourceType,
+    requestUrl,
+    baseOrigin,
+  });
+  if (cancelledNextPrefetch || cancelledLocationLookup || cancelledSearchLookup) return null;
 
   return `${resourceType} ${requestUrl}: ${failure.errorText}`;
 }
@@ -173,7 +192,7 @@ export function installDiagnostics(page, { label, baseUrl = defaultBaseUrl() } =
     consoleErrors.push(`${message.text()}${suffix}`);
   });
   page.on("requestfailed", (request) => {
-    const failure = relevantRequestFailure(request);
+    const failure = relevantRequestFailure(request, baseUrl.origin);
     if (failure) requestFailures.push(failure);
   });
   page.on("response", (response) => {

--- a/tests/browser-harness.test.mjs
+++ b/tests/browser-harness.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isExpectedAbortedSearchRequest } from "../scripts/browser/harness.mjs";
+
+const BASE_ORIGIN = "http://127.0.0.1:3000";
+
+function abortedSearch(requestUrl, overrides = {}) {
+  return isExpectedAbortedSearchRequest({
+    errorText: "net::ERR_ABORTED",
+    resourceType: "fetch",
+    requestUrl,
+    baseOrigin: BASE_ORIGIN,
+    ...overrides,
+  });
+}
+
+test("browser diagnostics ignore intentional aborts from both search endpoints", () => {
+  assert.equal(abortedSearch(`${BASE_ORIGIN}/api/enti?q=Ro&limit=7`), true);
+  assert.equal(abortedSearch(`${BASE_ORIGIN}/api/search?q=Rom&limit=8`), true);
+});
+
+test("browser diagnostics keep unrelated and suspicious request failures", () => {
+  assert.equal(abortedSearch(`${BASE_ORIGIN}/api/enti/c_a783`), false);
+  assert.equal(abortedSearch(`${BASE_ORIGIN}/api/enti?limit=7`), false);
+  assert.equal(abortedSearch("https://example.test/api/enti?q=Roma"), false);
+  assert.equal(
+    abortedSearch(`${BASE_ORIGIN}/api/enti?q=Roma`, { errorText: "net::ERR_FAILED" }),
+    false,
+  );
+  assert.equal(
+    abortedSearch(`${BASE_ORIGIN}/api/enti?q=Roma`, { resourceType: "document" }),
+    false,
+  );
+});


### PR DESCRIPTION
## Cosa cambia

La suite browser non considera più un errore la cancellazione intenzionale di una ricerca superata mentre l’utente continua a digitare o naviga.

Il filtro resta volutamente stretto: ignora soltanto `net::ERR_ABORTED` per richieste `fetch` same-origin verso `/api/enti` o `/api/search`, con una query `q` non vuota. Errori HTTP, errori di rete diversi, altre route e richieste cross-origin continuano a essere segnalati.

## Perché

Il fallimento osservato in CI su `/api/enti?q=Ro` era un falso positivo del test: il componente usa `AbortController` per annullare richieste ormai obsolete. L’applicazione e la navigazione funzionavano correttamente.

## Verifiche

- test del nuovo filtro: 2/2 PASS;
- regressioni UI mirate: 17/17 PASS;
- test offline guard: 4/4 PASS fuori sandbox;
- build di produzione: PASS, 80 route;
- browser core completo su vero `next start`: PASS;
- ESLint mirato e `git diff --check`: PASS;
- review indipendente: nessun P0/P1/P2.

La suite Node completa ha dato 530 PASS, 4 skip e un solo FAIL dovuto al divieto della sandbox di aprire un listener loopback; lo stesso test, eseguito con il permesso necessario, passa 4/4.
