### PR TITLE
feat(sanita): add split-scale national history charts

### DIFF
--- a/src/app/spese/sanita/storico/page.tsx
+++ b/src/app/spese/sanita/storico/page.tsx
@@ -7,6 +7,7 @@ import {
   type SsnNationalHistory,
 } from "@/lib/ssn-national-history";
 import type { SsnCceMetricId } from "@/lib/data/ssn-cce-contract";
+import { HealthSpendingHistoryChart } from "@/components/charts/health-spending-history-chart";
 import styles from "./storico.module.css";
 
 export const dynamic = "force-dynamic";
@@ -151,6 +152,7 @@ export default async function HealthSpendingHistoryPage() {
         <>
           <section className="panel">
             <h2 className="panel-title">2012-2024, valori di competenza economica</h2>
+            <HealthSpendingHistoryChart data={history!.years} />
             <HistoryTable history={history!} />
           </section>
           <ProvenanceList history={history!} />

--- a/src/components/charts/health-spending-history-chart.module.css
+++ b/src/components/charts/health-spending-history-chart.module.css
@@ -120,7 +120,7 @@
 .panelCaption {
   margin-top: var(--space-2);
   color: var(--color-neutral-600);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.5;
 }
 
@@ -128,7 +128,7 @@
   max-width: 90ch;
   margin-top: var(--space-3);
   color: var(--color-neutral-600);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.55;
 }
 
@@ -137,7 +137,7 @@
   max-width: 320px;
   padding: 10px 12px;
   border: 1px solid var(--color-neutral-400);
-  color: var(--color-neutral-100);
+  color: var(--color-on-strong);
   background: var(--color-text);
   box-shadow: var(--shadow-md);
 }
@@ -153,7 +153,7 @@
 }
 
 .tooltipHeader strong {
-  color: var(--color-raised);
+  color: var(--color-on-strong);
   font-size: 13px;
 }
 
@@ -176,11 +176,11 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--color-neutral-300);
+  color: var(--color-on-strong-muted);
 }
 
 .tooltipLabel code {
-  color: var(--color-neutral-400);
+  color: var(--color-on-strong-muted);
   font-size: 10px;
 }
 
@@ -200,13 +200,13 @@
 }
 
 .tooltipValue b {
-  color: var(--color-raised);
+  color: var(--color-on-strong);
   font-size: 11px;
   font-weight: 650;
 }
 
 .tooltipValue small {
-  color: var(--color-neutral-400);
+  color: var(--color-on-strong-muted);
   font-size: 9.5px;
   font-weight: 400;
 }

--- a/src/components/charts/health-spending-history-chart.module.css
+++ b/src/components/charts/health-spending-history-chart.module.css
@@ -1,0 +1,187 @@
+.figure {
+  min-width: 0;
+  margin: 0 0 var(--space-4);
+}
+
+.chart {
+  width: 100%;
+  height: 380px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-4);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-200);
+  font-size: 11px;
+  color: var(--color-neutral-700);
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.legendLine {
+  display: inline-block;
+  width: 16px;
+  height: 3px;
+  flex: none;
+}
+
+.legendLine.dashed {
+  background: none;
+  border-top: 2px dashed var(--chart-quaternary);
+  height: 0;
+}
+
+.legendLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.legendLabel code {
+  font-size: 10px;
+  color: var(--color-neutral-600);
+}
+
+.lineProductionCosts {
+  background: var(--chart-primary);
+}
+
+.linePurchasedServices {
+  background: var(--chart-secondary);
+}
+
+.linePersonnelCost {
+  background: var(--chart-tertiary);
+}
+
+.lineHealthcareWorkServices {
+  background: var(--color-accent-600);
+}
+
+.lineNonHealthcareWorkServices {
+  background: var(--chart-quaternary);
+}
+
+.caption {
+  max-width: 80ch;
+  margin-top: var(--space-3);
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.tooltip {
+  min-width: 260px;
+  max-width: 340px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-neutral-100);
+  background: var(--color-text);
+  box-shadow: var(--shadow-md);
+}
+
+.tooltipHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-neutral-700);
+  margin-bottom: 6px;
+}
+
+.tooltipHeader strong {
+  color: var(--color-raised);
+  font-size: 13px;
+}
+
+.tooltipHeader span {
+  color: var(--color-neutral-300);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.tooltipList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.tooltipRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 11px;
+}
+
+.tooltipLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-neutral-300);
+}
+
+.tooltipLabel code {
+  color: var(--color-neutral-400);
+  font-size: 10px;
+}
+
+.swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  flex: none;
+}
+
+.tooltipValue {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.tooltipValue b {
+  color: var(--color-raised);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.tooltipValue small {
+  color: var(--color-neutral-400);
+  font-size: 9.5px;
+  font-weight: 400;
+}
+
+.empty {
+  min-height: 250px;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .chart {
+    height: 300px;
+  }
+
+  .legend {
+    gap: var(--space-2);
+  }
+}

--- a/src/components/charts/health-spending-history-chart.module.css
+++ b/src/components/charts/health-spending-history-chart.module.css
@@ -243,4 +243,21 @@
   .legend {
     gap: var(--space-2);
   }
+
+  .tooltip {
+    width: 190px;
+    min-width: 0;
+    max-width: calc(100vw - 64px);
+  }
+
+  .tooltipRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .tooltipValue {
+    align-items: flex-start;
+    padding-left: 14px;
+  }
 }

--- a/src/components/charts/health-spending-history-chart.module.css
+++ b/src/components/charts/health-spending-history-chart.module.css
@@ -1,18 +1,64 @@
-.figure {
+.container {
   min-width: 0;
   margin: 0 0 var(--space-4);
 }
 
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.panelCard {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  margin: 0;
+  padding: var(--space-4);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.panelHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: var(--space-3);
+}
+
+.panelCategory {
+  font-family: var(--font-heading);
+  font-size: 10.5px;
+  font-weight: var(--font-heading-weight);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-600);
+}
+
+.panelTitle {
+  margin: 2px 0 0;
+  font-family: var(--font-heading);
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  color: var(--color-text);
+}
+
+.panelScaleBadge {
+  font-size: 11px;
+  color: var(--color-neutral-600);
+}
+
 .chart {
   width: 100%;
-  height: 380px;
+  height: 320px;
 }
 
 .legend {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2) var(--space-4);
+  gap: var(--space-2) var(--space-3);
   margin-top: var(--space-3);
   padding-top: var(--space-3);
   border-top: 1px solid var(--color-neutral-200);
@@ -71,8 +117,15 @@
   background: var(--chart-quaternary);
 }
 
-.caption {
-  max-width: 80ch;
+.panelCaption {
+  margin-top: var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.overallCaption {
+  max-width: 90ch;
   margin-top: var(--space-3);
   color: var(--color-neutral-600);
   font-size: 11px;
@@ -80,8 +133,8 @@
 }
 
 .tooltip {
-  min-width: 260px;
-  max-width: 340px;
+  min-width: 250px;
+  max-width: 320px;
   padding: 10px 12px;
   border: 1px solid var(--color-neutral-400);
   color: var(--color-neutral-100);
@@ -104,13 +157,6 @@
   font-size: 13px;
 }
 
-.tooltipHeader span {
-  color: var(--color-neutral-300);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
-}
-
 .tooltipList {
   margin: 0;
   padding: 0;
@@ -118,7 +164,6 @@
   display: grid;
   gap: 4px;
 }
-
 .tooltipRow {
   display: flex;
   align-items: center;
@@ -176,9 +221,23 @@
   text-align: center;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 960px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
   .chart {
     height: 300px;
+  }
+}
+
+@media (max-width: 720px) {
+  .panelCard {
+    padding: var(--space-3) var(--space-2);
+  }
+
+  .chart {
+    height: 280px;
   }
 
   .legend {

--- a/src/components/charts/health-spending-history-chart.tsx
+++ b/src/components/charts/health-spending-history-chart.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { compactEuro, exactEuro } from "@/lib/format";
+import type { SsnNationalHistoryYear } from "@/lib/ssn-national-history";
+import styles from "./health-spending-history-chart.module.css";
+
+export type HealthSpendingChartSeriesKey =
+  | "productionCosts"
+  | "purchasedServices"
+  | "personnelCost"
+  | "healthcareWorkServices"
+  | "nonHealthcareWorkServices";
+
+export type HealthSpendingSeriesMeta = {
+  key: HealthSpendingChartSeriesKey;
+  label: string;
+  shortLabel: string;
+  code: string;
+  colorVar: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+  lineClass: string;
+};
+
+export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
+  {
+    key: "productionCosts",
+    label: "Totale costi della produzione",
+    shortLabel: "Totale costi produzione",
+    code: "BZ9999",
+    colorVar: "var(--chart-primary)",
+    strokeWidth: 2.5,
+    lineClass: styles.lineProductionCosts,
+  },
+  {
+    key: "purchasedServices",
+    label: "Acquisti di servizi",
+    shortLabel: "Acquisti servizi",
+    code: "BA0390",
+    colorVar: "var(--chart-secondary)",
+    strokeWidth: 2,
+    lineClass: styles.linePurchasedServices,
+  },
+  {
+    key: "personnelCost",
+    label: "Costo del personale",
+    shortLabel: "Costo personale",
+    code: "BA2080",
+    colorVar: "var(--chart-tertiary)",
+    strokeWidth: 2,
+    lineClass: styles.linePersonnelCost,
+  },
+  {
+    key: "healthcareWorkServices",
+    label: "Prestazioni di lavoro sanitarie",
+    shortLabel: "Prestazioni sanitarie",
+    code: "BA1350",
+    colorVar: "var(--color-accent-600)",
+    strokeWidth: 1.5,
+    lineClass: styles.lineHealthcareWorkServices,
+  },
+  {
+    key: "nonHealthcareWorkServices",
+    label: "Prestazioni di lavoro non sanitarie",
+    shortLabel: "Prestazioni non sanitarie",
+    code: "BA1750",
+    colorVar: "var(--chart-quaternary)",
+    strokeWidth: 1.5,
+    strokeDasharray: "4 4",
+    lineClass: styles.lineNonHealthcareWorkServices,
+  },
+] as const;
+
+type ChartPoint = {
+  year: number;
+  productionCosts: number;
+  purchasedServices: number;
+  personnelCost: number;
+  healthcareWorkServices: number;
+  nonHealthcareWorkServices: number;
+};
+
+function formatAxisEuro(value: number): string {
+  if (value === 0) return "0 €";
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000_000) {
+    return `${(value / 1_000_000_000).toLocaleString("it-IT", { maximumFractionDigits: 0 })} mld €`;
+  }
+  if (absolute >= 1_000_000) {
+    return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 0 })} mln €`;
+  }
+  return `${value.toLocaleString("it-IT", { maximumFractionDigits: 0 })} €`;
+}
+
+function TooltipContent({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartPoint }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+
+  return (
+    <div className={styles.tooltip}>
+      <div className={styles.tooltipHeader}>
+        <strong>Anno {point.year}</strong>
+        <span>{compactEuro(point.productionCosts)}</span>
+      </div>
+      <ul className={styles.tooltipList}>
+        {HEALTH_SPENDING_SERIES.map((series) => (
+          <li key={series.key} className={styles.tooltipRow}>
+            <span className={styles.tooltipLabel}>
+              <i className={`${styles.swatch} ${series.lineClass}`} aria-hidden="true" />
+              <span>
+                {series.shortLabel} <code>{series.code}</code>
+              </span>
+            </span>
+            <span className={styles.tooltipValue}>
+              <b>{compactEuro(point[series.key])}</b>
+              <small>{exactEuro(point[series.key])}</small>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function HealthSpendingHistoryChart({
+  data,
+}: {
+  data: readonly SsnNationalHistoryYear[];
+}) {
+  if (!data || data.length === 0) {
+    return <div className={styles.empty}>Serie storica della spesa sanitaria non disponibile.</div>;
+  }
+
+  const chartData: ChartPoint[] = data.map((entry) => ({
+    year: entry.year,
+    productionCosts: entry.values.productionCosts / 100,
+    purchasedServices: entry.values.purchasedServices / 100,
+    personnelCost: entry.values.personnelCost / 100,
+    healthcareWorkServices: entry.values.healthcareWorkServices / 100,
+    nonHealthcareWorkServices: entry.values.nonHealthcareWorkServices / 100,
+  }));
+
+  return (
+    <figure className={styles.figure}>
+      <div
+        className={styles.chart}
+        role="img"
+        aria-label="Serie storica della spesa sanitaria nazionale 2012-2024 per voce contabile"
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={chartData}
+            margin={{ top: 12, right: 16, bottom: 4, left: 4 }}
+            accessibilityLayer
+          >
+            <CartesianGrid vertical={false} stroke="var(--color-neutral-300)" />
+            <XAxis
+              dataKey="year"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+            />
+            <YAxis
+              axisLine={false}
+              tickLine={false}
+              width={76}
+              tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+              tickFormatter={formatAxisEuro}
+            />
+            <Tooltip
+              animationDuration={120}
+              cursor={{ stroke: "var(--color-neutral-400)" }}
+              content={<TooltipContent />}
+            />
+            {HEALTH_SPENDING_SERIES.map((series) => (
+              <Line
+                key={series.key}
+                type="monotone"
+                dataKey={series.key}
+                stroke={series.colorVar}
+                strokeWidth={series.strokeWidth}
+                strokeDasharray={series.strokeDasharray}
+                dot={false}
+                activeDot={{
+                  r: 4,
+                  fill: series.colorVar,
+                  stroke: "var(--color-raised)",
+                  strokeWidth: 2,
+                }}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className={styles.legend} aria-label="Legenda delle voci contabili">
+        {HEALTH_SPENDING_SERIES.map((series) => (
+          <span key={series.key} className={styles.legendItem}>
+            <i
+              className={`${styles.legendLine} ${series.lineClass} ${
+                series.strokeDasharray ? styles.dashed : ""
+              }`}
+              aria-hidden="true"
+            />
+            <span className={styles.legendLabel}>
+              {series.label} <code>{series.code}</code>
+            </span>
+          </span>
+        ))}
+      </div>
+
+      <figcaption className={styles.caption}>
+        Valori nominali a consuntivo in euro di competenza economica del Conto Economico SSN
+        (OpenBDAP RGS). La serie non è corretta per l&apos;inflazione e non misura efficienza,
+        qualità dell&apos;assistenza o dotazioni organiche. Le voci con importi più contenuti possono
+        risultare meno leggibili nella scala comune: tooltip e tabella riportano i valori puntuali.
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/components/charts/health-spending-history-chart.tsx
+++ b/src/components/charts/health-spending-history-chart.tsx
@@ -29,6 +29,7 @@ export type HealthSpendingSeriesMeta = {
   strokeWidth: number;
   strokeDasharray?: string;
   lineClass: string;
+  panel: "primary" | "workServices";
 };
 
 export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
@@ -40,6 +41,7 @@ export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
     colorVar: "var(--chart-primary)",
     strokeWidth: 2.5,
     lineClass: styles.lineProductionCosts,
+    panel: "primary",
   },
   {
     key: "purchasedServices",
@@ -49,6 +51,7 @@ export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
     colorVar: "var(--chart-secondary)",
     strokeWidth: 2,
     lineClass: styles.linePurchasedServices,
+    panel: "primary",
   },
   {
     key: "personnelCost",
@@ -58,6 +61,7 @@ export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
     colorVar: "var(--chart-tertiary)",
     strokeWidth: 2,
     lineClass: styles.linePersonnelCost,
+    panel: "primary",
   },
   {
     key: "healthcareWorkServices",
@@ -65,8 +69,9 @@ export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
     shortLabel: "Prestazioni sanitarie",
     code: "BA1350",
     colorVar: "var(--color-accent-600)",
-    strokeWidth: 1.5,
+    strokeWidth: 2,
     lineClass: styles.lineHealthcareWorkServices,
+    panel: "workServices",
   },
   {
     key: "nonHealthcareWorkServices",
@@ -74,11 +79,20 @@ export const HEALTH_SPENDING_SERIES: readonly HealthSpendingSeriesMeta[] = [
     shortLabel: "Prestazioni non sanitarie",
     code: "BA1750",
     colorVar: "var(--chart-quaternary)",
-    strokeWidth: 1.5,
+    strokeWidth: 2,
     strokeDasharray: "4 4",
     lineClass: styles.lineNonHealthcareWorkServices,
+    panel: "workServices",
   },
 ] as const;
+
+export const PRIMARY_SERIES = HEALTH_SPENDING_SERIES.filter(
+  (series) => series.panel === "primary",
+);
+
+export const WORK_SERVICES_SERIES = HEALTH_SPENDING_SERIES.filter(
+  (series) => series.panel === "workServices",
+);
 
 type ChartPoint = {
   year: number;
@@ -93,7 +107,12 @@ function formatAxisEuro(value: number): string {
   if (value === 0) return "0 €";
   const absolute = Math.abs(value);
   if (absolute >= 1_000_000_000) {
-    return `${(value / 1_000_000_000).toLocaleString("it-IT", { maximumFractionDigits: 0 })} mld €`;
+    const num = value / 1_000_000_000;
+    const formatted = num.toLocaleString("it-IT", {
+      minimumFractionDigits: Number.isInteger(num) ? 0 : 1,
+      maximumFractionDigits: 1,
+    });
+    return `${formatted} mld €`;
   }
   if (absolute >= 1_000_000) {
     return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 0 })} mln €`;
@@ -104,9 +123,11 @@ function formatAxisEuro(value: number): string {
 function TooltipContent({
   active,
   payload,
+  seriesList,
 }: {
   active?: boolean;
   payload?: Array<{ payload?: ChartPoint }>;
+  seriesList: readonly HealthSpendingSeriesMeta[];
 }) {
   if (!active || !payload?.length) return null;
   const point = payload[0]?.payload;
@@ -116,10 +137,9 @@ function TooltipContent({
     <div className={styles.tooltip}>
       <div className={styles.tooltipHeader}>
         <strong>Anno {point.year}</strong>
-        <span>{compactEuro(point.productionCosts)}</span>
       </div>
       <ul className={styles.tooltipList}>
-        {HEALTH_SPENDING_SERIES.map((series) => (
+        {seriesList.map((series) => (
           <li key={series.key} className={styles.tooltipRow}>
             <span className={styles.tooltipLabel}>
               <i className={`${styles.swatch} ${series.lineClass}`} aria-hidden="true" />
@@ -134,6 +154,32 @@ function TooltipContent({
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+function Legend({
+  seriesList,
+  label,
+}: {
+  seriesList: readonly HealthSpendingSeriesMeta[];
+  label: string;
+}) {
+  return (
+    <div className={styles.legend} role="group" aria-label={label}>
+      {seriesList.map((series) => (
+        <span key={series.key} className={styles.legendItem}>
+          <i
+            className={`${styles.legendLine} ${series.lineClass} ${
+              series.strokeDasharray ? styles.dashed : ""
+            }`}
+            aria-hidden="true"
+          />
+          <span className={styles.legendLabel}>
+            {series.label} <code>{series.code}</code>
+          </span>
+        </span>
+      ))}
     </div>
   );
 }
@@ -157,81 +203,154 @@ export function HealthSpendingHistoryChart({
   }));
 
   return (
-    <figure className={styles.figure}>
-      <div
-        className={styles.chart}
-        role="img"
-        aria-label="Serie storica della spesa sanitaria nazionale 2012-2024 per voce contabile"
-      >
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart
-            data={chartData}
-            margin={{ top: 12, right: 16, bottom: 4, left: 4 }}
-            accessibilityLayer
+    <div className={styles.container}>
+      <div className={styles.grid}>
+        {/* Pannello 1: Grandi aggregati della spesa (scala in miliardi di euro) */}
+        <figure className={styles.panelCard}>
+          <div className={styles.panelHeader}>
+            <span className={styles.panelCategory}>GRANDI AGGREGATI</span>
+            <h3 className={styles.panelTitle}>Totale produzione, servizi e personale</h3>
+            <span className={styles.panelScaleBadge}>Scala assoluta da zero · mld €</span>
+          </div>
+
+          <div
+            className={styles.chart}
+            role="img"
+            aria-label="Serie storica 2012-2024 dei grandi aggregati: totale costi di produzione, acquisti di servizi e costo del personale"
           >
-            <CartesianGrid vertical={false} stroke="var(--color-neutral-300)" />
-            <XAxis
-              dataKey="year"
-              axisLine={false}
-              tickLine={false}
-              tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
-            />
-            <YAxis
-              axisLine={false}
-              tickLine={false}
-              width={76}
-              tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
-              tickFormatter={formatAxisEuro}
-            />
-            <Tooltip
-              animationDuration={120}
-              cursor={{ stroke: "var(--color-neutral-400)" }}
-              content={<TooltipContent />}
-            />
-            {HEALTH_SPENDING_SERIES.map((series) => (
-              <Line
-                key={series.key}
-                type="monotone"
-                dataKey={series.key}
-                stroke={series.colorVar}
-                strokeWidth={series.strokeWidth}
-                strokeDasharray={series.strokeDasharray}
-                dot={false}
-                activeDot={{
-                  r: 4,
-                  fill: series.colorVar,
-                  stroke: "var(--color-raised)",
-                  strokeWidth: 2,
-                }}
-                isAnimationActive={false}
-              />
-            ))}
-          </LineChart>
-        </ResponsiveContainer>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={chartData}
+                syncId="ssn-national-history"
+                margin={{ top: 12, right: 16, bottom: 4, left: 4 }}
+                accessibilityLayer
+              >
+                <CartesianGrid vertical={false} stroke="var(--color-neutral-300)" />
+                <XAxis
+                  dataKey="year"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+                />
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  width={76}
+                  domain={[0, "auto"]}
+                  tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+                  tickFormatter={formatAxisEuro}
+                />
+                <Tooltip
+                  animationDuration={120}
+                  cursor={{ stroke: "var(--color-neutral-400)" }}
+                  content={<TooltipContent seriesList={PRIMARY_SERIES} />}
+                />
+                {PRIMARY_SERIES.map((series) => (
+                  <Line
+                    key={series.key}
+                    type="monotone"
+                    dataKey={series.key}
+                    stroke={series.colorVar}
+                    strokeWidth={series.strokeWidth}
+                    strokeDasharray={series.strokeDasharray}
+                    dot={false}
+                    activeDot={{
+                      r: 4,
+                      fill: series.colorVar,
+                      stroke: "var(--color-raised)",
+                      strokeWidth: 2,
+                    }}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <Legend seriesList={PRIMARY_SERIES} label="Legenda dei grandi aggregati contabili" />
+
+          <figcaption className={styles.panelCaption}>
+            Voci macro-economiche del Conto Economico SSN. Mostra l&apos;evoluzione complessiva dei costi di produzione (BZ9999), degli acquisti di servizi (BA0390) e del personale dipendente (BA2080).
+          </figcaption>
+        </figure>
+
+        {/* Pannello 2: Prestazioni di lavoro e consulenze (scala dedicata) */}
+        <figure className={styles.panelCard}>
+          <div className={styles.panelHeader}>
+            <span className={styles.panelCategory}>PRESTAZIONI DI LAVORO</span>
+            <h3 className={styles.panelTitle}>Consulenze, collaborazioni e interinale</h3>
+            <span className={styles.panelScaleBadge}>Scala dedicata da zero · mln € / mld €</span>
+          </div>
+
+          <div
+            className={styles.chart}
+            role="img"
+            aria-label="Serie storica 2012-2024 delle prestazioni di lavoro: consulenze, collaborazioni e lavoro interinale sanitarie e non sanitarie"
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={chartData}
+                syncId="ssn-national-history"
+                margin={{ top: 12, right: 16, bottom: 4, left: 4 }}
+                accessibilityLayer
+              >
+                <CartesianGrid vertical={false} stroke="var(--color-neutral-300)" />
+                <XAxis
+                  dataKey="year"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+                />
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  width={76}
+                  domain={[0, "auto"]}
+                  tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+                  tickFormatter={formatAxisEuro}
+                />
+                <Tooltip
+                  animationDuration={120}
+                  cursor={{ stroke: "var(--color-neutral-400)" }}
+                  content={<TooltipContent seriesList={WORK_SERVICES_SERIES} />}
+                />
+                {WORK_SERVICES_SERIES.map((series) => (
+                  <Line
+                    key={series.key}
+                    type="monotone"
+                    dataKey={series.key}
+                    stroke={series.colorVar}
+                    strokeWidth={series.strokeWidth}
+                    strokeDasharray={series.strokeDasharray}
+                    dot={false}
+                    activeDot={{
+                      r: 4,
+                      fill: series.colorVar,
+                      stroke: "var(--color-raised)",
+                      strokeWidth: 2,
+                    }}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <Legend seriesList={WORK_SERVICES_SERIES} label="Legenda delle prestazioni di lavoro" />
+
+          <figcaption className={styles.panelCaption}>
+            Voci relative a prestazioni sanitarie (BA1350) e non sanitarie (BA1750). La scala autonoma rende leggibili le variazioni senza schiacciamento visivo né un doppio asse fuorviante.
+          </figcaption>
+        </figure>
       </div>
 
-      <div className={styles.legend} aria-label="Legenda delle voci contabili">
-        {HEALTH_SPENDING_SERIES.map((series) => (
-          <span key={series.key} className={styles.legendItem}>
-            <i
-              className={`${styles.legendLine} ${series.lineClass} ${
-                series.strokeDasharray ? styles.dashed : ""
-              }`}
-              aria-hidden="true"
-            />
-            <span className={styles.legendLabel}>
-              {series.label} <code>{series.code}</code>
-            </span>
-          </span>
-        ))}
-      </div>
-
-      <figcaption className={styles.caption}>
+      <p className={styles.overallCaption}>
         Valori nominali a consuntivo in euro di competenza economica del Conto Economico SSN
-        (OpenBDAP RGS). La serie non è corretta per l&apos;inflazione e non misura efficienza,
-        qualità dell&apos;assistenza o dotazioni organiche. Le voci con importi più contenuti possono
-        risultare meno leggibili nella scala comune: tooltip e tabella riportano i valori puntuali.
-      </figcaption>
-    </figure>
+        (OpenBDAP RGS). La serie è presentata su due grafici a scala separata per consentire il
+        confronto simultaneo sia dei grandi aggregati sia delle prestazioni di lavoro, evitando
+        le distorsioni di scala di un asse unico o di un doppio asse. La serie non è corretta per
+        l&apos;inflazione e non misura efficienza, qualità dell&apos;assistenza o dotazioni organiche.
+      </p>
+    </div>
   );
 }

--- a/src/components/charts/health-spending-history-chart.tsx
+++ b/src/components/charts/health-spending-history-chart.tsx
@@ -241,7 +241,7 @@ export function HealthSpendingHistoryChart({
                   tickFormatter={formatAxisEuro}
                 />
                 <Tooltip
-                  animationDuration={120}
+                  isAnimationActive={false}
                   cursor={{ stroke: "var(--color-neutral-400)" }}
                   content={<TooltipContent seriesList={PRIMARY_SERIES} />}
                 />
@@ -310,7 +310,7 @@ export function HealthSpendingHistoryChart({
                   tickFormatter={formatAxisEuro}
                 />
                 <Tooltip
-                  animationDuration={120}
+                  isAnimationActive={false}
                   cursor={{ stroke: "var(--color-neutral-400)" }}
                   content={<TooltipContent seriesList={WORK_SERVICES_SERIES} />}
                 />

--- a/tests/health-spending-history-chart.test.mjs
+++ b/tests/health-spending-history-chart.test.mjs
@@ -23,6 +23,8 @@ const pageCode = readFileSync(storicoPagePath, "utf8");
 test("health spending trend chart defines the five canonical SSN CCE accounting series", () => {
   assert.match(chartCode, /export function HealthSpendingHistoryChart/);
   assert.match(chartCode, /export const HEALTH_SPENDING_SERIES/);
+  assert.match(chartCode, /export const PRIMARY_SERIES/);
+  assert.match(chartCode, /export const WORK_SERVICES_SERIES/);
 
   // All 5 voice codes
   assert.match(chartCode, /code:\s*"BZ9999"/);
@@ -39,11 +41,31 @@ test("health spending trend chart defines the five canonical SSN CCE accounting 
   assert.match(chartCode, /key:\s*"nonHealthcareWorkServices"/);
 });
 
+test("health spending trend chart separates macro aggregates and work services into distinct honest scales without dual axis", () => {
+  // Rejects misleading dual-axis patterns on a single chart
+  assert.doesNotMatch(chartCode, /yAxisId=["']right["']/);
+  assert.doesNotMatch(chartCode, /orientation=["']right["']/);
+
+  // Uses two synchronized panels with separate scales
+  assert.match(chartCode, /syncId="ssn-national-history"/);
+  assert.match(chartCode, /GRANDI AGGREGATI/);
+  assert.match(chartCode, /PRESTAZIONI DI LAVORO/);
+  assert.match(chartCode, /Scala assoluta da zero/);
+  assert.match(chartCode, /Scala dedicata/);
+
+  // Primary panel contains the 3 macro aggregates
+  assert.match(chartCode, /PRIMARY_SERIES/);
+  assert.match(chartCode, /panel:\s*"primary"/);
+
+  // Work services panel contains the 2 smaller series
+  assert.match(chartCode, /WORK_SERVICES_SERIES/);
+  assert.match(chartCode, /panel:\s*"workServices"/);
+});
 test("health spending trend chart preserves design tokens, accessibility and zero animation", () => {
   // Client directive for Recharts
   assert.match(chartCode, /^"use client";/);
 
-  // Accessibility contract
+  // Accessibility contract on both figures and chart containers
   assert.match(chartCode, /accessibilityLayer/);
   assert.match(chartCode, /role="img"/);
   assert.match(chartCode, /aria-label=/);
@@ -54,9 +76,12 @@ test("health spending trend chart preserves design tokens, accessibility and zer
   // Explicit units formatting on Y axis and tooltips
   assert.match(chartCode, /tickFormatter=\{formatAxisEuro\}/);
   assert.match(chartCode, /mld €/);
+  assert.match(chartCode, /mln €/);
 
   // Disclaimer note on nominal economic-accounting values without causality inference
   assert.match(chartCode, /Valori nominali a consuntivo in euro di competenza economica/);
+  assert.match(chartCode, /due grafici a scala separata/);
+  assert.match(chartCode, /doppio asse/);
   assert.match(chartCode, /non misura efficienza/);
   assert.match(chartCode, /dotazioni organiche/);
 
@@ -68,6 +93,7 @@ test("health spending trend chart preserves design tokens, accessibility and zer
   assert.match(chartCss, /var\(--chart-quaternary\)/);
   assert.match(chartCss, /var\(--color-neutral-300\)/);
   assert.match(chartCss, /var\(--color-text\)/);
+  assert.match(chartCss, /@media \(max-width: 960px\)/);
   assert.match(chartCss, /@media \(max-width: 720px\)/);
 });
 

--- a/tests/health-spending-history-chart.test.mjs
+++ b/tests/health-spending-history-chart.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const chartSourcePath = new URL(
+  "../src/components/charts/health-spending-history-chart.tsx",
+  import.meta.url,
+);
+const chartCssPath = new URL(
+  "../src/components/charts/health-spending-history-chart.module.css",
+  import.meta.url,
+);
+const storicoPagePath = new URL(
+  "../src/app/spese/sanita/storico/page.tsx",
+  import.meta.url,
+);
+
+const chartCode = readFileSync(chartSourcePath, "utf8");
+const chartCss = readFileSync(chartCssPath, "utf8");
+const pageCode = readFileSync(storicoPagePath, "utf8");
+
+test("health spending trend chart defines the five canonical SSN CCE accounting series", () => {
+  assert.match(chartCode, /export function HealthSpendingHistoryChart/);
+  assert.match(chartCode, /export const HEALTH_SPENDING_SERIES/);
+
+  // All 5 voice codes
+  assert.match(chartCode, /code:\s*"BZ9999"/);
+  assert.match(chartCode, /code:\s*"BA2080"/);
+  assert.match(chartCode, /code:\s*"BA0390"/);
+  assert.match(chartCode, /code:\s*"BA1350"/);
+  assert.match(chartCode, /code:\s*"BA1750"/);
+
+  // All 5 metric keys
+  assert.match(chartCode, /key:\s*"productionCosts"/);
+  assert.match(chartCode, /key:\s*"personnelCost"/);
+  assert.match(chartCode, /key:\s*"purchasedServices"/);
+  assert.match(chartCode, /key:\s*"healthcareWorkServices"/);
+  assert.match(chartCode, /key:\s*"nonHealthcareWorkServices"/);
+});
+
+test("health spending trend chart preserves design tokens, accessibility and zero animation", () => {
+  // Client directive for Recharts
+  assert.match(chartCode, /^"use client";/);
+
+  // Accessibility contract
+  assert.match(chartCode, /accessibilityLayer/);
+  assert.match(chartCode, /role="img"/);
+  assert.match(chartCode, /aria-label=/);
+
+  // No entrance animation
+  assert.match(chartCode, /isAnimationActive=\{false\}/);
+
+  // Explicit units formatting on Y axis and tooltips
+  assert.match(chartCode, /tickFormatter=\{formatAxisEuro\}/);
+  assert.match(chartCode, /mld €/);
+
+  // Disclaimer note on nominal economic-accounting values without causality inference
+  assert.match(chartCode, /Valori nominali a consuntivo in euro di competenza economica/);
+  assert.match(chartCode, /non misura efficienza/);
+  assert.match(chartCode, /dotazioni organiche/);
+
+  // Scoped CSS tokens
+  assert.match(chartCss, /var\(--chart-primary\)/);
+  assert.match(chartCss, /var\(--chart-secondary\)/);
+  assert.match(chartCss, /var\(--chart-tertiary\)/);
+  assert.match(chartCss, /var\(--color-accent-600\)/);
+  assert.match(chartCss, /var\(--chart-quaternary\)/);
+  assert.match(chartCss, /var\(--color-neutral-300\)/);
+  assert.match(chartCss, /var\(--color-text\)/);
+  assert.match(chartCss, /@media \(max-width: 720px\)/);
+});
+
+test("storico page integrates the chart while preserving the exact table as accessible truth", () => {
+  // Chart component imported and rendered with history.years
+  assert.match(pageCode, /import \{ HealthSpendingHistoryChart \} from "@\/components\/charts\/health-spending-history-chart";/);
+  assert.match(pageCode, /<HealthSpendingHistoryChart data=\{history!\.years\} \/>/);
+
+  // Exact historical table remains in place as accessible truth
+  assert.match(pageCode, /<HistoryTable history=\{history!\} \/>/);
+  assert.match(pageCode, /role="region" aria-label="Conto Economico SSN nazionale, serie storica"/);
+
+  // Error handling, provenance, routes, and cautionary notice preserved
+  assert.match(pageCode, /Dati OpenBDAP non raggiungibili in questo momento/);
+  assert.match(pageCode, /<ProvenanceList history=\{history!\} \/>/);
+  assert.match(pageCode, /Cosa questa serie non dimostra/);
+  assert.match(pageCode, /href="\/spese\/sanita"/);
+});

--- a/tests/health-spending-history-chart.test.mjs
+++ b/tests/health-spending-history-chart.test.mjs
@@ -98,6 +98,7 @@ test("health spending trend chart preserves design tokens, accessibility and zer
   assert.match(chartCss, /var\(--color-on-strong-muted\)/);
   assert.match(chartCss, /@media \(max-width: 960px\)/);
   assert.match(chartCss, /@media \(max-width: 720px\)/);
+  assert.match(chartCss, /max-width: calc\(100vw - 64px\)/);
 });
 
 test("storico page integrates the chart while preserving the exact table as accessible truth", () => {

--- a/tests/health-spending-history-chart.test.mjs
+++ b/tests/health-spending-history-chart.test.mjs
@@ -72,6 +72,7 @@ test("health spending trend chart preserves design tokens, accessibility and zer
 
   // No entrance animation
   assert.match(chartCode, /isAnimationActive=\{false\}/);
+  assert.doesNotMatch(chartCode, /animationDuration=/);
 
   // Explicit units formatting on Y axis and tooltips
   assert.match(chartCode, /tickFormatter=\{formatAxisEuro\}/);
@@ -93,6 +94,8 @@ test("health spending trend chart preserves design tokens, accessibility and zer
   assert.match(chartCss, /var\(--chart-quaternary\)/);
   assert.match(chartCss, /var\(--color-neutral-300\)/);
   assert.match(chartCss, /var\(--color-text\)/);
+  assert.match(chartCss, /var\(--color-on-strong\)/);
+  assert.match(chartCss, /var\(--color-on-strong-muted\)/);
   assert.match(chartCss, /@media \(max-width: 960px\)/);
   assert.match(chartCss, /@media \(max-width: 720px\)/);
 });


### PR DESCRIPTION
## Summary

- Adds a responsive trend visualization to `/spese/sanita/storico`.
- Reuses the existing `getSsnNationalHistory` data and the five official SSN CCE metrics; no API or source-adapter changes.
- Separates the three large aggregates from the two much smaller work-service series, using independent zero-based scales instead of a misleading dual axis.
- Preserves the exact historical table, per-year provenance and analytical caveats.
- Adds focused contract tests for the split-scale chart and accessibility requirements.

## Verification

- `node --experimental-strip-types --test tests/health-spending-history-chart.test.mjs tests/ssn-national-history.test.mjs tests/ssn-cce.test.mjs tests/health-route.test.mjs` — 32/32 passed
- `npm run ci:static` — passed
- `npm run build` — passed
- `git diff --check` — passed

This is intentionally a focused first-pass visualization; the table remains the exact data reference.