### PR TITLE
docs: allinea CONTRIBUTING alla lista dei job CI e correggi tre refusi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,11 @@ distinti.
 
 ## Verifica locale
 
-La CI è organizzata in quattro job paralleli (`static`, `node`, `etl`,
-`production`) aggregati da `CI / required`. Puoi riprodurre gli stessi gate
-localmente con i comandi stabili:
+La CI è organizzata in cinque job paralleli (`static`, `security`, `node`,
+`etl`, `production`) aggregati da `CI / required`. Il job `security` esegue la
+scansione Zizmor dei workflow ed è bloccante, ma non ha un equivalente locale
+fra i comandi npm. Puoi riprodurre gli altri gate localmente con i comandi
+stabili:
 
 ```bash
 npm ci
@@ -59,7 +61,7 @@ completa usata dalla CI.
 ### ETL e artifact verification
 
 ```bash
-npm run test:etl        # full ETL transformation/reconciliation test suite (214 tests)
+npm run test:etl        # full ETL transformation/reconciliation test suite (295 tests)
 npm run test:snapshots  # generated-artifact registry + offline artifact checks
 ```
 
@@ -68,12 +70,12 @@ contratti fail-closed) una sola volta.
 
 `test:snapshots` valida il registro degli artifact generati
 (`scripts/ci/generated-artifacts.json`), esegue i controlli offline `--check`
-uniche per ogni artifact, verifica la pulizia del worktree e rileva file
+unici per ogni artifact, verifica la pulizia del worktree e rileva file
 generati non registrati. Non riesegue la suite ETL.
 
 ### Limite di trust: PR vs fonti ufficiali
 
-Le pull request validano i dati versioneati **offline**: il registro dimostra
+Le pull request validano i dati versionati **offline**: il registro dimostra
 che ogni artifact è internamente valido senza contattare fonti esterne.
 
 I workflow pianificati o manuali (`*-refresh.yml`) sono responsabili di


### PR DESCRIPTION
## Cosa cambia

Solo `CONTRIBUTING.md`. Nessuna modifica al codice, ai dati o alla CI.

- **Job della CI: quattro → cinque.** `CI / required` aggrega `[static, security, node, etl, production]` (`.github/workflows/ci.yml:233`). Il job mancante nella documentazione è la scansione Zizmor (`ci.yml:75`): non ha `needs`, quindi è parallelo agli altri, ed è bloccante perché usa `advanced-security: false`. Oggi chi apre una PR che diventa rossa su `security` non trova quel gate documentato.
- **Aggiunta una precisazione**: `security` non ha un equivalente locale fra i comandi npm, quindi la frase «Puoi riprodurre gli stessi gate localmente» diventa «gli altri gate». Senza questa nota si sostituirebbe un'imprecisione con un'altra.
- **Conteggio della suite ETL: 214 → 295.** Misurato con il comando documentato: `Ran 295 tests in 127.048s / OK (skipped=1)`.
- **Due refusi**: «i controlli offline `--check` *uniche* per ogni artifact» → `unici`, per concordanza con `i controlli`; «i dati *versioneati*» → `versionati`.

Se preferite non mantenere un numero che invecchia, sono altrettanto d'accordo a togliere del tutto il conteggio dei test invece di aggiornarlo: ditemi quale delle due preferite.

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [ ] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [x] `npm test`, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

Nessun test aggiunto: la PR cambia soltanto prosa. `tests/copy-quality.test.mjs`, che legge `CONTRIBUTING.md`, resta verde (3/3).

## Limiti e prove non eseguite

Nessun gate di codice è interessato da questa modifica.
