### PR TITLE
feat(security): aggiungi CSP in modalità Report-Only

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,9 +9,42 @@ const integratedSourceRuntimeFiles = [
   "src/data/generated/integrated/rows/*.jsonl.gz",
 ];
 
+// Keep this policy observational until browser and production checks show it
+// can be enforced safely. Next.js and Analytics currently need inline
+// scripts/styles; switching to nonces would also make static pages dynamic.
+const contentSecurityPolicyReportOnly = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+  "frame-ancestors 'self'",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.googletagmanager.com",
+  "font-src 'self'",
+  "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.googletagmanager.com",
+  "manifest-src 'self'",
+  "worker-src 'none'",
+  "media-src 'none'",
+  "frame-src 'none'",
+].join("; ");
+
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy-Report-Only",
+            value: contentSecurityPolicyReportOnly,
+          },
+        ],
+      },
+    ];
+  },
   outputFileTracingIncludes: {
     "/dati": integratedSourceRuntimeFiles,
     "/dati/*": integratedSourceRuntimeFiles,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:company-atlas": "node --experimental-strip-types --test tests/company-atlas.test.mjs",
     "test:browser:core": "node scripts/browser/core.mjs",
     "test:browser:editorial": "node --experimental-strip-types scripts/browser/editorial.mjs",
+    "test:csp:report-only": "node scripts/browser/csp-report-only.mjs",
     "test:browser:e2e": "node scripts/browser/core.mjs",
     "test:browser:integrated": "node --experimental-strip-types scripts/browser/editorial.mjs",
     "test:lighthouse": "node scripts/lighthouse_budget.mjs",

--- a/scripts/browser/csp-report-only.mjs
+++ b/scripts/browser/csp-report-only.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  closeBrowser,
+  createPage,
+  defaultBaseUrl,
+  delay,
+  launchBrowser,
+  navigate,
+  saveFailureArtifacts,
+  scenarioIdFromLabel,
+  waitForServer,
+} from "./harness.mjs";
+
+const ROUTES = ["/", "/territori", "/dati", "/debito", "/imprese"];
+const REPORT_ONLY_HEADER = "content-security-policy-report-only";
+const ENFORCED_HEADER = "content-security-policy";
+const CSP_CONSOLE_PATTERN = /content security policy/i;
+
+const baseUrl = defaultBaseUrl();
+let browser;
+
+try {
+  await waitForServer(baseUrl);
+  browser = await launchBrowser({ extraArgs: ["--disable-extensions"] });
+
+  for (const pathname of ROUTES) {
+    const label = `CSP Report-Only ${pathname}`;
+    const page = await createPage(browser, { width: 1280 });
+    const consoleViolations = [];
+    let eventViolations = [];
+
+    page.on("console", (message) => {
+      if (CSP_CONSOLE_PATTERN.test(message.text())) {
+        consoleViolations.push(message.text());
+      }
+    });
+    await page.evaluateOnNewDocument(() => {
+      window.__dvnsCspViolations = [];
+      window.addEventListener("securitypolicyviolation", (event) => {
+        window.__dvnsCspViolations.push({
+          blockedURI: event.blockedURI,
+          disposition: event.disposition,
+          effectiveDirective: event.effectiveDirective,
+          lineNumber: event.lineNumber,
+          columnNumber: event.columnNumber,
+          sourceFile: event.sourceFile,
+          violatedDirective: event.violatedDirective,
+        });
+      });
+    });
+
+    try {
+      const response = await navigate(page, {
+        url: new URL(pathname, baseUrl).href,
+        label,
+      });
+      const headers = response.headers();
+      assert.ok(headers[REPORT_ONLY_HEADER], `${label}: header Report-Only assente`);
+      assert.equal(
+        headers[ENFORCED_HEADER],
+        undefined,
+        `${label}: una CSP bloccante non deve essere pubblicata`,
+      );
+
+      // Capture afterInteractive scripts without waiting for an unbounded
+      // network-idle state.
+      await delay(1_000);
+      eventViolations = await page.evaluate(() => window.__dvnsCspViolations ?? []);
+      assert.deepEqual(
+        { eventViolations, consoleViolations },
+        { eventViolations: [], consoleViolations: [] },
+        `${label}: violazioni CSP rilevate:\n${JSON.stringify(
+          { eventViolations, consoleViolations },
+          null,
+          2,
+        )}`,
+      );
+      console.log(`PASS ${pathname}`);
+    } catch (error) {
+      const artifactDir = await saveFailureArtifacts(page, {
+        suite: "csp-report-only",
+        scenarioId: scenarioIdFromLabel(label),
+        label,
+        requestedUrl: new URL(pathname, baseUrl).href,
+        finalUrl: page.url(),
+        viewport: { width: 1280 },
+        diagnostics: {
+          pageerrors: [],
+          consoleErrors: consoleViolations,
+          requestFailures: [],
+          httpErrors: eventViolations.map((violation) => JSON.stringify(violation)),
+        },
+      });
+      if (artifactDir) {
+        await writeFile(
+          path.join(artifactDir, "violations.json"),
+          `${JSON.stringify({ eventViolations, consoleViolations }, null, 2)}\n`,
+        );
+      }
+      throw error;
+    } finally {
+      await page.close().catch(() => {});
+    }
+  }
+} finally {
+  if (browser) await closeBrowser(browser);
+}

--- a/scripts/ci/run-production-gates.sh
+++ b/scripts/ci/run-production-gates.sh
@@ -84,6 +84,10 @@ echo "::group::Browser editorial suite"
 npm run test:browser:editorial
 echo "::endgroup::"
 
+echo "::group::CSP Report-Only browser smoke"
+npm run test:csp:report-only
+echo "::endgroup::"
+
 echo "::group::Lighthouse budget"
 npm run test:lighthouse
 echo "::endgroup::"

--- a/tests/csp-report-only.test.mjs
+++ b/tests/csp-report-only.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const REPORT_ONLY_HEADER = "content-security-policy-report-only";
+const ENFORCED_HEADER = "content-security-policy";
+
+test("the CSP is defined once and remains report-only", async () => {
+  const [{ default: nextConfig }, vercelSource] = await Promise.all([
+    import("../next.config.ts"),
+    readFile(new URL("../vercel.json", import.meta.url), "utf8"),
+  ]);
+
+  assert.equal(typeof nextConfig.headers, "function");
+  const rules = await nextConfig.headers();
+  const cspRules = rules.filter((rule) =>
+    rule.headers.some((header) => header.key.toLowerCase() === REPORT_ONLY_HEADER),
+  );
+  assert.equal(cspRules.length, 1);
+  assert.equal(cspRules[0].source, "/:path*");
+
+  const headers = rules.flatMap((rule) => rule.headers);
+  const reportOnly = headers.filter(
+    (header) => header.key.toLowerCase() === REPORT_ONLY_HEADER,
+  );
+
+  assert.equal(reportOnly.length, 1);
+  assert.equal(
+    headers.some((header) => header.key.toLowerCase() === ENFORCED_HEADER),
+    false,
+  );
+
+  const vercel = JSON.parse(vercelSource);
+  const vercelHeaders = vercel.headers.flatMap((rule) => rule.headers);
+  assert.equal(
+    vercelHeaders.some((header) =>
+      [REPORT_ONLY_HEADER, ENFORCED_HEADER].includes(header.key.toLowerCase()),
+    ),
+    false,
+  );
+});
+
+test("the report-only policy covers current Next and Analytics resources without broad escapes", async () => {
+  const { default: nextConfig } = await import("../next.config.ts");
+  const rules = await nextConfig.headers();
+  const policy = rules
+    .flatMap((rule) => rule.headers)
+    .find((header) => header.key.toLowerCase() === REPORT_ONLY_HEADER)?.value;
+
+  assert.ok(policy);
+  for (const directive of [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "form-action 'self'",
+    "frame-ancestors 'self'",
+    "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self'",
+    "worker-src 'none'",
+    "media-src 'none'",
+    "frame-src 'none'",
+  ]) {
+    assert.ok(policy.includes(directive), `Direttiva CSP mancante: ${directive}`);
+  }
+
+  assert.match(policy, /connect-src[^;]*https:\/\/\*\.google-analytics\.com/);
+  assert.match(policy, /connect-src[^;]*https:\/\/\*\.analytics\.google\.com/);
+  assert.match(policy, /img-src[^;]*https:\/\/\*\.google-analytics\.com/);
+  assert.match(policy, /img-src[^;]*https:\/\/\*\.analytics\.google\.com/);
+  assert.doesNotMatch(policy, /'unsafe-eval'/);
+  assert.doesNotMatch(policy, /(?:^|\s)\*(?:\s|;|$)/);
+  assert.doesNotMatch(policy, /https?:\/\/\*(?:\s|;|$)/);
+  assert.doesNotMatch(policy, /(?:^|;\s*)(?:report-uri|report-to)\b/);
+  assert.doesNotMatch(policy, /upgrade-insecure-requests/);
+});


### PR DESCRIPTION
## Cosa cambia

Aggiunge una `Content-Security-Policy-Report-Only` globale. La policy viene osservata dal browser, ma non blocca ancora nessuna risorsa.

- autorizza il sito stesso e i soli domini Google Analytics usati dal progetto;
- non usa `unsafe-eval`, wildcard generiche, nonce o endpoint di raccolta;
- mantiene la generazione statica di Next.js;
- non modifica HSTS o gli altri header in `vercel.json`;
- aggiunge uno smoke browser dedicato sulle cinque route principali;
- salva screenshot e diagnostica strutturata se rileva una violazione.

La CSP bloccante resta fuori da questa PR: richiederà una decisione separata dopo osservazione in produzione.

## Verifiche

- test contratto CSP: 2/2 PASS;
- lint, typecheck, design e brand: PASS;
- build Next 16.3.1: PASS, 82 route;
- browser CSP: 5/5 route PASS;
- browser editoriale: 21 route a 390 e 1280 px PASS;
- Lighthouse: Performance 96, Accessibilità 100, Best Practices 100, SEO 100;
- suite Node: 590 PASS, 4 live OpenBDAP saltati per rete; il solo test loopback inizialmente bloccato dalla sandbox è PASS nel rerun isolato.

Il browser core di `main` ha mostrato un timeout intermittente nell'apertura del dialog del simulatore della Legge di Bilancio a 768 px. L'artifact non contiene errori CSP, console, pagina o rete. La CI ospitata deve comunque completare la suite prima del merge.

## Coordinamento

La draft PR #161 aggiunge `allowedDevOrigins` nello stesso `next.config.ts`. Questa PR tecnica va integrata per prima; poi #161 dovrà essere ribasata conservando sia `allowedDevOrigins` sia `headers()` e ripetendo build e browser smoke.

## Dopo il deploy

Verificare sul dominio pubblico:

- presenza di un solo header `Content-Security-Policy-Report-Only`;
- assenza di `Content-Security-Policy` bloccante;
- caricamento di Google Analytics;
- zero violazioni CSP sulle route principali.
