### PR TITLE
fix(ui): rendi visibili i periodi dell’Atlante Istruzione

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -64,28 +64,20 @@ async function assertResponsiveShell(page, label, width) {
   const navigationState = await page.evaluate(() => {
     const navigation = document.querySelector(".primary-nav");
     const note = document.querySelector(".nav-note");
-    if (!navigation || !note) return null;
+    if (!navigation) return null;
 
     const navigationBounds = navigation.getBoundingClientRect();
-    const noteBounds = note.getBoundingClientRect();
-    const noteStyle = getComputedStyle(note);
-    const noteVisible =
-      noteStyle.display !== "none" &&
-      noteStyle.visibility !== "hidden" &&
-      noteBounds.width > 0 &&
-      noteBounds.height > 0;
 
     return {
+      navigationLeft: navigationBounds.left,
       navigationRight: navigationBounds.right,
-      noteLeft: noteBounds.left,
-      noteVisible,
+      notePresent: Boolean(note),
     };
   });
-  assert.ok(navigationState, `${label}: navigazione primaria o nota fonti assente`);
-  assert.ok(
-    !navigationState.noteVisible || navigationState.navigationRight <= navigationState.noteLeft,
-    `${label}: navigazione primaria sovrapposta alla nota fonti`,
-  );
+  assert.ok(navigationState, `${label}: navigazione primaria assente`);
+  assert.equal(navigationState.notePresent, false, `${label}: nota fonti ridondante ancora presente`);
+  assert.ok(navigationState.navigationLeft >= 0, `${label}: navigazione fuori viewport a sinistra`);
+  assert.ok(navigationState.navigationRight <= width + 1, `${label}: navigazione fuori viewport a destra`);
 }
 
 async function assertCohesionTracePanelContrast(page, label) {
@@ -926,11 +918,22 @@ try {
         );
         assertTextMatches(await bodyText(page), /Statale/i, label);
 
-        const periodFilter = 'select[data-education-filter="period"]';
-        await page.select(periodFilter, "202324");
+        const periodFilter = 'button[data-education-filter="period"][data-value="202324"]';
+        await page.focus(periodFilter);
+        assert.equal(
+          await page.$eval(periodFilter, (element) => document.activeElement === element),
+          true,
+          `${label}: il periodo non riceve focus`,
+        );
+        await page.keyboard.press("Enter");
         await page.waitForFunction(
           () => new URL(window.location.href).searchParams.get("period") === "202324",
           { timeout: 3_000 },
+        );
+        assert.equal(
+          await page.$eval(periodFilter, (element) => element.getAttribute("aria-pressed")),
+          "true",
+          `${label}: il periodo attivo non è annunciato`,
         );
         assertTextMatches(await bodyText(page), /2023\/24/i, label);
 
@@ -1029,6 +1032,12 @@ try {
         (select) => select.value,
       );
       assert.equal(selectedSchoolTypeValue, "state");
+
+      const selectedPeriodValue = await page.$eval(
+        'button[data-education-filter="period"][aria-pressed="true"]',
+        (button) => button.getAttribute("data-value"),
+      );
+      assert.equal(selectedPeriodValue, "202425");
     },
   });
   completed.push("Atlante Istruzione deep-link filtri 1280px");

--- a/scripts/browser/editorial.mjs
+++ b/scripts/browser/editorial.mjs
@@ -90,33 +90,51 @@ async function inspectRoute(browser, pathname, title, width) {
           ),
         };
       });
+      const waitForDetailsState = async (expectedOpen) => {
+        await page.waitForFunction(
+          (element, open) => element.closest("details")?.open === open,
+          { timeout: 2_000 },
+          summary,
+          expectedOpen,
+        );
+        return readDetailsState();
+      };
 
       let detailsState = await readDetailsState();
       assert.equal(detailsState.hasDetails, true, `${label}: summary senza details nativo`);
       assert.equal(detailsState.summaryVisible, true, `${label}: summary del confine non visibile`);
-      if (detailsState.open) await summary.click();
-      detailsState = await readDetailsState();
+      if (detailsState.open) {
+        await summary.click();
+        detailsState = await waitForDetailsState(false);
+      }
       assert.equal(detailsState.open, false, `${label}: confine nativo non chiuso inizialmente`);
 
       await summary.focus();
       const focused = await summary.evaluate((element) => document.activeElement === element);
       assert.equal(focused, true, `${label}: summary del confine non riceve il focus`);
       await page.keyboard.press("Enter");
-      detailsState = await readDetailsState();
+      try {
+        detailsState = await waitForDetailsState(true);
+      } catch {
+        detailsState = await readDetailsState();
+      }
       if (!detailsState.open || !detailsState.contentVisible) {
-        if (detailsState.open) await summary.click();
+        if (detailsState.open) {
+          await summary.click();
+          await waitForDetailsState(false);
+        }
         await summary.focus();
         await page.keyboard.press("Space");
-        detailsState = await readDetailsState();
+        detailsState = await waitForDetailsState(true);
       }
       assert.equal(detailsState.open, true, `${label}: apertura da tastiera del confine fallita`);
       assert.equal(detailsState.contentVisible, true, `${label}: contenuto del confine non visibile`);
 
       await summary.click();
-      detailsState = await readDetailsState();
+      detailsState = await waitForDetailsState(false);
       assert.equal(detailsState.open, false, `${label}: chiusura click del confine fallita`);
       await summary.click();
-      detailsState = await readDetailsState();
+      detailsState = await waitForDetailsState(true);
       assert.equal(detailsState.open, true, `${label}: riapertura click del confine fallita`);
       assert.equal(detailsState.contentVisible, true, `${label}: contenuto non visibile dopo riapertura`);
       nativeLimits = true;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -373,14 +373,6 @@ nav li a { text-decoration: none; }
   display: block;
 }
 
-.nav-note {
-  margin-left: auto;
-  flex: none;
-  font-size: 12px;
-  color: var(--color-neutral-600);
-  white-space: nowrap;
-}
-
 .nav-scroll-hint { display: none; }
 
 /* ── page shells ────────────────────────────────────────────────────────── */
@@ -711,11 +703,9 @@ main { display: block; }
 
 /* ── responsive ─────────────────────────────────────────────────────────── */
 
-/* The nine sections need about 1300px to sit flat. Below that the row scrolls
-   inside itself rather than pushing the page sideways, and the note that
-   competes with it for the same line steps aside. */
+/* The primary sections need about 1300px to sit flat. Below that the row
+   scrolls inside itself rather than pushing the page sideways. */
 @media (max-width: 1320px) {
-  .nav-note { display: none; }
   .nav-item > a { padding-inline: 12px; }
   .nav-item-has-menu > a { padding-right: 4px; }
   .nav-row[data-menu-open="true"] {
@@ -764,7 +754,6 @@ main { display: block; }
   .brand { flex: 1; min-width: 0; }
   .brand-text strong { font-size: 19px; }
   .header-search { order: 3; width: 100%; }
-  .nav-note { display: none; }
 }
 
 @media (max-width: 900px) {
@@ -777,7 +766,6 @@ main { display: block; }
   .brand { flex: 1; min-width: 0; }
   .brand-text strong { font-size: 19px; }
   .header-search { order: 3; width: 100%; }
-  .nav-note { display: none; }
   .footer-sitemap-columns {
     column-count: 2;
     column-gap: var(--space-4);

--- a/src/components/education-atlas-filters.module.css
+++ b/src/components/education-atlas-filters.module.css
@@ -24,13 +24,54 @@
   gap: var(--space-3);
   align-items: end;
 }
-.controlGrid label { display: grid; gap: 6px; min-width: 0; }
-.controlGrid label > span {
+.controlGrid label,
+.periodFieldset {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+.controlGrid label > span,
+.periodFieldset legend {
   color: var(--color-neutral-700);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: .07em;
   text-transform: uppercase;
+}
+.periodFieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.periodFieldset legend { padding: 0; }
+.periodOptions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--color-neutral-400);
+}
+.periodOptions button {
+  min-width: 0;
+  min-height: 42px;
+  padding: 8px 6px;
+  color: var(--color-neutral-700);
+  background: var(--color-raised);
+  border: 0;
+  font-size: 12px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+.periodOptions button + button { border-left: 1px solid var(--color-neutral-300); }
+.periodOptions button:hover { color: var(--color-text); background: var(--color-neutral-100); }
+.periodOptions button[aria-pressed="true"] {
+  color: var(--color-raised);
+  background: var(--color-accent-700);
+}
+.periodOptions button:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 0;
 }
 .controlGrid select {
   width: 100%;

--- a/src/components/education-atlas-filters.tsx
+++ b/src/components/education-atlas-filters.tsx
@@ -47,17 +47,24 @@ export function EducationAtlasFilters({
         <p>Ogni scelta aggiorna mappa, distribuzione, trend e indirizzi osservati.</p>
       </div>
       <div className={styles.controlGrid}>
-        <label>
-          <span>Anno scolastico</span>
-          <select
-            value={filters.period}
-            onChange={(event) => updateFilter("period", event.target.value)}
-            data-atlas-filter="period"
-            data-education-filter="period"
-          >
-            {periods.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
-          </select>
-        </label>
+        <fieldset className={styles.periodFieldset}>
+          <legend>Anno scolastico</legend>
+          <div className={styles.periodOptions}>
+            {periods.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                aria-pressed={filters.period === option.id}
+                data-atlas-filter="period"
+                data-education-filter="period"
+                data-value={option.id}
+                onClick={() => updateFilter("period", option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </fieldset>
         <label>
           <span>Tipo di scuola</span>
           <select

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -265,7 +265,6 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
           Scorri
           <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.8} />
         </span>
-        <span className="nav-note">Fonti e dati sempre visibili</span>
       </div>
     </header>
   );

--- a/tests/education-atlas.test.mjs
+++ b/tests/education-atlas.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
@@ -167,4 +168,19 @@ test("education is an existing Atlante module in the navigation and MCP catalog"
   assert.ok(!businessMapGroup?.links.some((link) => link.href === "/istruzione"));
   const educationMapGroup = SITE_MAP_GROUPS.find((group) => group.title === "Istruzione");
   assert.ok(educationMapGroup?.links.some((link) => link.href === "/istruzione"));
+});
+
+test("education period choices stay visible and keyboard-operable", async () => {
+  const [component, css] = await Promise.all([
+    readFile(new URL("../src/components/education-atlas-filters.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/components/education-atlas-filters.module.css", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(component, /<fieldset className=\{styles\.periodFieldset\}>/);
+  assert.match(component, /<legend>Anno scolastico<\/legend>/);
+  assert.match(component, /aria-pressed=\{filters\.period === option\.id\}/);
+  assert.match(component, /data-value=\{option\.id\}/);
+  assert.doesNotMatch(component, /<select[\s\S]*?data-education-filter="period"/);
+  assert.match(css, /\.periodOptions button \{[\s\S]*?min-height: 42px;/);
+  assert.match(css, /\.periodOptions button:focus-visible/);
 });

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -37,6 +37,8 @@ test("primary navigation keeps dropdowns and no section subnav bar", async () =>
   );
   assert.match(navigationComponent, /nav-submenu/);
   assert.doesNotMatch(navigationComponent, /subnav-row|nav\.subnav|activeNavSection/);
+  assert.doesNotMatch(navigationComponent, /nav-note|Fonti e dati sempre visibili/);
+  assert.doesNotMatch(globalsCss, /\.nav-note/);
 });
 
 test("a submenu can be opened without a pointer that can hover", async () => {


### PR DESCRIPTION
## Cosa cambia

- rimuove la nota "Fonti e dati sempre visibili", che a 1440 px si sovrapponeva alla voce "Fonti";
- sostituisce il selettore nativo dei tre anni dell'Atlante Istruzione con tre pulsanti sempre visibili;
- mantiene invariati i selettori con molte opzioni: tipo di scuola, Regione e percorso;
- aggiorna i test browser per verificare tastiera, stato selezionato e assenza di sovrapposizioni.

## Perché

Il menu nativo dell'anno si apriva nel livello grafico del sistema operativo e poteva sembrare invisibile. Con sole tre scelte è più chiaro mostrarle direttamente.

## Verifiche

- audit tipografico su 69 route pubbliche: tutti gli elementi visibili usano Geist;
- audit controlli su 69 route: nessun pulsante o selettore visibile senza nome accessibile;
- test mirati: 17/17 PASS;
- lint, typecheck, design e brand: PASS;
- build Next.js: PASS, 84 pagine;
- browser core completo: PASS da 320 a 1600 px;
- prova locale reale su /istruzione: cambio anno da tastiera e aggiornamento URL/contenuti PASS.

## Coordinamento

PR UI atomica. Richiede review esplicita di Dom prima del merge. La PR #188 modifica anch'essa la navigazione e dovrà preservare questa rimozione dopo il rebase.