### PR TITLE
chore: ignora la cartella locale dei diagnostics browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ next-env.d.ts
 # Local browser QA artifacts
 /.playwright-cli/
 /output/
+/artifacts/
 
 # Local research notes
 /docs/research/PROJECT_AND_PRIORITIES_2026-08-24.md


### PR DESCRIPTION
## Cosa cambia

Una riga in `.gitignore`: aggiunge `/artifacts/` accanto agli altri output locali di QA browser già ignorati (`/output/`, `/.playwright-cli/`).

`scripts/browser/harness.mjs:15` scrive `artifacts/browser/<suite>/<scenario>/` con console log e diagnostics quando uno scenario browser fallisce, e solo in quel caso. `.github/workflows/ci.yml:204-210` tratta già quel percorso come artifact di build e lo carica con `upload-artifact` in caso di fallimento.

Non essendo ignorata, la cartella resta come contenuto non tracciato dopo ogni gate browser rosso, ed è facile trascinarla dentro una PR con un `git add -A`. È così che l'ho notata.

Ignorare la cartella non tocca il caricamento in CI, che legge direttamente dal filesystem.

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [ ] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [x] `npm test`, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

Verificato a mano: dopo la modifica `git check-ignore -v artifacts/browser/core/<scenario>/console.log` risponde `.gitignore:41:/artifacts/`, e `git status --porcelain` non elenca più la cartella.

Nessun test aggiunto: una regola di `.gitignore` non ha un comportamento applicativo da coprire.

## Limiti e prove non eseguite

Nessuno: la modifica non tocca codice, dati o workflow.
