### PR TITLE
feat(imprese): expose aggregate ISTAT business metrics

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -701,7 +701,7 @@ const completed = [];
 try {
   browser = await launchBrowser();
 
-  for (const width of [390, 768, 1280]) {
+  for (const width of [320, 390, 768, 1280]) {
     const label = `Atlante Imprese ${width}px`;
     await runScenario(browser, {
       label,
@@ -745,7 +745,16 @@ try {
     completed.push(label);
   }
 
-  for (const width of [390, 1280]) {
+  const istatMetricViews = [
+    ["turnover", /Fatturato aggregato/i, /migliaia di euro/i],
+    ["istat_local_units", /Unità locali \(ISTAT\)/i, /unità locali/i],
+    ["istat_employees", /Addetti \(ISTAT\)/i, /addetti/i],
+    ["istat_value_added", /Valore aggiunto aggregato/i, /migliaia di euro/i],
+    ["istat_value_added_per_employee", /Valore aggiunto per addetto/i, /euro per addetto/i],
+    ["istat_turnover_per_employee", /Fatturato per addetto/i, /euro per addetto/i],
+  ];
+
+  for (const width of [320, 390, 768, 1280]) {
     const label = `Atlante Imprese metriche ISTAT ${width}px`;
     await runScenario(browser, {
       label,
@@ -764,13 +773,26 @@ try {
           "istat_value_added_per_employee",
           `${label}: metrica ISTAT non selezionata dall'URL`,
         );
-        await page.select(metricFilter, "istat_local_units");
-        await page.waitForFunction(
-          () => new URL(window.location.href).searchParams.get("metric") === "istat_local_units",
-          { timeout: 3_000 },
-        );
-        assertTextMatches(await bodyText(page), /Unità locali \(ISTAT\)/i, label);
-        await assertResponsiveShell(page, `${label} cambio metrica`, width);
+        for (const [metric, titlePattern, unitPattern] of istatMetricViews) {
+          await page.select(metricFilter, metric);
+          await page.waitForFunction(
+            (expectedMetric) => new URL(window.location.href).searchParams.get("metric") === expectedMetric,
+            { timeout: 3_000 },
+            metric,
+          );
+          assertTextMatches(
+            await page.$eval("#map-panel-title", (element) => element.textContent ?? ""),
+            titlePattern,
+            `${label} ${metric}`,
+          );
+          assertTextMatches(
+            await page.$eval('section[aria-labelledby="scope-title"]', (element) => element.textContent ?? ""),
+            unitPattern,
+            `${label} ${metric}`,
+          );
+          assert.doesNotMatch(await bodyText(page), /NaN|undefined/i, `${label} ${metric}: valore non formattato`);
+          await assertResponsiveShell(page, `${label} ${metric}`, width);
+        }
       },
     });
     completed.push(label);

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -745,6 +745,37 @@ try {
     completed.push(label);
   }
 
+  for (const width of [390, 1280]) {
+    const label = `Atlante Imprese metriche ISTAT ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/imprese?metric=istat_value_added_per_employee&sector=INDUSTRIA",
+      width,
+      validate: async (page) => {
+        const text = await bodyText(page);
+        assertTextMatches(text, /Valore aggiunto per addetto/i, label);
+        assertTextMatches(text, /euro per addetto/i, label);
+        assertTextMatches(text, /Confronto per macro-settore/i, label);
+        assert.doesNotMatch(text, /NaN|undefined/i, `${label}: valore non formattato`);
+
+        const metricFilter = '[data-atlas-filter="metric"]';
+        assert.equal(
+          await page.$eval(metricFilter, (element) => element.value),
+          "istat_value_added_per_employee",
+          `${label}: metrica ISTAT non selezionata dall'URL`,
+        );
+        await page.select(metricFilter, "istat_local_units");
+        await page.waitForFunction(
+          () => new URL(window.location.href).searchParams.get("metric") === "istat_local_units",
+          { timeout: 3_000 },
+        );
+        assertTextMatches(await bodyText(page), /Unità locali \(ISTAT\)/i, label);
+        await assertResponsiveShell(page, `${label} cambio metrica`, width);
+      },
+    });
+    completed.push(label);
+  }
+
   await runScenario(browser, {
     label: "Atlante Imprese query navigation 390px",
     pathname: "/imprese?metric=employees",

--- a/scripts/etl/istat_enterprise_turnover.py
+++ b/scripts/etl/istat_enterprise_turnover.py
@@ -431,7 +431,7 @@ def validate_snapshot(snapshot: dict) -> None:
     if len(observations) != expected_count:
         raise ValueError(f"Attese {expected_count} osservazioni, trovate {len(observations)}")
 
-    keys = set()
+    rows_by_key: dict[str, dict] = {}
     for index, obs in enumerate(observations):
         if obs["observationType"] != "aggregate" or obs["geographyLevel"] != "region":
             raise ValueError(f"Osservazione non aggregata regionale all'indice {index}")
@@ -443,13 +443,52 @@ def validate_snapshot(snapshot: dict) -> None:
             raise ValueError(f"Metrica non valida all'indice {index}: {obs['metric']}")
         if obs["value"] is None or obs["value"] < 0:
             raise ValueError(f"Valore nullo o negativo all'indice {index}: {obs['value']}")
+        for field in ("localUnits", "employees", "valueAddedThousandEuro"):
+            if field not in obs or obs[field] is None:
+                raise ValueError(f"Campo {field} mancante all'indice {index}")
+        if obs["localUnits"] < 0 or obs["valueAddedThousandEuro"] < 0:
+            raise ValueError(f"Metrica economica negativa all'indice {index}")
+        if obs["employees"] <= 0:
+            raise ValueError(f"Addetti non positivi all'indice {index}")
         if obs["atecoVersion"] != ATECO_VERSION:
             raise ValueError(f"Versione ATECO non coerente all'indice {index}")
 
         key = f"{obs['geographyCode']}|{obs['macroSector']}"
-        if key in keys:
+        if key in rows_by_key:
             raise ValueError(f"Osservazione duplicata per {key}")
-        keys.add(key)
+        rows_by_key[key] = obs
+
+    def reconcile(label: str, total: float, industry: float, services: float, tolerance: float) -> None:
+        delta = total - industry - services
+        if abs(delta) > tolerance:
+            raise ValueError(f"{label} non riconcilia: totale meno Industria e Servizi = {delta}")
+
+    for region_code in EXPECTED_REGION_CODES:
+        total = rows_by_key[f"{region_code}|ALL"]
+        industry = rows_by_key[f"{region_code}|INDUSTRIA"]
+        services = rows_by_key[f"{region_code}|SERVIZI"]
+        reconcile(f"{region_code} fatturato", total["value"], industry["value"], services["value"], 1)
+        reconcile(
+            f"{region_code} unità locali",
+            total["localUnits"],
+            industry["localUnits"],
+            services["localUnits"],
+            0,
+        )
+        reconcile(
+            f"{region_code} addetti",
+            total["employees"],
+            industry["employees"],
+            services["employees"],
+            0.000001,
+        )
+        reconcile(
+            f"{region_code} valore aggiunto",
+            total["valueAddedThousandEuro"],
+            industry["valueAddedThousandEuro"],
+            services["valueAddedThousandEuro"],
+            1,
+        )
 
     # Parity check: Campania row from Table 1 must be exactly 216750478
     campania_all = next((obs for obs in observations if obs["geographyCode"] == "15" and obs["macroSector"] == "ALL"), None)
@@ -467,6 +506,28 @@ def validate_snapshot(snapshot: dict) -> None:
     # Check national turnover
     if snapshot["national"]["turnoverThousandEuro"] != 3_768_464_269:
         raise ValueError("Totale nazionale fatturato inatteso")
+    national = snapshot["national"]
+    reconcile(
+        "Unità locali nazionali",
+        national["localUnits"],
+        national["industryLocalUnits"],
+        national["servicesLocalUnits"],
+        0,
+    )
+    reconcile(
+        "Addetti nazionali",
+        national["employees"],
+        national["industryEmployees"],
+        national["servicesEmployees"],
+        0.000001,
+    )
+    reconcile(
+        "Valore aggiunto nazionale",
+        national["valueAddedThousandEuro"],
+        national["industryValueAddedThousandEuro"],
+        national["servicesValueAddedThousandEuro"],
+        0,
+    )
 
 
 def canonical_bytes(value: object) -> bytes:

--- a/src/app/imprese/page.tsx
+++ b/src/app/imprese/page.tsx
@@ -124,7 +124,7 @@ export default async function ImpresePage({
 }) {
   const params = await searchParams;
   const requestedMetric = first(params.metric);
-  const isTurnover = isIstatMetric(requestedMetric);
+  const isIstatView = isIstatMetric(requestedMetric);
   const match = searchMatch(first(params.q));
 
   const allMetricOptions = [
@@ -132,7 +132,7 @@ export default async function ImpresePage({
     ...istatMetricOptions().map((item) => ({ id: item.id, label: item.label })),
   ];
 
-  if (isTurnover) {
+  if (isIstatView) {
     const turnoverView = getIstatTurnoverView({
       metric: requestedMetric,
       region: first(params.region) ?? match.region,
@@ -266,7 +266,12 @@ export default async function ImpresePage({
                 <h2 id="ranking-title" className="panel-title">Prime 10 regioni</h2>
                 <span className={styles.headNote}>{turnoverView.metricUnit}</span>
               </div>
-              <div className="table-scroll" role="region" aria-label="Prime 10 regioni ordinate per valore assoluto" tabIndex={0}>
+              <div
+                className="table-scroll"
+                role="region"
+                aria-label={`Prime 10 regioni ordinate per ${turnoverView.metricShortLabel.toLowerCase()}`}
+                tabIndex={0}
+              >
                 <table className="table">
                   <thead><tr><th scope="col">#</th><th scope="col">Regione</th><th scope="col" className="num">{turnoverView.metricShortLabel}</th></tr></thead>
                   <tbody>
@@ -316,14 +321,16 @@ export default async function ImpresePage({
               </div>
               <h3 className={styles.sourceTitle}>{source.label}</h3>
               <p className={styles.sourcePublisher}>{source.publisher}</p>
-              <p className={styles.sourceCaveat}>{source.caveat}</p>
+              {turnoverView.caveats.map((caveat) => (
+                <p className={styles.sourceCaveat} key={caveat}>{caveat}</p>
+              ))}
               <a className="btn btn-block" href={source.url} target="_blank" rel="noreferrer">Scarica le tavole ufficiali ISTAT ↗</a>
             </section>
 
             <aside className={`notice ${styles.boundaryNotice}`}>
               <strong>Confine del modulo</strong>
               <p>
-                Qui non troverai nomi di aziende, identificativi, codici fiscali, partite IVA o bilanci
+                Qui non troverai nomi di aziende, identificativi, codici fiscali, partite IVA, fatturati o bilanci
                 esatti di singole imprese. Il dato è un aggregato regionale e per macro-settore (Industria/Servizi)
                 proveniente dalla stima anticipata ISTAT (Registro Frame Territoriale Anticipato 2024, ATECO 2007 agg. 2022),
                 riferito alle unità locali con almeno un dipendente.

--- a/src/app/imprese/page.tsx
+++ b/src/app/imprese/page.tsx
@@ -15,9 +15,12 @@ import {
 } from "@/lib/company-atlas";
 import {
   getIstatTurnoverView,
+  isIstatMetric,
+  istatMetricOptions,
   istatTurnoverRegionOptions,
   istatTurnoverSectorOptions,
 } from "@/lib/istat-turnover";
+import type { IstatMetricFormat } from "@/lib/istat-turnover-contract";
 import styles from "./imprese.module.css";
 
 export const metadata: Metadata = {
@@ -40,7 +43,7 @@ function compactCount(value: number | null): string {
   if (Math.abs(value) >= 1_000) {
     return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 1 })} mila`;
   }
-  return integer(value);
+  return integer(Math.round(value));
 }
 
 function compactTurnover(value: number | null): string {
@@ -52,7 +55,32 @@ function compactTurnover(value: number | null): string {
   if (absolute >= 1_000) {
     return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })} mln €`;
   }
-  return `${integer(value)} mila €`;
+  return `${integer(Math.round(value))} mila €`;
+}
+
+function compactEuroPerEmployee(value: number | null): string {
+  if (value === null) return "n.d.";
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000) {
+    return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 2, useGrouping: "always" })} mln € / addetto`;
+  }
+  if (absolute >= 1_000) {
+    return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })} mila € / addetto`;
+  }
+  return `${integer(Math.round(value))} € / addetto`;
+}
+
+function formatIstatValue(value: number | null, format: IstatMetricFormat): string {
+  if (value === null) return "n.d.";
+  switch (format) {
+    case "thousand-euro":
+      return compactTurnover(value);
+    case "integer":
+    case "decimal":
+      return compactCount(value);
+    case "euro-per-employee":
+      return compactEuroPerEmployee(value);
+  }
 }
 
 function RegionalIdentity({
@@ -96,22 +124,24 @@ export default async function ImpresePage({
 }) {
   const params = await searchParams;
   const requestedMetric = first(params.metric);
-  const isTurnover = requestedMetric === "turnover";
+  const isTurnover = isIstatMetric(requestedMetric);
   const match = searchMatch(first(params.q));
 
   const allMetricOptions = [
     ...companyAtlasMetricOptions().map((item) => ({ id: item.id, label: item.label })),
-    { id: "turnover", label: "Fatturato aggregato (ISTAT)" },
+    ...istatMetricOptions().map((item) => ({ id: item.id, label: item.label })),
   ];
 
   if (isTurnover) {
     const turnoverView = getIstatTurnoverView({
+      metric: requestedMetric,
       region: first(params.region) ?? match.region,
       sector: first(params.sector),
     });
     const source = turnoverView.sources[0];
     const topSectors = turnoverView.sectorBreakdown;
     const sectorTotal = turnoverView.sectorBreakdown.reduce((sum, item) => sum + (item.value ?? 0), 0);
+    const sectorMaximum = Math.max(...topSectors.map((item) => item.value ?? 0), 0);
     const topRegions = turnoverView.ranking.slice(0, 10);
     const visibleRegion = turnoverView.selectedRegion;
     const filterOptions = {
@@ -131,8 +161,8 @@ export default async function ImpresePage({
             <span className={styles.kicker}>Modulo Imprese · Stima anticipata ISTAT 2024</span>
             <h1>Atlante Imprese Italia</h1>
             <p>
-              Dove si concentra il fatturato del sistema produttivo? Esplora i dati aggregati del
-              Registro Frame Territoriale Anticipato 2024 per regione e macro-settore economico.
+              Dove si concentrano fatturato, addetti, unità locali e valore aggiunto del sistema produttivo?
+              Esplora i dati aggregati del Registro Frame Territoriale Anticipato 2024 per regione e macro-settore economico.
             </p>
           </div>
           <div className={styles.heroMeta}>
@@ -144,7 +174,7 @@ export default async function ImpresePage({
 
         <CompanyAtlasFilters
           filters={{
-            metric: "turnover",
+            metric: turnoverView.metric,
             period: turnoverView.period,
             region: turnoverView.region === "ALL" ? "all" : turnoverView.region,
             sector: turnoverView.sector === "ALL" ? "all" : turnoverView.sector,
@@ -162,7 +192,7 @@ export default async function ImpresePage({
                 <h2 id="scope-title" className="panel-title">Perimetro selezionato</h2>
                 <span className="status status-attiva">Snapshot ISTAT</span>
               </div>
-              <strong className={styles.headline}>{compactTurnover(turnoverView.nationalValue)}</strong>
+              <strong className={styles.headline}>{formatIstatValue(turnoverView.nationalValue, turnoverView.metricFormat)}</strong>
               <p className={styles.headlineNote}>{turnoverView.metricUnit} · {turnoverView.periodLabel}</p>
 
               <dl className={styles.factRows}>
@@ -178,20 +208,31 @@ export default async function ImpresePage({
 
             <section className="panel" aria-labelledby="sector-title">
               <div className={styles.panelHead}>
-                <h2 id="sector-title" className="panel-title">Distribuzione per macro-settore</h2>
+                <h2 id="sector-title" className="panel-title">
+                  {turnoverView.metricFormat === "euro-per-employee" ? "Confronto per macro-settore" : "Distribuzione per macro-settore"}
+                </h2>
                 <span className={styles.headNote}>Industria e Servizi</span>
               </div>
               <ul className={styles.sectorList}>
                 {topSectors.map((sector) => {
                   const share = sector.value !== null && sectorTotal > 0 ? (sector.value / sectorTotal) * 100 : 0;
+                  const relativeWidth = turnoverView.metricFormat === "euro-per-employee"
+                    ? (sector.value !== null && sectorMaximum > 0 ? (sector.value / sectorMaximum) * 100 : 0)
+                    : share;
                   return (
                     <li key={sector.code}>
                       <div className={`${styles.sectorLabel} ${styles.sectorLabelPlain}`}>
                         <span>{sector.label}</span>
-                        <strong>{compactTurnover(sector.value)}</strong>
+                        <strong>{formatIstatValue(sector.value, turnoverView.metricFormat)}</strong>
                       </div>
-                      <i aria-hidden="true"><b style={{ width: `${share}%` }} /></i>
-                      <small>{sector.value === null ? "n.d." : percent(share)} del perimetro osservato</small>
+                      <i aria-hidden="true"><b style={{ width: `${relativeWidth}%` }} /></i>
+                      <small>
+                        {sector.value === null
+                          ? "n.d."
+                          : turnoverView.metricFormat === "euro-per-employee"
+                            ? "confronto tra macro-settori"
+                            : `${percent(share)} del perimetro osservato`}
+                      </small>
                     </li>
                   );
                 })}
@@ -213,7 +254,7 @@ export default async function ImpresePage({
                 regions={turnoverView.regionPoints}
                 selectedRegion={turnoverView.region === "ALL" ? "all" : turnoverView.region}
                 metricUnit={turnoverView.metricUnit}
-                valueFormat="thousand-euro"
+                valueFormat={turnoverView.metricFormat}
               />
               <p className={styles.attribution}>
                 Confini amministrativi a fini statistici: <a href="https://www.istat.it/storage/cartografia/confini_amministrativi/generalizzati/2026/Limiti01012026_g.zip" target="_blank" rel="noreferrer">ISTAT, 1 gennaio 2026</a>, CC BY 4.0. La scala della mappa è relativa al perimetro visualizzato.
@@ -223,23 +264,23 @@ export default async function ImpresePage({
             <section className="panel" aria-labelledby="ranking-title">
               <div className={styles.panelHead}>
                 <h2 id="ranking-title" className="panel-title">Prime 10 regioni</h2>
-                <span className={styles.headNote}>valori compatti in euro</span>
+                <span className={styles.headNote}>{turnoverView.metricUnit}</span>
               </div>
               <div className="table-scroll" role="region" aria-label="Prime 10 regioni ordinate per valore assoluto" tabIndex={0}>
                 <table className="table">
-                  <thead><tr><th scope="col">#</th><th scope="col">Regione</th><th scope="col" className="num">Fatturato</th></tr></thead>
+                  <thead><tr><th scope="col">#</th><th scope="col">Regione</th><th scope="col" className="num">{turnoverView.metricShortLabel}</th></tr></thead>
                   <tbody>
                     {topRegions.map((region, index) => (
                       <tr key={region.code}>
                         <td className="num">{index + 1}</td>
                         <th scope="row"><Link href={atlasHref(turnoverView, region.code)}><RegionalIdentity region={region} /></Link></th>
-                        <td className="num">{compactTurnover(region.value)}</td>
+                        <td className="num">{formatIstatValue(region.value, turnoverView.metricFormat)}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
-              <p className={styles.note}>Sono mostrate le prime 10 regioni per fatturato aggregato. Clicca una regione per fissarla nella mappa e nel perimetro.</p>
+              <p className={styles.note}>Sono mostrate le prime 10 regioni per {turnoverView.metricShortLabel.toLowerCase()}. Clicca una regione per fissarla nella mappa e nel perimetro.</p>
             </section>
           </div>
 
@@ -257,7 +298,7 @@ export default async function ImpresePage({
                     <strong>{visibleRegion.name}</strong>
                   </div>
                 ) : <strong>Italia</strong>}
-                <b>{compactTurnover(visibleRegion?.value ?? turnoverView.nationalValue)}</b>
+                <b>{formatIstatValue(visibleRegion?.value ?? turnoverView.nationalValue, turnoverView.metricFormat)}</b>
                 <small>{turnoverView.metricUnit} · {turnoverView.selectedSectorLabel}</small>
               </div>
               <dl className={styles.factRows}>
@@ -282,8 +323,8 @@ export default async function ImpresePage({
             <aside className={`notice ${styles.boundaryNotice}`}>
               <strong>Confine del modulo</strong>
               <p>
-                Qui non troverai nomi di aziende, identificativi, codici fiscali, partite IVA o fatturato
-                esatto di singole imprese. Il dato è un aggregato regionale e per macro-settore (Industria/Servizi)
+                Qui non troverai nomi di aziende, identificativi, codici fiscali, partite IVA o bilanci
+                esatti di singole imprese. Il dato è un aggregato regionale e per macro-settore (Industria/Servizi)
                 proveniente dalla stima anticipata ISTAT (Registro Frame Territoriale Anticipato 2024, ATECO 2007 agg. 2022),
                 riferito alle unità locali con almeno un dipendente.
               </p>

--- a/src/components/company-atlas-filters.tsx
+++ b/src/components/company-atlas-filters.tsx
@@ -12,6 +12,15 @@ function sectorChoiceLabel(id: string, label: string) {
   return `${id} · ${label}`;
 }
 
+const ISTAT_METRIC_IDS = new Set([
+  "turnover",
+  "istat_local_units",
+  "istat_employees",
+  "istat_value_added",
+  "istat_value_added_per_employee",
+  "istat_turnover_per_employee",
+]);
+
 type CompanyAtlasFiltersProps = Readonly<{
   filters: Required<Pick<AtlasFilters, "metric" | "period" | "region" | "sector" | "band">>;
   metrics: SelectOption[];
@@ -45,7 +54,9 @@ export function CompanyAtlasFilters({
       params.delete("period");
       params.delete("band");
       // ATECO 2025 sections and ISTAT macro-sectors are different domains.
-      if (value === "turnover" || filters.metric === "turnover") params.delete("sector");
+      if (ISTAT_METRIC_IDS.has(value) !== ISTAT_METRIC_IDS.has(filters.metric)) {
+        params.delete("sector");
+      }
     }
 
     const query = params.toString();

--- a/src/components/company-atlas-map.tsx
+++ b/src/components/company-atlas-map.tsx
@@ -12,7 +12,7 @@ type CompanyAtlasMapProps = Readonly<{
   regions: RegionPoint[];
   selectedRegion: string;
   metricUnit: string;
-  valueFormat?: "thousand-euro" | "integer" | "decimal" | "euro-per-employee" | "count";
+  valueFormat?: "thousand-euro" | "integer" | "decimal" | "euro-per-employee";
   mapTitle?: string;
   mapDescription?: string;
 }>;
@@ -143,7 +143,7 @@ export function CompanyAtlasMap({
                 tabIndex={focusable ? 0 : -1}
                 role="button"
                 aria-pressed={selected}
-                aria-label={`${region?.name ?? geometry.name}: ${region?.value === null || region?.value === undefined ? "dato non disponibile" : `${displayValue(region.value)}${valueFormat ? ` (unità fonte: ${metricUnit})` : ` ${metricUnit}`}`}`}
+                aria-label={`${region?.name ?? geometry.name}: ${region?.value === null || region?.value === undefined ? "dato non disponibile" : `${displayValue(region.value)} (unità: ${metricUnit})`}`}
                 data-hovered={hovered ? "true" : undefined}
                 data-selected={selected ? "true" : undefined}
                 onPointerEnter={() => setHoveredCode(geometry.code)}

--- a/src/components/company-atlas-map.tsx
+++ b/src/components/company-atlas-map.tsx
@@ -12,7 +12,7 @@ type CompanyAtlasMapProps = Readonly<{
   regions: RegionPoint[];
   selectedRegion: string;
   metricUnit: string;
-  valueFormat?: "thousand-euro";
+  valueFormat?: "thousand-euro" | "integer" | "decimal" | "euro-per-employee" | "count";
   mapTitle?: string;
   mapDescription?: string;
 }>;
@@ -97,7 +97,20 @@ export function CompanyAtlasMap({
       }
       return `${integer(value)} mila €`;
     }
-    return integer(value);
+    if (valueFormat === "euro-per-employee") {
+      const absolute = Math.abs(value);
+      if (absolute >= 1_000_000) {
+        return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 2, useGrouping: "always" })} mln € / addetto`;
+      }
+      if (absolute >= 1_000) {
+        return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 1, useGrouping: "always" })} mila € / addetto`;
+      }
+      return `${integer(Math.round(value))} € / addetto`;
+    }
+    if (valueFormat === "decimal") {
+      return value.toLocaleString("it-IT", { maximumFractionDigits: 1 });
+    }
+    return integer(Math.round(value));
   }
 
   return (

--- a/src/lib/istat-turnover-contract.ts
+++ b/src/lib/istat-turnover-contract.ts
@@ -27,11 +27,11 @@ export const istatTurnoverObservationSchema = z.object({
   period: z.literal("2024"),
   unit: z.literal("migliaia di euro"),
   value: z.number().int().nonnegative(),
-  localUnits: z.number().int().nonnegative().optional(),
-  employees: z.number().nonnegative().optional(),
+  localUnits: z.number().int().nonnegative(),
+  employees: z.number().positive(),
   payrollEmployees: z.number().nonnegative().optional(),
   laborCostThousandEuro: z.number().int().nonnegative().optional(),
-  valueAddedThousandEuro: z.number().int().nonnegative().optional(),
+  valueAddedThousandEuro: z.number().int().nonnegative(),
   purchasesThousandEuro: z.number().int().nonnegative().optional(),
   sourceId: z.literal("istat-frame-territoriale-2024"),
 }).strict();
@@ -121,7 +121,7 @@ export const istatTurnoverSnapshotSchema = istatTurnoverSnapshotBaseSchema.super
   }
 
   const observationKeys = new Set<string>();
-  const byRegionSector = new Map<string, number>();
+  const byRegionSector = new Map<string, (typeof snapshot.observations)[number]>();
 
   for (const [index, row] of snapshot.observations.entries()) {
     if (!regionSet.has(row.geographyCode)) {
@@ -132,7 +132,7 @@ export const istatTurnoverSnapshotSchema = istatTurnoverSnapshotBaseSchema.super
       issue(["observations", index], `Osservazione duplicata per ${key}`);
     }
     observationKeys.add(key);
-    byRegionSector.set(key, row.value);
+    byRegionSector.set(key, row);
   }
 
   if (snapshot.observations.length !== 60) {
@@ -140,9 +140,9 @@ export const istatTurnoverSnapshotSchema = istatTurnoverSnapshotBaseSchema.super
   }
 
   // Campania parity check: Tavola 1 turnover must be exactly 216750478
-  const campaniaAll = byRegionSector.get("15|ALL");
-  const campaniaInd = byRegionSector.get("15|INDUSTRIA");
-  const campaniaSer = byRegionSector.get("15|SERVIZI");
+  const campaniaAll = byRegionSector.get("15|ALL")?.value;
+  const campaniaInd = byRegionSector.get("15|INDUSTRIA")?.value;
+  const campaniaSer = byRegionSector.get("15|SERVIZI")?.value;
 
   if (campaniaAll !== 216_750_478) {
     issue(["observations"], `Valore Campania ALL non conforme: atteso 216750478, ricevuto ${campaniaAll}`);
@@ -159,10 +159,67 @@ export const istatTurnoverSnapshotSchema = istatTurnoverSnapshotBaseSchema.super
     }
   }
 
+  const reconcile = (
+    path: (string | number)[],
+    label: string,
+    total: number,
+    industry: number,
+    services: number,
+    tolerance: number,
+  ) => {
+    const delta = total - industry - services;
+    if (Math.abs(delta) > tolerance) {
+      issue(path, `${label} non riconcilia: totale meno Industria e Servizi = ${delta}`);
+    }
+  };
+
+  for (const code of EXPECTED_REGION_CODES) {
+    const total = byRegionSector.get(`${code}|ALL`);
+    const industry = byRegionSector.get(`${code}|INDUSTRIA`);
+    const services = byRegionSector.get(`${code}|SERVIZI`);
+    if (!total || !industry || !services) continue;
+
+    reconcile(["observations"], `${code} fatturato`, total.value, industry.value, services.value, 1);
+    reconcile(["observations"], `${code} unità locali`, total.localUnits, industry.localUnits, services.localUnits, 0);
+    reconcile(["observations"], `${code} addetti`, total.employees, industry.employees, services.employees, 0.000001);
+    reconcile(
+      ["observations"],
+      `${code} valore aggiunto`,
+      total.valueAddedThousandEuro,
+      industry.valueAddedThousandEuro,
+      services.valueAddedThousandEuro,
+      1,
+    );
+  }
+
   // National total parity
   if (snapshot.national.turnoverThousandEuro !== 3_768_464_269) {
     issue(["national", "turnoverThousandEuro"], "Totale nazionale fatturato non conforme all'aggregato ufficiale");
   }
+  reconcile(
+    ["national", "localUnits"],
+    "Unità locali nazionali",
+    snapshot.national.localUnits,
+    snapshot.national.industryLocalUnits,
+    snapshot.national.servicesLocalUnits,
+    0,
+  );
+  reconcile(
+    ["national", "employees"],
+    "Addetti nazionali",
+    snapshot.national.employees,
+    snapshot.national.industryEmployees,
+    snapshot.national.servicesEmployees,
+    0.000001,
+  );
+  reconcile(
+    ["national", "valueAddedThousandEuro"],
+    "Valore aggiunto nazionale",
+    snapshot.national.valueAddedThousandEuro,
+    snapshot.national.industryValueAddedThousandEuro,
+    snapshot.national.servicesValueAddedThousandEuro,
+    0,
+  );
 });
 
 export type IstatTurnoverObservation = z.infer<typeof istatTurnoverObservationSchema>;

--- a/src/lib/istat-turnover-contract.ts
+++ b/src/lib/istat-turnover-contract.ts
@@ -3,6 +3,18 @@ import { z } from "zod";
 export const istatMacroSectorSchema = z.enum(["ALL", "INDUSTRIA", "SERVIZI"]);
 export type IstatMacroSector = z.infer<typeof istatMacroSectorSchema>;
 
+export const istatMetricIdSchema = z.enum([
+  "turnover",
+  "istat_local_units",
+  "istat_employees",
+  "istat_value_added",
+  "istat_value_added_per_employee",
+  "istat_turnover_per_employee",
+]);
+export type IstatMetricId = z.infer<typeof istatMetricIdSchema>;
+
+export type IstatMetricFormat = "thousand-euro" | "integer" | "decimal" | "euro-per-employee";
+
 export const istatTurnoverObservationSchema = z.object({
   observationType: z.literal("aggregate"),
   geographyLevel: z.literal("region"),

--- a/src/lib/istat-turnover.ts
+++ b/src/lib/istat-turnover.ts
@@ -4,6 +4,8 @@ import rawSnapshot from "@/data/generated/istat-enterprise-turnover-2024.json";
 import {
   validateIstatTurnoverSnapshot,
   type IstatMacroSector,
+  type IstatMetricFormat,
+  type IstatMetricId,
   type IstatTurnoverObservation,
   type IstatTurnoverSnapshot,
 } from "@/lib/istat-turnover-contract";
@@ -11,6 +13,159 @@ import {
 export const istatTurnoverSnapshot: IstatTurnoverSnapshot = validateIstatTurnoverSnapshot(rawSnapshot);
 
 export const ISTAT_TURNOVER_ALL = "ALL" as const;
+
+export type IstatMetricDefinition = Readonly<{
+  id: IstatMetricId;
+  label: string;
+  metricLabel: string;
+  shortLabel: string;
+  unit: string;
+  format: IstatMetricFormat;
+  description: string;
+  caveat: string;
+}>;
+
+export const ISTAT_METRICS: readonly IstatMetricDefinition[] = [
+  {
+    id: "turnover",
+    label: "Fatturato aggregato (ISTAT)",
+    metricLabel: "Fatturato aggregato",
+    shortLabel: "Fatturato",
+    unit: "migliaia di euro",
+    format: "thousand-euro",
+    description: (
+      "Fatturato aggregato delle imprese per territorio e macro-settore economico (Stima anticipata ISTAT 2024, "
+      + "Registro Frame Territoriale Anticipato, ATECO 2007 agg. 2022, unità locali con almeno un dipendente)."
+    ),
+    caveat: "Il fatturato è espresso in migliaia di euro e classificato in ATECO 2007 aggiornamento 2022. I dati sono aggregati per territorio e non identificano singole aziende o persone fisiche.",
+  },
+  {
+    id: "istat_local_units",
+    label: "Unità locali (ISTAT)",
+    metricLabel: "Unità locali (ISTAT)",
+    shortLabel: "Unità locali",
+    unit: "unità locali",
+    format: "integer",
+    description: (
+      "Numero di unità locali di imprese con almeno un dipendente per territorio e macro-settore economico "
+      + "(Stima anticipata ISTAT 2024, Registro Frame Territoriale Anticipato)."
+    ),
+    caveat: "I dati si riferiscono alle sole unità locali di imprese con almeno un dipendente del Registro Frame Territoriale Anticipato 2024; non rappresentano l'universo completo delle sedi attive.",
+  },
+  {
+    id: "istat_employees",
+    label: "Addetti (ISTAT)",
+    metricLabel: "Addetti (ISTAT)",
+    shortLabel: "Addetti",
+    unit: "addetti",
+    format: "decimal",
+    description: (
+      "Addetti complessivi (dipendenti e indipendenti) operanti nelle unità locali con almeno un dipendente "
+      + "per territorio e macro-settore economico (Stima anticipata ISTAT 2024, Registro Frame Territoriale Anticipato)."
+    ),
+    caveat: "Numero medio annuo di addetti registrati nelle unità locali con almeno un dipendente. Dati aggregati a livello regionale e di macro-settore.",
+  },
+  {
+    id: "istat_value_added",
+    label: "Valore aggiunto aggregato (ISTAT)",
+    metricLabel: "Valore aggiunto aggregato",
+    shortLabel: "Valore aggiunto",
+    unit: "migliaia di euro",
+    format: "thousand-euro",
+    description: (
+      "Valore aggiunto aggregato a prezzi base per territorio e macro-settore economico (Stima anticipata ISTAT 2024, "
+      + "Registro Frame Territoriale Anticipato, ATECO 2007 agg. 2022, unità locali con almeno un dipendente)."
+    ),
+    caveat: "Il valore aggiunto misura la ricchezza netta creata dall'attività produttiva aggregata sul territorio regionale al netto dei consumi intermedi.",
+  },
+  {
+    id: "istat_value_added_per_employee",
+    label: "Valore aggiunto per addetto (ISTAT)",
+    metricLabel: "Valore aggiunto per addetto",
+    shortLabel: "Valore aggiunto per addetto",
+    unit: "euro per addetto",
+    format: "euro-per-employee",
+    description: (
+      "Produttività apparente del lavoro: rapporto tra il valore aggiunto aggregato e il totale degli addetti "
+      + "nelle unità locali con almeno un dipendente (Stima anticipata ISTAT 2024)."
+    ),
+    caveat: "Indicatore derivato: valore aggiunto diviso per il numero di addetti. È una media statistica aggregata territoriale/macro-settoriale e non riflette la redditività di una specifica singola impresa.",
+  },
+  {
+    id: "istat_turnover_per_employee",
+    label: "Fatturato per addetto (ISTAT)",
+    metricLabel: "Fatturato per addetto",
+    shortLabel: "Fatturato per addetto",
+    unit: "euro per addetto",
+    format: "euro-per-employee",
+    description: (
+      "Fatturato medio per addetto: rapporto tra fatturato aggregato e addetti nelle unità locali con almeno un "
+      + "dipendente per territorio e macro-settore (Stima anticipata ISTAT 2024)."
+    ),
+    caveat: "Indicatore derivato: fatturato diviso per il numero di addetti. È una media statistica territoriale/macro-settoriale e non riflette il fatturato di una specifica singola azienda.",
+  },
+] as const;
+
+const metricById = new Map<IstatMetricId, IstatMetricDefinition>(
+  ISTAT_METRICS.map((m) => [m.id, m]),
+);
+
+const ISTAT_METRIC_ALIASES = new Set([
+  "turnover",
+  "turnover_istat",
+  "company_turnover_istat",
+  "fatturato",
+  "istat_local_units",
+  "local_units_istat",
+  "local_units",
+  "istat_employees",
+  "employees_istat",
+  "istat_value_added",
+  "value_added_istat",
+  "value_added",
+  "istat_value_added_per_employee",
+  "value_added_per_employee",
+  "produttivita",
+  "istat_turnover_per_employee",
+  "turnover_per_employee",
+]);
+
+export function isIstatMetric(metric: string | undefined): boolean {
+  if (!metric) return false;
+  return ISTAT_METRIC_ALIASES.has(metric.trim().toLowerCase());
+}
+
+export function normalizeIstatMetric(value: string | undefined): IstatMetricId {
+  if (!value) return "turnover";
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "turnover" || trimmed === "turnover_istat" || trimmed === "company_turnover_istat" || trimmed === "fatturato") {
+    return "turnover";
+  }
+  if (trimmed === "istat_local_units" || trimmed === "local_units_istat" || trimmed === "local_units") {
+    return "istat_local_units";
+  }
+  if (trimmed === "istat_employees" || trimmed === "employees_istat") {
+    return "istat_employees";
+  }
+  if (trimmed === "istat_value_added" || trimmed === "value_added_istat" || trimmed === "value_added") {
+    return "istat_value_added";
+  }
+  if (
+    trimmed === "istat_value_added_per_employee" ||
+    trimmed === "value_added_per_employee" ||
+    trimmed === "produttivita"
+  ) {
+    return "istat_value_added_per_employee";
+  }
+  if (trimmed === "istat_turnover_per_employee" || trimmed === "turnover_per_employee") {
+    return "istat_turnover_per_employee";
+  }
+  return "turnover";
+}
+
+export function istatMetricOptions() {
+  return ISTAT_METRICS.map(({ id, label, description }) => ({ id, label, description }));
+}
 
 export type IstatTurnoverDatasetQuery = Readonly<{
   dataset?: string;
@@ -90,7 +245,6 @@ export function queryIstatTurnoverDataset(query: IstatTurnoverDatasetQuery = {})
     observations = observations.filter((obs) => obs.macroSector === normalizedSector);
   } else if (sectorFilter === undefined || sectorFilter.toLowerCase() === "all" || sectorFilter.toUpperCase() === "ALL") {
     // If no specific sector filter is given, return all macro-sectors or total according to request
-    // By default, observations contains ALL, INDUSTRIA, SERVIZI
   }
 
   const limit = Math.min(100, Math.max(1, Math.trunc(query.limit ?? 50)));
@@ -129,10 +283,89 @@ export function queryIstatTurnoverDataset(query: IstatTurnoverDatasetQuery = {})
   };
 }
 
+function extractObservationValue(obs: IstatTurnoverObservation | undefined, metricId: IstatMetricId): number | null {
+  if (!obs) return null;
+  switch (metricId) {
+    case "turnover":
+      return obs.value;
+    case "istat_local_units":
+      return obs.localUnits ?? null;
+    case "istat_employees":
+      return obs.employees ?? null;
+    case "istat_value_added":
+      return obs.valueAddedThousandEuro ?? null;
+    case "istat_value_added_per_employee": {
+      const va = obs.valueAddedThousandEuro;
+      const emp = obs.employees;
+      if (va === undefined || emp === undefined || emp <= 0) return null;
+      return (va * 1000) / emp;
+    }
+    case "istat_turnover_per_employee": {
+      const to = obs.value;
+      const emp = obs.employees;
+      if (to === undefined || emp === undefined || emp <= 0) return null;
+      return (to * 1000) / emp;
+    }
+  }
+}
+
+function extractNationalValue(metricId: IstatMetricId, sector: IstatMacroSector): number {
+  const nat = istatTurnoverSnapshot.national;
+  if (sector === "INDUSTRIA") {
+    switch (metricId) {
+      case "turnover":
+        return nat.industryTurnoverThousandEuro;
+      case "istat_local_units":
+        return nat.industryLocalUnits;
+      case "istat_employees":
+        return nat.industryEmployees;
+      case "istat_value_added":
+        return nat.industryValueAddedThousandEuro;
+      case "istat_value_added_per_employee":
+        return (nat.industryValueAddedThousandEuro * 1000) / nat.industryEmployees;
+      case "istat_turnover_per_employee":
+        return (nat.industryTurnoverThousandEuro * 1000) / nat.industryEmployees;
+    }
+  }
+  if (sector === "SERVIZI") {
+    switch (metricId) {
+      case "turnover":
+        return nat.servicesTurnoverThousandEuro;
+      case "istat_local_units":
+        return nat.servicesLocalUnits;
+      case "istat_employees":
+        return nat.servicesEmployees;
+      case "istat_value_added":
+        return nat.servicesValueAddedThousandEuro;
+      case "istat_value_added_per_employee":
+        return (nat.servicesValueAddedThousandEuro * 1000) / nat.servicesEmployees;
+      case "istat_turnover_per_employee":
+        return (nat.servicesTurnoverThousandEuro * 1000) / nat.servicesEmployees;
+    }
+  }
+  // ALL
+  switch (metricId) {
+    case "turnover":
+      return nat.turnoverThousandEuro;
+    case "istat_local_units":
+      return nat.localUnits;
+    case "istat_employees":
+      return nat.employees;
+    case "istat_value_added":
+      return nat.valueAddedThousandEuro;
+    case "istat_value_added_per_employee":
+      return (nat.valueAddedThousandEuro * 1000) / nat.employees;
+    case "istat_turnover_per_employee":
+      return (nat.turnoverThousandEuro * 1000) / nat.employees;
+  }
+}
+
 export type IstatTurnoverView = Readonly<{
-  metric: "turnover";
+  metric: IstatMetricId;
   metricLabel: string;
+  metricShortLabel: string;
   metricUnit: string;
+  metricFormat: IstatMetricFormat;
   metricDescription: string;
   period: "2024";
   periodLabel: string;
@@ -149,7 +382,11 @@ export type IstatTurnoverView = Readonly<{
   matchedObservationCount: number;
 }>;
 
-export function getIstatTurnoverView(filters: { region?: string; sector?: string } = {}): IstatTurnoverView {
+export function getIstatTurnoverView(
+  filters: { metric?: string; region?: string; sector?: string } = {},
+): IstatTurnoverView {
+  const metricId = normalizeIstatMetric(filters.metric);
+  const definition = metricById.get(metricId)!;
   const normalizedRegion = normalizeRegionCode(filters.region);
   const normalizedSector = normalizeSectorCode(filters.sector);
 
@@ -158,7 +395,7 @@ export function getIstatTurnoverView(filters: { region?: string; sector?: string
     return {
       code: region.code,
       name: region.name,
-      value: obs?.value ?? null,
+      value: extractObservationValue(obs, metricId),
     };
   });
 
@@ -168,13 +405,11 @@ export function getIstatTurnoverView(filters: { region?: string; sector?: string
   const sectorBreakdown = (["INDUSTRIA", "SERVIZI"] as const).map((sectorCode) => {
     const label = macroSectorByCode.get(sectorCode)?.label ?? sectorCode;
     if (normalizedRegion === "ALL") {
-      const nationalVal = sectorCode === "INDUSTRIA"
-        ? istatTurnoverSnapshot.national.industryTurnoverThousandEuro
-        : istatTurnoverSnapshot.national.servicesTurnoverThousandEuro;
+      const nationalVal = extractNationalValue(metricId, sectorCode);
       return { code: sectorCode, label, value: nationalVal };
     }
     const obs = observationMap.get(`${normalizedRegion}|${sectorCode}`);
-    return { code: sectorCode, label, value: obs?.value ?? null };
+    return { code: sectorCode, label, value: extractObservationValue(obs, metricId) };
   });
 
   const selectedRegion = normalizedRegion === "ALL"
@@ -183,13 +418,7 @@ export function getIstatTurnoverView(filters: { region?: string; sector?: string
 
   let nationalValue: number;
   if (normalizedRegion === "ALL") {
-    if (normalizedSector === "INDUSTRIA") {
-      nationalValue = istatTurnoverSnapshot.national.industryTurnoverThousandEuro;
-    } else if (normalizedSector === "SERVIZI") {
-      nationalValue = istatTurnoverSnapshot.national.servicesTurnoverThousandEuro;
-    } else {
-      nationalValue = istatTurnoverSnapshot.national.turnoverThousandEuro;
-    }
+    nationalValue = extractNationalValue(metricId, normalizedSector);
   } else {
     nationalValue = selectedRegion?.value ?? 0;
   }
@@ -197,13 +426,12 @@ export function getIstatTurnoverView(filters: { region?: string; sector?: string
   const selectedSectorLabel = macroSectorByCode.get(normalizedSector)?.label ?? "Tutti i settori (Industria e Servizi)";
 
   return {
-    metric: "turnover",
-    metricLabel: "Fatturato aggregato",
-    metricUnit: "migliaia di euro",
-    metricDescription: (
-      "Fatturato aggregato delle imprese per territorio e macro-settore economico (Stima anticipata ISTAT 2024, "
-      + "Registro Frame Territoriale Anticipato, ATECO 2007 agg. 2022, unità locali con almeno un dipendente)."
-    ),
+    metric: metricId,
+    metricLabel: definition.metricLabel,
+    metricShortLabel: definition.shortLabel,
+    metricUnit: definition.unit,
+    metricFormat: definition.format,
+    metricDescription: definition.description,
     period: "2024",
     periodLabel: "Anno 2024",
     region: normalizedRegion,
@@ -217,6 +445,7 @@ export function getIstatTurnoverView(filters: { region?: string; sector?: string
     sources: [istatTurnoverSnapshot.source],
     caveats: [
       istatTurnoverSnapshot.source.caveat,
+      definition.caveat,
       "I dati sono aggregati per regione e macro-settore: non identificano aziende, persone fisiche o ricavi esatti di singole società.",
     ],
     matchedObservationCount: normalizedRegion === "ALL" ? 20 : 1,

--- a/src/lib/istat-turnover.ts
+++ b/src/lib/istat-turnover.ts
@@ -110,24 +110,24 @@ const metricById = new Map<IstatMetricId, IstatMetricDefinition>(
   ISTAT_METRICS.map((m) => [m.id, m]),
 );
 
-const ISTAT_METRIC_ALIASES = new Set([
-  "turnover",
-  "turnover_istat",
-  "company_turnover_istat",
-  "fatturato",
-  "istat_local_units",
-  "local_units_istat",
-  "local_units",
-  "istat_employees",
-  "employees_istat",
-  "istat_value_added",
-  "value_added_istat",
-  "value_added",
-  "istat_value_added_per_employee",
-  "value_added_per_employee",
-  "produttivita",
-  "istat_turnover_per_employee",
-  "turnover_per_employee",
+const ISTAT_METRIC_ALIASES = new Map<string, IstatMetricId>([
+  ["turnover", "turnover"],
+  ["turnover_istat", "turnover"],
+  ["company_turnover_istat", "turnover"],
+  ["fatturato", "turnover"],
+  ["istat_local_units", "istat_local_units"],
+  ["local_units_istat", "istat_local_units"],
+  ["local_units", "istat_local_units"],
+  ["istat_employees", "istat_employees"],
+  ["employees_istat", "istat_employees"],
+  ["istat_value_added", "istat_value_added"],
+  ["value_added_istat", "istat_value_added"],
+  ["value_added", "istat_value_added"],
+  ["istat_value_added_per_employee", "istat_value_added_per_employee"],
+  ["value_added_per_employee", "istat_value_added_per_employee"],
+  ["produttivita", "istat_value_added_per_employee"],
+  ["istat_turnover_per_employee", "istat_turnover_per_employee"],
+  ["turnover_per_employee", "istat_turnover_per_employee"],
 ]);
 
 export function isIstatMetric(metric: string | undefined): boolean {
@@ -137,30 +137,7 @@ export function isIstatMetric(metric: string | undefined): boolean {
 
 export function normalizeIstatMetric(value: string | undefined): IstatMetricId {
   if (!value) return "turnover";
-  const trimmed = value.trim().toLowerCase();
-  if (trimmed === "turnover" || trimmed === "turnover_istat" || trimmed === "company_turnover_istat" || trimmed === "fatturato") {
-    return "turnover";
-  }
-  if (trimmed === "istat_local_units" || trimmed === "local_units_istat" || trimmed === "local_units") {
-    return "istat_local_units";
-  }
-  if (trimmed === "istat_employees" || trimmed === "employees_istat") {
-    return "istat_employees";
-  }
-  if (trimmed === "istat_value_added" || trimmed === "value_added_istat" || trimmed === "value_added") {
-    return "istat_value_added";
-  }
-  if (
-    trimmed === "istat_value_added_per_employee" ||
-    trimmed === "value_added_per_employee" ||
-    trimmed === "produttivita"
-  ) {
-    return "istat_value_added_per_employee";
-  }
-  if (trimmed === "istat_turnover_per_employee" || trimmed === "turnover_per_employee") {
-    return "istat_turnover_per_employee";
-  }
-  return "turnover";
+  return ISTAT_METRIC_ALIASES.get(value.trim().toLowerCase()) ?? "turnover";
 }
 
 export function istatMetricOptions() {

--- a/tests/etl/test_istat_enterprise_turnover.py
+++ b/tests/etl/test_istat_enterprise_turnover.py
@@ -129,6 +129,21 @@ class IstatEnterpriseTurnoverETLTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_snapshot(corrupted_campania)
 
+        missing_metric = json.loads(json.dumps(snapshot))
+        missing_metric["observations"][0].pop("localUnits")
+        with self.assertRaisesRegex(ValueError, "localUnits mancante"):
+            validate_snapshot(missing_metric)
+
+        broken_region_metric = json.loads(json.dumps(snapshot))
+        broken_region_metric["observations"][0]["valueAddedThousandEuro"] += 2
+        with self.assertRaisesRegex(ValueError, "valore aggiunto non riconcilia"):
+            validate_snapshot(broken_region_metric)
+
+        broken_national_metric = json.loads(json.dumps(snapshot))
+        broken_national_metric["national"]["localUnits"] += 1
+        with self.assertRaisesRegex(ValueError, "Unità locali nazionali non riconcilia"):
+            validate_snapshot(broken_national_metric)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/istat-enterprise-turnover.test.mjs
+++ b/tests/istat-enterprise-turnover.test.mjs
@@ -10,6 +10,10 @@ const {
   istatTurnoverRegionOptions,
   istatTurnoverSectorOptions,
   istatTurnoverSource,
+  isIstatMetric,
+  istatMetricOptions,
+  ISTAT_METRICS,
+  normalizeIstatMetric,
 } = await import("../src/lib/istat-turnover.ts");
 
 const {
@@ -47,7 +51,6 @@ test("the generated ISTAT turnover snapshot is valid under Zod contract", () => 
     assert.ok(region.name.length > 0);
   }
 });
-
 test("Campania row in Tavola 1 equals exactly 216750478 migliaia di euro and reconciles macro-sectors", () => {
   const campaniaAll = istatTurnoverSnapshot.observations.find(
     (obs) => obs.geographyCode === "15" && obs.macroSector === "ALL",
@@ -209,4 +212,212 @@ test("fonti lists the lightweight ISTAT turnover source next to the camera sourc
   assert.match(pageSource, /fatturato individuale/);
   assert.deepEqual(istatTurnoverSourceMetadata, istatTurnoverSnapshot.source);
   assert.deepEqual(istatTurnoverSourceMetadata, istatTurnoverSource());
+});
+
+test("isIstatMetric recognizes all ISTAT metrics and aliases while leaving InfoCamere metrics untouched", () => {
+  // Supported ISTAT metrics
+  assert.equal(isIstatMetric("turnover"), true);
+  assert.equal(isIstatMetric("company_turnover_istat"), true);
+  assert.equal(isIstatMetric("fatturato"), true);
+  assert.equal(isIstatMetric("istat_local_units"), true);
+  assert.equal(isIstatMetric("local_units_istat"), true);
+  assert.equal(isIstatMetric("local_units"), true);
+  assert.equal(isIstatMetric("istat_employees"), true);
+  assert.equal(isIstatMetric("employees_istat"), true);
+  assert.equal(isIstatMetric("istat_value_added"), true);
+  assert.equal(isIstatMetric("value_added_istat"), true);
+  assert.equal(isIstatMetric("value_added"), true);
+  assert.equal(isIstatMetric("istat_value_added_per_employee"), true);
+  assert.equal(isIstatMetric("value_added_per_employee"), true);
+  assert.equal(isIstatMetric("produttivita"), true);
+  assert.equal(isIstatMetric("istat_turnover_per_employee"), true);
+  assert.equal(isIstatMetric("turnover_per_employee"), true);
+  assert.equal(isIstatMetric("istat_not_a_metric"), false);
+  assert.equal(isIstatMetric("random_istat"), false);
+
+  // InfoCamere metrics must NOT be intercepted as ISTAT
+  assert.equal(isIstatMetric("active_enterprises"), false);
+  assert.equal(isIstatMetric("employees"), false); // InfoCamere workforce metric
+  assert.equal(isIstatMetric("active_local_units"), false);
+  assert.equal(isIstatMetric("production_value_band_count"), false);
+  assert.equal(isIstatMetric(undefined), false);
+  assert.equal(isIstatMetric(""), false);
+});
+
+test("normalizeIstatMetric maps metric IDs and aliases correctly", () => {
+  assert.equal(normalizeIstatMetric("turnover"), "turnover");
+  assert.equal(normalizeIstatMetric("company_turnover_istat"), "turnover");
+  assert.equal(normalizeIstatMetric("fatturato"), "turnover");
+  assert.equal(normalizeIstatMetric("istat_local_units"), "istat_local_units");
+  assert.equal(normalizeIstatMetric("local_units_istat"), "istat_local_units");
+  assert.equal(normalizeIstatMetric("local_units"), "istat_local_units");
+  assert.equal(normalizeIstatMetric("istat_employees"), "istat_employees");
+  assert.equal(normalizeIstatMetric("employees_istat"), "istat_employees");
+  assert.equal(normalizeIstatMetric("istat_value_added"), "istat_value_added");
+  assert.equal(normalizeIstatMetric("value_added"), "istat_value_added");
+  assert.equal(normalizeIstatMetric("istat_value_added_per_employee"), "istat_value_added_per_employee");
+  assert.equal(normalizeIstatMetric("value_added_per_employee"), "istat_value_added_per_employee");
+  assert.equal(normalizeIstatMetric("produttivita"), "istat_value_added_per_employee");
+  assert.equal(normalizeIstatMetric("istat_turnover_per_employee"), "istat_turnover_per_employee");
+  assert.equal(normalizeIstatMetric("turnover_per_employee"), "istat_turnover_per_employee");
+  assert.equal(normalizeIstatMetric(undefined), "turnover");
+  assert.equal(normalizeIstatMetric("unknown_xyz"), "turnover");
+});
+
+test("istatMetricOptions exposes all 6 metrics with explicit descriptions, units, and formats", () => {
+  const options = istatMetricOptions();
+  assert.equal(options.length, 6);
+  assert.deepEqual(
+    options.map((o) => o.id),
+    [
+      "turnover",
+      "istat_local_units",
+      "istat_employees",
+      "istat_value_added",
+      "istat_value_added_per_employee",
+      "istat_turnover_per_employee",
+    ],
+  );
+
+  for (const item of ISTAT_METRICS) {
+    assert.ok(item.label.length > 0);
+    assert.ok(item.metricLabel.length > 0);
+    assert.ok(item.shortLabel.length > 0);
+    assert.ok(item.unit.length > 0);
+    assert.ok(item.description.length > 0);
+    assert.ok(item.caveat.length > 0);
+    assert.ok(["thousand-euro", "integer", "decimal", "euro-per-employee"].includes(item.format));
+  }
+});
+
+test("getIstatTurnoverView correctly calculates and returns local units", () => {
+  const nationalView = getIstatTurnoverView({ metric: "istat_local_units" });
+  assert.equal(nationalView.metric, "istat_local_units");
+  assert.equal(nationalView.metricLabel, "Unità locali (ISTAT)");
+  assert.equal(nationalView.metricUnit, "unità locali");
+  assert.equal(nationalView.metricFormat, "integer");
+  assert.equal(nationalView.nationalValue, 1_972_649);
+  assert.equal(nationalView.regionPoints.length, 20);
+
+  // National sector breakdown
+  assert.equal(nationalView.sectorBreakdown[0].value, 544_980); // Industria
+  assert.equal(nationalView.sectorBreakdown[1].value, 1_427_669); // Servizi
+  assert.equal(
+    nationalView.sectorBreakdown[0].value + nationalView.sectorBreakdown[1].value,
+    nationalView.nationalValue,
+  );
+
+  // Campania regional view
+  const campaniaView = getIstatTurnoverView({ metric: "istat_local_units", region: "15" });
+  assert.equal(campaniaView.selectedRegion?.code, "15");
+  assert.equal(campaniaView.selectedRegion?.name, "Campania");
+  assert.equal(campaniaView.selectedRegion?.value, 179_367);
+  assert.equal(campaniaView.sectorBreakdown[0].value, 48_885); // Industria
+  assert.equal(campaniaView.sectorBreakdown[1].value, 130_482); // Servizi
+  assert.equal(
+    campaniaView.sectorBreakdown[0].value + campaniaView.sectorBreakdown[1].value,
+    campaniaView.selectedRegion?.value,
+  );
+});
+
+test("getIstatTurnoverView correctly calculates and returns employees", () => {
+  const nationalView = getIstatTurnoverView({ metric: "istat_employees" });
+  assert.equal(nationalView.metric, "istat_employees");
+  assert.equal(nationalView.metricLabel, "Addetti (ISTAT)");
+  assert.equal(nationalView.metricUnit, "addetti");
+  assert.equal(nationalView.metricFormat, "decimal");
+  assert.equal(nationalView.nationalValue, 15_332_958.22);
+  assert.equal(nationalView.sectorBreakdown[0].value, 5_356_775.67); // Industria
+  assert.equal(nationalView.sectorBreakdown[1].value, 9_976_182.55); // Servizi
+  assert.equal(
+    Math.round((nationalView.sectorBreakdown[0].value + nationalView.sectorBreakdown[1].value) * 100),
+    Math.round(nationalView.nationalValue * 100),
+  );
+
+  // Campania regional view
+  const campaniaView = getIstatTurnoverView({ metric: "istat_employees", region: "15" });
+  assert.equal(campaniaView.selectedRegion?.value, 1_087_048.37);
+  assert.equal(campaniaView.sectorBreakdown[0].value, 342_967.35); // Industria
+  assert.equal(campaniaView.sectorBreakdown[1].value, 744_081.02); // Servizi
+  assert.equal(
+    Math.round((campaniaView.sectorBreakdown[0].value + campaniaView.sectorBreakdown[1].value) * 100),
+    Math.round(campaniaView.selectedRegion.value * 100),
+  );
+});
+
+test("getIstatTurnoverView correctly calculates and returns value added", () => {
+  const nationalView = getIstatTurnoverView({ metric: "istat_value_added" });
+  assert.equal(nationalView.metric, "istat_value_added");
+  assert.equal(nationalView.metricLabel, "Valore aggiunto aggregato");
+  assert.equal(nationalView.metricUnit, "migliaia di euro");
+  assert.equal(nationalView.metricFormat, "thousand-euro");
+  assert.equal(nationalView.nationalValue, 960_538_669);
+  assert.equal(nationalView.sectorBreakdown[0].value, 434_968_295); // Industria
+  assert.equal(nationalView.sectorBreakdown[1].value, 525_570_374); // Servizi
+  assert.equal(
+    nationalView.sectorBreakdown[0].value + nationalView.sectorBreakdown[1].value,
+    nationalView.nationalValue,
+  );
+
+  // Campania regional view
+  const campaniaView = getIstatTurnoverView({ metric: "istat_value_added", region: "15" });
+  assert.equal(campaniaView.selectedRegion?.value, 52_725_025);
+  assert.equal(campaniaView.sectorBreakdown[0].value, 21_589_486); // Industria
+  assert.equal(campaniaView.sectorBreakdown[1].value, 31_135_539); // Servizi
+  assert.equal(
+    campaniaView.sectorBreakdown[0].value + campaniaView.sectorBreakdown[1].value,
+    campaniaView.selectedRegion.value,
+  );
+});
+
+test("getIstatTurnoverView correctly calculates per-employee derived metrics", () => {
+  // Value Added per employee (apparent labour productivity)
+  const vaPerEmpNat = getIstatTurnoverView({ metric: "istat_value_added_per_employee" });
+  assert.equal(vaPerEmpNat.metric, "istat_value_added_per_employee");
+  assert.equal(vaPerEmpNat.metricUnit, "euro per addetto");
+  assert.equal(vaPerEmpNat.metricFormat, "euro-per-employee");
+  const expectedNatVa = (960_538_669 * 1000) / 15_332_958.22;
+  assert.ok(Math.abs(vaPerEmpNat.nationalValue - expectedNatVa) < 0.001);
+
+  const vaPerEmpCampania = getIstatTurnoverView({ metric: "istat_value_added_per_employee", region: "15" });
+  const expectedCampaniaVa = (52_725_025 * 1000) / 1_087_048.37;
+  assert.ok(Math.abs((vaPerEmpCampania.selectedRegion?.value ?? 0) - expectedCampaniaVa) < 0.001);
+
+  // Turnover per employee
+  const toPerEmpNat = getIstatTurnoverView({ metric: "istat_turnover_per_employee" });
+  assert.equal(toPerEmpNat.metric, "istat_turnover_per_employee");
+  assert.equal(toPerEmpNat.metricUnit, "euro per addetto");
+  assert.equal(toPerEmpNat.metricFormat, "euro-per-employee");
+  const expectedNatTo = (3_768_464_269 * 1000) / 15_332_958.22;
+  assert.ok(Math.abs(toPerEmpNat.nationalValue - expectedNatTo) < 0.001);
+
+  const toPerEmpCampania = getIstatTurnoverView({ metric: "istat_turnover_per_employee", region: "15" });
+  const expectedCampaniaTo = (216_750_478 * 1000) / 1_087_048.37;
+  assert.ok(Math.abs((toPerEmpCampania.selectedRegion?.value ?? 0) - expectedCampaniaTo) < 0.001);
+});
+
+test("ranking is strictly descending and valid for every ISTAT metric", () => {
+  const metrics = [
+    "turnover",
+    "istat_local_units",
+    "istat_employees",
+    "istat_value_added",
+    "istat_value_added_per_employee",
+    "istat_turnover_per_employee",
+  ];
+
+  for (const metric of metrics) {
+    const view = getIstatTurnoverView({ metric });
+    assert.equal(view.ranking.length, 20);
+    assert.equal(view.regionPoints.length, 20);
+
+    for (let i = 1; i < view.ranking.length; i++) {
+      const prev = view.ranking[i - 1]?.value ?? 0;
+      const curr = view.ranking[i]?.value ?? 0;
+      assert.ok(
+        prev >= curr,
+        `Ranking for ${metric} not descending at index ${i}: ${prev} < ${curr}`,
+      );
+    }
+  }
 });

--- a/tests/istat-enterprise-turnover.test.mjs
+++ b/tests/istat-enterprise-turnover.test.mjs
@@ -51,6 +51,21 @@ test("the generated ISTAT turnover snapshot is valid under Zod contract", () => 
     assert.ok(region.name.length > 0);
   }
 });
+
+test("the public ISTAT metrics fail closed on missing fields and broken reconciliations", () => {
+  const missingField = structuredClone(istatTurnoverSnapshot);
+  delete missingField.observations[0].localUnits;
+  assert.throws(() => validateIstatTurnoverSnapshot(missingField));
+
+  const brokenRegion = structuredClone(istatTurnoverSnapshot);
+  brokenRegion.observations[0].valueAddedThousandEuro += 2;
+  assert.throws(() => validateIstatTurnoverSnapshot(brokenRegion), /valore aggiunto non riconcilia/i);
+
+  const brokenNational = structuredClone(istatTurnoverSnapshot);
+  brokenNational.national.localUnits += 1;
+  assert.throws(() => validateIstatTurnoverSnapshot(brokenNational), /Unità locali nazionali non riconcilia/i);
+});
+
 test("Campania row in Tavola 1 equals exactly 216750478 migliaia di euro and reconciles macro-sectors", () => {
   const campaniaAll = istatTurnoverSnapshot.observations.find(
     (obs) => obs.geographyCode === "15" && obs.macroSector === "ALL",
@@ -194,13 +209,14 @@ test("getIstatTurnoverView builds compliant view for dashboard", () => {
 test("turnover sector list shows the ISTAT label once, without the 22px ATECO code column", async () => {
   const pageSource = await readFile(new URL("../src/app/imprese/page.tsx", import.meta.url), "utf8");
   const turnoverBlock = pageSource.slice(
-    pageSource.indexOf("isTurnover"),
+    pageSource.indexOf("isIstatView"),
     pageSource.indexOf("const view = getCompanyAtlasView"),
   );
 
   assert.match(turnoverBlock, /sectorLabelPlain/);
   assert.doesNotMatch(turnoverBlock, /<b>\{sector\.code\}<\/b>/);
   assert.match(turnoverBlock, /\{sector\.label\}/);
+  assert.match(turnoverBlock, /turnoverView\.caveats\.map/);
 });
 
 test("fonti lists the lightweight ISTAT turnover source next to the camera sources", async () => {
@@ -376,6 +392,7 @@ test("getIstatTurnoverView correctly calculates per-employee derived metrics", (
   assert.equal(vaPerEmpNat.metric, "istat_value_added_per_employee");
   assert.equal(vaPerEmpNat.metricUnit, "euro per addetto");
   assert.equal(vaPerEmpNat.metricFormat, "euro-per-employee");
+  assert.match(vaPerEmpNat.caveats.join(" "), /Indicatore derivato/i);
   const expectedNatVa = (960_538_669 * 1000) / 15_332_958.22;
   assert.ok(Math.abs(vaPerEmpNat.nationalValue - expectedNatVa) < 0.001);
 


### PR DESCRIPTION
## Cosa cambia

- espone sei viste dallo snapshot aggregato ISTAT 2024 già presente: fatturato, unità locali, addetti, valore aggiunto, valore aggiunto per addetto e fatturato per addetto;
- mantiene espliciti unità, periodo, provenienza, copertura e limiti del dato;
- conserva integralmente il percorso InfoCamere/ATECO e aggiunge il cambio metrica responsivo.

## Confine dei dati

La PR usa soltanto campi aggregati già presenti nello snapshot ISTAT. Non aggiunge nomi, identificativi, codici fiscali, partite IVA o dati economici di singole imprese.

I due valori per addetto sono indicatori derivati: dividono gli aggregati ufficiali per il numero medio annuo di addetti dello stesso territorio e macro-settore. Non misurano la redditività di una singola azienda.

## Integrazione maintainer

La testa `3c27185` è ribasata su `main` al commit `6dbbfc0`.

Durante l’integrazione sono stati aggiunti:

- contratto fail-closed per i tre campi usati dalle nuove metriche;
- riconciliazioni regionali e nazionali tra totale, Industria e Servizi;
- caveat specifici visibili per ogni metrica;
- test negativi TypeScript e Python;
- browser test delle sei viste a 320, 390, 768 e 1280 px, con URL, focus, selezione e assenza di overflow.

## Verifica locale

- test mirati dati/UI: 34/34 PASS;
- ETL ISTAT e verifica snapshot offline: 7/7 PASS;
- lint, typecheck, design e brand: PASS;
- build Next.js: PASS, 84/84 pagine;
- browser core completo sul build di produzione: PASS.

I test che aprono listener loopback non possono funzionare nel sandbox ristretto; ripetuti fuori dal sandbox, risultano 4/4 PASS per Node e 7/7 PASS per Python.

Il fallimento Vercel del fork è dovuto alla richiesta di autorizzazione al team “Dom's projects”, non a un errore di build dell’applicazione.
