### PR TITLE
feat(api): aggiungi un health endpoint verificabile

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,37 @@
+const RESPONSE_HEADERS = {
+  "Cache-Control": "private, no-store",
+  "X-Content-Type-Options": "nosniff",
+};
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/iu;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 5;
+
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, {
+    status,
+    headers: RESPONSE_HEADERS,
+  });
+}
+
+function deployedRevision(): string | null {
+  if (process.env.VERCEL !== "1") return "unknown";
+
+  const revision = process.env.VERCEL_GIT_COMMIT_SHA?.trim() ?? "";
+  return COMMIT_SHA.test(revision) ? revision.toLowerCase() : null;
+}
+
+export function GET(): Response {
+  const revision = deployedRevision();
+  if (revision === null) {
+    return json({ ok: false, error: "revision_unavailable" }, 503);
+  }
+
+  return json({
+    ok: true,
+    service: "dvns-web",
+    revision,
+  });
+}

--- a/tests/health-route.test.mjs
+++ b/tests/health-route.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { GET } = await import("../src/app/api/health/route.ts");
+
+const HEALTH_URL = "https://example.test/api/health";
+const VALID_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+function response() {
+  return GET(new Request(HEALTH_URL));
+}
+
+async function withEnvironment(values, callback) {
+  const previous = {
+    VERCEL: process.env.VERCEL,
+    VERCEL_GIT_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA,
+  };
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function assertResponseHeaders(result) {
+  assert.equal(result.headers.get("cache-control"), "private, no-store");
+  assert.equal(result.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(result.headers.get("content-type"), "application/json");
+}
+
+test("health endpoint returns the exact local contract without exposing deployment data", async () => {
+  await withEnvironment({ VERCEL: undefined, VERCEL_GIT_COMMIT_SHA: VALID_SHA }, async () => {
+    const result = response();
+    assert.equal(result.status, 200);
+    assertResponseHeaders(result);
+    assert.deepEqual(await result.json(), {
+      ok: true,
+      service: "dvns-web",
+      revision: "unknown",
+    });
+  });
+});
+
+test("health endpoint normalizes a valid deployed commit SHA", async () => {
+  await withEnvironment({ VERCEL: "1", VERCEL_GIT_COMMIT_SHA: `  ${VALID_SHA.toUpperCase()}  ` }, async () => {
+    const result = response();
+    assert.equal(result.status, 200);
+    assertResponseHeaders(result);
+    assert.deepEqual(await result.json(), {
+      ok: true,
+      service: "dvns-web",
+      revision: VALID_SHA,
+    });
+  });
+});
+
+test("health endpoint fails closed on Vercel when the commit SHA is missing or invalid", async () => {
+  for (const revision of [undefined, "not-a-commit", `${VALID_SHA}0`]) {
+    await withEnvironment({ VERCEL: "1", VERCEL_GIT_COMMIT_SHA: revision }, async () => {
+      const result = response();
+      assert.equal(result.status, 503, revision ?? "missing SHA");
+      assertResponseHeaders(result);
+      assert.deepEqual(await result.json(), {
+        ok: false,
+        error: "revision_unavailable",
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Cosa cambia

Aggiunge `GET /api/health`, un controllo leggero che non interroga fonti esterne.

Risposta normale:

```json
{
  "ok": true,
  "service": "dvns-web",
  "revision": "commit-servito"
}
```

In locale la revisione è `unknown`. Su Vercel viene accettato soltanto uno SHA Git valido di 40 caratteri; se manca o è invalido l’endpoint fallisce in modo esplicito con `503 revision_unavailable`.

## Sicurezza e comportamento

- `private, no-store`;
- `X-Content-Type-Options: nosniff`;
- route dinamica, runtime Node e durata massima 5 secondi;
- nessun segreto, dato infrastrutturale o chiamata esterna.

## Verifiche

- test contratto, header e fail-closed: 3/3 PASS;
- typecheck ed ESLint: PASS;
- `git diff --check`: PASS;
- build di produzione: PASS, 80 route con `/api/health` dinamica;
- probe su vero `next start`: `200`, JSON e header corretti;
- review indipendente: nessun P0/P1.

Dopo il preview Vercel verificheremo anche che la revisione restituita coincida esattamente con la testa di questa PR.
