### PR TITLE
feat(discovery): aggiungi sitemap e robots

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,8 +17,8 @@
 
 ## API e MCP
 
-- [MCP Streamable HTTP](https://www.dovevannoinostrisoldi.com/api/mcp): endpoint pubblico read-only. Chiama prima `list_datasets`, poi `query_dataset`; il catalogo dichiara filtri, freschezza, provenienza e caveat.
-- [Pagina MCP](https://www.dovevannoinostrisoldi.com/mcp): configurazione del client, dataset interrogabili e servizi complementari.
+- [MCP Streamable HTTP](https://www.dovevannoinostrisoldi.com/api/mcp): endpoint canonico pubblico e read-only. Chiama prima `list_datasets`, poi `query_dataset`; il catalogo dichiara filtri, freschezza, provenienza e caveat.
+- [Pagina MCP](https://www.dovevannoinostrisoldi.com/mcp): pagina informativa per configurare il client e consultare i limiti. Per compatibilità, lo stesso percorso accetta anche `POST` e `OPTIONS` MCP; il riferimento canonico resta `/api/mcp`.
 - [Assistente testuale](https://www.dovevannoinostrisoldi.com/assistente): interfaccia deterministica read-only con pochi intenti allowlisted; non usa provider LLM o voce e non conserva il prompt.
 - [API assistente](https://www.dovevannoinostrisoldi.com/api/assistant): `POST` JSON same-origin con `{ "prompt": "..." }`; una sola query, prompt massimo 500 caratteri e timeout bounded.
 - [Catalogo fonti via API](https://www.dovevannoinostrisoldi.com/api/fonti/stato): stato operativo delle fonti quando disponibile.

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from "next";
+import { publicRobots } from "@/lib/public-discovery";
+import { PUBLIC_SITE_URL } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return publicRobots(PUBLIC_SITE_URL);
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from "next";
+import { publicSitemap } from "@/lib/public-discovery";
+import { PUBLIC_SITE_URL } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return publicSitemap(PUBLIC_SITE_URL);
+}

--- a/src/lib/public-discovery.ts
+++ b/src/lib/public-discovery.ts
@@ -1,0 +1,119 @@
+import type { MetadataRoute } from "next";
+
+type PublicPath = "/" | `/${string}`;
+
+/**
+ * Canonical pages that search engines may index. This is deliberately
+ * separate from the visual navigation: a page can remain public even when it
+ * is not promoted in the header or footer.
+ *
+ * Dynamic entity, project and dataset pages are omitted until their complete
+ * canonical URL sets can be enumerated without making sitemap generation
+ * depend on request-time data.
+ */
+export const PUBLIC_INDEXABLE_PATHS = [
+  "/",
+  "/appalti",
+  "/appalti/dettaglio",
+  "/assistente",
+  "/coesione",
+  "/coesione/asili",
+  "/confronti",
+  "/controlli",
+  "/dati",
+  "/debito",
+  "/enti",
+  "/esplora",
+  "/fonti",
+  "/fonti/catalogo",
+  "/fonti/copertura",
+  "/fonti/stato",
+  "/imprese",
+  "/incarichi",
+  "/incarichi/dettaglio",
+  "/istituzioni",
+  "/mcp",
+  "/metodologia",
+  "/ministeri",
+  "/palazzo-chigi",
+  "/parlamento",
+  "/partecipazioni",
+  "/pnrr/incarichi",
+  "/privacy",
+  "/regioni",
+  "/spese",
+  "/spese/consulenze",
+  "/spese/invalidita",
+  "/spese/legge-di-bilancio",
+  "/spese/operative",
+  "/spese/sanita",
+  "/spese/sanita/storico",
+  "/spese/territoriale",
+  "/stato",
+  "/stato/legislature",
+  "/supporter",
+  "/supporto",
+  "/termini",
+  "/territori",
+  "/territori/confronto",
+  "/territori/fisco",
+  "/territori/irpef",
+  "/trasparenza",
+  "/appalti/affidamenti-diretti",
+  "/appalti/fornitori",
+  "/appalti/rinnovi-proroghe",
+  "/appalti/consip-da-confrontare",
+  "/incarichi/consulenze-legali",
+  "/incarichi/pnrr",
+  "/incarichi/nominativi",
+  "/incarichi/personale-organi",
+  "/spese/eventi",
+  "/spese/campagne",
+  "/spese/affitti",
+  "/spese/missioni",
+  "/spese/auto-welfare",
+  "/spese/rimborsi",
+  "/spese/capitoli-progetti",
+  "/trasparenza/documenti-mancanti",
+  "/trasparenza/perimetro-enti",
+  "/controlli/segnalazioni",
+  "/controlli/corte-dei-conti",
+  "/controlli/working-set",
+  "/confronti/catalogo",
+] as const satisfies readonly PublicPath[];
+
+/** Pages that the concise llms.txt overview must always expose. */
+export const LLMS_DISCOVERY_PATHS = [
+  "/",
+  "/spese",
+  "/territori",
+  "/territori/irpef",
+  "/stato",
+  "/coesione",
+  "/enti",
+  "/parlamento",
+  "/controlli",
+  "/fonti",
+  "/mcp",
+  "/assistente",
+  "/metodologia",
+  "/privacy",
+  "/supporter",
+] as const satisfies readonly (typeof PUBLIC_INDEXABLE_PATHS)[number][];
+
+export function publicSitemap(siteUrl: string): MetadataRoute.Sitemap {
+  return PUBLIC_INDEXABLE_PATHS.map((path) => ({
+    url: new URL(path, siteUrl).href,
+  }));
+}
+
+export function publicRobots(siteUrl: string): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/tests/llms-txt.test.mjs
+++ b/tests/llms-txt.test.mjs
@@ -2,52 +2,30 @@ import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import { test } from "node:test";
+import {
+  LLMS_DISCOVERY_PATHS,
+  PUBLIC_INDEXABLE_PATHS,
+} from "../src/lib/public-discovery.ts";
+import { PUBLIC_SITE_URL } from "../src/lib/site.ts";
 
 const llmsPath = new URL("../public/llms.txt", import.meta.url);
-const siteOrigin = "https://www.dovevannoinostrisoldi.com";
 
-const requiredLinks = [
-  "/",
-  "/spese",
-  "/territori",
-  "/territori/irpef",
-  "/stato",
-  "/coesione",
-  "/enti",
-  "/parlamento",
-  "/controlli",
-  "/fonti",
-  "/mcp",
+const requiredApiLinks = [
   "/api/mcp",
   "/api/spese/comuni",
   "/api/spese/comuni/distribuzione",
   "/api/spese/invalidita",
   "/api/territori/fisco",
   "/api/territori/irpef",
-  "/privacy",
-  "/supporter",
 ];
 
 const routeFiles = {
-  "/": "../src/app/page.tsx",
-  "/spese": "../src/app/spese/page.tsx",
-  "/territori": "../src/app/territori/page.tsx",
-  "/territori/irpef": "../src/app/territori/irpef/page.tsx",
-  "/stato": "../src/app/stato/page.tsx",
-  "/coesione": "../src/app/coesione/page.tsx",
-  "/enti": "../src/app/enti/page.tsx",
-  "/parlamento": "../src/app/parlamento/page.tsx",
-  "/controlli": "../src/app/controlli/page.tsx",
-  "/fonti": "../src/app/fonti/page.tsx",
-  "/mcp": "../src/app/mcp/page.tsx",
   "/api/mcp": "../src/app/api/mcp/route.ts",
   "/api/spese/comuni": "../src/app/api/spese/comuni/route.ts",
   "/api/spese/comuni/distribuzione": "../src/app/api/spese/comuni/distribuzione/route.ts",
   "/api/spese/invalidita": "../src/app/api/spese/invalidita/route.ts",
   "/api/territori/fisco": "../src/app/api/territori/fisco/route.ts",
   "/api/territori/irpef": "../src/app/api/territori/irpef/route.ts",
-  "/privacy": "../src/app/privacy/page.tsx",
-  "/supporter": "../src/app/supporter/page.tsx",
 };
 
 test("llms.txt is a complete, canonical static discovery surface", async () => {
@@ -62,15 +40,29 @@ test("llms.txt is a complete, canonical static discovery surface", async () => {
   assert.doesNotMatch(text, /localhost|127\.0\.0\.1|<dominio|\b(?:TODO|TBD)\b/i);
 
   const links = [...text.matchAll(/\]\((https?:\/\/[^)]+)\)/g)].map((match) => new URL(match[1]));
+  const requiredLinks = [...LLMS_DISCOVERY_PATHS, ...requiredApiLinks];
   assert.ok(links.length >= requiredLinks.length, "discovery file should expose the main public surfaces");
   assert.ok(links.every((link) => link.protocol === "https:"), "all links must be HTTPS");
+  assert.match(text, /\/api\/mcp\): endpoint canonico pubblico e read-only/);
+  assert.match(text, /\/mcp\): pagina informativa[\s\S]*`POST` e `OPTIONS` MCP[\s\S]*canonico resta `\/api\/mcp`/);
+
+  for (const link of links) {
+    if (link.origin !== PUBLIC_SITE_URL || link.pathname.startsWith("/api/")) continue;
+    assert.equal(
+      PUBLIC_INDEXABLE_PATHS.includes(link.pathname),
+      true,
+      `internal HTML link is missing from the sitemap catalog: ${link.pathname}`,
+    );
+  }
 
   for (const path of requiredLinks) {
     assert.equal(
-      links.some((link) => link.origin === siteOrigin && link.pathname === path),
+      links.some((link) => link.origin === PUBLIC_SITE_URL && link.pathname === path),
       true,
-      `missing canonical link: ${siteOrigin}${path}`,
+      `missing canonical link: ${PUBLIC_SITE_URL}${path}`,
     );
-    await access(new URL(routeFiles[path], import.meta.url), constants.R_OK);
+    if (requiredApiLinks.includes(path)) {
+      await access(new URL(routeFiles[path], import.meta.url), constants.R_OK);
+    }
   }
 });

--- a/tests/public-discovery.test.mjs
+++ b/tests/public-discovery.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { access, readdir } from "node:fs/promises";
+import { constants } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { EDITORIAL_TOPICS } from "../src/lib/integrated-editorial.ts";
+import {
+  LLMS_DISCOVERY_PATHS,
+  PUBLIC_INDEXABLE_PATHS,
+  publicRobots,
+  publicSitemap,
+} from "../src/lib/public-discovery.ts";
+import { PUBLIC_SITE_URL } from "../src/lib/site.ts";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const appRoot = path.join(repositoryRoot, "src", "app");
+
+async function collectStaticPagePaths(directory, segments = []) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths = [];
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name === "page.tsx") {
+      if (!segments.some((segment) => segment.startsWith("["))) {
+        paths.push(segments.length === 0 ? "/" : `/${segments.join("/")}`);
+      }
+      continue;
+    }
+    if (entry.isDirectory()) {
+      paths.push(...await collectStaticPagePaths(path.join(directory, entry.name), [...segments, entry.name]));
+    }
+  }
+
+  return paths;
+}
+
+test("the public discovery catalog is canonical, unique and complete for static pages", async () => {
+  assert.equal(PUBLIC_SITE_URL, "https://www.dovevannoinostrisoldi.com");
+  assert.equal(new Set(PUBLIC_INDEXABLE_PATHS).size, PUBLIC_INDEXABLE_PATHS.length);
+
+  for (const routePath of PUBLIC_INDEXABLE_PATHS) {
+    const url = new URL(routePath, PUBLIC_SITE_URL);
+    assert.equal(routePath.startsWith("/"), true);
+    assert.equal(routePath.includes("?"), false);
+    assert.equal(routePath.includes("#"), false);
+    assert.equal(routePath.includes("["), false);
+    assert.equal(routePath.includes("]"), false);
+    assert.equal(url.origin, PUBLIC_SITE_URL);
+    assert.equal(url.pathname, routePath);
+  }
+
+  const staticPages = (await collectStaticPagePaths(appRoot)).sort();
+  const catalogStaticPages = PUBLIC_INDEXABLE_PATHS
+    .filter((routePath) => !EDITORIAL_TOPICS.some(
+      (topic) => routePath === `/${topic.section}/${topic.slug}`,
+    ))
+    .slice()
+    .sort();
+  assert.deepEqual(catalogStaticPages, staticPages);
+});
+
+test("all and only the statically generated editorial topics are in the sitemap catalog", () => {
+  const expected = EDITORIAL_TOPICS
+    .map((topic) => `/${topic.section}/${topic.slug}`)
+    .sort();
+  const actual = PUBLIC_INDEXABLE_PATHS
+    .filter((routePath) => expected.includes(routePath))
+    .slice()
+    .sort();
+  assert.deepEqual(actual, expected);
+});
+
+test("sitemap exposes only canonical HTTPS public pages", () => {
+  const sitemap = publicSitemap(PUBLIC_SITE_URL);
+  assert.deepEqual(
+    sitemap.map((entry) => entry.url),
+    PUBLIC_INDEXABLE_PATHS.map((routePath) => new URL(routePath, PUBLIC_SITE_URL).href),
+  );
+  for (const entry of sitemap) {
+    const url = new URL(entry.url);
+    assert.equal(url.protocol, "https:");
+    assert.equal(url.origin, PUBLIC_SITE_URL);
+    assert.equal(url.search, "");
+    assert.equal(url.hash, "");
+    assert.equal(url.pathname.startsWith("/api/"), false);
+  }
+});
+
+test("robots permits public pages without blocking Next assets", () => {
+  const robots = publicRobots(PUBLIC_SITE_URL);
+  assert.deepEqual(robots.rules, {
+    userAgent: "*",
+    allow: "/",
+    disallow: "/api/",
+  });
+  assert.equal(robots.sitemap, `${PUBLIC_SITE_URL}/sitemap.xml`);
+  assert.equal(robots.rules.disallow.includes("/_next/"), false);
+});
+
+test("llms discovery paths are indexable and resolve to public pages", async () => {
+  for (const routePath of LLMS_DISCOVERY_PATHS) {
+    assert.equal(PUBLIC_INDEXABLE_PATHS.includes(routePath), true);
+    const pagePath = routePath === "/"
+      ? path.join(appRoot, "page.tsx")
+      : path.join(appRoot, routePath.slice(1), "page.tsx");
+    await access(pagePath, constants.R_OK);
+  }
+});


### PR DESCRIPTION
## Cosa cambia

- aggiunge `/sitemap.xml` con 68 pagine pubbliche canoniche: 47 route esplicite e 21 pagine editoriali generate staticamente;
- aggiunge `/robots.txt`, consentendo le pagine pubbliche e bloccando solo `/api/`;
- mantiene il catalogo di indicizzazione separato dalla navigazione visuale;
- aggiorna `llms.txt`: `/api/mcp` è l'endpoint canonico, mentre `/mcp` resta la pagina informativa e l'alias compatibile per `POST` e `OPTIONS`;
- aggiunge controlli contro URL duplicati, query, API, route fantasma e divergenze tra pagine, sitemap e `llms.txt`.

Le route dinamiche per enti, CUP e dataset non sono incluse: non hanno ancora un insieme completo di URL canonici enumerato senza dati a runtime. Non blocchiamo `/cerca` in `robots.txt`: dopo il redesign userà `noindex,follow`, che i crawler devono poter leggere.

## Verifica

- test discovery/MCP: 8/8 PASS;
- suite Node: 588 PASS, 4 test live OpenBDAP saltati; il solo test loopback bloccato dalla sandbox è PASS 4/4 fuori sandbox;
- lint, typecheck, design e brand: PASS;
- build Next.js: PASS, 82 route generate, incluse `/sitemap.xml` e `/robots.txt`;
- smoke sulla build reale: `/sitemap.xml`, `/robots.txt` e `/llms.txt` rispondono 200 con contenuto e MIME corretti.

PR tecnica e isolata: nessuna modifica a layout, navigazione, dati, ETL o MCP runtime.
