### PR TITLE
feat(territori): aggiungi i quattro profili OpenCivitas

### DIFF
--- a/src/app/territori/confronto/opencivitas-quadrants.module.css
+++ b/src/app/territori/confronto/opencivitas-quadrants.module.css
@@ -1,0 +1,390 @@
+.module {
+  min-width: 0;
+}
+
+.header,
+.plotHeading,
+.detailHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-5);
+}
+
+.header {
+  margin-bottom: var(--space-5);
+}
+
+.kicker {
+  margin: 0 0 5px;
+  color: var(--color-accent-700);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.intro,
+.plotHeading p,
+.detailHeading p {
+  max-width: 72ch;
+  margin: var(--space-2) 0 0;
+  color: var(--color-neutral-700);
+  font-size: 13px;
+}
+
+.coverage {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(100px, 1fr));
+  gap: 1px;
+  flex: none;
+  margin: 0;
+  background: var(--color-neutral-300);
+}
+
+.coverage > div {
+  min-width: 0;
+  padding: 10px 12px;
+  background: var(--color-neutral-100);
+}
+
+.coverage dt,
+.quadrantTotals dt {
+  color: var(--color-neutral-600);
+  font-size: 10px;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.coverage dd {
+  margin: 3px 0 0;
+  font-size: 18px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+}
+
+.figure {
+  min-width: 0;
+  margin: 0;
+}
+
+.plotHeading {
+  align-items: end;
+  margin-bottom: var(--space-4);
+}
+
+.plotHeading h3,
+.detailHeading h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 16px;
+}
+
+.scaleNote,
+.completeTag {
+  flex: none;
+  margin: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--color-neutral-300);
+  color: var(--color-neutral-700);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.chartFrame {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.yAxisLabel {
+  align-self: center;
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: .04em;
+  text-align: center;
+  text-transform: uppercase;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.plotWrap {
+  min-width: 0;
+}
+
+.plot {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(190px, auto));
+  min-width: 0;
+  border: 1px solid var(--color-neutral-400);
+}
+
+.quadrant {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: clamp(12px, 2.2vw, 24px);
+  overflow-wrap: anywhere;
+  border-right: 1px solid var(--color-neutral-400);
+  border-bottom: 1px solid var(--color-neutral-400);
+  background: var(--color-neutral-100);
+}
+
+.quadrant:nth-child(2n) {
+  border-right: 0;
+}
+
+.quadrant:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.quadrant[data-quadrant="low-high"] {
+  background: var(--color-positive-bg);
+}
+
+.quadrant[data-quadrant="high-high"] {
+  background: var(--color-accent-100);
+}
+
+.quadrant[data-quadrant="high-low"] {
+  background: var(--color-warning-bg);
+}
+
+.quadrantBands {
+  margin: 0 0 6px;
+  color: var(--color-neutral-600);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.quadrant h4 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: clamp(15px, 2vw, 19px);
+  line-height: 1.2;
+}
+
+.quadrantDescription {
+  max-width: 34ch;
+  margin: 7px 0 0;
+  color: var(--color-neutral-800);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.count {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  margin: auto 0 var(--space-3);
+  padding-top: var(--space-4);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.count strong {
+  font-size: clamp(24px, 3.8vw, 38px);
+  font-weight: 780;
+  letter-spacing: -.04em;
+  line-height: 1;
+}
+
+.count span {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+}
+
+.quadrantTotals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.quadrantTotals > div {
+  min-width: 0;
+  padding-top: 7px;
+  border-top: 1px solid color-mix(in srgb, var(--color-neutral-900) 22%, transparent);
+}
+
+.quadrantTotals dd {
+  margin: 3px 0 0;
+  color: var(--color-text);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.xAxis {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-2);
+  margin-top: 7px;
+  color: var(--color-neutral-600);
+  font-size: 10px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.xAxis span:nth-child(2) {
+  color: var(--color-neutral-700);
+  font-weight: 700;
+  text-align: center;
+}
+
+.xAxis span:last-child {
+  text-align: right;
+}
+
+.caption,
+.excluded,
+.provenance {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+}
+
+.caption {
+  display: block;
+  margin-top: var(--space-4);
+}
+
+.detail {
+  margin-top: var(--space-6);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.detailHeading {
+  align-items: end;
+  margin-bottom: var(--space-3);
+}
+
+.tableScroll {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scroll-padding-inline: var(--space-2);
+}
+
+.tableScroll:focus-visible {
+  outline-offset: 3px;
+}
+
+.table {
+  min-width: 760px;
+}
+
+.table caption {
+  padding: 0 0 8px;
+  color: var(--color-neutral-700);
+  font-size: 11px;
+  text-align: left;
+}
+
+.table th:first-child {
+  min-width: 240px;
+}
+
+.table tfoot th,
+.table tfoot td {
+  padding-top: 12px;
+  border-top: 2px solid var(--color-neutral-400);
+  font-weight: 750;
+}
+
+.table th small {
+  max-width: 36ch;
+  overflow-wrap: anywhere;
+}
+
+.excluded {
+  margin: var(--space-3) 0 0;
+}
+
+.provenance {
+  margin: var(--space-5) 0 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-neutral-200);
+  line-height: 1.5;
+}
+
+.provenance a {
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 760px) {
+  .header,
+  .plotHeading,
+  .detailHeading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .coverage {
+    width: 100%;
+  }
+
+  .scaleNote,
+  .completeTag {
+    justify-self: start;
+  }
+}
+
+@media (max-width: 520px) {
+  .chartFrame {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .yAxisLabel {
+    justify-self: start;
+    writing-mode: horizontal-tb;
+    transform: none;
+  }
+
+  .plot {
+    grid-template-rows: repeat(2, minmax(220px, auto));
+  }
+
+  .quadrant {
+    padding: 12px;
+  }
+
+  .quadrantTotals {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .quadrantTotals > div {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: baseline;
+  }
+
+  .quadrantTotals dd {
+    text-align: right;
+  }
+
+  .xAxis {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .xAxis span:nth-child(2) {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    text-align: left;
+  }
+
+  .xAxis span:last-child {
+    grid-column: 2;
+    grid-row: 2;
+  }
+}

--- a/src/app/territori/confronto/opencivitas-quadrants.module.css
+++ b/src/app/territori/confronto/opencivitas-quadrants.module.css
@@ -128,7 +128,8 @@
   min-width: 0;
   flex-direction: column;
   padding: clamp(12px, 2.2vw, 24px);
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
+  word-break: normal;
   border-right: 1px solid var(--color-neutral-400);
   border-bottom: 1px solid var(--color-neutral-400);
   background: var(--color-neutral-100);
@@ -186,6 +187,7 @@
   padding-top: var(--space-4);
   color: var(--color-text);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .count strong {
@@ -219,7 +221,7 @@
   font-size: 12px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
 }
 
 .xAxis {
@@ -302,7 +304,8 @@
 
 .table th small {
   max-width: 36ch;
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 .excluded {
@@ -318,6 +321,12 @@
 
 .provenance a {
   overflow-wrap: anywhere;
+}
+
+.scrollInstruction {
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 11px;
 }
 
 @media (max-width: 760px) {
@@ -350,11 +359,23 @@
   }
 
   .plot {
-    grid-template-rows: repeat(2, minmax(220px, auto));
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: none;
   }
 
   .quadrant {
     padding: 12px;
+    min-height: 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-neutral-400);
+  }
+
+  .quadrant:nth-last-child(-n + 2) {
+    border-bottom: 1px solid var(--color-neutral-400);
+  }
+
+  .quadrant:last-child {
+    border-bottom: 0;
   }
 
   .quadrantTotals {
@@ -371,6 +392,11 @@
 
   .quadrantTotals dd {
     text-align: right;
+  }
+
+  .count {
+    margin: var(--space-3) 0;
+    padding-top: 0;
   }
 
   .xAxis {

--- a/src/app/territori/confronto/opencivitas-quadrants.tsx
+++ b/src/app/territori/confronto/opencivitas-quadrants.tsx
@@ -33,19 +33,19 @@ const QUADRANT_COPY: Record<OpenCivitasQuadrantKey, Readonly<{
   description: string;
 }>> = {
   "low-low": {
-    title: "Spesa 0–5 · servizi 0–5",
+    title: "Spesa da 0 a 5 · servizi da 0 a 5",
     description: "Entrambi i livelli pubblicati sono sotto la soglia descrittiva.",
   },
   "low-high": {
-    title: "Spesa 0–5 · servizi 6–10",
+    title: "Spesa da 0 a 5 · servizi da 6 a 10",
     description: "Il livello della spesa è sotto soglia; quello dei servizi è almeno 6.",
   },
   "high-low": {
-    title: "Spesa 6–10 · servizi 0–5",
+    title: "Spesa da 6 a 10 · servizi da 0 a 5",
     description: "Il livello della spesa è almeno 6; quello dei servizi è sotto soglia.",
   },
   "high-high": {
-    title: "Spesa 6–10 · servizi 6–10",
+    title: "Spesa da 6 a 10 · servizi da 6 a 10",
     description: "Entrambi i livelli pubblicati sono almeno 6.",
   },
 };
@@ -56,7 +56,7 @@ function signedEuro(cents: number, compact = false): string {
 }
 
 function bandLabel(band: "low" | "high"): string {
-  return band === "high" ? "6–10" : "0–5";
+  return band === "high" ? "da 6 a 10" : "da 0 a 5";
 }
 
 function quadrantLabel(quadrant: OpenCivitasQuadrant): string {
@@ -108,7 +108,7 @@ export function OpenCivitasQuadrants({
           <div>
             <h3 id="opencivitas-plot-title">Livello dei servizi e livello della spesa</h3>
             <p>
-              Distribuzione dei Comuni per i quali sono disponibili entrambi i livelli 0–10. I testi dentro
+              Distribuzione dei Comuni per i quali sono disponibili entrambi i livelli da 0 a 10. I testi dentro
               ogni riquadro riportano sempre la stessa informazione del colore.
             </p>
           </div>
@@ -116,7 +116,7 @@ export function OpenCivitasQuadrants({
         </div>
 
         <div className={styles.chartFrame}>
-          <p className={styles.yAxisLabel}>Livello dei servizi · 0–10</p>
+          <p className={styles.yAxisLabel}>Livello dei servizi · da 0 a 10</p>
           <div className={styles.plotWrap}>
             <div
               className={styles.plot}
@@ -157,13 +157,13 @@ export function OpenCivitasQuadrants({
             </div>
             <div className={styles.xAxis} aria-hidden="true">
               <span>Spesa sotto soglia</span>
-              <span>Livello della spesa · 0–10</span>
+              <span>Livello della spesa · da 0 a 10</span>
               <span>Spesa almeno 6</span>
             </div>
           </div>
         </div>
         <figcaption className={styles.caption}>
-          La soglia divide i livelli pubblicati in 0–5 e 6–10. La differenza monetaria è spesa
+          La soglia divide i livelli pubblicati tra valori da 0 a 5 e valori da 6 a 10. La differenza monetaria è spesa
           storica meno fabbisogno standard: non è una misura di efficienza, spreco o risparmio.
         </figcaption>
       </figure>

--- a/src/app/territori/confronto/opencivitas-quadrants.tsx
+++ b/src/app/territori/confronto/opencivitas-quadrants.tsx
@@ -1,0 +1,257 @@
+import type { OpenCivitasMunicipality } from "@/lib/data/opencivitas-contract";
+import { exactEuro, integer } from "@/lib/format";
+import {
+  OPEN_CIVITAS_QUADRANT_THRESHOLD,
+  summarizeOpenCivitasQuadrants,
+  type OpenCivitasQuadrant,
+  type OpenCivitasQuadrantKey,
+} from "@/lib/opencivitas-quadrants";
+import styles from "./opencivitas-quadrants.module.css";
+
+type OpenCivitasQuadrantsProps = {
+  municipalities: readonly OpenCivitasMunicipality[];
+  referenceYear: number;
+  territorialScope: string;
+  source: Readonly<{
+    owner: string;
+    dataset: string;
+    datasetUrl: string;
+    license: string;
+  }>;
+};
+
+const QUADRANT_ORDER: readonly OpenCivitasQuadrantKey[] = [
+  "low-high",
+  "high-high",
+  "low-low",
+  "high-low",
+];
+
+const QUADRANT_COPY: Record<OpenCivitasQuadrantKey, Readonly<{
+  title: string;
+  description: string;
+}>> = {
+  "low-low": {
+    title: "Spesa 0–5 · servizi 0–5",
+    description: "Entrambi i livelli pubblicati sono sotto la soglia descrittiva.",
+  },
+  "low-high": {
+    title: "Spesa 0–5 · servizi 6–10",
+    description: "Il livello della spesa è sotto soglia; quello dei servizi è almeno 6.",
+  },
+  "high-low": {
+    title: "Spesa 6–10 · servizi 0–5",
+    description: "Il livello della spesa è almeno 6; quello dei servizi è sotto soglia.",
+  },
+  "high-high": {
+    title: "Spesa 6–10 · servizi 6–10",
+    description: "Entrambi i livelli pubblicati sono almeno 6.",
+  },
+};
+
+function compactEuro(cents: number): string {
+  const euros = cents / 100;
+  const absolute = Math.abs(euros);
+  if (absolute >= 1_000_000_000) {
+    return `${euros.toLocaleString("it-IT", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      useGrouping: "always",
+    })} mld €`;
+  }
+  if (absolute >= 1_000_000) {
+    return `${euros.toLocaleString("it-IT", {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+      useGrouping: "always",
+    })} mln €`;
+  }
+  return exactEuro(euros);
+}
+
+function signedEuro(cents: number, compact = false): string {
+  const value = compact ? compactEuro(cents) : exactEuro(cents / 100);
+  return cents > 0 ? `+${value}` : value;
+}
+
+function bandLabel(band: "low" | "high"): string {
+  return band === "high" ? "6–10" : "0–5";
+}
+
+function quadrantLabel(quadrant: OpenCivitasQuadrant): string {
+  return `${QUADRANT_COPY[quadrant.key].title}: ${integer(quadrant.municipalities)} Comuni`;
+}
+
+export function OpenCivitasQuadrants({
+  municipalities,
+  referenceYear,
+  territorialScope,
+  source,
+}: OpenCivitasQuadrantsProps) {
+  const summary = summarizeOpenCivitasQuadrants(municipalities);
+  const quadrantsByKey = new Map(summary.quadrants.map((quadrant) => [quadrant.key, quadrant]));
+  const orderedQuadrants = QUADRANT_ORDER.flatMap((key) => {
+    const quadrant = quadrantsByKey.get(key);
+    return quadrant ? [quadrant] : [];
+  });
+
+  return (
+    <section className={`panel ${styles.module}`} aria-labelledby="opencivitas-quadrants-title">
+      <header className={styles.header}>
+        <div>
+          <p className={styles.kicker}>OpenCivitas · lettura descrittiva</p>
+          <h2 className="panel-title" id="opencivitas-quadrants-title">
+            Quattro profili nel confronto comunale
+          </h2>
+          <p className={styles.intro}>
+            Ogni Comune è collocato usando il livello della spesa e il livello dei servizi pubblicati
+            dalla fonte. La soglia adottata qui è {OPEN_CIVITAS_QUADRANT_THRESHOLD}: i gruppi non sono
+            una graduatoria e non spiegano da soli le differenze tra Comuni.
+          </p>
+        </div>
+        <dl className={styles.coverage}>
+          <div>
+            <dt>Comuni coperti</dt>
+            <dd>{integer(summary.coveredMunicipalities)}</dd>
+          </div>
+          <div>
+            <dt>Livelli completi</dt>
+            <dd>{integer(summary.completeMunicipalities)}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <figure className={styles.figure} aria-labelledby="opencivitas-plot-title">
+        <div className={styles.plotHeading}>
+          <div>
+            <h3 id="opencivitas-plot-title">Livello dei servizi e livello della spesa</h3>
+            <p>
+              Quota di Comuni per i quali sono disponibili entrambi i livelli 0–10. I testi dentro
+              ogni riquadro riportano sempre la stessa informazione del colore.
+            </p>
+          </div>
+          <p className={styles.scaleNote}>Soglia: livello {OPEN_CIVITAS_QUADRANT_THRESHOLD}</p>
+        </div>
+
+        <div className={styles.chartFrame}>
+          <p className={styles.yAxisLabel}>Livello dei servizi · 0–10</p>
+          <div className={styles.plotWrap}>
+            <div
+              className={styles.plot}
+              role="group"
+              aria-label={`Distribuzione dei ${integer(summary.completeMunicipalities)} Comuni con livelli completi`}
+            >
+              {orderedQuadrants.map((quadrant) => (
+                <article
+                  className={styles.quadrant}
+                  data-quadrant={quadrant.key}
+                  key={quadrant.key}
+                  aria-label={quadrantLabel(quadrant)}
+                >
+                  <p className={styles.quadrantBands}>
+                    Spesa {bandLabel(quadrant.spendingBand)} · servizi {bandLabel(quadrant.serviceBand)}
+                  </p>
+                  <h4>{QUADRANT_COPY[quadrant.key].title}</h4>
+                  <p className={styles.quadrantDescription}>{QUADRANT_COPY[quadrant.key].description}</p>
+                  <p className={styles.count}>
+                    <strong>{integer(quadrant.municipalities)}</strong> <span>Comuni</span>
+                  </p>
+                  <dl className={styles.quadrantTotals}>
+                    <div>
+                      <dt>Spesa storica</dt>
+                      <dd>{compactEuro(quadrant.historicalSpendingCents)}</dd>
+                    </div>
+                    <div>
+                      <dt>Fabbisogno standard</dt>
+                      <dd>{compactEuro(quadrant.standardSpendingCents)}</dd>
+                    </div>
+                    <div>
+                      <dt>Differenza</dt>
+                      <dd>{signedEuro(quadrant.differenceCents, true)}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+            <div className={styles.xAxis} aria-hidden="true">
+              <span>Spesa sotto soglia</span>
+              <span>Livello della spesa · 0–10</span>
+              <span>Spesa almeno 6</span>
+            </div>
+          </div>
+        </div>
+        <figcaption className={styles.caption}>
+          La soglia divide i livelli pubblicati in 0–5 e 6–10. La differenza monetaria è spesa
+          storica meno fabbisogno standard: non è una misura di efficienza, spreco o risparmio.
+        </figcaption>
+      </figure>
+
+      <section className={styles.detail} aria-labelledby="opencivitas-exact-title">
+        <div className={styles.detailHeading}>
+          <div>
+            <h3 id="opencivitas-exact-title">Numeri esatti per profilo</h3>
+            <p>
+              Somme calcolate in centesimi sulle {integer(summary.completeMunicipalities)} osservazioni
+              complete; la differenza è riconciliata come spesa storica meno fabbisogno standard.
+            </p>
+          </div>
+          <span className={styles.completeTag}>Totale completo: {integer(summary.completeMunicipalities)}</span>
+        </div>
+        <div
+          className={styles.tableScroll}
+          role="region"
+          aria-label="Tabella esatta dei profili OpenCivitas. Scorri orizzontalmente per vedere tutte le colonne."
+          tabIndex={0}
+        >
+          <table className={`table ${styles.table}`}>
+            <caption>
+              OpenCivitas {referenceYear}: Comuni con livelli completi e importi aggregati per profilo.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Profilo</th>
+                <th className="num" scope="col">Comuni</th>
+                <th className="num" scope="col">Spesa storica</th>
+                <th className="num" scope="col">Fabbisogno standard</th>
+                <th className="num" scope="col">Differenza</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orderedQuadrants.map((quadrant) => (
+                <tr key={quadrant.key}>
+                  <th scope="row">
+                    {QUADRANT_COPY[quadrant.key].title}
+                    <small>{QUADRANT_COPY[quadrant.key].description}</small>
+                  </th>
+                  <td className="num">{integer(quadrant.municipalities)}</td>
+                  <td className="num">{exactEuro(quadrant.historicalSpendingCents / 100)}</td>
+                  <td className="num">{exactEuro(quadrant.standardSpendingCents / 100)}</td>
+                  <td className="num">{signedEuro(quadrant.differenceCents)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <th scope="row">Totale osservazioni complete</th>
+                <td className="num">{integer(summary.completeTotals.municipalities)}</td>
+                <td className="num">{exactEuro(summary.completeTotals.historicalSpendingCents / 100)}</td>
+                <td className="num">{exactEuro(summary.completeTotals.standardSpendingCents / 100)}</td>
+                <td className="num">{signedEuro(summary.completeTotals.differenceCents)}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+        <p className={styles.excluded}>
+          {integer(summary.excludedMunicipalities)} Comuni coperti non entrano nei quattro profili
+          perché almeno uno dei due livelli non è disponibile nella fonte.
+        </p>
+      </section>
+
+      <p className={styles.provenance}>
+        Fonte: <a href={source.datasetUrl} rel="noreferrer" target="_blank">{source.dataset}</a> · {source.owner} ·
+        periodo {referenceYear} · {territorialScope} · licenza {source.license}. La lettura è descrittiva
+        e non dimostra efficienza, spreco, risparmio o qualità dei servizi.
+      </p>
+    </section>
+  );
+}

--- a/src/app/territori/confronto/opencivitas-quadrants.tsx
+++ b/src/app/territori/confronto/opencivitas-quadrants.tsx
@@ -1,5 +1,6 @@
 import type { OpenCivitasMunicipality } from "@/lib/data/opencivitas-contract";
-import { exactEuro, integer } from "@/lib/format";
+import { HorizontalScrollRegion } from "@/components/horizontal-scroll-region";
+import { compactEuroFromCents, exactEuro, integer } from "@/lib/format";
 import {
   OPEN_CIVITAS_QUADRANT_THRESHOLD,
   summarizeOpenCivitasQuadrants,
@@ -49,28 +50,8 @@ const QUADRANT_COPY: Record<OpenCivitasQuadrantKey, Readonly<{
   },
 };
 
-function compactEuro(cents: number): string {
-  const euros = cents / 100;
-  const absolute = Math.abs(euros);
-  if (absolute >= 1_000_000_000) {
-    return `${euros.toLocaleString("it-IT", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-      useGrouping: "always",
-    })} mld €`;
-  }
-  if (absolute >= 1_000_000) {
-    return `${euros.toLocaleString("it-IT", {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
-      useGrouping: "always",
-    })} mln €`;
-  }
-  return exactEuro(euros);
-}
-
 function signedEuro(cents: number, compact = false): string {
-  const value = compact ? compactEuro(cents) : exactEuro(cents / 100);
+  const value = compact ? compactEuroFromCents(cents) : exactEuro(cents / 100);
   return cents > 0 ? `+${value}` : value;
 }
 
@@ -106,7 +87,8 @@ export function OpenCivitasQuadrants({
           <p className={styles.intro}>
             Ogni Comune è collocato usando il livello della spesa e il livello dei servizi pubblicati
             dalla fonte. La soglia adottata qui è {OPEN_CIVITAS_QUADRANT_THRESHOLD}: i gruppi non sono
-            una graduatoria e non spiegano da soli le differenze tra Comuni.
+            una graduatoria e non spiegano da soli le differenze tra Comuni. Il riepilogo usa l’intero
+            perimetro OpenCivitas: i filtri della tabella comunale successiva non modificano questi profili.
           </p>
         </div>
         <dl className={styles.coverage}>
@@ -126,7 +108,7 @@ export function OpenCivitasQuadrants({
           <div>
             <h3 id="opencivitas-plot-title">Livello dei servizi e livello della spesa</h3>
             <p>
-              Quota di Comuni per i quali sono disponibili entrambi i livelli 0–10. I testi dentro
+              Distribuzione dei Comuni per i quali sono disponibili entrambi i livelli 0–10. I testi dentro
               ogni riquadro riportano sempre la stessa informazione del colore.
             </p>
           </div>
@@ -159,11 +141,11 @@ export function OpenCivitasQuadrants({
                   <dl className={styles.quadrantTotals}>
                     <div>
                       <dt>Spesa storica</dt>
-                      <dd>{compactEuro(quadrant.historicalSpendingCents)}</dd>
+                      <dd>{compactEuroFromCents(quadrant.historicalSpendingCents)}</dd>
                     </div>
                     <div>
                       <dt>Fabbisogno standard</dt>
-                      <dd>{compactEuro(quadrant.standardSpendingCents)}</dd>
+                      <dd>{compactEuroFromCents(quadrant.standardSpendingCents)}</dd>
                     </div>
                     <div>
                       <dt>Differenza</dt>
@@ -197,11 +179,14 @@ export function OpenCivitasQuadrants({
           </div>
           <span className={styles.completeTag}>Totale completo: {integer(summary.completeMunicipalities)}</span>
         </div>
-        <div
+        <p className={styles.scrollInstruction} id="opencivitas-exact-description">
+          Su schermi stretti puoi scorrere la tabella orizzontalmente; quando la regione è a fuoco,
+          Freccia destra/sinistra e Home/Fine spostano la vista.
+        </p>
+        <HorizontalScrollRegion
+          ariaDescribedBy="opencivitas-exact-description"
+          ariaLabel="Tabella esatta dei profili OpenCivitas. Scorri orizzontalmente per vedere tutte le colonne."
           className={styles.tableScroll}
-          role="region"
-          aria-label="Tabella esatta dei profili OpenCivitas. Scorri orizzontalmente per vedere tutte le colonne."
-          tabIndex={0}
         >
           <table className={`table ${styles.table}`}>
             <caption>
@@ -240,7 +225,7 @@ export function OpenCivitasQuadrants({
               </tr>
             </tfoot>
           </table>
-        </div>
+        </HorizontalScrollRegion>
         <p className={styles.excluded}>
           {integer(summary.excludedMunicipalities)} Comuni coperti non entrano nei quattro profili
           perché almeno uno dei due livelli non è disponibile nella fonte.

--- a/src/app/territori/confronto/page.tsx
+++ b/src/app/territori/confronto/page.tsx
@@ -11,6 +11,7 @@ import {
   getMunicipalityGeographyByIstatCode,
   type MunicipalityGeography,
 } from "@/lib/municipality-geography";
+import { OpenCivitasQuadrants } from "./opencivitas-quadrants";
 import styles from "./confronto.module.css";
 
 export const metadata: Metadata = {
@@ -260,6 +261,13 @@ export default async function MunicipalComparisonPage({
           da servizi, costi locali o uso delle risorse. Il numero da solo non spiega il perché.
         </p>
       </div>
+
+      <OpenCivitasQuadrants
+        municipalities={openCivitasSnapshot.municipalities}
+        referenceYear={openCivitasSnapshot.referenceYear}
+        source={openCivitasSnapshot.source}
+        territorialScope={openCivitasSnapshot.coverage.territorialScope}
+      />
 
       <section className="panel" aria-labelledby="filters-title">
         <h2 className="panel-title" id="filters-title">

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -51,6 +51,14 @@ export function compactEuro(value: number): string {
   return euroFormatter.format(value);
 }
 
+/** Formats an integer-cent source value without changing its measurement unit. */
+export function compactEuroFromCents(cents: number): string {
+  if (!Number.isSafeInteger(cents)) {
+    throw new Error("L'importo in centesimi deve essere un intero sicuro");
+  }
+  return compactEuro(cents / 100);
+}
+
 /**
  * Formats a value in the unit that suits `reference`.
  *

--- a/src/lib/opencivitas-quadrants.ts
+++ b/src/lib/opencivitas-quadrants.ts
@@ -1,6 +1,6 @@
 import type { OpenCivitasMunicipality } from "./data/opencivitas-contract";
 
-/** The page uses the published 0–10 levels as two descriptive bands. */
+/** The page uses the published 0-10 levels as two descriptive bands. */
 export const OPEN_CIVITAS_QUADRANT_THRESHOLD = 6;
 
 export const OPEN_CIVITAS_QUADRANT_KEYS = [

--- a/src/lib/opencivitas-quadrants.ts
+++ b/src/lib/opencivitas-quadrants.ts
@@ -1,0 +1,179 @@
+import type { OpenCivitasMunicipality } from "./data/opencivitas-contract";
+
+/** The page uses the published 0–10 levels as two descriptive bands. */
+export const OPEN_CIVITAS_QUADRANT_THRESHOLD = 6;
+
+export const OPEN_CIVITAS_QUADRANT_KEYS = [
+  "low-low",
+  "low-high",
+  "high-low",
+  "high-high",
+] as const;
+
+export type OpenCivitasQuadrantKey = (typeof OPEN_CIVITAS_QUADRANT_KEYS)[number];
+export type OpenCivitasLevelBand = "low" | "high";
+
+export type OpenCivitasAggregate = Readonly<{
+  municipalities: number;
+  historicalSpendingCents: number;
+  standardSpendingCents: number;
+  differenceCents: number;
+}>;
+
+export type OpenCivitasQuadrant = OpenCivitasAggregate & Readonly<{
+  key: OpenCivitasQuadrantKey;
+  spendingBand: OpenCivitasLevelBand;
+  serviceBand: OpenCivitasLevelBand;
+}>;
+
+export type OpenCivitasQuadrantSummary = Readonly<{
+  coveredMunicipalities: number;
+  completeMunicipalities: number;
+  excludedMunicipalities: number;
+  completeTotals: OpenCivitasAggregate;
+  quadrants: readonly OpenCivitasQuadrant[];
+}>;
+
+type MutableAggregate = {
+  municipalities: number;
+  historicalSpendingCents: number;
+  standardSpendingCents: number;
+  differenceCents: number;
+};
+
+type QuadrantDefinition = Readonly<{
+  key: OpenCivitasQuadrantKey;
+  spendingBand: OpenCivitasLevelBand;
+  serviceBand: OpenCivitasLevelBand;
+}>;
+
+const QUADRANT_DEFINITIONS: readonly QuadrantDefinition[] = [
+  { key: "low-low", spendingBand: "low", serviceBand: "low" },
+  { key: "low-high", spendingBand: "low", serviceBand: "high" },
+  { key: "high-low", spendingBand: "high", serviceBand: "low" },
+  { key: "high-high", spendingBand: "high", serviceBand: "high" },
+];
+
+function emptyAggregate(): MutableAggregate {
+  return {
+    municipalities: 0,
+    historicalSpendingCents: 0,
+    standardSpendingCents: 0,
+    differenceCents: 0,
+  };
+}
+
+function safeSum(left: number, right: number, field: string): number {
+  const result = left + right;
+  if (!Number.isSafeInteger(result)) {
+    throw new Error(`OpenCivitas: aggregato ${field} oltre il limite intero sicuro`);
+  }
+  return result;
+}
+
+function validateMoney(municipality: OpenCivitasMunicipality): void {
+  for (const [field, value] of [
+    ["historicalSpendingCents", municipality.historicalSpendingCents],
+    ["standardSpendingCents", municipality.standardSpendingCents],
+    ["differenceCents", municipality.differenceCents],
+  ] as const) {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`OpenCivitas: ${field} non è un intero sicuro`);
+    }
+  }
+  if (municipality.historicalSpendingCents < 0 || municipality.standardSpendingCents <= 0) {
+    throw new Error("OpenCivitas: importi comunali fuori intervallo");
+  }
+  if (
+    municipality.differenceCents !==
+    municipality.historicalSpendingCents - municipality.standardSpendingCents
+  ) {
+    throw new Error(`OpenCivitas: differenza non riconciliata per ${municipality.istatCode}`);
+  }
+}
+
+function validateLevel(value: number | null, field: string): void {
+  if (value !== null && (!Number.isInteger(value) || value < 0 || value > 10)) {
+    throw new Error(`OpenCivitas: ${field} fuori dalla scala 0-10`);
+  }
+}
+
+function addAggregate(target: MutableAggregate, municipality: OpenCivitasMunicipality): void {
+  target.municipalities += 1;
+  target.historicalSpendingCents = safeSum(
+    target.historicalSpendingCents,
+    municipality.historicalSpendingCents,
+    "spesa storica",
+  );
+  target.standardSpendingCents = safeSum(
+    target.standardSpendingCents,
+    municipality.standardSpendingCents,
+    "fabbisogno standard",
+  );
+  target.differenceCents = safeSum(
+    target.differenceCents,
+    municipality.differenceCents,
+    "differenza",
+  );
+}
+
+function quadrantFor(
+  spendingLevel: number,
+  serviceLevel: number,
+): OpenCivitasQuadrantKey {
+  const spendingBand = spendingLevel >= OPEN_CIVITAS_QUADRANT_THRESHOLD ? "high" : "low";
+  const serviceBand = serviceLevel >= OPEN_CIVITAS_QUADRANT_THRESHOLD ? "high" : "low";
+  return `${spendingBand}-${serviceBand}` as OpenCivitasQuadrantKey;
+}
+
+/**
+ * Groups only municipalities with both published levels into four descriptive
+ * bands and reconciles each monetary aggregate in cents.
+ */
+export function summarizeOpenCivitasQuadrants(
+  municipalities: readonly OpenCivitasMunicipality[],
+): OpenCivitasQuadrantSummary {
+  const aggregates = new Map<OpenCivitasQuadrantKey, MutableAggregate>(
+    QUADRANT_DEFINITIONS.map(({ key }) => [key, emptyAggregate()]),
+  );
+  const completeTotals = emptyAggregate();
+  let completeMunicipalities = 0;
+
+  for (const municipality of municipalities) {
+    validateMoney(municipality);
+    validateLevel(municipality.spendingLevel, "livello della spesa");
+    validateLevel(municipality.serviceLevel, "livello dei servizi");
+    if (municipality.spendingLevel === null || municipality.serviceLevel === null) continue;
+
+    const key = quadrantFor(municipality.spendingLevel, municipality.serviceLevel);
+    const aggregate = aggregates.get(key);
+    if (!aggregate) throw new Error(`OpenCivitas: quadrante inatteso ${key}`);
+    addAggregate(aggregate, municipality);
+    addAggregate(completeTotals, municipality);
+    completeMunicipalities += 1;
+  }
+
+  const quadrants = QUADRANT_DEFINITIONS.map((definition) => {
+    const aggregate = aggregates.get(definition.key);
+    if (!aggregate) throw new Error(`OpenCivitas: quadrante mancante ${definition.key}`);
+    if (aggregate.differenceCents !== aggregate.historicalSpendingCents - aggregate.standardSpendingCents) {
+      throw new Error(`OpenCivitas: aggregato non riconciliato ${definition.key}`);
+    }
+    return { ...definition, ...aggregate };
+  });
+
+  if (
+    completeTotals.differenceCents !==
+    completeTotals.historicalSpendingCents - completeTotals.standardSpendingCents
+  ) {
+    throw new Error("OpenCivitas: totale degli aggregati non riconciliato");
+  }
+
+  return {
+    coveredMunicipalities: municipalities.length,
+    completeMunicipalities,
+    excludedMunicipalities: municipalities.length - completeMunicipalities,
+    completeTotals: { ...completeTotals },
+    quadrants,
+  };
+}

--- a/tests/opencivitas-quadrants.test.mjs
+++ b/tests/opencivitas-quadrants.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { assertOpenCivitasSnapshot } from "../src/lib/data/opencivitas-contract.ts";
+import { compactEuroFromCents } from "../src/lib/format.ts";
 import {
   OPEN_CIVITAS_QUADRANT_THRESHOLD,
   summarizeOpenCivitasQuadrants,
@@ -51,6 +52,15 @@ test("OpenCivitas quadrants use the published levels and reconcile the complete 
   );
 });
 
+test("OpenCivitas compact euro formatter preserves billion and million units", () => {
+  assert.equal(compactEuroFromCents(954_431_037_886), "9,54 mld €");
+  assert.equal(compactEuroFromCents(835_871_581_264), "8,36 mld €");
+  assert.equal(compactEuroFromCents(-170_902_013_628), "-1,71 mld €");
+  assert.equal(compactEuroFromCents(123_456_789), "1,2 mln €");
+  assert.match(compactEuroFromCents(123_456), /1\.234,56/);
+  assert.throws(() => compactEuroFromCents(Number.MAX_SAFE_INTEGER + 1), /intero sicuro/);
+});
+
 test("OpenCivitas quadrant view exposes direct labels, exact table semantics and caveat", () => {
   const page = readFileSync(new URL("../src/app/territori/confronto/page.tsx", import.meta.url), "utf8");
   const component = readFileSync(
@@ -71,12 +81,18 @@ test("OpenCivitas quadrant view exposes direct labels, exact table semantics and
   assert.match(component, /<caption>/);
   assert.match(component, /scope="col"/);
   assert.match(component, /scope="row"/);
-  assert.match(component, /role="region"/);
+  assert.match(component, /HorizontalScrollRegion/);
   assert.match(component, /Scorri orizzontalmente/);
+  assert.match(component, /intero[\s\S]*perimetro OpenCivitas/);
+  assert.match(component, /filtri[\s\S]*non modificano/);
+  assert.match(component, /Distribuzione dei Comuni/);
+  assert.match(component, /ariaDescribedBy="opencivitas-exact-description"/);
   assert.match(component, /periodo \{referenceYear\}/);
   assert.match(component, /non dimostra efficienza, spreco, risparmio/);
   assert.match(style, /overflow-x: auto/);
   assert.match(style, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+  assert.match(style, /grid-template-columns: minmax\(0, 1fr\)/);
+  assert.match(style, /white-space: nowrap/);
   assert.match(style, /@media \(max-width: 520px\)/);
   assert.doesNotMatch(component, /efficienza[^\n]*(?:misura|indice)/i);
   assert.doesNotMatch(component, /risparmio[^\n]*(?:stimato|ottenuto|generato)/i);

--- a/tests/opencivitas-quadrants.test.mjs
+++ b/tests/opencivitas-quadrants.test.mjs
@@ -74,10 +74,10 @@ test("OpenCivitas quadrant view exposes direct labels, exact table semantics and
 
   assert.match(page, /<OpenCivitasQuadrants/);
   assert.match(component, /<figure/);
-  assert.match(component, /Spesa 0–5 · servizi 0–5/);
-  assert.match(component, /Spesa 0–5 · servizi 6–10/);
-  assert.match(component, /Spesa 6–10 · servizi 0–5/);
-  assert.match(component, /Spesa 6–10 · servizi 6–10/);
+  assert.match(component, /Spesa da 0 a 5 · servizi da 0 a 5/);
+  assert.match(component, /Spesa da 0 a 5 · servizi da 6 a 10/);
+  assert.match(component, /Spesa da 6 a 10 · servizi da 0 a 5/);
+  assert.match(component, /Spesa da 6 a 10 · servizi da 6 a 10/);
   assert.match(component, /<caption>/);
   assert.match(component, /scope="col"/);
   assert.match(component, /scope="row"/);

--- a/tests/opencivitas-quadrants.test.mjs
+++ b/tests/opencivitas-quadrants.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { assertOpenCivitasSnapshot } from "../src/lib/data/opencivitas-contract.ts";
+import {
+  OPEN_CIVITAS_QUADRANT_THRESHOLD,
+  summarizeOpenCivitasQuadrants,
+} from "../src/lib/opencivitas-quadrants.ts";
+
+const snapshotPath = new URL("../src/data/generated/opencivitas-2022.json", import.meta.url);
+
+function snapshot() {
+  return assertOpenCivitasSnapshot(JSON.parse(readFileSync(snapshotPath, "utf8")));
+}
+
+test("OpenCivitas quadrants use the published levels and reconcile the complete universe", () => {
+  const data = snapshot();
+  const result = summarizeOpenCivitasQuadrants(data.municipalities);
+
+  assert.equal(OPEN_CIVITAS_QUADRANT_THRESHOLD, 6);
+  assert.equal(result.coveredMunicipalities, 6_557);
+  assert.equal(result.completeMunicipalities, 6_547);
+  assert.equal(result.excludedMunicipalities, 10);
+  assert.deepEqual(
+    result.quadrants.map(({ key, municipalities }) => [key, municipalities]),
+    [
+      ["low-low", 2_778],
+      ["low-high", 1_994],
+      ["high-low", 779],
+      ["high-high", 996],
+    ],
+  );
+
+  for (const aggregate of [...result.quadrants, result.completeTotals]) {
+    assert.equal(
+      aggregate.differenceCents,
+      aggregate.historicalSpendingCents - aggregate.standardSpendingCents,
+    );
+  }
+  assert.equal(
+    result.quadrants.reduce((sum, quadrant) => sum + quadrant.historicalSpendingCents, 0),
+    result.completeTotals.historicalSpendingCents,
+  );
+  assert.equal(
+    result.quadrants.reduce((sum, quadrant) => sum + quadrant.standardSpendingCents, 0),
+    result.completeTotals.standardSpendingCents,
+  );
+  assert.equal(
+    result.quadrants.reduce((sum, quadrant) => sum + quadrant.differenceCents, 0),
+    result.completeTotals.differenceCents,
+  );
+});
+
+test("OpenCivitas quadrant view exposes direct labels, exact table semantics and caveat", () => {
+  const page = readFileSync(new URL("../src/app/territori/confronto/page.tsx", import.meta.url), "utf8");
+  const component = readFileSync(
+    new URL("../src/app/territori/confronto/opencivitas-quadrants.tsx", import.meta.url),
+    "utf8",
+  );
+  const style = readFileSync(
+    new URL("../src/app/territori/confronto/opencivitas-quadrants.module.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(page, /<OpenCivitasQuadrants/);
+  assert.match(component, /<figure/);
+  assert.match(component, /Spesa 0–5 · servizi 0–5/);
+  assert.match(component, /Spesa 0–5 · servizi 6–10/);
+  assert.match(component, /Spesa 6–10 · servizi 0–5/);
+  assert.match(component, /Spesa 6–10 · servizi 6–10/);
+  assert.match(component, /<caption>/);
+  assert.match(component, /scope="col"/);
+  assert.match(component, /scope="row"/);
+  assert.match(component, /role="region"/);
+  assert.match(component, /Scorri orizzontalmente/);
+  assert.match(component, /periodo \{referenceYear\}/);
+  assert.match(component, /non dimostra efficienza, spreco, risparmio/);
+  assert.match(style, /overflow-x: auto/);
+  assert.match(style, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+  assert.match(style, /@media \(max-width: 520px\)/);
+  assert.doesNotMatch(component, /efficienza[^\n]*(?:misura|indice)/i);
+  assert.doesNotMatch(component, /risparmio[^\n]*(?:stimato|ottenuto|generato)/i);
+});
+
+test("quadrant aggregation fails closed when an amount no longer reconciles", () => {
+  const data = snapshot();
+  const broken = structuredClone(data.municipalities);
+  broken[0].differenceCents += 1;
+  assert.throws(() => summarizeOpenCivitasQuadrants(broken), /differenza non riconciliata/);
+});


### PR DESCRIPTION
## Cosa cambia

- aggiunge a /territori/confronto una lettura in quattro profili basata sui livelli di spesa e servizi già pubblicati da OpenCivitas;
- mostra conteggi e importi aggregati, con etichette dirette e colori non usati come unica informazione;
- aggiunge una tabella esatta accessibile e scorrevole da tastiera su mobile;
- mantiene fonte, periodo, licenza e caveat accanto alla visualizzazione.

## Perimetro e cautele

La soglia 6 divide soltanto i livelli ufficiali 0–10 in due fasce descrittive. Non misura efficienza, spreco, risparmio o qualità dei servizi. Il riepilogo usa tutti i 6.547 Comuni con entrambi i livelli disponibili; 10 Comuni coperti restano fuori dai quattro profili perché hanno almeno un livello mancante. I filtri della tabella comunale non modificano il riepilogo.

La visualizzazione prende spunto da un esempio esterno, ma dati, aggregazioni, copy, codice e accessibilità sono stati ricostruiti e verificati sul nostro snapshot ufficiale.

## Verifiche

- 14 test mirati OpenCivitas e Istruzione verdi dopo il rebase su main;
- lint, typecheck, design e brand verdi;
- build Next.js verde, 84 pagine generate;
- browser 320, 390, 768 e 1280 px: nessun overflow globale o errore console;
- Home/Fine sulla tabella mobile: scorrimento 0 → 438 → 0;
- suite browser core completa verde prima del rebase; il main con #143 ha poi superato integralmente CI, production gates e deploy.

PR UI atomica: richiede review esplicita del maintainer e non è in auto-merge.