### PR TITLE
fix(governi): allinea stati e anno base dei grafici

### DIFF
--- a/src/app/governi/current-government-overview.module.css
+++ b/src/app/governi/current-government-overview.module.css
@@ -431,6 +431,11 @@
   background: var(--color-accent-100);
 }
 
+.indicatorCard[data-result="flat"] .cardHeading > b {
+  color: var(--color-neutral-700);
+  background: var(--color-neutral-100);
+}
+
 .indicatorCard > p {
   min-height: 34px;
   margin: 10px 0 12px;
@@ -554,6 +559,10 @@
 
 .cardFooter > b[data-peer="behind"] {
   color: var(--color-accent-800);
+}
+
+.cardFooter > b[data-peer="aligned"] {
+  color: var(--color-neutral-700);
 }
 
 .peerSection {

--- a/src/app/governi/current-government-overview.tsx
+++ b/src/app/governi/current-government-overview.tsx
@@ -71,6 +71,15 @@ const INDICATOR_COPY: Readonly<Record<string, { label: string; group: string; qu
   },
 };
 
+const MOVEMENT_EPSILON = 0.05;
+
+function movement(value: number) {
+  if (Math.abs(value) < MOVEMENT_EPSILON) return { state: "flat", label: "→ Stabile" } as const;
+  return value > 0
+    ? { state: "up", label: "↑ Migliora" } as const
+    : { state: "down", label: "↓ Peggiora" } as const;
+}
+
 function median(values: readonly number[]) {
   const sorted = [...values].sort((left, right) => left - right);
   return sorted[Math.floor(sorted.length / 2)] ?? 0;
@@ -165,8 +174,8 @@ export function CurrentGovernmentOverview({
   calculation: Calculation;
   currentSignals: GovernmentCurrentSignalsView;
 }) {
-  const improved = calculation.indicators.filter((indicator) => indicator.orientedChange > 0).length;
-  const aheadOfPeers = calculation.indicators.filter((indicator) => indicator.relativeChange > 0).length;
+  const improved = calculation.indicators.filter((indicator) => indicator.orientedChange >= MOVEMENT_EPSILON).length;
+  const aheadOfPeers = calculation.indicators.filter((indicator) => indicator.relativeChange >= MOVEMENT_EPSILON).length;
 
   return (
     <>
@@ -230,16 +239,18 @@ export function CurrentGovernmentOverview({
               group: "Economia",
               question: indicator.limitations,
             };
-            const improvedNow = indicator.orientedChange >= 0;
-            const peerAhead = indicator.relativeChange >= 0;
+            const trend = movement(indicator.orientedChange);
+            const peerPosition = Math.abs(indicator.relativeChange) < MOVEMENT_EPSILON
+              ? "aligned"
+              : indicator.relativeChange > 0 ? "ahead" : "behind";
             return (
-              <article className={styles.indicatorCard} key={indicator.id} data-result={improvedNow ? "up" : "down"}>
+              <article className={styles.indicatorCard} key={indicator.id} data-result={trend.state}>
                 <div className={styles.cardHeading}>
                   <div>
                     <span>{copy.group}</span>
                     <h3>{copy.label}</h3>
                   </div>
-                  <b>{improvedNow ? "↑ Migliora" : "↓ Peggiora"}</b>
+                  <b>{trend.label}</b>
                 </div>
                 <p>{copy.question}</p>
                 <div className={styles.valueRow}>
@@ -257,7 +268,7 @@ export function CurrentGovernmentOverview({
                 <TrendSparkline indicator={indicator} />
                 <div className={styles.cardFooter}>
                   <span>Era {sourceValue(indicator.baselineValue, indicator.id)}</span>
-                  <b data-peer={peerAhead ? "ahead" : "behind"}>{comparisonLabel(indicator)}</b>
+                  <b data-peer={peerPosition}>{comparisonLabel(indicator)}</b>
                 </div>
               </article>
             );
@@ -270,7 +281,13 @@ export function CurrentGovernmentOverview({
   );
 }
 
-export function CurrentGovernmentPeerComparison({ indicators }: { indicators: readonly Indicator[] }) {
+export function CurrentGovernmentPeerComparison({
+  indicators,
+  baselineYear,
+}: {
+  indicators: readonly Indicator[];
+  baselineYear: number;
+}) {
   return (
       <section className={styles.peerSection} aria-labelledby="confronto-peer">
         <div className={styles.peerHeading}>
@@ -278,7 +295,7 @@ export function CurrentGovernmentPeerComparison({ indicators }: { indicators: re
             <span>Italia contro economie nello stesso periodo</span>
             <h2 id="confronto-peer">Confronto con Francia, Germania e Spagna</h2>
           </div>
-          <p>Scegli un indicatore. Lo zero è il 2022; più in alto significa miglioramento.</p>
+          <p>Scegli un indicatore. Lo zero è il {baselineYear}; più in alto significa miglioramento.</p>
         </div>
         <GovernmentIndicatorChart indicators={indicators} />
       </section>

--- a/src/app/governi/page.tsx
+++ b/src/app/governi/page.tsx
@@ -177,7 +177,12 @@ export default function GovernmentsPage() {
         <Link href={`/governi/confronta?x=${current.id}`}>Apri il confronto</Link>
       </section>
 
-      {currentScore && <CurrentGovernmentPeerComparison indicators={currentScore.indicators} />}
+      {currentScore && (
+        <CurrentGovernmentPeerComparison
+          indicators={currentScore.indicators}
+          baselineYear={currentScore.baselineYear}
+        />
+      )}
 
       <details className={styles.explorer} id="metodo-dati">
         <summary>

--- a/tests/government-scorecard-ui.test.mjs
+++ b/tests/government-scorecard-ui.test.mjs
@@ -69,11 +69,16 @@ test("current overview turns all six indicators into readable trends and peer co
   assert.match(currentOverview, /2020 = 100/);
   assert.match(currentOverview, /Mediana peer/);
   assert.match(currentOverview, /comparisonLabel\(indicator\)/);
+  assert.match(currentOverview, /Math\.abs\(value\) < MOVEMENT_EPSILON/);
+  assert.match(currentOverview, /label: "→ Stabile"/);
+  assert.match(currentOverview, /data-peer=\{peerPosition\}/);
   assert.match(currentOverview, /export function CurrentGovernmentPeerComparison/);
+  assert.match(currentOverview, /Lo zero è il \{baselineYear\}/);
   assert.match(currentOverview, /<GovernmentIndicatorChart indicators=\{indicators\} \/>/);
   assert.match(currentOverview, /role="img"/);
   assert.match(currentOverview, /<CurrentGovernmentSignals data=\{currentSignals\} \/>/);
-  assert.match(page, /<CurrentGovernmentPeerComparison indicators=\{currentScore\.indicators\} \/>/);
+  assert.match(page, /indicators=\{currentScore\.indicators\}/);
+  assert.match(page, /baselineYear=\{currentScore\.baselineYear\}/);
   assert.ok(page.indexOf("Scegli due governi e sovrapponi i dati") < page.indexOf("<CurrentGovernmentPeerComparison"));
 });
 


### PR DESCRIPTION
## Perché

Questa PR è intenzionalmente dipendente da #195 e contiene solo due correzioni semantiche emerse dall'audit UI:

- una variazione visualizzata come `0,0` poteva essere etichettata e colorata come miglioramento;
- il confronto con i peer dichiarava sempre `Lo zero è il 2022`, anche se l'anno base è già parte del calcolo e cambierà con il prossimo governo.

La formula, i dati, i pesi e lo scoring non cambiano.

## Cosa cambia

- usa una soglia di visualizzazione di `0,05`, coerente con l'arrotondamento a una cifra decimale, per distinguere miglioramento, peggioramento e stabilità;
- applica uno stato neutro anche a `In linea con i peer`;
- passa `baselineYear` dal calcolo al grafico, eliminando l'anno hardcoded;
- aggiunge test di regressione mirati.

## Come verificare

- `npm run ci:static`
- `node --test tests/government-scorecard-ui.test.mjs tests/government-scorecard-accessibility.test.mjs tests/government-scorecard-discovery.test.mjs tests/institutions-hub.test.mjs`
- `npm run test:node` — 679 pass, 1 skip intenzionale, 0 fail
- `npm run build`
- `bash scripts/ci/run-production-gates.sh` — browser core/editoriale, CSP, MCP e Lighthouse verdi

Verifica browser locale anche a 320, 390, 768 e 1280 px, comprese tabella dati, scheda Meloni e confronto Prodi I/Meloni I, senza overflow o errori console.

## Rischi e rollback

Diff limitato a quattro file della UI scorecard. Nessuna sorgente o contratto dati viene toccato. Il commit può essere rimosso senza modificare #194 o il resto di #195.

## Nota per la review

Dopo il merge di questa patch nella branch di #195, la review UI va eseguita sulla nuova testa e non più su `4bbeee7`.
