### PR TITLE
docs: mention the budget-law simulator in public descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Il progetto resta indipendente. Un contributo su Buy Me a Coffee aiuta a pagare 
 | [Territori](https://www.dovevannoinostrisoldi.com/territori) | Confronti per regione/Comune, CPT e IRPEF MEF |
 | [Fondi e progetti](https://www.dovevannoinostrisoldi.com/coesione) | OpenCoesione e traccia PNRR asili (Italia Domani) |
 | [Spese dello Stato](https://www.dovevannoinostrisoldi.com/stato) | Pagamenti per funzione e amministrazione (OpenBDAP/RGS) |
+| [Legge di Bilancio](https://www.dovevannoinostrisoldi.com/spese/legge-di-bilancio) | Stanziamenti per missione e riallocazione ipotetica (OpenBDAP, competenza A1, non cassa) |
 | [Enti e società](https://www.dovevannoinostrisoldi.com/enti) | Indice PA, schede enti, partecipazioni MEF |
 | [Istituzioni](https://www.dovevannoinostrisoldi.com/istituzioni) | Parlamento, sanità, invalidità e altri dossier |
 | [Cosa controllare](https://www.dovevannoinostrisoldi.com/controlli) | Segnali da fonti ufficiali, con limiti espliciti |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@
 - [Territori](https://www.dovevannoinostrisoldi.com/territori): confronti territoriali sui pagamenti comunali e collegamenti a CPT e MEF IRPEF.
 - [IRPEF territoriale](https://www.dovevannoinostrisoldi.com/territori/irpef): contribuenti, redditi, imposta netta dichiarata e addizionali MEF 2024 per Regione, Provincia e Comune.
 - [Spese dello Stato](https://www.dovevannoinostrisoldi.com/stato): pagamenti OpenBDAP per missione, amministrazione e categoria.
+- [Legge di Bilancio](https://www.dovevannoinostrisoldi.com/spese/legge-di-bilancio): variazione dello stanziamento pubblicato per missione (OpenBDAP, competenza A1) e scenario ipotetico di riallocazione. Non è cassa né una previsione.
 - [Fondi e progetti](https://www.dovevannoinostrisoldi.com/coesione): aggregati OpenCoesione su costi, pagamenti, temi, nature e stati.
 - [Enti e società](https://www.dovevannoinostrisoldi.com/enti): ricerca nell'Indice PA e collegamenti alle partecipazioni pubbliche.
 - [Parlamento](https://www.dovevannoinostrisoldi.com/parlamento): documenti e valori strutturati verificati della Camera, quando disponibili.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
     template: "%s · DoveVannoINostriSoldi",
   },
   description:
-    "Dati pubblici italiani spiegati in modo semplice, con la fonte sempre a portata di mano.",
+    "Dati pubblici italiani spiegati in modo semplice, con la fonte sempre a portata di mano. Include un simulatore di riallocazione della Legge di Bilancio sullo stanziamento OpenBDAP, non sulla cassa.",
 };
 
 export const viewport: Viewport = {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -5,7 +5,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: "Dove vanno i nostri soldi?",
     short_name: "Soldi pubblici",
     description:
-      "Dati pubblici italiani spiegati in modo semplice, con la fonte sempre a portata di mano.",
+      "Dati pubblici italiani spiegati in modo semplice, con la fonte sempre a portata di mano. Include un simulatore di riallocazione della Legge di Bilancio sullo stanziamento OpenBDAP, non sulla cassa.",
     start_url: "/",
     display: "standalone",
     background_color: "#f3f2f2",

--- a/src/lib/public-discovery.ts
+++ b/src/lib/public-discovery.ts
@@ -89,6 +89,7 @@ export const LLMS_DISCOVERY_PATHS = [
   "/territori",
   "/territori/irpef",
   "/stato",
+  "/spese/legge-di-bilancio",
   "/coesione",
   "/enti",
   "/parlamento",


### PR DESCRIPTION
## Summary

- Adds the Legge di Bilancio reallocation simulator to the README, `llms.txt`, site metadata and PWA description.
- The scenario is described as an OpenBDAP competence appropriation (A1), not cash and not a forecast.

## Test plan

- [x] `node --experimental-strip-types --test tests/llms-txt.test.mjs tests/public-discovery.test.mjs tests/copy-quality.test.mjs`
- [ ] After merge, share the homepage and check that the link preview mentions the simulator


Made with [Cursor](https://cursor.com)