### PR TITLE
feat(ops): monitora app e MCP in produzione

### DIFF
--- a/.github/workflows/runtime-health.yml
+++ b/.github/workflows/runtime-health.yml
@@ -1,0 +1,78 @@
+name: Runtime health
+
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-health
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: probe
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    env:
+      CANONICAL_BASE_URL: https://www.dovevannoinostrisoldi.com
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22.23.2"
+
+      - name: Probe canonical runtime health
+        run: node scripts/runtime-health.mjs --output "$RUNNER_TEMP/runtime-health.json"
+
+      - name: Write runtime health summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Runtime health"
+            echo ""
+            node - "$RUNNER_TEMP/runtime-health.json" <<'NODE'
+          const fs = require("node:fs");
+
+          const file = process.argv[2];
+          if (!fs.existsSync(file)) {
+            console.log("_The health probe did not produce a JSON payload._");
+          } else {
+            try {
+              const payload = JSON.parse(fs.readFileSync(file, "utf8"));
+              const checks = Array.isArray(payload?.checks) ? payload.checks : [];
+              const passed = checks.filter((check) => check?.status === "pass").length;
+              const failed = checks.filter((check) => check?.status === "fail").length;
+              const warnings = Array.isArray(payload?.warnings) ? payload.warnings.length : 0;
+              const revision = checks.find((check) => check?.name === "health")?.revision;
+              console.log("| Field | Value |");
+              console.log("| --- | --- |");
+              console.log(`| Result | ${payload?.ok === true ? "pass" : "fail"} |`);
+              console.log(`| Checks | ${passed} pass, ${failed} fail, ${checks.length} total |`);
+              console.log(`| Warnings | ${warnings} |`);
+              console.log(`| Revision | ${/^[0-9a-f]{40}$/u.test(revision ?? "") ? revision : "unknown"} |`);
+            } catch {
+              console.log("_The health probe payload was not valid JSON._");
+            }
+          }
+          NODE
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload runtime health evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: runtime-health
+          path: ${{ runner.temp }}/runtime-health.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/runtime-health.mjs
+++ b/scripts/runtime-health.mjs
@@ -1,0 +1,932 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_BASE_URL = "https://www.dovevannoinostrisoldi.com";
+export const MAX_BODY_BYTES = 750_000;
+export const DEFAULT_TIMEOUT_MS = 20_000;
+export const SOURCE_HEALTH_TIMEOUT_MS = 90_000;
+export const DEFAULT_MAX_ATTEMPTS = 2;
+export const DEFAULT_REPORT_PATH = path.join(
+  process.cwd(),
+  "artifacts",
+  "runtime-health",
+  "report.json",
+);
+
+const MCP_CONTENT_TYPE = /(?:application\/json|text\/event-stream)/i;
+const JSON_CONTENT_TYPE = /application\/json/i;
+const HTML_CONTENT_TYPE = /text\/html/i;
+const SHA = /^[0-9a-f]{40}$/iu;
+const EXPECTED_MCP_SERVER_NAME = "dove-vanno-i-nostri-soldi";
+
+const MCP_HEADERS = {
+  Accept: "application/json, text/event-stream",
+  "Content-Type": "application/json",
+};
+
+const REQUIRED_TOOLS = ["list_datasets", "query_dataset"];
+const EXPECTED_SOURCE_IDS = [
+  "ipa",
+  "ipa-struttura",
+  "openbdap",
+  "anac",
+  "inps",
+  "cpt",
+  "mef-irpef",
+  "siope",
+  "istat",
+  "opencoesione",
+  "italiadomani",
+  "opencivitas",
+  "consulenti",
+  "camera",
+  "senato",
+  "pcm",
+  "partecipazioni-pubbliche",
+  "bancaditalia",
+  "eurostat",
+];
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export function isRetryableStatus(status) {
+  return status === 408
+    || status === 425
+    || status === 429
+    || (status >= 500 && status <= 599);
+}
+
+export class RuntimeHealthError extends Error {
+  constructor(message, { code = "check_failed", retryable = false, attempts = 1, cause } = {}) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "RuntimeHealthError";
+    this.code = code;
+    this.retryable = retryable;
+    this.attempts = attempts;
+  }
+}
+
+function isLoopbackHostname(hostname) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+export function resolveBaseUrl(
+  value = DEFAULT_BASE_URL,
+  { additionalAllowedOrigins = [] } = {},
+) {
+  let baseUrl;
+  try {
+    baseUrl = new URL(value);
+  } catch (error) {
+    throw new RuntimeHealthError("CANONICAL_BASE_URL non valida", {
+      code: "invalid_base_url",
+      cause: error,
+    });
+  }
+  const loopback = isLoopbackHostname(baseUrl.hostname);
+  if (baseUrl.protocol !== "https:" && !(loopback && baseUrl.protocol === "http:")) {
+    throw new RuntimeHealthError("CANONICAL_BASE_URL richiede HTTPS, salvo loopback locale", {
+      code: "invalid_base_url",
+    });
+  }
+  if (baseUrl.username || baseUrl.password) {
+    throw new RuntimeHealthError("CANONICAL_BASE_URL non può contenere credenziali", {
+      code: "invalid_base_url",
+    });
+  }
+  baseUrl.hash = "";
+  baseUrl.search = "";
+  const allowedOrigins = new Set([DEFAULT_BASE_URL, ...additionalAllowedOrigins]);
+  if (!loopback && !allowedOrigins.has(baseUrl.origin)) {
+    throw new RuntimeHealthError("CANONICAL_BASE_URL non è un'origine autorizzata", {
+      code: "invalid_base_url",
+    });
+  }
+  return baseUrl;
+}
+
+function bodyContentLength(response) {
+  const raw = response.headers.get("content-length");
+  if (raw === null || !/^\d+$/.test(raw.trim())) return null;
+  const length = Number(raw);
+  return Number.isSafeInteger(length) ? length : null;
+}
+
+async function cancelBody(body, reason) {
+  try {
+    await body?.cancel(reason);
+  } catch {
+    // The response is already being discarded; cancellation is best effort.
+  }
+}
+
+/** Read a response without ever accumulating more than maxBytes. */
+export async function readBodyBounded(response, maxBytes = MAX_BODY_BYTES) {
+  const declaredLength = bodyContentLength(response);
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    await cancelBody(response.body, "runtime health response body limit exceeded");
+    throw new RuntimeHealthError(
+      `Risposta oltre il limite di ${maxBytes} byte`,
+      { code: "body_too_large" },
+    );
+  }
+
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!(value instanceof Uint8Array)) {
+        throw new RuntimeHealthError("Risposta con chunk non binario", {
+          code: "body_read_failed",
+          retryable: false,
+        });
+      }
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel("runtime health response body limit exceeded").catch(() => undefined);
+        throw new RuntimeHealthError(
+          `Risposta oltre il limite di ${maxBytes} byte`,
+          { code: "body_too_large" },
+        );
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    if (error instanceof RuntimeHealthError) throw error;
+    throw new RuntimeHealthError("Lettura della risposta interrotta", {
+      code: "body_read_failed",
+      retryable: true,
+      cause: error,
+    });
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function retryableError(error) {
+  return !(error instanceof RuntimeHealthError)
+    || error.retryable === true
+    || error.code === "body_read_failed";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Fetch with one bounded retry for GET/HEAD only. Non-idempotent methods are
+ * never replayed; response/schema policy failures are never retried.
+ */
+export async function requestWithRetry(
+  url,
+  {
+    fetchImpl = globalThis.fetch,
+    sleepImpl = sleep,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    maxBodyBytes = MAX_BODY_BYTES,
+    signal: callerSignal,
+    ...init
+  } = {},
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new RuntimeHealthError("fetch non disponibile", { code: "fetch_unavailable" });
+  }
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > DEFAULT_MAX_ATTEMPTS) {
+    throw new RuntimeHealthError("maxAttempts deve essere 1 oppure 2", { code: "invalid_retry_policy" });
+  }
+  const method = String(init.method ?? "GET").toUpperCase();
+  const effectiveMaxAttempts = method === "GET" || method === "HEAD" ? maxAttempts : 1;
+
+  let lastError;
+  for (let attempt = 1; attempt <= effectiveMaxAttempts; attempt += 1) {
+    try {
+      callerSignal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(timeoutMs);
+      const response = await fetchImpl(url, {
+        ...init,
+        redirect: "manual",
+        signal: callerSignal
+          ? AbortSignal.any([callerSignal, timeoutSignal])
+          : timeoutSignal,
+      });
+
+      if (isRetryableStatus(response.status) && attempt < effectiveMaxAttempts) {
+        await cancelBody(response.body, "retryable runtime health response");
+        callerSignal?.throwIfAborted();
+        await sleepImpl(attempt * 250);
+        callerSignal?.throwIfAborted();
+        continue;
+      }
+
+      if (isRetryableStatus(response.status)) {
+        await cancelBody(response.body, "final retryable runtime health response");
+        return { response, body: "", attempts: attempt };
+      }
+
+      let body;
+      try {
+        body = await readBodyBounded(response, maxBodyBytes);
+      } catch (error) {
+        if (!retryableError(error) || attempt >= effectiveMaxAttempts) throw error;
+        lastError = error;
+        callerSignal?.throwIfAborted();
+        await sleepImpl(attempt * 250);
+        callerSignal?.throwIfAborted();
+        continue;
+      }
+      return { response, body, attempts: attempt };
+    } catch (error) {
+      if (error instanceof RuntimeHealthError && error.code === "body_too_large") {
+        error.attempts = attempt;
+        throw error;
+      }
+      if (attempt >= effectiveMaxAttempts || !retryableError(error)) {
+        throw new RuntimeHealthError(
+          `Richiesta fallita dopo ${attempt} tentativo/i: ${errorMessage(error)}`,
+          { code: "network_error", retryable: false, attempts: attempt, cause: error },
+        );
+      }
+      lastError = error;
+      callerSignal?.throwIfAborted();
+      await sleepImpl(attempt * 250);
+      callerSignal?.throwIfAborted();
+    }
+  }
+
+  throw new RuntimeHealthError(
+    `Richiesta fallita: ${errorMessage(lastError)}`,
+    { code: "network_error", retryable: false, attempts: effectiveMaxAttempts, cause: lastError },
+  );
+}
+
+function parseJson(value, label) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new RuntimeHealthError(`${label}: JSON non valido`, {
+      code: "invalid_json",
+      cause: error,
+    });
+  }
+}
+
+/** Parse either a direct JSON-RPC envelope or one of the JSON data frames in SSE. */
+export function parseRpcEnvelope(body, label = "MCP") {
+  const trimmed = body.trim().replace(/^\uFEFF/u, "");
+  if (trimmed.startsWith("{")) return parseJson(trimmed, label);
+
+  const frames = [];
+  let frame = [];
+  for (const line of body.split(/\r?\n/u)) {
+    if (line === "") {
+      if (frame.length > 0) frames.push(frame.join("\n"));
+      frame = [];
+      continue;
+    }
+    if (/^data:\s?/u.test(line)) frame.push(line.replace(/^data:\s?/u, "").trim());
+  }
+  if (frame.length > 0) frames.push(frame.join("\n"));
+
+  for (let index = frames.length - 1; index >= 0; index -= 1) {
+    const candidate = frames[index].trim();
+    if (!candidate || candidate === "[DONE]") continue;
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // Continue looking for the latest complete JSON frame.
+    }
+  }
+  throw new RuntimeHealthError(`${label}: envelope JSON-RPC assente`, {
+    code: "invalid_rpc",
+  });
+}
+
+export function requireRpcResult(envelope, label = "MCP") {
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+    throw new RuntimeHealthError(`${label}: envelope non è un oggetto`, { code: "invalid_rpc" });
+  }
+  if (envelope.jsonrpc !== "2.0" || !(typeof envelope.id === "string" || typeof envelope.id === "number")) {
+    throw new RuntimeHealthError(`${label}: versione JSON-RPC o id non validi`, { code: "invalid_rpc" });
+  }
+  if (envelope.error !== undefined) {
+    throw new RuntimeHealthError(`${label}: errore JSON-RPC`, { code: "rpc_error" });
+  }
+  if (!envelope.result || typeof envelope.result !== "object") {
+    throw new RuntimeHealthError(`${label}: result mancante`, { code: "invalid_rpc" });
+  }
+  return envelope.result;
+}
+
+export function assertContentType(response, expected, label) {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!expected.test(contentType)) {
+    throw new RuntimeHealthError(`${label}: Content-Type inatteso`, { code: "invalid_content_type" });
+  }
+  return contentType;
+}
+
+export function assertMcpHeaders(response, label = "MCP") {
+  if (response.headers.get("cache-control") !== "private, no-store") {
+    throw new RuntimeHealthError(`${label}: Cache-Control non è private, no-store`, {
+      code: "invalid_cache_policy",
+    });
+  }
+  if (response.headers.get("x-content-type-options") !== "nosniff") {
+    throw new RuntimeHealthError(`${label}: X-Content-Type-Options non è nosniff`, {
+      code: "invalid_security_headers",
+    });
+  }
+}
+
+export function validateHomepage(response, body) {
+  if (response.status !== 200) {
+    throw new RuntimeHealthError(`Homepage HTTP ${response.status}`, { code: "unexpected_status" });
+  }
+  assertContentType(response, HTML_CONTENT_TYPE, "Homepage");
+  if (!body.includes("DoveVannoINostriSoldi") && !body.includes("Dove vanno i nostri soldi pubblici")) {
+    throw new RuntimeHealthError("Homepage senza marker applicativo", { code: "invalid_homepage" });
+  }
+  return { status: response.status };
+}
+
+export function validateHealthPayload(response, body) {
+  if (response.status !== 200) {
+    throw new RuntimeHealthError(`Health HTTP ${response.status}`, { code: "unexpected_status" });
+  }
+  assertContentType(response, JSON_CONTENT_TYPE, "Health");
+  const payload = parseJson(body, "Health");
+  if (payload?.ok !== true || payload.service !== "dvns-web" || !SHA.test(payload.revision ?? "")) {
+    throw new RuntimeHealthError("Health con contratto non valido", { code: "invalid_health_contract" });
+  }
+  return { status: response.status, revision: payload.revision };
+}
+
+export function validateSourceHealthPayload(response, body) {
+  if (response.status !== 200) {
+    throw new RuntimeHealthError(`Source health HTTP ${response.status}`, { code: "unexpected_status" });
+  }
+  assertContentType(response, JSON_CONTENT_TYPE, "Source health");
+  const payload = parseJson(body, "Source health");
+  if (
+    payload?.ok !== true
+    || !Array.isArray(payload.sources)
+    || !payload.summary
+    || typeof payload.summary !== "object"
+  ) {
+    throw new RuntimeHealthError("Source health con contratto non valido", {
+      code: "invalid_source_health_contract",
+    });
+  }
+  const allowedReachability = new Set(["up", "down", "not-probed"]);
+  const sourceIds = new Set();
+  for (const source of payload.sources) {
+    if (
+      !source
+      || typeof source !== "object"
+      || source.integration !== "active"
+      || typeof source.sourceId !== "string"
+      || source.sourceId.trim() === ""
+      || sourceIds.has(source.sourceId)
+      || !allowedReachability.has(source.reachability)
+    ) {
+      throw new RuntimeHealthError("Source health con fonte operativa non valida", {
+        code: "invalid_source_health_contract",
+      });
+    }
+    sourceIds.add(source.sourceId);
+  }
+  if (
+    sourceIds.size !== EXPECTED_SOURCE_IDS.length
+    || EXPECTED_SOURCE_IDS.some((sourceId) => !sourceIds.has(sourceId))
+  ) {
+    throw new RuntimeHealthError("Source health non coincide con il registro operativo", {
+      code: "invalid_source_health_contract",
+    });
+  }
+  const active = payload.sources;
+  const reachable = active.filter((source) => source.reachability === "up");
+  const down = active.filter((source) => source.reachability === "down");
+  const notProbed = active.filter((source) => source.reachability === "not-probed");
+  if (
+    active.length === 0
+    || payload.summary.total !== payload.sources.length
+    || payload.summary.active !== active.length
+    || payload.summary.reachable !== reachable.length
+    || payload.summary.unreachable !== down.length
+    || payload.summary.notProbed !== notProbed.length
+  ) {
+    throw new RuntimeHealthError("Source health senza registro operativo completo", {
+      code: "invalid_source_health_contract",
+    });
+  }
+  if (down.length > 0) {
+    throw new RuntimeHealthError(`${down.length} fonte/i ufficiale/i non raggiungibile/i`, {
+      code: "source_unreachable",
+    });
+  }
+  return {
+    status: response.status,
+    active: active.length,
+    reachable: reachable.length,
+    notProbed: notProbed.length,
+  };
+}
+
+export function validateInitializePayload(response, body) {
+  if (response.status !== 200) {
+    throw new RuntimeHealthError(`MCP initialize HTTP ${response.status}`, { code: "unexpected_status" });
+  }
+  assertContentType(response, MCP_CONTENT_TYPE, "MCP initialize");
+  assertMcpHeaders(response, "MCP initialize");
+  const result = requireRpcResult(parseRpcEnvelope(body, "MCP initialize"), "MCP initialize");
+  if (
+    result.protocolVersion !== "2025-11-25"
+    || result.serverInfo?.name !== EXPECTED_MCP_SERVER_NAME
+    || result.serverInfo.title !== "DoveVannoINostriSoldi"
+    || typeof result.serverInfo.version !== "string"
+    || result.serverInfo.version.trim() === ""
+    || result.serverInfo.websiteUrl !== DEFAULT_BASE_URL
+    || !result.capabilities
+    || typeof result.capabilities !== "object"
+    || Array.isArray(result.capabilities)
+    || !["resources", "prompts", "tools"].every(
+      (capability) => result.capabilities[capability]
+        && typeof result.capabilities[capability] === "object",
+    )
+  ) {
+    throw new RuntimeHealthError("MCP initialize con contratto server non valido", {
+      code: "invalid_initialize_contract",
+    });
+  }
+  return { status: response.status, serverName: result.serverInfo.name };
+}
+
+export function validateToolsListPayload(response, body, label = "MCP tools/list") {
+  if (response.status !== 200) {
+    throw new RuntimeHealthError(`${label} HTTP ${response.status}`, { code: "unexpected_status" });
+  }
+  assertContentType(response, MCP_CONTENT_TYPE, label);
+  assertMcpHeaders(response, label);
+  const result = requireRpcResult(parseRpcEnvelope(body, label), label);
+  if (!Array.isArray(result.tools)) {
+    throw new RuntimeHealthError(`${label} senza elenco tools`, { code: "invalid_tools_contract" });
+  }
+  const names = new Set(result.tools.map((tool) => tool?.name));
+  if (result.tools.length !== REQUIRED_TOOLS.length || names.size !== REQUIRED_TOOLS.length) {
+    throw new RuntimeHealthError(`${label}: elenco tools inatteso o duplicato`, {
+      code: "invalid_tools_contract",
+    });
+  }
+  for (const required of REQUIRED_TOOLS) {
+    if (!names.has(required)) {
+      throw new RuntimeHealthError(`${label}: tool ${required} assente`, { code: "missing_tool" });
+    }
+  }
+  for (const required of REQUIRED_TOOLS) {
+    const tool = result.tools.find((candidate) => candidate?.name === required);
+    const annotations = tool?.annotations;
+    const inputRequired = tool?.inputSchema?.required ?? [];
+    const outputRequired = tool?.outputSchema?.required ?? [];
+    const inputProperties = tool?.inputSchema?.properties;
+    const outputProperties = tool?.outputSchema?.properties;
+    const schemasValid = required === "list_datasets"
+      ? Object.keys(inputProperties ?? {}).length === 0
+        && inputRequired.length === 0
+        && ["datasets", "relatedMcpServices"].every(
+          (field) => outputRequired.includes(field) && Object.hasOwn(outputProperties ?? {}, field),
+        )
+      : inputRequired.includes("dataset")
+        && ["dataset", "year", "query", "level", "limit"].every(
+          (field) => Object.hasOwn(inputProperties ?? {}, field),
+        )
+        && ["ok", "dataset"].every(
+          (field) => outputRequired.includes(field) && Object.hasOwn(outputProperties ?? {}, field),
+        );
+    if (
+      typeof tool?.title !== "string"
+      || tool.title.trim() === ""
+      || typeof tool.description !== "string"
+      || tool.description.trim() === ""
+      || tool.inputSchema?.type !== "object"
+      || tool.inputSchema?.additionalProperties !== false
+      || tool.outputSchema?.type !== "object"
+      || tool.outputSchema?.additionalProperties !== false
+      || !schemasValid
+      || JSON.stringify(tool.securitySchemes) !== '[{"type":"noauth"}]'
+      || JSON.stringify(tool._meta?.securitySchemes) !== '[{"type":"noauth"}]'
+      || annotations?.readOnlyHint !== true
+      || annotations.destructiveHint !== false
+      || annotations.idempotentHint !== true
+      || annotations.openWorldHint !== false
+    ) {
+      throw new RuntimeHealthError(`${label}: annotazioni read-only non valide per ${required}`, {
+        code: "invalid_tool_annotations",
+      });
+    }
+  }
+  return { status: response.status, toolCount: result.tools.length, contract: result.tools };
+}
+
+export function validateSnapshotQueryPayload(response, body) {
+  if (response.status !== 200) {
+    throw new RuntimeHealthError(`MCP snapshot query HTTP ${response.status}`, {
+      code: "unexpected_status",
+    });
+  }
+  assertContentType(response, MCP_CONTENT_TYPE, "MCP snapshot query");
+  assertMcpHeaders(response, "MCP snapshot query");
+  const result = requireRpcResult(parseRpcEnvelope(body, "MCP snapshot query"), "MCP snapshot query");
+  if (result.isError === true) {
+    throw new RuntimeHealthError("MCP snapshot query con isError=true", { code: "rpc_tool_error" });
+  }
+  const structured = result.structuredContent;
+  if (
+    !structured
+    || structured.ok !== true
+    || structured.dataset !== "mef_irpef_comunale"
+    || structured.query?.dataset !== "mef_irpef_comunale"
+    || structured.query?.year !== 2024
+    || structured.query?.level !== "municipality"
+    || structured.query?.query !== "Abano"
+    || structured.query?.limit !== 1
+    || !structured.data
+    || typeof structured.data !== "object"
+    || structured.data.dataset !== "mef_irpef_comunale"
+    || structured.data.period?.taxYear !== 2024
+    || structured.data.level !== "municipality"
+    || structured.data.query?.query !== "Abano"
+    || structured.data.pagination?.returned !== 1
+    || structured.data.pagination?.limit !== 1
+    || structured.data.pagination?.total !== 1
+    || structured.data.pagination?.offset !== 0
+    || !Array.isArray(structured.data.data)
+    || structured.data.data.length !== 1
+    || structured.data.data[0]?.territory?.code !== "028001"
+    || structured.data.data[0]?.territory?.name !== "ABANO TERME"
+    || structured.data.provenance?.source?.owner !== "MEF – Dipartimento delle Finanze"
+    || !Array.isArray(result.content)
+    || !result.content.some(
+      (item) => item?.type === "text" && item.text.includes("mef_irpef_comunale"),
+    )
+  ) {
+    throw new RuntimeHealthError("MCP snapshot query con contratto non valido", {
+      code: "invalid_snapshot_query_contract",
+    });
+  }
+  let assetUrl;
+  try {
+    assetUrl = new URL(structured.data.provenance.source.assetUrl);
+  } catch {
+    assetUrl = null;
+  }
+  if (assetUrl?.protocol !== "https:" || assetUrl.hostname !== "www1.finanze.gov.it") {
+    throw new RuntimeHealthError("MCP snapshot query senza provenienza HTTPS valida", {
+      code: "invalid_snapshot_query_contract",
+    });
+  }
+  return { status: response.status, dataset: "mef_irpef_comunale", returned: 1 };
+}
+
+function endpoint(baseUrl, pathname) {
+  return new URL(pathname, baseUrl).href;
+}
+
+function safeError(error) {
+  const message = errorMessage(error).replace(/\s+/gu, " ").trim();
+  return message.length > 240 ? `${message.slice(0, 237)}...` : message;
+}
+
+function checkRecord(name, result, startedAt) {
+  return {
+    name,
+    status: "pass",
+    durationMs: Math.max(0, Date.now() - startedAt),
+    attempts: result.attempts ?? 1,
+    ...Object.fromEntries(
+      Object.entries(result).filter(
+        ([key]) => !["body", "response", "attempts", "status", "contract"].includes(key),
+      ),
+    ),
+  };
+}
+
+function checkFailure(name, error, startedAt) {
+  return {
+    name,
+    status: "fail",
+    durationMs: Math.max(0, Date.now() - startedAt),
+    attempts: error instanceof RuntimeHealthError ? error.attempts : 1,
+    error: safeError(error),
+    code: error instanceof RuntimeHealthError ? error.code : "check_failed",
+  };
+}
+
+function validateRequestResult(result, validator) {
+  try {
+    return validator(result.response, result.body);
+  } catch (error) {
+    if (error instanceof RuntimeHealthError) {
+      error.attempts = result.attempts;
+    }
+    throw error;
+  }
+}
+
+async function requestCheck(baseUrl, pathname, options = {}) {
+  const result = await requestWithRetry(endpoint(baseUrl, pathname), options);
+  return {
+    ...result,
+    contentType: result.response.headers.get("content-type") ?? "",
+  };
+}
+
+/**
+ * Run all checks sequentially so the expensive source probe is never
+ * multiplied by parallel monitor work. Source and MCP POST probes use one
+ * attempt only to avoid overlapping upstream fans or replaying requests.
+ */
+export async function runHealthMonitor({
+  baseUrl = DEFAULT_BASE_URL,
+  fetchImpl = globalThis.fetch,
+  sleepImpl = sleep,
+  observedAt = new Date().toISOString(),
+  additionalAllowedOrigins = [],
+} = {}) {
+  const resolvedBaseUrl = resolveBaseUrl(baseUrl, { additionalAllowedOrigins });
+  let canonicalToolsContract;
+  const report = {
+    ok: true,
+    observedAt,
+    baseUrl: resolvedBaseUrl.origin,
+    checks: [],
+    warnings: [],
+  };
+
+  const checks = [
+    {
+      name: "homepage",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+        });
+        return validateRequestResult(result, validateHomepage);
+      },
+    },
+    {
+      name: "health",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/api/health", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+        });
+        return validateRequestResult(result, validateHealthPayload);
+      },
+    },
+    {
+      name: "source-health",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/api/fonti/stato", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: SOURCE_HEALTH_TIMEOUT_MS,
+          maxAttempts: 1,
+        });
+        return validateRequestResult(result, validateSourceHealthPayload);
+      },
+    },
+    {
+      name: "mcp-api-initialize",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/api/mcp", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+          maxAttempts: 1,
+          method: "POST",
+          headers: MCP_HEADERS,
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              clientInfo: { name: "dvns-runtime-health", version: "1.0.0" },
+            },
+          }),
+        });
+        return validateRequestResult(result, validateInitializePayload);
+      },
+    },
+    {
+      name: "mcp-api-tools-list",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/api/mcp", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+          maxAttempts: 1,
+          method: "POST",
+          headers: MCP_HEADERS,
+          body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+        });
+        const validated = validateRequestResult(
+          result,
+          (response, body) => validateToolsListPayload(response, body, "MCP API tools/list"),
+        );
+        canonicalToolsContract = JSON.stringify(validated.contract);
+        return validated;
+      },
+    },
+    {
+      name: "mcp-alias-tools-list",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/mcp", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+          maxAttempts: 1,
+          method: "POST",
+          headers: MCP_HEADERS,
+          body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+        });
+        const validated = validateRequestResult(
+          result,
+          (response, body) => validateToolsListPayload(response, body, "MCP alias tools/list"),
+        );
+        if (canonicalToolsContract === undefined || JSON.stringify(validated.contract) !== canonicalToolsContract) {
+          throw new RuntimeHealthError("MCP alias con contratto tools diverso dall'endpoint canonico", {
+            code: "alias_contract_drift",
+          });
+        }
+        return validated;
+      },
+    },
+    {
+      name: "mcp-snapshot-query",
+      run: async () => {
+        const result = await requestCheck(resolvedBaseUrl, "/api/mcp", {
+          fetchImpl,
+          sleepImpl,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+          maxAttempts: 1,
+          method: "POST",
+          headers: MCP_HEADERS,
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 4,
+            method: "tools/call",
+            params: {
+              name: "query_dataset",
+              arguments: {
+                dataset: "mef_irpef_comunale",
+                year: 2024,
+                level: "municipality",
+                query: "Abano",
+                limit: 1,
+              },
+            },
+          }),
+        });
+        return validateRequestResult(result, validateSnapshotQueryPayload);
+      },
+    },
+  ];
+
+  for (const check of checks) {
+    const startedAt = Date.now();
+    try {
+      const result = await check.run();
+      const record = checkRecord(check.name, result, startedAt);
+      report.checks.push(record);
+      if (result.warning) {
+        report.warnings.push({ check: check.name, warning: result.warning, down: result.down });
+      }
+    } catch (error) {
+      report.ok = false;
+      report.checks.push(checkFailure(check.name, error, startedAt));
+    }
+  }
+
+  return report;
+}
+
+export async function writeReport(report, reportPath = DEFAULT_REPORT_PATH) {
+  await fs.mkdir(path.dirname(reportPath), { recursive: true });
+  await fs.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+function printSummary(report) {
+  const lines = [
+    "## Runtime health",
+    "",
+    "| Check | Status | Attempts | Duration | Detail |",
+    "| --- | --- | ---: | ---: | --- |",
+  ];
+  for (const check of report.checks) {
+    const detail = check.error ?? (check.warning ?? "ok");
+    lines.push(`| ${check.name} | ${check.status} | ${check.attempts} | ${check.durationMs} ms | ${detail} |`);
+  }
+  for (const warning of report.warnings) {
+    lines.push(`| ${warning.check} | warning | — | — | ${warning.warning} |`);
+  }
+  const summary = lines.join("\n");
+  console.log(summary);
+}
+
+export function parseCliArgs(argv = []) {
+  let reportPath;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument !== "--output") {
+      const error = new RuntimeHealthError(`Argomento CLI non riconosciuto: ${argument}`, {
+        code: "invalid_cli",
+      });
+      error.reportPath = reportPath;
+      throw error;
+    }
+    const candidate = argv[index + 1];
+    if (!candidate || candidate.startsWith("--")) {
+      const error = new RuntimeHealthError("--output richiede un percorso", {
+        code: "invalid_cli",
+      });
+      error.reportPath = reportPath;
+      throw error;
+    }
+    if (reportPath !== undefined) {
+      const error = new RuntimeHealthError("--output specificato più di una volta", {
+        code: "invalid_cli",
+      });
+      error.reportPath = reportPath;
+      throw error;
+    }
+    reportPath = candidate;
+    index += 1;
+  }
+  return { reportPath };
+}
+
+export async function main({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  sleepImpl = sleep,
+  argv = process.argv.slice(2),
+  reportPath,
+} = {}) {
+  let resolvedReportPath = reportPath ?? env.RUNTIME_HEALTH_REPORT_PATH ?? DEFAULT_REPORT_PATH;
+  let report;
+  try {
+    const cli = parseCliArgs(argv);
+    resolvedReportPath = cli.reportPath ?? resolvedReportPath;
+    report = await runHealthMonitor({
+      baseUrl: env.CANONICAL_BASE_URL ?? DEFAULT_BASE_URL,
+      fetchImpl,
+      sleepImpl,
+    });
+  } catch (error) {
+    if (error?.reportPath) resolvedReportPath = error.reportPath;
+    report = {
+      ok: false,
+      observedAt: new Date().toISOString(),
+      baseUrl: null,
+      checks: [],
+      warnings: [],
+      error: safeError(error),
+    };
+  }
+
+  await writeReport(report, resolvedReportPath);
+  printSummary(report);
+  return report.ok ? 0 : 1;
+}
+
+const isMain = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  main().then((code) => {
+    process.exitCode = code;
+  }).catch((error) => {
+    console.error(`Runtime health report failure: ${safeError(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/etl/test_workflow_governance.py
+++ b/tests/etl/test_workflow_governance.py
@@ -71,6 +71,47 @@ class WorkflowGovernanceTests(unittest.TestCase):
         ):
             self.assertIn(fragment, text)
 
+    def test_runtime_health_is_scheduled_pinned_and_secret_free(self):
+        text = self.read("runtime-health.yml")
+        self.assertRegex(text, r'(?m)^\s*-\s*cron:\s*"7,22,37,52 \* \* \* \*"\s*$')
+        self.assertIn("  workflow_dispatch:", text)
+        self.assertIn("  contents: read", text)
+        self.assertRegex(text, r"(?m)^\s*group:\s*runtime-health\s*$")
+        self.assertRegex(text, r"(?m)^\s*cancel-in-progress:\s*true\s*$")
+        self.assertIn("runs-on: ubuntu-24.04", text)
+        self.assertIn("timeout-minutes: 8", text)
+        self.assertIn("CANONICAL_BASE_URL: https://www.dovevannoinostrisoldi.com", text)
+        self.assertIn(
+            "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6",
+            text,
+        )
+        self.assertIn(
+            "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7",
+            text,
+        )
+        self.assertIn(
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7",
+            text,
+        )
+        self.assertRegex(text, r"node-version:\s*[\"']22(?:\.\d+\.\d+)?[\"']")
+        self.assertIn("persist-credentials: false", text)
+        self.assertIn(
+            'node scripts/runtime-health.mjs --output "$RUNNER_TEMP/runtime-health.json"',
+            text,
+        )
+        self.assertIn("GITHUB_STEP_SUMMARY", text)
+        self.assertNotIn("Object.entries(payload)", text)
+        self.assertIn("| Warnings |", text)
+        self.assertIn("| Revision |", text)
+        self.assertRegex(text, r"(?m)^\s*if:\s*failure\(\)\s*$")
+        self.assertIn("name: runtime-health", text)
+        self.assertIn("path: ${{ runner.temp }}/runtime-health.json", text)
+        self.assertIn("if-no-files-found: ignore", text)
+        self.assertIn("retention-days: 7", text)
+        self.assertNotRegex(text, r"\bnpm\s+(?:install|ci)\b")
+        for forbidden in ("GITHUB_TOKEN", "github.token", "secrets.", "webhook", "Authorization"):
+            self.assertNotIn(forbidden, text)
+
     def test_parliament_temporary_unavailability_is_failure_with_summary(self):
         text = self.read("parliament-sources.yml")
         self.assertIn("Fonte parlamentare temporaneamente non verificabile", text)

--- a/tests/runtime-health.test.mjs
+++ b/tests/runtime-health.test.mjs
@@ -1,0 +1,575 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  MAX_BODY_BYTES,
+  RuntimeHealthError,
+  isRetryableStatus,
+  main,
+  parseCliArgs,
+  parseRpcEnvelope,
+  readBodyBounded,
+  requestWithRetry,
+  resolveBaseUrl,
+  runHealthMonitor,
+  validateHealthPayload,
+  validateInitializePayload,
+  validateSourceHealthPayload,
+  validateSnapshotQueryPayload,
+  validateToolsListPayload,
+  writeReport,
+} from "../scripts/runtime-health.mjs";
+
+const REVISION = "a".repeat(40);
+const SOURCE_IDS = [
+  "ipa", "ipa-struttura", "openbdap", "anac", "inps", "cpt", "mef-irpef", "siope",
+  "istat", "opencoesione", "italiadomani", "opencivitas", "consulenti", "camera", "senato",
+  "pcm", "partecipazioni-pubbliche", "bancaditalia", "eurostat",
+];
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  "cache-control": "private, no-store",
+  "x-content-type-options": "nosniff",
+};
+const TOOLS = [
+  {
+    name: "list_datasets",
+    title: "Elenca dataset",
+    description: "Elenca i dataset pubblici disponibili.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    outputSchema: {
+      type: "object",
+      properties: { datasets: { type: "array" }, relatedMcpServices: { type: "array" } },
+      required: ["datasets", "relatedMcpServices"],
+      additionalProperties: false,
+    },
+    securitySchemes: [{ type: "noauth" }],
+    _meta: { securitySchemes: [{ type: "noauth" }] },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "query_dataset",
+    title: "Interroga dataset",
+    description: "Interroga un dataset pubblico.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dataset: { type: "string" },
+        year: { type: "integer" },
+        query: { type: "string" },
+        level: { type: "string" },
+        limit: { type: "integer" },
+      },
+      required: ["dataset"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: { ok: { type: "boolean" }, dataset: { type: "string" } },
+      required: ["ok", "dataset"],
+      additionalProperties: false,
+    },
+    securitySchemes: [{ type: "noauth" }],
+    _meta: { securitySchemes: [{ type: "noauth" }] },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+];
+
+function makeResponse(body, { status = 200, headers = {} } = {}) {
+  const payload = typeof body === "string" ? body : JSON.stringify(body);
+  return new Response(payload, { status, headers });
+}
+
+function jsonResponse(body, options = {}) {
+  return makeResponse(body, {
+    ...options,
+    headers: { "content-type": "application/json", ...(options.headers ?? {}) },
+  });
+}
+
+function rpcResponse(result, { sse = false } = {}) {
+  const envelope = JSON.stringify({ jsonrpc: "2.0", id: 1, result });
+  const body = sse ? `event: message\ndata: ${envelope}\n\n` : envelope;
+  return makeResponse(body, {
+    headers: {
+      ...MCP_HEADERS,
+      "content-type": sse ? "text/event-stream" : "application/json",
+    },
+  });
+}
+
+function sourcePayload({ down = false } = {}) {
+  return {
+    ok: true,
+    summary: {
+      total: SOURCE_IDS.length,
+      active: SOURCE_IDS.length,
+      reachable: down ? SOURCE_IDS.length - 1 : SOURCE_IDS.length,
+      unreachable: down ? 1 : 0,
+      notProbed: 0,
+    },
+    sources: SOURCE_IDS.map((sourceId, index) => ({
+      sourceId,
+      integration: "active",
+      reachability: down && index === 0 ? "down" : "up",
+    })),
+  };
+}
+
+function snapshotResult() {
+  return {
+    structuredContent: {
+      ok: true,
+      dataset: "mef_irpef_comunale",
+      query: {
+        dataset: "mef_irpef_comunale",
+        year: 2024,
+        level: "municipality",
+        query: "Abano",
+        limit: 1,
+      },
+      data: {
+        dataset: "mef_irpef_comunale",
+        period: { taxYear: 2024 },
+        level: "municipality",
+        query: { query: "Abano" },
+        pagination: { returned: 1, limit: 1, total: 1, offset: 0 },
+        data: [{ territory: { code: "028001", name: "ABANO TERME" } }],
+        provenance: {
+          source: {
+            owner: "MEF – Dipartimento delle Finanze",
+            assetUrl: "https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php",
+          },
+        },
+      },
+    },
+    content: [{ type: "text", text: "Risultato mef_irpef_comunale" }],
+  };
+}
+
+function appFetch({ sourceDown = false, aliasDrift = false, calls = [] } = {}) {
+  return async (url, init = {}) => {
+    const requestUrl = new URL(url);
+    const method = init.method ?? "GET";
+    calls.push({ method, path: requestUrl.pathname, body: init.body });
+
+    if (method === "GET" && requestUrl.pathname === "/") {
+      return makeResponse("<!doctype html><title>DoveVannoINostriSoldi</title>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+    if (method === "GET" && requestUrl.pathname === "/api/health") {
+      return jsonResponse({ ok: true, service: "dvns-web", revision: REVISION });
+    }
+    if (method === "GET" && requestUrl.pathname === "/api/fonti/stato") {
+      return jsonResponse(sourcePayload({ down: sourceDown }));
+    }
+    if (method === "POST" && (requestUrl.pathname === "/api/mcp" || requestUrl.pathname === "/mcp")) {
+      const request = JSON.parse(init.body);
+      if (request.method === "initialize") {
+        return rpcResponse({
+          protocolVersion: "2025-11-25",
+          serverInfo: {
+            name: "dove-vanno-i-nostri-soldi",
+            title: "DoveVannoINostriSoldi",
+            version: "0.2.0",
+            websiteUrl: "https://www.dovevannoinostrisoldi.com",
+          },
+          capabilities: { resources: {}, prompts: {}, tools: {} },
+        });
+      }
+      if (request.method === "tools/list") {
+        const tools = aliasDrift && requestUrl.pathname === "/mcp"
+          ? TOOLS.map((tool, index) => index === 0 ? { ...tool, description: "Contratto diverso" } : tool)
+          : TOOLS;
+        return rpcResponse({ tools }, { sse: requestUrl.pathname === "/mcp" });
+      }
+      if (request.method === "tools/call") return rpcResponse(snapshotResult());
+    }
+    throw new Error(`unexpected fake request ${method} ${requestUrl.pathname}`);
+  };
+}
+
+async function temporaryDirectory() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "dvns-runtime-health-test-"));
+}
+
+test("resolveBaseUrl accepts the canonical origin and rejects unsafe values", () => {
+  assert.equal(
+    resolveBaseUrl("https://example.test/path?q=secret#fragment", {
+      additionalAllowedOrigins: ["https://example.test"],
+    }).href,
+    "https://example.test/path",
+  );
+  assert.equal(resolveBaseUrl("http://127.0.0.1:3000/path").href, "http://127.0.0.1:3000/path");
+  assert.throws(() => resolveBaseUrl("ftp://example.test"), (error) => error.code === "invalid_base_url");
+  assert.throws(() => resolveBaseUrl("http://169.254.169.254/latest"), (error) => error.code === "invalid_base_url");
+  assert.throws(() => resolveBaseUrl("https://attacker.invalid"), (error) => error.code === "invalid_base_url");
+  assert.throws(() => resolveBaseUrl("https://user:pass@example.test"), (error) => error.code === "invalid_base_url");
+});
+
+test("parseCliArgs is strict and only accepts one --output path", () => {
+  assert.deepEqual(parseCliArgs([]), { reportPath: undefined });
+  assert.deepEqual(parseCliArgs(["--output", "/tmp/report.json"]), { reportPath: "/tmp/report.json" });
+  for (const argv of [["--unknown"], ["--output"], ["--output", "--unknown"], ["--output", "/tmp/a", "--output", "/tmp/b"]]) {
+    assert.throws(() => parseCliArgs(argv), (error) => error.code === "invalid_cli");
+  }
+});
+
+test("parseRpcEnvelope handles direct JSON and split SSE data frames", () => {
+  const direct = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+  assert.deepEqual(parseRpcEnvelope(JSON.stringify(direct)), direct);
+  const split = [
+    "event: message",
+    'data: {"jsonrpc":"2.0",',
+    'data: "id":1,',
+    'data: "result":{"ok":true}}',
+    "",
+  ].join("\n");
+  assert.deepEqual(parseRpcEnvelope(split), direct);
+  const multiple = [
+    `data: ${JSON.stringify({ jsonrpc: "2.0", id: 0, result: { ok: false } })}`,
+    "",
+    `data: ${JSON.stringify(direct)}`,
+    "",
+  ].join("\n");
+  assert.deepEqual(parseRpcEnvelope(multiple), direct);
+  assert.throws(() => parseRpcEnvelope("event: message\ndata: [DONE]\n"), (error) => error.code === "invalid_rpc");
+});
+
+test("readBodyBounded rejects declared and streamed bodies and cancels them", async () => {
+  const declared = new Response("abcd", { headers: { "content-length": "4" } });
+  await assert.rejects(
+    readBodyBounded(declared, 3),
+    (error) => error instanceof RuntimeHealthError && error.code === "body_too_large",
+  );
+
+  const streamed = new Response("abcd");
+  await assert.rejects(
+    readBodyBounded(streamed, 3),
+    (error) => error instanceof RuntimeHealthError && error.code === "body_too_large",
+  );
+  assert.equal(await readBodyBounded(new Response("ok"), MAX_BODY_BYTES), "ok");
+});
+
+test("requestWithRetry retries network failures and every transient status exactly once", async () => {
+  for (const status of [501, 599]) {
+    let calls = 0;
+    const result = await requestWithRetry("https://example.test/status", {
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? makeResponse("transient", { status })
+          : makeResponse("ok", { headers: { "content-type": "text/plain" } });
+      },
+      sleepImpl: async () => undefined,
+    });
+    assert.equal(calls, 2);
+    assert.equal(result.attempts, 2);
+    assert.equal(result.body, "ok");
+  }
+
+  let networkCalls = 0;
+  const networkResult = await requestWithRetry("https://example.test/network", {
+    fetchImpl: async () => {
+      networkCalls += 1;
+      if (networkCalls === 1) throw new TypeError("socket closed");
+      return makeResponse("ok");
+    },
+    sleepImpl: async () => undefined,
+  });
+  assert.equal(networkCalls, 2);
+  assert.equal(networkResult.attempts, 2);
+  assert.equal(isRetryableStatus(408), true);
+  assert.equal(isRetryableStatus(425), true);
+  assert.equal(isRetryableStatus(429), true);
+  assert.equal(isRetryableStatus(500), true);
+  assert.equal(isRetryableStatus(599), true);
+  assert.equal(isRetryableStatus(400), false);
+});
+
+test("requestWithRetry does not retry permanent HTTP or body-limit failures", async () => {
+  let permanentCalls = 0;
+  const permanent = await requestWithRetry("https://example.test/permanent", {
+    fetchImpl: async () => {
+      permanentCalls += 1;
+      return makeResponse("bad request", { status: 400 });
+    },
+    sleepImpl: async () => undefined,
+  });
+  assert.equal(permanentCalls, 1);
+  assert.equal(permanent.attempts, 1);
+  assert.equal(permanent.response.status, 400);
+
+  let oversizedCalls = 0;
+  await assert.rejects(
+    requestWithRetry("https://example.test/large", {
+      fetchImpl: async () => {
+        oversizedCalls += 1;
+        return makeResponse("1234");
+      },
+      maxBodyBytes: 3,
+      sleepImpl: async () => undefined,
+    }),
+    (error) => error instanceof RuntimeHealthError && error.code === "body_too_large",
+  );
+  assert.equal(oversizedCalls, 1);
+});
+
+test("requestWithRetry never replays POST and composes caller cancellation", async () => {
+  let postCalls = 0;
+  const postResult = await requestWithRetry("https://example.test/post", {
+    method: "POST",
+    maxAttempts: 2,
+    fetchImpl: async () => {
+      postCalls += 1;
+      return makeResponse("transient", { status: 501 });
+    },
+  });
+  assert.equal(postCalls, 1);
+  assert.equal(postResult.attempts, 1);
+
+  const controller = new AbortController();
+  controller.abort(new DOMException("cancelled", "AbortError"));
+  let cancelledCalls = 0;
+  await assert.rejects(
+    requestWithRetry("https://example.test/cancelled", {
+      signal: controller.signal,
+      fetchImpl: async () => {
+        cancelledCalls += 1;
+        return makeResponse("unexpected");
+      },
+    }),
+    (error) => error.name === "AbortError",
+  );
+  assert.equal(cancelledCalls, 0);
+});
+
+test("requestWithRetry aborts on timeout and never follows redirects", async () => {
+  await assert.rejects(
+    requestWithRetry("https://example.test/slow", {
+      fetchImpl: async (_url, init) => new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+      }),
+      timeoutMs: 5,
+      maxAttempts: 1,
+    }),
+    (error) => error instanceof RuntimeHealthError
+      && error.code === "network_error"
+      && error.attempts === 1,
+  );
+
+  let redirectPolicy;
+  const redirect = await requestWithRetry("https://example.test/redirect", {
+    fetchImpl: async (_url, init) => {
+      redirectPolicy = init.redirect;
+      return makeResponse("", { status: 302, headers: { location: "https://attacker.invalid" } });
+    },
+    redirect: "follow",
+  });
+  assert.equal(redirectPolicy, "manual");
+  assert.equal(redirect.response.status, 302);
+});
+
+test("runHealthMonitor fails on unreachable sources and performs checks sequentially", async () => {
+  const calls = [];
+  const report = await runHealthMonitor({
+    baseUrl: "https://example.test/ignored?q=redact#fragment",
+    fetchImpl: appFetch({ sourceDown: true, calls }),
+    sleepImpl: async () => undefined,
+    observedAt: "2026-08-28T00:00:00.000Z",
+    additionalAllowedOrigins: ["https://example.test"],
+  });
+
+  assert.equal(report.ok, false);
+  assert.equal(report.baseUrl, "https://example.test");
+  assert.equal(report.checks.length, 7);
+  assert.equal(report.checks.filter((check) => check.status === "pass").length, 6);
+  const sourceHealth = report.checks.find((check) => check.name === "source-health");
+  assert.equal(sourceHealth.status, "fail");
+  assert.equal(sourceHealth.code, "source_unreachable");
+  assert.equal(sourceHealth.attempts, 1);
+  assert.equal(report.checks.find((check) => check.name === "health").revision, REVISION);
+  assert.deepEqual(calls.map((call) => call.path), [
+    "/",
+    "/api/health",
+    "/api/fonti/stato",
+    "/api/mcp",
+    "/api/mcp",
+    "/mcp",
+    "/api/mcp",
+  ]);
+  assert.equal(report.warnings.length, 0);
+  const queryCall = calls.at(-1);
+  const queryRequest = JSON.parse(queryCall.body);
+  assert.deepEqual(queryRequest.params.arguments, {
+    dataset: "mef_irpef_comunale",
+    year: 2024,
+    level: "municipality",
+    query: "Abano",
+    limit: 1,
+  });
+  assert.doesNotMatch(JSON.stringify(report), /redact|authorization|cookie|snapshot raw/i);
+  assert.ok(report.checks.every((check) => !Object.hasOwn(check, "body") && !Object.hasOwn(check, "response")));
+  assert.ok(report.checks.every((check) => !Object.hasOwn(check, "contract")));
+});
+
+test("runHealthMonitor rejects MCP alias contract drift", async () => {
+  const report = await runHealthMonitor({
+    baseUrl: "https://example.test",
+    additionalAllowedOrigins: ["https://example.test"],
+    fetchImpl: appFetch({ aliasDrift: true }),
+    sleepImpl: async () => undefined,
+  });
+  const alias = report.checks.find((check) => check.name === "mcp-alias-tools-list");
+  assert.equal(report.ok, false);
+  assert.equal(alias.status, "fail");
+  assert.equal(alias.code, "alias_contract_drift");
+  assert.equal(alias.attempts, 1);
+});
+
+test("runHealthMonitor preserves two attempts when the final response is retryable", async () => {
+  const calls = [];
+  const report = await runHealthMonitor({
+    baseUrl: "https://example.test",
+    fetchImpl: async (url, init) => {
+      const requestUrl = new URL(url);
+      calls.push(requestUrl.pathname);
+      if (requestUrl.pathname === "/api/health") {
+        return jsonResponse({ secret: "should-not-leak" }, { status: 501 });
+      }
+      return appFetch({ calls })(url, init);
+    },
+    sleepImpl: async () => undefined,
+    additionalAllowedOrigins: ["https://example.test"],
+  });
+  const health = report.checks.find((check) => check.name === "health");
+  assert.equal(report.ok, false);
+  assert.equal(health.status, "fail");
+  assert.equal(health.attempts, 2);
+  assert.equal(health.code, "unexpected_status");
+  assert.equal(report.checks.find((check) => check.name === "mcp-api-initialize").attempts, 1);
+  assert.doesNotMatch(JSON.stringify(report), /should-not-leak|content-length|cache-control/i);
+});
+
+test("contract validators reject malformed health, tools, snapshot, and security headers", () => {
+  assert.throws(
+    () => validateHealthPayload(jsonResponse({ ok: true, service: "dvns-web", revision: "local" }), JSON.stringify({ ok: true })),
+    (error) => error.code === "invalid_health_contract",
+  );
+  assert.throws(
+    () => validateSourceHealthPayload(
+      jsonResponse({ ok: true, summary: { total: 0, active: 0 }, sources: [] }),
+      JSON.stringify({ ok: true, summary: { total: 0, active: 0 }, sources: [] }),
+    ),
+    (error) => error.code === "invalid_source_health_contract",
+  );
+  const malformedSource = sourcePayload();
+  malformedSource.sources[0].reachability = "unknown";
+  assert.throws(
+    () => validateSourceHealthPayload(jsonResponse(malformedSource), JSON.stringify(malformedSource)),
+    (error) => error.code === "invalid_source_health_contract",
+  );
+  const unreconciledSource = sourcePayload();
+  unreconciledSource.summary.reachable = 0;
+  assert.throws(
+    () => validateSourceHealthPayload(jsonResponse(unreconciledSource), JSON.stringify(unreconciledSource)),
+    (error) => error.code === "invalid_source_health_contract",
+  );
+  const unknownSource = sourcePayload();
+  unknownSource.sources[0].sourceId = "bogus";
+  assert.throws(
+    () => validateSourceHealthPayload(jsonResponse(unknownSource), JSON.stringify(unknownSource)),
+    (error) => error.code === "invalid_source_health_contract",
+  );
+  const incompleteInitialize = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: { protocolVersion: "2025-11-25", serverInfo: { name: "other" }, capabilities: {} },
+  };
+  assert.throws(
+    () => validateInitializePayload(
+      rpcResponse(incompleteInitialize.result),
+      JSON.stringify(incompleteInitialize),
+    ),
+    (error) => error.code === "invalid_initialize_contract",
+  );
+  assert.throws(
+    () => validateToolsListPayload(rpcResponse({ tools: TOOLS }), JSON.stringify({ result: { tools: TOOLS } })),
+    (error) => error.code === "invalid_rpc",
+  );
+  const unsafeTools = TOOLS.map((tool) => ({
+    ...tool,
+    annotations: { ...tool.annotations, openWorldHint: true },
+  }));
+  assert.throws(
+    () => validateToolsListPayload(
+      rpcResponse({ tools: unsafeTools }),
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: unsafeTools } }),
+    ),
+    (error) => error.code === "invalid_tool_annotations",
+  );
+  assert.throws(
+    () => validateToolsListPayload(
+      rpcResponse({ tools: [{ name: "query_dataset", annotations: { readOnlyHint: false } }] }),
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
+    ),
+    (error) => error.code === "missing_tool" || error.code === "invalid_tools_contract",
+  );
+  const duplicateTools = [TOOLS[0], { ...TOOLS[0] }];
+  assert.throws(
+    () => validateToolsListPayload(
+      rpcResponse({ tools: duplicateTools }),
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: duplicateTools } }),
+    ),
+    (error) => error.code === "invalid_tools_contract",
+  );
+  const wrongSnapshot = rpcResponse({
+    structuredContent: {
+      ok: true,
+      dataset: "other",
+      data: { pagination: { returned: 2 } },
+    },
+  });
+  assert.throws(
+    () => validateSnapshotQueryPayload(wrongSnapshot, JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} })),
+    (error) => error.code === "invalid_snapshot_query_contract",
+  );
+  const badHeaders = new Response("{}", {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "public, max-age=60" },
+  });
+  assert.throws(
+    () => validateSnapshotQueryPayload(badHeaders, JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} })),
+    (error) => error.code === "invalid_cache_policy",
+  );
+});
+
+test("writeReport and main write a redacted report on CLI failure", async () => {
+  const directory = await temporaryDirectory();
+  const reportPath = path.join(directory, "nested", "report.json");
+  const report = { ok: false, checks: [{ name: "x", status: "fail", error: "safe" }] };
+  await writeReport(report, reportPath);
+  assert.deepEqual(JSON.parse(await fs.readFile(reportPath, "utf8")), report);
+
+  const cliReportPath = path.join(directory, "cli-report.json");
+  const code = await main({ argv: ["--output", cliReportPath, "--unknown"], fetchImpl: appFetch() });
+  assert.equal(code, 1);
+  const cliReport = JSON.parse(await fs.readFile(cliReportPath, "utf8"));
+  assert.equal(cliReport.ok, false);
+  assert.match(cliReport.error, /Argomento CLI non riconosciuto/);
+  assert.doesNotMatch(JSON.stringify(cliReport), /body|headers|authorization/i);
+});

--- a/tests/runtime-health.test.mjs
+++ b/tests/runtime-health.test.mjs
@@ -362,7 +362,14 @@ test("requestWithRetry aborts on timeout and never follows redirects", async () 
   await assert.rejects(
     requestWithRetry("https://example.test/slow", {
       fetchImpl: async (_url, init) => new Promise((_resolve, reject) => {
-        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+        // AbortSignal.timeout() does not keep Node's event loop alive. Keep one
+        // bounded timer referenced so this fake transport can observe abort on
+        // the same Node 22 runtime used by GitHub Actions.
+        const guard = setTimeout(() => reject(new Error("timeout signal was not observed")), 100);
+        init.signal.addEventListener("abort", () => {
+          clearTimeout(guard);
+          reject(init.signal.reason);
+        }, { once: true });
       }),
       timeoutMs: 5,
       maxAttempts: 1,


### PR DESCRIPTION
## Cosa cambia

Aggiunge un monitor di produzione ogni 15 minuti, sfalsato rispetto all'inizio dell'ora.

Controlla in sequenza:

- homepage e `/api/health`;
- contratto completo delle 19 fonti su `/api/fonti/stato`;
- `initialize` e `tools/list` su `/api/mcp`;
- parità di `tools/list` tramite l'alias `/mcp`;
- una piccola query snapshot MEF, senza interrogare fonti esterne dal tool MCP.

Il workflow ha soli permessi `contents: read`, action pin tramite SHA, timeout, risposte limitate e artifact JSON solo in caso di errore. Non registra body, header o contratti completi nel report.

## Sicurezza e affidabilità

- HTTPS canonico obbligatorio; HTTP consentito solo su loopback per gli smoke locali;
- redirect mai seguiti;
- i POST MCP non vengono ritentati;
- il probe fonti usa un solo tentativo per evitare fan-out duplicati;
- una fonte `down`, un registro incompleto o un contratto MCP divergente fanno fallire il monitor;
- il report conserva lo SHA realmente servito da `/api/health`.

## Verifica

- test monitor: 13/13 PASS;
- governance workflow: 9/9 PASS;
- suite Node: 546 PASS, 4 live skip; unico bind negato dal sandbox ripetuto fuori sandbox 4/4 PASS;
- suite ETL: 291 PASS, 1 skip; bind loopback/Unix ripetuti fuori sandbox 7/7 PASS;
- lint, typecheck, action pins e actionlint: PASS;
- build Next.js: PASS, 80 route;
- vero `next start` locale: 7/7 probe PASS;
- produzione sul commit `1554d519`: 7/7 probe PASS.

## Rischio residuo separato

`/api/fonti/stato` esegue ancora probe live e non usa una cache/single-flight condivisa. Questa PR limita il monitor a una chiamata seriale senza retry; la trasformazione dell'endpoint in uno stato persistito/cacheato va trattata in una PR tecnica separata.
