### PR TITLE
fix(health): registra la fonte ISTAT

### DIFF
--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -163,7 +163,8 @@
       "id": "istat-municipality-geography",
       "owner": "ISTAT SITUAS municipal geography snapshot",
       "files": [
-        "src/data/generated/istat-municipality-geography.json"
+        "src/data/generated/istat-municipality-geography.json",
+        "src/data/generated/istat-municipality-geography.meta.json"
       ],
       "verificationMode": "online-refresh",
       "offlineCheck": {

--- a/scripts/etl/istat_municipality_geography.py
+++ b/scripts/etl/istat_municipality_geography.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT = ROOT / "src/data/generated/istat-municipality-geography.json"
+DEFAULT_METADATA_OUTPUT = ROOT / "src/data/generated/istat-municipality-geography.meta.json"
 BASE_URL = "https://situas-servizi.istat.it/publish/reportspooljson"
 REFERENCE_DATES = {
     2022: "31/12/2022",
@@ -187,6 +188,27 @@ def build_snapshot() -> dict:
     }
 
 
+def build_metadata(snapshot: dict) -> dict:
+    latest = snapshot["years"][-1]
+    day, month, year = latest["referenceDate"].split("/")
+    return {
+        "schemaVersion": 1,
+        "datasetId": snapshot["datasetId"],
+        "generatedAt": snapshot["generatedAt"],
+        "availableYears": [item["year"] for item in snapshot["years"]],
+        "latest": {
+            "year": latest["year"],
+            "sourceTimestamp": f"{year}-{month}-{day}",
+            "municipalities": latest["municipalities"],
+        },
+    }
+
+
+def validate_metadata(snapshot: dict, metadata: object) -> None:
+    if metadata != build_metadata(snapshot):
+        raise SnapshotError("metadati health non coerenti con lo snapshot")
+
+
 def validate_snapshot(snapshot: object) -> None:
     if not isinstance(snapshot, dict) or snapshot.get("schemaVersion") != 1:
         raise SnapshotError("schemaVersion inattesa")
@@ -232,27 +254,43 @@ def validate_snapshot(snapshot: object) -> None:
                 raise SnapshotError(f"{year}: provenienza {report} non valida")
 
 
-def validate_committed(path: Path = DEFAULT_OUTPUT) -> None:
+def validate_committed(
+    path: Path = DEFAULT_OUTPUT,
+    metadata_path: Path | None = None,
+) -> None:
+    metadata_path = metadata_path or path.with_name(f"{path.stem}.meta.json")
     try:
         snapshot = json.loads(path.read_text(encoding="utf-8"))
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
-        raise SnapshotError(f"snapshot non leggibile: {path}") from error
+        raise SnapshotError("snapshot o metadati health non leggibili") from error
     validate_snapshot(snapshot)
+    validate_metadata(snapshot, metadata)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--metadata-output", type=Path, default=None)
     parser.add_argument("--validate-committed", action="store_true")
     args = parser.parse_args()
+    metadata_output = args.metadata_output or args.output.with_name(
+        f"{args.output.stem}.meta.json"
+    )
     if args.validate_committed:
-        validate_committed(args.output)
-        print(f"validated {args.output}")
+        validate_committed(args.output, metadata_output)
+        print(f"validated {args.output} and {metadata_output}")
         return
     snapshot = build_snapshot()
+    metadata = build_metadata(snapshot)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(snapshot, ensure_ascii=False, separators=(",", ":")) + "\n", encoding="utf-8")
-    print(f"wrote {args.output} ({sum(year['municipalities'] for year in snapshot['years'])} righe)")
+    metadata_output.parent.mkdir(parents=True, exist_ok=True)
+    metadata_output.write_text(json.dumps(metadata, ensure_ascii=False, separators=(",", ":")) + "\n", encoding="utf-8")
+    print(
+        f"wrote {args.output} and {metadata_output} "
+        f"({sum(year['municipalities'] for year in snapshot['years'])} righe)"
+    )
 
 
 if __name__ == "__main__":

--- a/src/data/generated/istat-municipality-geography.meta.json
+++ b/src/data/generated/istat-municipality-geography.meta.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"datasetId":"istat-municipality-geography","generatedAt":"2026-08-25T00:00:00Z","availableYears":[2022,2023,2024,2025,2026],"latest":{"year":2026,"sourceTimestamp":"2026-08-25","municipalities":7894}}

--- a/src/lib/data/source-health.ts
+++ b/src/lib/data/source-health.ts
@@ -25,6 +25,7 @@ import { MEF_IRPEF_SOURCE } from "@/lib/data/mef-irpef-source";
 import { PNRR_CHILDCARE_SOURCE } from "@/lib/data/pnrr-childcare-source";
 import { getSsnCceSourceHealth, type SsnCceSourceHealth } from "@/lib/ssn-cce-snapshot";
 import { getPublicDebtSnapshot } from "@/lib/public-debt";
+import istatMunicipalityGeographyMetadata from "@/data/generated/istat-municipality-geography.meta.json";
 
 export type SourceIntegrationState = "active";
 export type SourceReachability = "up" | "down" | "not-probed";
@@ -75,6 +76,51 @@ function text(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const cleaned = value.trim();
   return cleaned || null;
+}
+
+type IstatMunicipalityGeographyMetadata = Readonly<{
+  schemaVersion: 1;
+  datasetId: "istat-municipality-geography";
+  generatedAt: string;
+  availableYears: number[];
+  latest: Readonly<{
+    year: number;
+    sourceTimestamp: string;
+    municipalities: number;
+  }>;
+}>;
+
+export function validateIstatMunicipalityGeographyMetadata(
+  value: unknown,
+): IstatMunicipalityGeographyMetadata {
+  const metadata = value as Partial<IstatMunicipalityGeographyMetadata>;
+  const years = metadata.availableYears;
+  const latest = metadata.latest;
+  const validIsoDate = (date: unknown) =>
+    typeof date === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/u.test(date) &&
+    !Number.isNaN(new Date(`${date}T00:00:00Z`).valueOf());
+
+  if (
+    metadata.schemaVersion !== 1 ||
+    metadata.datasetId !== "istat-municipality-geography" ||
+    typeof metadata.generatedAt !== "string" ||
+    Number.isNaN(new Date(metadata.generatedAt).valueOf()) ||
+    !Array.isArray(years) ||
+    years.length === 0 ||
+    !years.every((year, index) =>
+      Number.isSafeInteger(year) && (index === 0 || year > years[index - 1]!),
+    ) ||
+    !latest ||
+    latest.year !== years.at(-1) ||
+    !validIsoDate(latest.sourceTimestamp) ||
+    !Number.isSafeInteger(latest.municipalities) ||
+    latest.municipalities < 7_800
+  ) {
+    throw new Error("Metadati health ISTAT SITUAS non validi");
+  }
+
+  return metadata as IstatMunicipalityGeographyMetadata;
 }
 
 function freshnessFor(sourceId: SourceId, sourceTimestamp: string | null): Freshness {
@@ -412,6 +458,20 @@ function snapshotManagedMefIrpef(): SourceHealth {
   };
 }
 
+function snapshotManagedIstat(): SourceHealth {
+  const metadata = validateIstatMunicipalityGeographyMetadata(
+    istatMunicipalityGeographyMetadata,
+  );
+  return {
+    ...baseHealth("istat"),
+    reachability: "not-probed",
+    freshness: freshnessFor("istat", metadata.latest.sourceTimestamp),
+    latencyMs: null,
+    detail: `Snapshot SITUAS generato il ${metadata.generatedAt.slice(0, 10)} · dati al ${metadata.latest.sourceTimestamp} · geografia comunale ${metadata.latest.year} · ${metadata.latest.municipalities.toLocaleString("it-IT")} comuni · serie ${metadata.availableYears.at(0)}-${metadata.latest.year}`,
+    recordCount: metadata.latest.municipalities,
+  };
+}
+
 function snapshotManagedMefParticipations(): SourceHealth {
   return {
     ...baseHealth("partecipazioni-pubbliche"),
@@ -501,6 +561,7 @@ export function getSnapshotManagedSourceHealth(): SourceHealth[] {
     snapshotManagedInps(),
     snapshotManagedCpt(),
     snapshotManagedMefIrpef(),
+    snapshotManagedIstat(),
     snapshotManagedOpenCoesione(),
     snapshotManagedPnrrChildcare(),
     snapshotManagedOpenCivitas(),
@@ -514,6 +575,31 @@ export function getSnapshotManagedSourceHealth(): SourceHealth[] {
   ];
 }
 
+type SourceHealthAdapter = () => SourceHealth | Promise<SourceHealth>;
+
+/** One concrete health adapter for every source policy. */
+export const SOURCE_HEALTH_ADAPTERS = Object.freeze({
+  ipa: probeIpa,
+  "ipa-struttura": probeIpaStructure,
+  openbdap: probeOpenBdap,
+  anac: snapshotManagedAnac,
+  inps: snapshotManagedInps,
+  cpt: snapshotManagedCpt,
+  "mef-irpef": snapshotManagedMefIrpef,
+  siope: probeSiope,
+  istat: snapshotManagedIstat,
+  opencoesione: snapshotManagedOpenCoesione,
+  italiadomani: snapshotManagedPnrrChildcare,
+  opencivitas: snapshotManagedOpenCivitas,
+  consulenti: snapshotManagedConsulenti,
+  camera: snapshotManagedCamera,
+  senato: snapshotManagedSenate,
+  pcm: snapshotManagedPcm,
+  "partecipazioni-pubbliche": snapshotManagedMefParticipations,
+  bancaditalia: () => snapshotManagedPublicDebt("bancaditalia"),
+  eurostat: () => snapshotManagedPublicDebt("eurostat"),
+} satisfies Record<SourceId, SourceHealthAdapter>);
+
 /** Orders every adapter by the public registry and fails closed on omissions. */
 export function orderSourceHealth(entries: readonly SourceHealth[]): SourceHealth[] {
   const bySource = new Map(entries.map((entry) => [entry.sourceId, entry]));
@@ -525,17 +611,10 @@ export function orderSourceHealth(entries: readonly SourceHealth[]): SourceHealt
 }
 
 export async function getSourceHealthOverview(): Promise<SourceHealth[]> {
-  const [ipa, ipaStructure, openbdap, siope] = await Promise.all([
-    probeIpa(),
-    probeIpaStructure(),
-    probeOpenBdap(),
-    probeSiope(),
-  ]);
-  return orderSourceHealth([
-    ipa,
-    ipaStructure,
-    openbdap,
-    siope,
-    ...getSnapshotManagedSourceHealth(),
-  ]);
+  const entries = await Promise.all(SOURCE_IDS.map((sourceId) => {
+    const adapter = SOURCE_HEALTH_ADAPTERS[sourceId] as SourceHealthAdapter | undefined;
+    if (!adapter) throw new Error(`Adapter operativo senza probe: ${sourceId}`);
+    return adapter();
+  }));
+  return orderSourceHealth(entries);
 }

--- a/tests/etl/test_istat_municipality_geography.py
+++ b/tests/etl/test_istat_municipality_geography.py
@@ -24,6 +24,30 @@ class IstatMunicipalityGeographyTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.SnapshotError, "annualità inattese"):
             MODULE.validate_snapshot(snapshot)
 
+    def test_health_metadata_is_derived_from_the_snapshot(self):
+        snapshot = {
+            "datasetId": "istat-municipality-geography",
+            "generatedAt": "2026-08-26T00:00:00Z",
+            "years": [
+                {"year": 2025, "referenceDate": "31/12/2025", "municipalities": 7_896},
+                {"year": 2026, "referenceDate": "25/08/2026", "municipalities": 7_894},
+            ],
+        }
+        self.assertEqual(
+            MODULE.build_metadata(snapshot),
+            {
+                "schemaVersion": 1,
+                "datasetId": "istat-municipality-geography",
+                "generatedAt": "2026-08-26T00:00:00Z",
+                "availableYears": [2025, 2026],
+                "latest": {
+                    "year": 2026,
+                    "sourceTimestamp": "2026-08-25",
+                    "municipalities": 7_894,
+                },
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/source-health.test.mjs
+++ b/tests/source-health.test.mjs
@@ -3,7 +3,12 @@ import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
 const { SOURCE_IDS, SOURCE_POLICIES } = await import("../src/lib/data/source-policy.ts");
-const { getSnapshotManagedSourceHealth, orderSourceHealth } = await import(
+const {
+  getSnapshotManagedSourceHealth,
+  orderSourceHealth,
+  SOURCE_HEALTH_ADAPTERS,
+  validateIstatMunicipalityGeographyMetadata,
+} = await import(
   "../src/lib/data/source-health.ts"
 );
 
@@ -37,8 +42,14 @@ function fakeLiveHealth(sourceId) {
   };
 }
 
-test("source health registry covers every operational source, including ANAC, INPS and CPT", () => {
+test("source health registry covers every operational source, including ANAC, INPS and CPT", async () => {
+  assert.deepEqual(Object.keys(SOURCE_HEALTH_ADAPTERS), SOURCE_IDS);
+  assert.ok(Object.values(SOURCE_HEALTH_ADAPTERS).every((adapter) => typeof adapter === "function"));
   const snapshots = getSnapshotManagedSourceHealth();
+  for (const snapshot of snapshots) {
+    const health = await SOURCE_HEALTH_ADAPTERS[snapshot.sourceId]();
+    assert.equal(health.sourceId, snapshot.sourceId);
+  }
   const snapshotIds = new Set(snapshots.map((entry) => entry.sourceId));
   const live = SOURCE_IDS
     .filter((sourceId) => !snapshotIds.has(sourceId))
@@ -86,6 +97,31 @@ test("source health registry covers every operational source, including ANAC, IN
   assert.equal(pnrr?.recordCount, 3_841);
   assert.equal(pnrr?.freshness.sourceTimestamp, "2026-06-13");
   assert.match(pnrr?.detail ?? "", /18\.851 gare/);
+  const istat = overview.find((entry) => entry.sourceId === "istat");
+  assert.equal(istat?.reachability, "not-probed");
+  assert.equal(istat?.recordCount, 7_894);
+  assert.equal(istat?.freshness.sourceTimestamp, "2026-08-25");
+  assert.match(istat?.detail ?? "", /SITUAS/);
+  assert.match(istat?.detail ?? "", /generato il 2026-08-25/);
+  assert.match(istat?.detail ?? "", /dati al 2026-08-25/);
+  assert.match(istat?.detail ?? "", /7894 comuni/);
+});
+
+test("ISTAT health metadata fails closed on sidecar drift", () => {
+  assert.throws(
+    () => validateIstatMunicipalityGeographyMetadata({
+      schemaVersion: 1,
+      datasetId: "istat-municipality-geography",
+      generatedAt: "2026-08-25T00:00:00Z",
+      availableYears: [2026],
+      latest: {
+        year: 2025,
+        sourceTimestamp: "25/08/2026",
+        municipalities: 7_894,
+      },
+    }),
+    /Metadati health ISTAT SITUAS non validi/,
+  );
 });
 
 test("source health registry fails closed when an adapter is omitted", () => {


### PR DESCRIPTION
## Cosa corregge

`/api/fonti/stato` restituiva HTTP 500 perché `istat` era presente nel registro delle fonti operative, ma non aveva un adapter di health. Il test precedente mascherava l'omissione costruendo un adapter finto per ogni fonte mancante.

## Modifiche

- aggiunge l'adapter snapshot `istat` con stato `not-probed`, periodo, copertura e provenienza corretti;
- ripristina un registro tipizzato ed esaustivo per tutte le 19 fonti operative;
- aggiunge un piccolo sidecar generato per la health di ISTAT, evitando di caricare lo snapshot geografico da circa 34 MB nell'endpoint;
- verifica il sidecar sia nell'ETL sia a runtime;
- rende i test fail-closed su adapter mancanti o associati alla fonte sbagliata.

## Verifica

- test source-health: 3/3 pass;
- test ISTAT ETL: 3/3 pass;
- artifact checks: 18/18 pass, 26 gruppi e 47 file coperti;
- typecheck, lint e `git diff --check`: pass;
- build Next.js: pass, 80 route generate;
- smoke sulla build: `/api/fonti/stato` risponde 200 con 19 fonti e l'entry ISTAT corretta;
- suite Node completa: 533 pass, 4 live skip; il solo test loopback bloccato dal sandbox è stato ripetuto fuori sandbox, 4/4 pass;
- suite ETL completa: 290 pass, 1 skip; i 3 test socket bloccati dal sandbox sono stati ripetuti fuori sandbox, 7/7 pass.

Nessuna modifica UI. Nessun overlap diretto con i file applicativi delle PR aperte; #143 e #161 toccano soltanto altri hunk del manifest degli artefatti.
