### PR TITLE
fix(a11y): nomina tabelle e contenitori scorrevoli senza nome accessibile

### DIFF
--- a/src/app/esplora/page.tsx
+++ b/src/app/esplora/page.tsx
@@ -1,10 +1,11 @@
+import type { Metadata } from "next";
 import { EsploraSearch } from "./EsploraSearch";
 import Link from "next/link";
 import { loadInvestigativeMeta } from "@/lib/investigative-explorer";
 import styles from "./esplora.module.css";
 
-export const metadata = {
-  title: "Esplora relazioni · Dove vanno i nostri soldi?",
+export const metadata: Metadata = {
+  title: "Esplora relazioni",
   description:
     "Ricerca trasversale di persone ed enti negli incarichi pubblici (fetta incarichi-nominativi-shard). I riferimenti CIG/CUP e di atto sono in nota e ricercabili.",
 };
@@ -24,7 +25,7 @@ export default function EsploraPage() {
           Fetta verticale su <code>incarichi-nominativi-shard</code>: ogni arco collega una
           persona a un ente (incarico). Su{" "}
           <strong>{searchable.toLocaleString("it-IT")}</strong> relazioni ricercabili, i
-          riferimenti CIG/CUP e di atto compaiono in nota ed sono ricercabili. Non fondiamo
+          riferimenti CIG/CUP e di atto compaiono in nota e sono ricercabili. Non fondiamo
           persone con lo stesso nome senza un id stabile.
         </p>
         {suspects > 0 ? (

--- a/src/app/stato/page.tsx
+++ b/src/app/stato/page.tsx
@@ -299,8 +299,8 @@ function SpendingDashboard({ snapshot }: { snapshot: StateSpendingSnapshot }) {
               <table className="table">
                 <thead>
                   <tr>
-                    <th>Amministrazione</th>
-                    <th>Pagato</th>
+                    <th scope="col">Amministrazione</th>
+                    <th scope="col">Pagato</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/components/editorial-topic-page.tsx
+++ b/src/components/editorial-topic-page.tsx
@@ -181,7 +181,12 @@ export default async function EditorialTopicPage({ topic }: { topic: EditorialTo
                   </div>
                 </dl>
                 {result.rows.length > 0 && columns.length > 0 ? (
-                  <div className={`table-scroll ${styles.tableWrap}`} tabIndex={0}>
+                  <div
+                    className={`table-scroll ${styles.tableWrap}`}
+                    role="region"
+                    aria-label={`Prime ${integer(result.rows.length)} righe di ${configured.label}`}
+                    tabIndex={0}
+                  >
                     <table className="table">
                       <caption className={styles.visuallyHidden}>
                         Prime {integer(result.rows.length)} righe di {configured.label}

--- a/src/components/integrated-domain-hub.tsx
+++ b/src/components/integrated-domain-hub.tsx
@@ -156,7 +156,12 @@ export default async function IntegratedDomainHub({
             <small>{integer(selected.length)} insiemi con stato, righe, fonti e limiti</small>
           </span>
         </summary>
-        <div className={`table-scroll ${styles.tableWrap}`} tabIndex={0}>
+        <div
+          className={`table-scroll ${styles.tableWrap}`}
+          role="region"
+          aria-label={`Registro tecnico degli insiemi in ${title}`}
+          tabIndex={0}
+        >
           <table className="table">
             <caption className={styles.visuallyHidden}>Registro tecnico degli insiemi in {title}</caption>
             <thead>

--- a/src/components/italy-regions-map.tsx
+++ b/src/components/italy-regions-map.tsx
@@ -279,11 +279,11 @@ export function ItalyRegionsMap({
       <div className={styles.srOnly}>
         <table>
           <caption>Valori regionali esatti dei pagamenti comunali SIOPE</caption>
-          <thead><tr><th>Regione</th><th>Totale</th><th>Per abitante coperto</th><th>Comuni</th></tr></thead>
+          <thead><tr><th scope="col">Regione</th><th scope="col">Totale</th><th scope="col">Per abitante coperto</th><th scope="col">Comuni</th></tr></thead>
           <tbody>
             {regions.map((region) => (
               <tr key={region.region}>
-                <th>{region.region}</th>
+                <th scope="row">{region.region}</th>
                 <td>{exactEuro(region.value)}</td>
                 <td>{region.perCapita === null ? "Non disponibile" : exactEuro(region.perCapita)}</td>
                 <td>{integer(region.municipalities)}</td>

--- a/tests/ui-markup-contracts.test.mjs
+++ b/tests/ui-markup-contracts.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readdir, readFile } from "node:fs/promises";
 import { extname, join } from "node:path";
 import test from "node:test";
+import ts from "typescript";
 
 const root = new URL("..", import.meta.url);
 const uiRoots = ["src/app", "src/components"];
@@ -22,6 +23,31 @@ async function uiSources() {
   return Promise.all(paths.map(async (path) => [path, await readFile(new URL(path, root), "utf8")]));
 }
 
+function jsxElements(path, source) {
+  const sourceFile = ts.createSourceFile(
+    path,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const elements = [];
+  const visit = (node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      elements.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return { elements, sourceFile };
+}
+
+function jsxAttribute(element, sourceFile, name) {
+  return element.attributes.properties.find(
+    (attribute) => ts.isJsxAttribute(attribute) && attribute.name.getText(sourceFile) === name,
+  );
+}
+
 // Un'intestazione senza scope lascia allo screen reader il compito di indovinare
 // se descrive una colonna o una riga.
 test("every table header declares its scope", async () => {
@@ -40,12 +66,20 @@ test("every table header declares its scope", async () => {
 // ruolo e senza nome accessibile chi usa uno screen reader entra in un elemento
 // anonimo e non sa che cosa contiene.
 test("focusable containers expose a role and an accessible name", async () => {
+  const containerNames = new Set(["div", "section", "table", "pre", "figure", "ul", "ol"]);
   const offenders = [];
   for (const [path, source] of await uiSources()) {
-    for (const match of source.matchAll(/<(div|section|table|pre|figure|ul|ol)\b((?:[^<>]|\{[^{}]*\})*?)>/gs)) {
-      const tag = match[0];
-      if (!tag.includes("tabIndex={0}")) continue;
-      if (/\srole=/.test(tag) && /\saria-label(ledby)?=/.test(tag)) continue;
+    const { elements, sourceFile } = jsxElements(path, source);
+    for (const element of elements) {
+      if (!containerNames.has(element.tagName.getText(sourceFile))) continue;
+      if (jsxAttribute(element, sourceFile, "tabIndex")?.initializer?.getText(sourceFile) !== "{0}") continue;
+      const hasRole = Boolean(jsxAttribute(element, sourceFile, "role"));
+      const hasAccessibleName = Boolean(
+        jsxAttribute(element, sourceFile, "aria-label")
+        || jsxAttribute(element, sourceFile, "aria-labelledby"),
+      );
+      if (hasRole && hasAccessibleName) continue;
+      const tag = element.getText(sourceFile);
       offenders.push(`${path}: ${tag.replace(/\s+/g, " ").slice(0, 120)}`);
     }
   }

--- a/tests/ui-markup-contracts.test.mjs
+++ b/tests/ui-markup-contracts.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import test from "node:test";
+
+const root = new URL("..", import.meta.url);
+const uiRoots = ["src/app", "src/components"];
+
+async function filesBelow(relativePath) {
+  const entries = await readdir(new URL(`${relativePath}/`, root), { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const child = join(relativePath, entry.name);
+    if (entry.isDirectory()) files.push(...await filesBelow(child));
+    if (entry.isFile() && extname(entry.name) === ".tsx") files.push(child);
+  }
+  return files;
+}
+
+async function uiSources() {
+  const paths = (await Promise.all(uiRoots.map(filesBelow))).flat();
+  return Promise.all(paths.map(async (path) => [path, await readFile(new URL(path, root), "utf8")]));
+}
+
+// Un'intestazione senza scope lascia allo screen reader il compito di indovinare
+// se descrive una colonna o una riga.
+test("every table header declares its scope", async () => {
+  const offenders = [];
+  for (const [path, source] of await uiSources()) {
+    for (const match of source.matchAll(/<th(\s[^>]*)?>/g)) {
+      if (!/\sscope=/.test(match[0])) {
+        offenders.push(`${path}: ${match[0]}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `intestazioni senza scope:\n${offenders.join("\n")}`);
+});
+
+// Un contenitore scorrevole con tabIndex={0} riceve il focus da tastiera: senza
+// ruolo e senza nome accessibile chi usa uno screen reader entra in un elemento
+// anonimo e non sa che cosa contiene.
+test("focusable containers expose a role and an accessible name", async () => {
+  const offenders = [];
+  for (const [path, source] of await uiSources()) {
+    for (const match of source.matchAll(/<(div|section|table|pre|figure|ul|ol)\b((?:[^<>]|\{[^{}]*\})*?)>/gs)) {
+      const tag = match[0];
+      if (!tag.includes("tabIndex={0}")) continue;
+      if (/\srole=/.test(tag) && /\saria-label(ledby)?=/.test(tag)) continue;
+      offenders.push(`${path}: ${tag.replace(/\s+/g, " ").slice(0, 120)}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `contenitori focalizzabili senza nome accessibile:\n${offenders.join("\n")}`);
+});
+
+// layout.tsx applica gia' il template "%s · DoveVannoINostriSoldi": una pagina
+// che ripete il marchio lo stampa due volte nel <title>.
+test("no page title repeats the site brand already added by the layout", async () => {
+  const layout = await readFile(new URL("src/app/layout.tsx", root), "utf8");
+  assert.match(layout, /template:\s*"%s · DoveVannoINostriSoldi"/);
+
+  const offenders = [];
+  for (const [path, source] of await uiSources()) {
+    if (!path.endsWith("page.tsx")) continue;
+    for (const match of source.matchAll(/title:\s*"([^"]*)"/g)) {
+      if (/dove\s*vanno\s*i\s*nostri\s*soldi/i.test(match[1])) {
+        offenders.push(`${path}: ${match[1]}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `titoli che ripetono il marchio:\n${offenders.join("\n")}`);
+});


### PR DESCRIPTION
## Cosa cambia

Correzioni di accessibilità e metadati. Nessun dato, fonte, periodo o limite cambia, e nessun testo che descrive un numero è toccato.

- `integrated-domain-hub.tsx` e `editorial-topic-page.tsx`: i due contenitori scorrevoli con `tabIndex={0}` non avevano né `role` né nome accessibile, quindi chi usa uno screen reader riceveva il focus dentro un contenitore anonimo. Aggiunti `role="region"` e un `aria-label` che riusa la `<caption>` già presente e nascosta visivamente, come nei ~25 contenitori analoghi del progetto.
- `italy-regions-map.tsx` e `src/app/stato/page.tsx`: sei `<th>` senza `scope`, a fronte di 316 che lo dichiarano. Il caso più rilevante è la tabella di `italy-regions-map`, che vive dentro `.srOnly` e quindi esiste soltanto per le tecnologie assistive.
- `src/app/esplora/page.tsx`: il titolo ripeteva il marchio. `layout.tsx` applica già `template: "%s · DoveVannoINostriSoldi"`, quindi il `<title>` risultava `Esplora relazioni · Dove vanno i nostri soldi? · DoveVannoINostriSoldi`, con il marchio due volte e in due grafie diverse. Ora la pagina passa il titolo nudo come le altre 44.
- `src/app/esplora/page.tsx`: `metadata` tipizzato come `Metadata`, era l'unica delle 45 pagine senza tipo, e refuso «ed sono» → «e sono». La `description` della stessa pagina scriveva già la forma corretta.
- `tests/ui-markup-contracts.test.mjs`: tre controlli statici su `src/app` e `src/components`, nello stile di `ui-craft-regressions` e `copy-quality`.

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [x] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [x] `npm test`, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

I tre test nuovi falliscono 3/3 sul commit padre e passano 3/3 su questo ramo.

Risultati, con Node 22.23.2 come da `.nvmrc`:

- `npm run ci:static`: PASS (lint, typecheck, design:check, brand:check);
- `npm run test:node`: 598 test, 597 PASS, 0 FAIL, 1 saltato perché `RUN_SERVER_TESTS` non è impostato;
- `npm run build`: PASS;
- `npm run test:mcp:http`: 13/13 check;
- `npm run test:mcp:load`: 60/60 richieste, p95 35 ms su budget 3000 ms.

La suite ETL Python non è stata rieseguita su questo ramo perché la PR non tocca `scripts/etl/` né gli artifact generati. Eseguita su `main` per riferimento: 295 test, OK.

### UI e accessibilità

- [ ] Ho verificato tastiera, focus, stati vuoto/errore/caricamento e console browser.
- [ ] Ho verificato 390, 768 e 1280 px senza overflow o contenuti irraggiungibili.
- [x] Tabelle e grafici hanno un equivalente accessibile.

Le prime due caselle restano scoperte: vedi la sezione seguente.

## Limiti e prove non eseguite

`npm run test:browser:core` non arriva in fondo sulla mia macchina. Si interrompe con un `ProtocolError` di puppeteer sullo scenario «Legge di Bilancio modifica→condivisione» a 390 e 768 px, e la chiamata CDP che va in timeout cambia a ogni tentativo (`Runtime.callFunctionOn`, poi `DOM.describeNode`).

Ho ripetuto la stessa suite su `origin/main` non modificato, stessa macchina e stesso Node: fallisce in modo identico. I diagnostics salvati non contengono errori di pagina, di console, di rete o HTTP. Sembra quindi lo stesso timeout intermittente già descritto nella PR #173 e non una conseguenza di questa modifica, ma non posso dimostrarlo verde in locale.

Di conseguenza non ho potuto eseguire neppure `test:browser:editorial`, `test:csp:report-only` e `test:lighthouse`, che nella catena dei gate di produzione vengono dopo. La verifica a 390, 768 e 1280 px e i controlli di tastiera e console restano da confermare in CI.
