### PR TITLE
feat(segnalazioni): pulsante globale «Segnala un problema» con creazione automatica di issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,13 @@ MCP_ALLOWED_HOSTS=
 # Token fornito da OpenAI durante la verifica del dominio per la directory Apps.
 # Se assente o non valido, la route challenge risponde 404.
 OPENAI_APPS_CHALLENGE_TOKEN=
+
+# GitHub App usata da POST /api/segnalazioni per creare le issue del pulsante
+# «Segnala un problema». Installala solo su questo repository con il solo
+# permesso Issues: Read and write. Se una variabile manca, l'endpoint risponde
+# 503 e il modulo propone il composer GitHub precompilato.
+REPORT_GITHUB_APP_ID=
+REPORT_GITHUB_INSTALLATION_ID=
+# Chiave privata PEM dell'App; su Vercel può essere incollata con i newline
+# letterali oppure con \n escapati.
+REPORT_GITHUB_APP_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ docs/               metodo, architettura, note legali
 
 ## Contribuire
 
-Segnalazioni utili: fonti mancanti, correzioni alle spiegazioni, qualità dei dati, accessibilità.
+Segnalazioni utili: fonti mancanti, correzioni alle spiegazioni, qualità dei dati, accessibilità. Dal sito puoi usare il pulsante «Segnala un problema», presente in ogni pagina: crea una issue pubblica già strutturata ([docs/SEGNALAZIONI.md](docs/SEGNALAZIONI.md)).
 
 Prima di una PR leggi [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,4 +23,6 @@ accesso a variabili d'ambiente, SSRF, injection, esposizione di dati non pubblic
 dipendenze compromesse e workflow GitHub con privilegi eccessivi.
 
 I problemi di qualità o interpretazione dei dati senza impatto di sicurezza
-vanno segnalati con una issue ordinaria, allegando la fonte ufficiale.
+vanno segnalati con una issue ordinaria, allegando la fonte ufficiale, oppure
+con il pulsante «Segnala un problema» del sito, che crea la stessa issue
+pubblica. Quel modulo non è un canale riservato: non usarlo per vulnerabilità.

--- a/docs/SEGNALAZIONI.md
+++ b/docs/SEGNALAZIONI.md
@@ -1,7 +1,8 @@
 # Segnala un problema
 
-Il pulsante «Segnala un problema», presente in ogni pagina pubblica tramite il
-layout radice (`src/app/layout.tsx`) e nel footer, apre un dialog che raccoglie
+Il controllo globale è un'icona 44px in basso a destra (nome accessibile
+«Segnala un problema»). Lo stesso ingresso, con etichetta visibile, è nel
+footer e in `/supporto`. Apre un dialog che raccoglie
 una segnalazione strutturata e la trasforma in una issue pubblica del
 repository. Questa nota descrive il contratto, i limiti e le scelte di
 sicurezza, così che codice, `/supporto`, `/privacy` e `SECURITY.md` restino

--- a/docs/SEGNALAZIONI.md
+++ b/docs/SEGNALAZIONI.md
@@ -1,0 +1,123 @@
+# Segnala un problema
+
+Il pulsante «Segnala un problema», presente in ogni pagina pubblica tramite il
+layout radice (`src/app/layout.tsx`) e nel footer, apre un dialog che raccoglie
+una segnalazione strutturata e la trasforma in una issue pubblica del
+repository. Questa nota descrive il contratto, i limiti e le scelte di
+sicurezza, così che codice, `/supporto`, `/privacy` e `SECURITY.md` restino
+coerenti. Nasce dalla issue #197.
+
+## Componenti
+
+| Parte | File | Ruolo |
+|---|---|---|
+| Trigger | `src/components/report-problem/report-problem-button.tsx` | Bottone client minimale; carica il dialog con `next/dynamic` solo alla prima attivazione. |
+| Dialog | `src/components/report-problem/report-problem-dialog.tsx` | `<dialog>` nativo (`showModal`, focus trap, `Esc`), validazione con lo stesso schema del server, stati vuoto/invio/errore/successo. |
+| Contratto | `src/lib/report/contract.ts` | Schema `zod` fail-closed, normalizzazione del testo, rendering della issue, URL del composer GitHub. Importato anche dal browser: nessun segreto. |
+| Endpoint | `src/app/api/segnalazioni/route.ts` | `POST` same-origin; guardie HTTP condivise (`src/lib/http/public-post-guard.ts`), rate limit, idempotenza, chiamata a GitHub. |
+| Client GitHub | `src/lib/report/github.ts` | Token di installazione GitHub App via JWT RS256 (`node:crypto`), creazione e ricerca issue, timeout espliciti. |
+| Limitatore | `src/lib/report/rate-limit.ts` | Finestra scorrevole in memoria per indirizzo (hash) e per istanza. |
+
+## Cosa viene inviato
+
+Il client invia solo questi campi; qualsiasi chiave in più (`labels`,
+`assignees`, `repository`, `title`, …) fa rifiutare l'intera richiesta.
+
+| Campo | Vincolo |
+|---|---|
+| `clientKey` | UUID generato dal browser all'apertura del dialog; chiave di idempotenza. |
+| `category` | `bug`, `dato`, `accessibilita`, `altro`. |
+| `observed`, `expected`, `steps` | Obbligatori, max 2 000 caratteri ciascuno dopo normalizzazione. |
+| `sourceUrl` | Facoltativo; obbligatorio per `dato`. Solo `https`, senza credenziali. |
+| `page.path` | Solo percorso relativo (`/…`) valido sul dominio canonico; il server compone l'URL. |
+| `page.title` | Max 200 caratteri. |
+| `context.reportedAt`, `context.openedAt` | ISO 8601; l'invio deve avvenire almeno 3 s dopo l'apertura e non oltre 24 h. |
+| `context.viewport`, `context.userAgent` | Dichiarati nel form. Nessun IP, nome o email. |
+| `website` | Honeypot: deve restare vuoto. |
+
+Il corpo JSON non può superare 12 288 byte; `Content-Type`, `Origin` e `Host`
+devono essere coerenti con il sito, come per `/api/assistant`.
+
+## Issue generata
+
+Titolo e struttura sono decisi dal server:
+
+```text
+[Segnalazione] <categoria>: <percorso pagina>
+```
+
+Il corpo inizia con un marker HTML nascosto `<!-- dvns-report-key: <uuid> -->`
+e contiene le sezioni «Tipo di problema», «Pagina», «Risultato osservato»,
+«Risultato atteso», «Passaggi per riprodurre», «Fonte ufficiale, se
+pertinente», «Contesto tecnico» e la nota che il contenuto non è verificato.
+Per la categoria `dato` viene aggiunto il richiamo che un valore diverso non
+dimostra spreco, frode o responsabilità.
+
+Ogni testo dell'utente è racchiuso in un blocco ` ```text ` con fence più lunga
+di qualsiasi sequenza di backtick contenuta: dentro una fence GitHub non
+interpreta HTML, `@mention`, `#riferimenti` o link, quindi il form non può
+notificare persone né iniettare markup. Il titolo della pagina, usato in linea,
+viene ripulito dai caratteri Markdown e le `@` sono sostituite con `＠`.
+
+La label applicata è `segnalazione`. Va creata una sola volta nel repository.
+
+## Sicurezza e anti-abuso
+
+- **Credenziale.** Solo lato server: GitHub App installata su questo repository
+  con il solo permesso *Issues: Read and write*. Il token di installazione è
+  richiesto con `permissions: { issues: "write" }` e `repositories:
+  [DoveVannoINostriSoldi]`, cache in memoria fino a 60 s prima della scadenza.
+  Variabili: `REPORT_GITHUB_APP_ID`, `REPORT_GITHUB_INSTALLATION_ID`,
+  `REPORT_GITHUB_APP_PRIVATE_KEY` (PEM, con newline letterali o `\n`).
+- **Fail-closed.** Se una variabile manca o non è valida, l'endpoint risponde
+  `503 unavailable` con `fallbackUrl` verso il composer GitHub precompilato. È
+  una degradazione documentata, non un'implementazione equivalente.
+- **Anti-bot.** Honeypot `website`, controllo temporale apertura→invio, rate
+  limit per indirizzo (3 ogni 10 minuti) e per istanza (30 ogni 10 minuti).
+  L'indirizzo viene ridotto a hash SHA-256 e tenuto solo in memoria. Nessun
+  challenge esterno nel primo rilascio: la scelta evita script di terze parti
+  e modifiche alla CSP, ma è più debole di un captcha e può essere rivista.
+- **Rate limit non durevole.** Il sito non ha uno store condiviso: il limite
+  vale per istanza serverless calda. Il limite globale effettivo è quindi
+  quello di GitHub più `30 × istanze`. Se l'abuso diventa reale, il passo
+  successivo previsto è uno store esterno (per esempio Redis via REST).
+- **Idempotenza.** Il server tiene in memoria le ultime chiavi servite e, prima
+  di creare, cerca il marker fra le issue con label `segnalazione` create nelle
+  ultime 24 h tramite la lista issue (consistente, a differenza della search).
+  Retry, doppio click o timeout con la stessa `clientKey` restituiscono la
+  issue esistente con `duplicate: true`.
+- **Log.** Il contenuto della segnalazione non viene mai loggato; in caso di
+  errore GitHub si registra solo la classe dell'errore e lo stato HTTP.
+- **Risposte.** Gli errori del provider sono tradotti in messaggi generici; il
+  browser verifica che gli URL restituiti puntino a `https://github.com/`.
+- **Fuori scope.** Vulnerabilità (rimandate al report privato dal dialog e da
+  `/supporto`), allegati, nome/email, modifica di issue esistenti.
+
+## Verifica
+
+```bash
+node --experimental-strip-types --test tests/report-contract.test.mjs
+node --experimental-strip-types --test tests/report-github.test.mjs
+node --experimental-strip-types --test tests/report-route.test.mjs
+npm run build && npm start &   # oppure scripts/ci/run-production-gates.sh
+npm run test:browser:report
+```
+
+La suite Node usa una chiave RSA generata al volo e un `fetch` finto: nessuna
+issue reale viene creata. La suite browser intercetta `POST /api/segnalazioni`
+per simulare successo ed errore del provider e, nell'ultimo scenario, colpisce
+l'endpoint reale senza credenziali verificando il fallback. È inclusa in
+`scripts/ci/run-production-gates.sh`.
+
+Verifica manuale prevista: 390, 768 e 1280 px, tastiera (`Tab`, `Enter`,
+`Esc`), ritorno del focus al pulsante, console pulita, nessun overflow.
+
+## Attivazione in produzione
+
+1. Creare una GitHub App nell'organizzazione con permesso *Issues: Read and
+   write*, nessun webhook, installata solo su `DoveVannoINostriSoldi`.
+2. Generare una chiave privata e annotare App ID e Installation ID.
+3. Impostare le tre variabili su Vercel (Production e, se utile, Preview).
+4. Creare la label `segnalazione` nel repository.
+5. Inviare una segnalazione di prova da produzione e verificarne titolo,
+   struttura e label; chiuderla come test.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:education-atlas": "node --experimental-strip-types --test tests/education-atlas.test.mjs",
     "test:browser:core": "node scripts/browser/core.mjs",
     "test:browser:editorial": "node --experimental-strip-types scripts/browser/editorial.mjs",
+    "test:browser:report": "node scripts/browser/report.mjs",
     "test:csp:report-only": "node scripts/browser/csp-report-only.mjs",
     "test:browser:e2e": "node scripts/browser/core.mjs",
     "test:browser:integrated": "node --experimental-strip-types scripts/browser/editorial.mjs",

--- a/scripts/browser/report.mjs
+++ b/scripts/browser/report.mjs
@@ -39,8 +39,10 @@ async function triggerGeometry(page, selector) {
       right: rect.right,
       top: rect.top,
       bottom: rect.bottom,
+      width: rect.width,
       height: rect.height,
       text: button.textContent?.trim() ?? "",
+      name: button.getAttribute("aria-label") ?? "",
       visible: style.display !== "none" && style.visibility !== "hidden" && rect.width > 0,
       innerWidth: window.innerWidth,
       innerHeight: window.innerHeight,
@@ -153,8 +155,10 @@ try {
         const label = `${width}px`;
         const trigger = await triggerGeometry(page, TRIGGER);
         assert.ok(trigger?.visible, `${label}: trigger globale assente`);
-        assert.equal(trigger.text, "Segnala un problema", `${label}: nome del trigger`);
+        assert.equal(trigger.name, "Segnala un problema", `${label}: nome accessibile del trigger`);
+        assert.equal(trigger.text, "Segnala un problema", `${label}: etichetta visivamente nascosta`);
         assert.ok(trigger.height >= 44, `${label}: area di tocco ${trigger.height}px < 44px`);
+        assert.ok(trigger.width <= 48, `${label}: il trigger globale deve restare un'icona (${trigger.width}px)`);
         assert.ok(trigger.left >= 0 && trigger.right <= trigger.innerWidth + 1, `${label}: trigger fuori viewport`);
         assert.ok(trigger.bottom <= trigger.innerHeight + 1, `${label}: trigger sotto il viewport`);
 

--- a/scripts/browser/report.mjs
+++ b/scripts/browser/report.mjs
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import {
+  closeBrowser,
+  defaultBaseUrl,
+  delay,
+  launchBrowser,
+  runScenario,
+  waitForServer,
+} from "./harness.mjs";
+
+/**
+ * "Segnala un problema": the global trigger, the dialog and its four states.
+ *
+ * GitHub is never contacted: successful and failed submissions are simulated by
+ * intercepting POST /api/segnalazioni at the browser boundary. Only the last
+ * scenario reaches the real endpoint, which on CI has no credentials and must
+ * answer 503 with the prefilled GitHub composer as fallback.
+ */
+
+const baseUrl = defaultBaseUrl();
+const ENDPOINT = "/api/segnalazioni";
+const TRIGGER = 'button[data-report-problem-trigger="floating"]';
+const INLINE_TRIGGER = 'button[data-report-problem-trigger="inline"]';
+const DIALOG = "dialog[open]";
+const ISSUE_URL = "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/4242";
+
+if (!/^https?:$/.test(baseUrl.protocol)) {
+  throw new Error("DVNS_BASE_URL deve usare il protocollo HTTP oppure HTTPS.");
+}
+
+async function triggerGeometry(page, selector) {
+  return page.evaluate((sel) => {
+    const button = document.querySelector(sel);
+    if (!button) return null;
+    const rect = button.getBoundingClientRect();
+    const style = getComputedStyle(button);
+    return {
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      bottom: rect.bottom,
+      height: rect.height,
+      text: button.textContent?.trim() ?? "",
+      visible: style.display !== "none" && style.visibility !== "hidden" && rect.width > 0,
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+    };
+  }, selector);
+}
+
+async function dialogState(page) {
+  return page.evaluate(() => {
+    const dialog = document.querySelector("dialog[open]");
+    if (!dialog) return null;
+    const rect = dialog.getBoundingClientRect();
+    const labelledBy = dialog.getAttribute("aria-labelledby");
+    const title = labelledBy ? document.getElementById(labelledBy)?.textContent?.trim() : null;
+    return {
+      title,
+      containsFocus: dialog.contains(document.activeElement),
+      activeTag: document.activeElement?.tagName ?? null,
+      fitsViewport: rect.left >= 0 && rect.right <= window.innerWidth + 1 && rect.top >= 0 && rect.bottom <= window.innerHeight + 1,
+      scrollWidthOk: dialog.scrollWidth <= dialog.clientWidth + 1,
+    };
+  });
+}
+
+/**
+ * Activates the trigger until the dialog appears. The first activation can
+ * land before hydration on a cold server and be lost: that is a plain HTML
+ * button with no handler yet, not a defect in the dialog.
+ */
+async function activateUntilOpen(page, activate, label) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await activate();
+    try {
+      await page.waitForSelector(DIALOG, { visible: true, timeout: 2_000 });
+      return;
+    } catch {
+      // retry after hydration has had time to attach the handler
+    }
+  }
+  assert.fail(`${label}: il dialog non si apre dopo ripetute attivazioni`);
+}
+
+async function openDialog(page, { label, selector = TRIGGER }) {
+  await page.waitForSelector(selector, { visible: true });
+  await activateUntilOpen(page, () => page.click(selector), label);
+  const state = await dialogState(page);
+  assert.ok(state, `${label}: dialog non aperto`);
+  assert.equal(state.title, "Segnala un problema", `${label}: titolo dialog`);
+  assert.equal(state.containsFocus, true, `${label}: il focus deve entrare nel dialog`);
+  assert.equal(state.fitsViewport, true, `${label}: il dialog esce dal viewport`);
+  assert.equal(state.scrollWidthOk, true, `${label}: overflow orizzontale nel dialog`);
+  return state;
+}
+
+async function fillField(page, labelText, value) {
+  const handle = await page.evaluateHandle((text) => {
+    const label = Array.from(document.querySelectorAll("dialog[open] label"))
+      .find((node) => node.textContent?.trim().startsWith(text));
+    return label ? document.getElementById(label.getAttribute("for") ?? "") : null;
+  }, labelText);
+  const element = handle.asElement();
+  assert.ok(element, `campo «${labelText}» non trovato`);
+  await element.click({ clickCount: 3 });
+  await element.type(value);
+}
+
+async function chooseCategory(page, value) {
+  await page.click(`dialog[open] input[name="category"][value="${value}"]`);
+}
+
+function interceptEndpoint(page, respond) {
+  return page.setRequestInterception(true).then(() => {
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (request.method() === "POST" && url.pathname === ENDPOINT) {
+        const payload = JSON.parse(request.postData() ?? "{}");
+        const { status, body } = respond(payload);
+        request.respond({
+          status,
+          contentType: "application/json",
+          headers: { "cache-control": "private, no-store" },
+          body: JSON.stringify(body),
+        });
+        return;
+      }
+      request.continue();
+    });
+  });
+}
+
+/** A 503 from the report endpoint is the behaviour under test, not a page error. */
+const allowReportUnavailable = (failure) => failure.includes("/api/segnalazioni") && /503/.test(failure);
+
+async function submit(page) {
+  await page.click('dialog[open] button[type="submit"]');
+}
+
+let browser;
+try {
+  await waitForServer(baseUrl);
+  browser = await launchBrowser({ extraArgs: ["--disable-extensions"] });
+
+  for (const width of [390, 768, 1280]) {
+    await runScenario(browser, {
+      suite: "report",
+      label: `Segnala un problema: trigger e tastiera a ${width}px`,
+      pathname: "/",
+      width,
+      validate: async (page) => {
+        const label = `${width}px`;
+        const trigger = await triggerGeometry(page, TRIGGER);
+        assert.ok(trigger?.visible, `${label}: trigger globale assente`);
+        assert.equal(trigger.text, "Segnala un problema", `${label}: nome del trigger`);
+        assert.ok(trigger.height >= 44, `${label}: area di tocco ${trigger.height}px < 44px`);
+        assert.ok(trigger.left >= 0 && trigger.right <= trigger.innerWidth + 1, `${label}: trigger fuori viewport`);
+        assert.ok(trigger.bottom <= trigger.innerHeight + 1, `${label}: trigger sotto il viewport`);
+
+        const overlap = await page.evaluate((sel) => {
+          const button = document.querySelector(sel);
+          const rect = button.getBoundingClientRect();
+          const probe = document.elementFromPoint(rect.left - 8, rect.top + rect.height / 2);
+          return probe ? !button.contains(probe) : true;
+        }, TRIGGER);
+        assert.equal(overlap, true, `${label}: il trigger non deve estendersi oltre il proprio bordo`);
+
+        // Keyboard: the trigger is focusable and opens with Enter; Esc closes and returns focus.
+        await activateUntilOpen(page, async () => {
+          await page.focus(TRIGGER);
+          await page.keyboard.press("Enter");
+        }, label);
+        const opened = await dialogState(page);
+        assert.equal(opened.containsFocus, true, `${label}: focus non nel dialog`);
+        assert.equal(await page.$eval(TRIGGER, (node) => node.getAttribute("aria-expanded")), "true");
+
+        await page.keyboard.press("Escape");
+        await page.waitForSelector(DIALOG, { hidden: true });
+        const focusBack = await page.evaluate((sel) => document.activeElement === document.querySelector(sel), TRIGGER);
+        assert.equal(focusBack, true, `${label}: dopo Esc il focus deve tornare al trigger`);
+        assert.equal(await page.$eval(TRIGGER, (node) => node.getAttribute("aria-expanded")), "false");
+      },
+    });
+  }
+
+  await runScenario(browser, {
+    suite: "report",
+    label: "Segnala un problema: validazione e invio riuscito su route dinamica",
+    pathname: "/enti/agid",
+    width: 1280,
+    afterNavigate: async (page) => {
+      await interceptEndpoint(page, (payload) => {
+        assert.equal(payload.page.path, "/enti/agid", "il path della pagina viene allegato");
+        assert.equal(payload.category, "dato");
+        assert.equal(payload.website, "", "honeypot vuoto");
+        assert.ok(payload.context.viewport.width > 0);
+        assert.ok(Date.parse(payload.context.openedAt) <= Date.parse(payload.context.reportedAt));
+        return { status: 201, body: { ok: true, issue: { number: 4242, url: ISSUE_URL }, duplicate: false } };
+      });
+    },
+    validate: async (page) => {
+      await openDialog(page, { label: "route dinamica" });
+
+      // Empty submit: errors linked to fields, announced, focus on the first one.
+      await submit(page);
+      await page.waitForSelector('dialog[open] [role="alert"]', { visible: true });
+      const emptyState = await page.evaluate(() => {
+        const invalid = Array.from(document.querySelectorAll('dialog[open] [aria-invalid="true"]'));
+        return {
+          invalidCount: invalid.length,
+          firstFocused: invalid[0] === document.activeElement,
+          describedOk: invalid.every((node) => {
+            const ids = (node.getAttribute("aria-describedby") ?? "").split(/\s+/).filter(Boolean);
+            return ids.some((id) => document.getElementById(id)?.textContent?.includes("obbligatorio"));
+          }),
+        };
+      });
+      assert.equal(emptyState.invalidCount, 3, "tre campi obbligatori vuoti devono risultare invalidi");
+      assert.equal(emptyState.firstFocused, true, "il focus va sul primo campo invalido");
+      assert.equal(emptyState.describedOk, true, "ogni errore è collegato al campo");
+
+      await fillField(page, "Cosa è successo", "La spesa 2024 mostrata è 1.000 €.");
+      await fillField(page, "Cosa ti aspettavi", "La fonte riporta 2.000 €.");
+      await fillField(page, "Passaggi per riprodurre", "Apri la scheda ente e leggi il totale.");
+      await chooseCategory(page, "dato");
+      const reminder = await page.$eval("dialog[open]", (node) => node.textContent);
+      assert.match(reminder, /non dimostra da solo spreco, frode o responsabilità/);
+      assert.match(reminder, /issue\s+pubblica/i);
+      assert.match(reminder, /report privato GitHub/);
+
+      // Contesting a datum without a source is refused client-side.
+      await submit(page);
+      await page.waitForSelector('dialog[open] input[type="url"][aria-invalid="true"]', { visible: true });
+      await fillField(page, "Fonte ufficiale", "https://www.istat.it/fonte-ufficiale");
+
+      await submit(page);
+      await page.waitForSelector('dialog[open] [role="status"]', { visible: true });
+      const success = await page.evaluate(() => {
+        const status = document.querySelector('dialog[open] [role="status"]');
+        const link = status?.querySelector("a[href]");
+        return { text: status?.textContent ?? "", href: link?.getAttribute("href") ?? null };
+      });
+      assert.match(success.text, /Segnalazione inviata/);
+      assert.match(success.text, /#4242/);
+      assert.equal(success.href, ISSUE_URL);
+      assert.equal(await page.$('dialog[open] button[type="submit"]'), null, "nessun doppio submit dopo il successo");
+    },
+  });
+
+  await runScenario(browser, {
+    suite: "report",
+    label: "Segnala un problema: errore del provider conserva i dati e offre il fallback",
+    pathname: "/supporto",
+    width: 768,
+    expectedFailure: allowReportUnavailable,
+    afterNavigate: async (page) => {
+      let attempts = 0;
+      await interceptEndpoint(page, () => {
+        attempts += 1;
+        assert.equal(attempts, 1, "un solo invio per click");
+        return {
+          status: 503,
+          body: {
+            ok: false,
+            code: "unavailable",
+            message: "GitHub non ha risposto.",
+            fallbackUrl: "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/new?title=x",
+          },
+        };
+      });
+    },
+    validate: async (page) => {
+      await openDialog(page, { label: "supporto", selector: INLINE_TRIGGER });
+      await fillField(page, "Cosa è successo", "Testo che non deve andare perso");
+      await fillField(page, "Cosa ti aspettavi", "Atteso");
+      await fillField(page, "Passaggi per riprodurre", "Passi");
+      await submit(page);
+      await page.waitForSelector('dialog[open] [role="alert"] a[href^="https://github.com/"]', { visible: true });
+      const kept = await page.evaluate(() => {
+        const areas = Array.from(document.querySelectorAll("dialog[open] textarea")).map((node) => node.value);
+        const alert = document.querySelector('dialog[open] [role="alert"]');
+        return { areas, alert: alert?.textContent ?? "", submitEnabled: !document.querySelector('dialog[open] button[type="submit"]').disabled };
+      });
+      assert.equal(kept.areas[0], "Testo che non deve andare perso", "il contenuto resta nel form");
+      assert.match(kept.alert, /Invio non riuscito/);
+      assert.match(kept.alert, /modulo GitHub precompilato/);
+      assert.equal(kept.submitEnabled, true, "si può riprovare");
+    },
+  });
+
+  await runScenario(browser, {
+    suite: "report",
+    label: "Segnala un problema: endpoint reale senza credenziali degrada al composer GitHub",
+    pathname: "/territori/irpef",
+    width: 390,
+    expectedFailure: allowReportUnavailable,
+    validate: async (page) => {
+      await openDialog(page, { label: "endpoint reale" });
+      await fillField(page, "Cosa è successo", "Osservato dal browser");
+      await fillField(page, "Cosa ti aspettavi", "Atteso dal browser");
+      await fillField(page, "Passaggi per riprodurre", "1. Apri\n2. Guarda");
+      // The server refuses submissions faster than a person could type.
+      await delay(3_200);
+      await submit(page);
+      await page.waitForSelector('dialog[open] [role="alert"] a[href^="https://github.com/"]', { visible: true, timeout: 15_000 });
+      const fallback = await page.$eval('dialog[open] [role="alert"] a[href^="https://github.com/"]', (node) => node.getAttribute("href"));
+      const url = new URL(fallback);
+      assert.equal(url.pathname, "/Italian-Builders-Org/DoveVannoINostriSoldi/issues/new");
+      assert.match(url.searchParams.get("title"), /^\[Segnalazione\] Bug del sito: \/territori\/irpef/);
+      assert.ok(url.searchParams.get("body").includes("Osservato dal browser"));
+      assert.ok(!url.searchParams.get("body").includes("dvns-report-key"));
+    },
+  });
+
+  console.log("Browser report suite: OK");
+} finally {
+  await closeBrowser(browser);
+}

--- a/scripts/ci/run-production-gates.sh
+++ b/scripts/ci/run-production-gates.sh
@@ -84,6 +84,10 @@ echo "::group::Browser editorial suite"
 npm run test:browser:editorial
 echo "::endgroup::"
 
+echo "::group::Browser report suite"
+npm run test:browser:report
+echo "::endgroup::"
+
 echo "::group::CSP Report-Only browser smoke"
 npm run test:csp:report-only
 echo "::endgroup::"

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -4,138 +4,25 @@ import {
   parseAssistantRequest,
 } from "@/lib/assistant/contracts";
 import { executeAssistant } from "@/lib/assistant/executor";
+import { jsonResponse, readBoundedBody, rejectPublicPost } from "@/lib/http/public-post-guard";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 15;
 
-const MAX_REQUEST_BYTES = 16_384;
-const NO_STORE = {
-  "cache-control": "private, no-store",
-  "x-content-type-options": "nosniff",
-};
+const GUARD = { maxRequestBytes: 16_384 } as const;
 
 function json(body: unknown, status = 200, headers?: HeadersInit) {
-  return Response.json(body, { status, headers: { ...NO_STORE, ...headers } });
-}
-
-function normalizedHost(value: string): string | null {
-  const candidate = value.trim().toLocaleLowerCase("en-US").replace(/\.$/u, "");
-  if (!candidate || /[\s/@]/u.test(candidate)) return null;
-  return candidate;
-}
-
-function isLoopbackHost(value: string): boolean {
-  return /^(?:localhost|127\.0\.0\.1|\[::1\])(?::\d{1,5})?$/u.test(value);
-}
-
-function allowedHosts(request: Request): Set<string> {
-  const requestUrlHost = normalizedHost(new URL(request.url).host);
-  const configured = [process.env.VERCEL_PROJECT_PRODUCTION_URL, process.env.VERCEL_URL]
-    .filter((value): value is string => Boolean(value?.trim()))
-    .map((value) => value.replace(/^https?:\/\//iu, ""))
-    .map(normalizedHost)
-    .filter((value): value is string => value !== null);
-  const allowed = new Set(configured);
-  if (requestUrlHost) allowed.add(requestUrlHost);
-
-  const requestHost = normalizedHost(request.headers.get("host") ?? "");
-  if (requestHost && requestUrlHost && isLoopbackHost(requestHost) && isLoopbackHost(requestUrlHost)) {
-    allowed.add(requestHost);
-  }
-  return allowed;
-}
-
-function rejectRequest(request: Request): Response | null {
-  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim();
-  if (contentType !== "application/json") {
-    return json({ ok: false, error: "Content-Type non supportato" }, 415);
-  }
-
-  const requestHost = normalizedHost(request.headers.get("host") ?? "");
-  if (!requestHost || !allowedHosts(request).has(requestHost)) {
-    return json({ ok: false, error: "Host non consentito" }, 403);
-  }
-
-  const origin = request.headers.get("origin");
-  let originUrl: URL;
-  try {
-    originUrl = new URL(origin ?? "");
-  } catch {
-    return json({ ok: false, error: "Origin non consentita" }, 403);
-  }
-  const originHost = normalizedHost(originUrl.host);
-  const allowedProtocol = originUrl.protocol === "https:" ||
-    (originUrl.protocol === "http:" && isLoopbackHost(requestHost));
-  if (originHost !== requestHost || !allowedProtocol) {
-    return json({ ok: false, error: "Origin non consentita" }, 403);
-  }
-
-  const declaredLength = request.headers.get("content-length");
-  if (declaredLength !== null) {
-    if (!/^\d+$/u.test(declaredLength)) {
-      return json({ ok: false, error: "Content-Length non valido" }, 400);
-    }
-    if (Number(declaredLength) > MAX_REQUEST_BYTES) {
-      return json({ ok: false, error: "Richiesta troppo grande" }, 413);
-    }
-  }
-
-  return null;
-}
-
-async function boundedBody(request: Request): Promise<string | Response> {
-  if (!request.body) return json({ ok: false, error: "Corpo richiesta assente" }, 400);
-
-  const reader = request.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  let aborted = request.signal.aborted;
-  const abortReader = () => {
-    aborted = true;
-    void reader.cancel(request.signal.reason).catch(() => undefined);
-  };
-  if (aborted) {
-    await reader.cancel(request.signal.reason).catch(() => undefined);
-    return json({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
-  }
-  request.signal.addEventListener("abort", abortReader, { once: true });
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (aborted) return json({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
-      if (done) break;
-      total += value.byteLength;
-      if (total > MAX_REQUEST_BYTES) {
-        await reader.cancel("Assistant request body limit exceeded").catch(() => undefined);
-        return json({ ok: false, error: "Richiesta troppo grande" }, 413);
-      }
-      chunks.push(value);
-    }
-
-    const body = new Uint8Array(total);
-    let offset = 0;
-    for (const chunk of chunks) {
-      body.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    try {
-      return new TextDecoder("utf-8", { fatal: true }).decode(body);
-    } catch {
-      return json({ ok: false, error: "Corpo UTF-8 non valido" }, 400);
-    }
-  } finally {
-    request.signal.removeEventListener("abort", abortReader);
-  }
+  return jsonResponse(body, status, headers);
 }
 
 export async function POST(request: Request) {
-  const rejected = rejectRequest(request);
+  const rejected = rejectPublicPost(request, GUARD);
   if (rejected) return rejected;
 
   let rawBody: string | Response;
   try {
-    rawBody = await boundedBody(request);
+    rawBody = await readBoundedBody(request, GUARD);
   } catch {
     return json({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
   }

--- a/src/app/api/segnalazioni/route.ts
+++ b/src/app/api/segnalazioni/route.ts
@@ -1,0 +1,160 @@
+import { jsonResponse, readBoundedBody, rejectPublicPost } from "@/lib/http/public-post-guard";
+import {
+  buildIssueDraft,
+  githubComposerUrl,
+  parseReportRequest,
+  REPORT_LIMITS,
+  timingRejection,
+  type IssueDraft,
+  type ReportResponse,
+} from "@/lib/report/contract";
+import {
+  GitHubUnavailableError,
+  hashedLimiterKey,
+  readGitHubAppConfig,
+  ReportGitHubClient,
+  type GitHubAppConfig,
+  type GitHubIssueRef,
+} from "@/lib/report/github";
+import { clientAddress, SlidingWindowLimiter } from "@/lib/report/rate-limit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+
+const GUARD = { maxRequestBytes: REPORT_LIMITS.requestBytesMax } as const;
+const TEN_MINUTES = 10 * 60 * 1_000;
+const DUPLICATE_LOOKBACK_MS = 24 * 60 * 60 * 1_000;
+const RECENT_ISSUES_MAX = 500;
+
+// Per warm instance: a person rarely files more than a few reports in a row,
+// and the whole site should not push GitHub harder than this even under load.
+const perAddress = new SlidingWindowLimiter({ windowMs: TEN_MINUTES, max: 3 });
+const perInstance = new SlidingWindowLimiter({ windowMs: TEN_MINUTES, max: 30 });
+
+// Idempotency memory for the fast path (double click, immediate retry). The
+// durable check is the marker lookup on GitHub itself.
+const recentIssues = new Map<string, GitHubIssueRef>();
+
+let cachedClient: { config: GitHubAppConfig; client: ReportGitHubClient } | null = null;
+
+function githubClient(): ReportGitHubClient | null {
+  const config = readGitHubAppConfig();
+  if (!config) return null;
+  const same = cachedClient &&
+    cachedClient.config.appId === config.appId &&
+    cachedClient.config.installationId === config.installationId &&
+    cachedClient.config.privateKeyPem === config.privateKeyPem;
+  if (!same) {
+    cachedClient = {
+      config,
+      client: new ReportGitHubClient(config, {
+        // Resolved per call so a test double installed on globalThis is honoured.
+        fetch: (input, init) => globalThis.fetch(input, init),
+      }),
+    };
+  }
+  return cachedClient!.client;
+}
+
+function remember(clientKey: string, issue: GitHubIssueRef): void {
+  recentIssues.set(clientKey, issue);
+  if (recentIssues.size > RECENT_ISSUES_MAX) {
+    const oldest = recentIssues.keys().next().value;
+    if (oldest !== undefined) recentIssues.delete(oldest);
+  }
+}
+
+function failure(
+  status: number,
+  code: Extract<ReportResponse, { ok: false }>["code"],
+  message: string,
+  draft?: IssueDraft,
+  headers?: HeadersInit,
+): Response {
+  const body: ReportResponse = draft
+    ? { ok: false, code, message, fallbackUrl: githubComposerUrl(draft) }
+    : { ok: false, code, message };
+  return jsonResponse(body, status, headers);
+}
+
+export async function POST(request: Request) {
+  const rejected = rejectPublicPost(request, GUARD);
+  if (rejected) return rejected;
+
+  let rawBody: string | Response;
+  try {
+    rawBody = await readBoundedBody(request, GUARD);
+  } catch {
+    return jsonResponse({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
+  }
+  if (rawBody instanceof Response) return rawBody;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return failure(400, "invalid_request", "Richiesta JSON non valida");
+  }
+
+  const parsed = parseReportRequest(payload);
+  if (!parsed.ok) return failure(400, "invalid_request", parsed.message);
+  const report = parsed.value;
+
+  const now = Date.now();
+  const timing = timingRejection(report.context, now);
+  if (timing) return failure(400, "invalid_request", timing);
+
+  const draft = buildIssueDraft(report);
+
+  const address = clientAddress(request);
+  const addressAllowed = address ? perAddress.consume(hashedLimiterKey(address), now) : true;
+  if (!addressAllowed || !perInstance.consume("instance", now)) {
+    return failure(
+      429,
+      "rate_limited",
+      "Troppe segnalazioni in poco tempo. Riprova più tardi oppure usa il modulo GitHub.",
+      draft,
+      { "retry-after": "600" },
+    );
+  }
+
+  const client = githubClient();
+  if (!client) {
+    return failure(
+      503,
+      "unavailable",
+      "L’invio automatico non è configurato su questo ambiente. Puoi aprire la segnalazione su GitHub con i dati già compilati.",
+      draft,
+    );
+  }
+
+  const remembered = recentIssues.get(report.clientKey);
+  if (remembered) {
+    const body: ReportResponse = { ok: true, issue: remembered, duplicate: true };
+    return jsonResponse(body, 200);
+  }
+
+  try {
+    const existing = await client.findIssueByKey(report.clientKey, now - DUPLICATE_LOOKBACK_MS);
+    if (existing) {
+      remember(report.clientKey, existing);
+      const body: ReportResponse = { ok: true, issue: existing, duplicate: true };
+      return jsonResponse(body, 200);
+    }
+    const issue = await client.createIssue(draft);
+    remember(report.clientKey, issue);
+    const body: ReportResponse = { ok: true, issue, duplicate: false };
+    return jsonResponse(body, 201);
+  } catch (error) {
+    // Only the failure class and the upstream status are logged: never the report.
+    const status = error instanceof GitHubUnavailableError ? error.status : null;
+    console.error(`[segnalazioni] GitHub non disponibile${status ? ` (HTTP ${status})` : ""}`);
+    return failure(
+      503,
+      "unavailable",
+      "GitHub non ha risposto. La segnalazione non è andata persa: puoi inviarla dal modulo GitHub precompilato o riprovare fra poco.",
+      draft,
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -267,6 +267,12 @@ nav li a { text-decoration: none; }
 }
 .header-action-icon:hover { color: var(--color-accent-700); }
 
+/* Room for the fixed "Segnala un problema" control so it never hides the last
+   line of content or a footer link on narrow screens. */
+@media (max-width: 768px) {
+  body { padding-bottom: calc(44px + var(--space-6)); }
+}
+
 /* ── primary navigation ─────────────────────────────────────────────────── */
 
 .nav-row {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist } from "next/font/google";
 import { GoogleAnalytics } from "@/components/google-analytics";
 import { Navigation } from "@/components/navigation";
 import { SectionNav } from "@/components/section-nav";
+import { ReportProblemButton } from "@/components/report-problem/report-problem-button";
 import { SiteFooter } from "@/components/site-footer";
 import { mefIrpefSourceMeta } from "@/lib/data/mef-irpef-source";
 import { siopeMunicipalSnapshot } from "@/lib/siope-snapshot";
@@ -57,6 +58,7 @@ export default function RootLayout({
         <div id="contenuto-principale" tabIndex={-1}>{children}</div>
         <SectionNav />
         <SiteFooter latestTerritorialCheckLabel={latestTerritorialCheckLabel} />
+        <ReportProblemButton />
       </body>
     </html>
   );

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -85,6 +85,20 @@ export default function PrivacyPage() {
       </section>
 
       <section className="panel">
+        <h2 className="panel-title">Modulo «Segnala un problema»</h2>
+        <p>
+          Il modulo presente in ogni pagina crea una issue <strong>pubblica</strong> nel repository
+          GitHub del progetto. Oltre al testo che scrivi, allega il percorso e il titolo della
+          pagina, data e ora dell&apos;invio, la dimensione della finestra e la stringa del browser
+          (user agent), utili a riprodurre il problema. Non chiede nome o email e non accetta
+          allegati. L&apos;indirizzo IP è usato dal server solo in forma non reversibile e in
+          memoria per limitare gli invii ripetuti; non viene scritto nella issue né nei log
+          applicativi, che non registrano il contenuto della segnalazione. Il testo inviato è
+          conservato da GitHub secondo le sue condizioni: non inserire dati personali.
+        </p>
+      </section>
+
+      <section className="panel">
         <h2 className="panel-title">I tuoi diritti</h2>
         <p>
           Un canale privato per accesso, correzione, cancellazione, limitazione, portabilità quando

--- a/src/app/supporto/page.tsx
+++ b/src/app/supporto/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ReportProblemButton } from "@/components/report-problem/report-problem-button";
 import { PUBLIC_MCP_ENDPOINT, REPO_URL } from "@/lib/site";
 import styles from "../legal-page.module.css";
 
@@ -18,11 +19,24 @@ export default function SupportPage() {
       <section className="panel">
         <h2 className="panel-title">Problemi e richieste tecniche</h2>
         <p>
-          Apri una <a href={`${REPO_URL}/issues`}>issue pubblica su GitHub</a> indicando pagina o
-          endpoint, risultato atteso, risultato osservato, data e passaggi per riprodurlo. Non
-          inserire dati personali, credenziali o informazioni riservate. Per una vulnerabilità non
-          ancora corretta non aprire una issue: usa il{" "}
+          Il modo più rapido è il pulsante <ReportProblemButton variant="inline" /> presente in
+          ogni pagina: raccoglie tipo di problema, risultato osservato, risultato atteso, passaggi
+          per riprodurlo ed eventuale fonte ufficiale, allega pagina, data e ora, dimensione della
+          finestra e versione del browser, e crea una issue pubblica nel repository restituendone
+          il link. Se l&apos;invio automatico non è disponibile, il modulo propone il composer
+          GitHub già compilato.
+        </p>
+        <p>
+          In alternativa apri direttamente una <a href={`${REPO_URL}/issues`}>issue pubblica su
+          GitHub</a> indicando pagina o endpoint, risultato atteso, risultato osservato, data e
+          passaggi per riprodurlo. In entrambi i casi non inserire dati personali, credenziali o
+          informazioni riservate: le issue sono pubbliche. Per una vulnerabilità non
+          ancora corretta non usare né il modulo né una issue: usa il{" "}
           <a href={`${REPO_URL}/security/advisories/new`}>report privato GitHub</a>.
+        </p>
+        <p>
+          Per contestare un dato indica il link della fonte ufficiale con cui lo confronti. Un
+          valore diverso da quello atteso non dimostra da solo spreco, frode o responsabilità.
         </p>
       </section>
 

--- a/src/components/report-problem/report-problem-button.tsx
+++ b/src/components/report-problem/report-problem-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Flag02Icon } from "@hugeicons/core-free-icons";
+import styles from "./report-problem.module.css";
+
+// The dialog, its schema and its styles are downloaded only on the first
+// activation: the button itself is the only interactive code every page pays for.
+const ReportProblemDialog = dynamic(
+  () => import("./report-problem-dialog").then((module) => module.ReportProblemDialog),
+  { ssr: false },
+);
+
+type ReportProblemButtonProps = Readonly<{
+  /** `floating` is the global control; `inline` is a plain text button for footers and pages. */
+  variant?: "floating" | "inline";
+}>;
+
+export function ReportProblemButton({ variant = "floating" }: ReportProblemButtonProps) {
+  const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const openDialog = useCallback(() => {
+    setMounted(true);
+    setOpen(true);
+  }, []);
+
+  const closeDialog = useCallback(() => setOpen(false), []);
+
+  // Native dialogs restore focus themselves in most browsers; be explicit so
+  // the behaviour is identical everywhere. Runs after the closed state has
+  // been committed, so the trigger is guaranteed to be focusable again.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (wasOpenRef.current && !open) triggerRef.current?.focus();
+    wasOpenRef.current = open;
+  }, [open]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={variant === "floating" ? styles.floatingTrigger : styles.inlineTrigger}
+        onClick={openDialog}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        data-report-problem-trigger={variant}
+      >
+        <HugeiconsIcon icon={Flag02Icon} size={16} strokeWidth={1.8} aria-hidden="true" />
+        Segnala un problema
+      </button>
+      {/* Portalled to <body>: the inline variant lives inside <p>, which cannot contain a <dialog>. */}
+      {mounted ? createPortal(<ReportProblemDialog open={open} onClose={closeDialog} />, document.body) : null}
+    </>
+  );
+}

--- a/src/components/report-problem/report-problem-button.tsx
+++ b/src/components/report-problem/report-problem-button.tsx
@@ -49,10 +49,16 @@ export function ReportProblemButton({ variant = "floating" }: ReportProblemButto
         onClick={openDialog}
         aria-haspopup="dialog"
         aria-expanded={open}
+        aria-label="Segnala un problema"
+        title="Segnala un problema"
         data-report-problem-trigger={variant}
       >
-        <HugeiconsIcon icon={Flag02Icon} size={16} strokeWidth={1.8} aria-hidden="true" />
-        Segnala un problema
+        <HugeiconsIcon icon={Flag02Icon} size={variant === "floating" ? 18 : 16} strokeWidth={1.8} aria-hidden="true" />
+        {variant === "floating" ? (
+          <span className={styles.visuallyHidden}>Segnala un problema</span>
+        ) : (
+          "Segnala un problema"
+        )}
       </button>
       {/* Portalled to <body>: the inline variant lives inside <p>, which cannot contain a <dialog>. */}
       {mounted ? createPortal(<ReportProblemDialog open={open} onClose={closeDialog} />, document.body) : null}

--- a/src/components/report-problem/report-problem-dialog.tsx
+++ b/src/components/report-problem/report-problem-dialog.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { type FormEvent, useEffect, useId, useRef, useState } from "react";
+import {
+  REPORT_CATEGORIES,
+  REPORT_CATEGORY_IDS,
+  REPORT_ENDPOINT,
+  REPORT_LIMITS,
+  reportRequestSchema,
+  SECURITY_ADVISORY_URL,
+  type ReportCategory,
+  type ReportResponse,
+} from "@/lib/report/contract";
+import styles from "./report-problem.module.css";
+
+type ReportProblemDialogProps = Readonly<{
+  open: boolean;
+  onClose: () => void;
+}>;
+
+type FieldName = "category" | "observed" | "expected" | "steps" | "sourceUrl";
+type FieldErrors = Partial<Record<FieldName, string>>;
+
+type Submission =
+  | Readonly<{ state: "idle" }>
+  | Readonly<{ state: "sending" }>
+  | Readonly<{ state: "sent"; number: number; url: string; duplicate: boolean }>
+  | Readonly<{ state: "failed"; message: string; fallbackUrl: string | null }>;
+
+const FIELD_LABELS: Record<FieldName, string> = {
+  category: "Tipo di problema",
+  observed: "Cosa è successo",
+  expected: "Cosa ti aspettavi",
+  steps: "Passaggi per riprodurre il problema",
+  sourceUrl: "Fonte ufficiale",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isReportResponse(value: unknown): value is ReportResponse {
+  if (!isRecord(value) || typeof value.ok !== "boolean") return false;
+  if (value.ok) {
+    return isRecord(value.issue) && typeof value.issue.number === "number" &&
+      typeof value.issue.url === "string" && value.issue.url.startsWith("https://github.com/");
+  }
+  return typeof value.code === "string" && typeof value.message === "string" &&
+    (value.fallbackUrl === undefined ||
+      (typeof value.fallbackUrl === "string" && value.fallbackUrl.startsWith("https://github.com/")));
+}
+
+/** Only the fields the user can act on are mapped; everything else is a generic error. */
+function fieldErrorsFrom(issues: ReadonlyArray<{ path: PropertyKey[]; message: string }>): FieldErrors {
+  const errors: FieldErrors = {};
+  for (const issue of issues) {
+    const field = String(issue.path[0] ?? "");
+    if (field in FIELD_LABELS && !(field in errors)) {
+      errors[field as FieldName] = issue.message;
+    }
+  }
+  return errors;
+}
+
+export function ReportProblemDialog({ open, onClose }: ReportProblemDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const baseId = useId();
+  const id = (suffix: string) => `${baseId}-${suffix}`;
+
+  const [category, setCategory] = useState<ReportCategory>("bug");
+  const [observed, setObserved] = useState("");
+  const [expected, setExpected] = useState("");
+  const [steps, setSteps] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [website, setWebsite] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [submission, setSubmission] = useState<Submission>({ state: "idle" });
+  const [page, setPage] = useState<{ path: string; title: string; openedAt: string; clientKey: string } | null>(null);
+
+  // Page context is captured when the dialog opens, so a report describes the
+  // page the person was actually looking at even if they navigate afterwards.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      setPage((current) => ({
+        path: `${window.location.pathname}${window.location.search}`,
+        title: document.title,
+        openedAt: new Date().toISOString(),
+        // The key survives a reopen so a retry of the same report never duplicates it.
+        clientKey: current?.clientKey ?? crypto.randomUUID(),
+      }));
+      dialog.showModal();
+      firstFieldRef.current?.focus();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  const sourceRequired = category === "dato";
+  const observedLeft = REPORT_LIMITS.observedMax - observed.length;
+  const expectedLeft = REPORT_LIMITS.expectedMax - expected.length;
+  const stepsLeft = REPORT_LIMITS.stepsMax - steps.length;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submission.state === "sending" || submission.state === "sent" || !page) return;
+
+    const fresh = {
+      clientKey: page.clientKey,
+      category,
+      observed,
+      expected,
+      steps,
+      ...(sourceUrl.trim() ? { sourceUrl: sourceUrl.trim() } : {}),
+      page: { path: page.path, title: page.title },
+      context: {
+        reportedAt: new Date().toISOString(),
+        openedAt: page.openedAt,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        userAgent: navigator.userAgent.slice(0, REPORT_LIMITS.userAgentMax),
+      },
+      website,
+    };
+    const validation = reportRequestSchema.safeParse(fresh);
+    if (!validation.success) {
+      const fieldErrors = fieldErrorsFrom(validation.error.issues);
+      setErrors(fieldErrors);
+      const first = (Object.keys(fieldErrors) as FieldName[])[0];
+      if (first) document.getElementById(id(first))?.focus();
+      return;
+    }
+    setErrors({});
+    setSubmission({ state: "sending" });
+
+    try {
+      const response = await fetch(REPORT_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(fresh),
+      });
+      const body: unknown = await response.json().catch(() => null);
+      if (!isReportResponse(body)) {
+        throw new Error(`Risposta inattesa (HTTP ${response.status})`);
+      }
+      if (body.ok) {
+        setSubmission({ state: "sent", number: body.issue.number, url: body.issue.url, duplicate: body.duplicate });
+        return;
+      }
+      setSubmission({ state: "failed", message: body.message, fallbackUrl: body.fallbackUrl ?? null });
+    } catch {
+      setSubmission({
+        state: "failed",
+        message: "Non è stato possibile contattare il server. I dati inseriti sono ancora qui: riprova fra poco.",
+        fallbackUrl: null,
+      });
+    }
+  }
+
+  function resetAndClose() {
+    if (submission.state === "sent") {
+      setObserved("");
+      setExpected("");
+      setSteps("");
+      setSourceUrl("");
+      setCategory("bug");
+      setSubmission({ state: "idle" });
+      setPage(null);
+    }
+    onClose();
+  }
+
+  const sending = submission.state === "sending";
+  const sent = submission.state === "sent";
+  const errorList = (Object.keys(errors) as FieldName[]).map((field) => ({ field, message: errors[field]! }));
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      aria-labelledby={id("title")}
+      aria-describedby={id("intro")}
+      onCancel={(event) => {
+        event.preventDefault();
+        resetAndClose();
+      }}
+      onClose={() => {
+        if (open) onClose();
+      }}
+    >
+      <div className={styles.header}>
+        <div>
+          <h2 id={id("title")} className={styles.title}>Segnala un problema</h2>
+          <p id={id("intro")} className={styles.intro}>
+            La segnalazione diventa una issue <strong>pubblica</strong> su GitHub. Non inserire dati
+            personali, credenziali o informazioni riservate.
+          </p>
+        </div>
+        <button type="button" className={styles.close} onClick={resetAndClose} aria-label="Chiudi">
+          ×
+        </button>
+      </div>
+
+      {sent ? (
+        <div className={styles.success} role="status" aria-live="polite">
+          <p className={styles.successTitle}>
+            <span aria-hidden="true">✓ </span>
+            {submission.duplicate ? "Segnalazione già registrata" : "Segnalazione inviata"}
+          </p>
+          <p>
+            {submission.duplicate
+              ? "Questa segnalazione era già arrivata: non ne è stata creata una seconda."
+              : "Grazie. La issue è pubblica e verrà valutata confrontandola con la fonte ufficiale."}
+          </p>
+          <p>
+            <a href={submission.url} target="_blank" rel="noreferrer" className={styles.issueLink}>
+              Apri la issue #{submission.number} su GitHub
+            </a>
+          </p>
+          <button type="button" className={styles.secondary} onClick={resetAndClose}>Chiudi</button>
+        </div>
+      ) : (
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          {errorList.length > 0 ? (
+            <div className={styles.errorSummary} role="alert" id={id("errors")}>
+              <strong>Controlla i campi segnalati</strong>
+              <ul>
+                {errorList.map(({ field, message }) => (
+                  <li key={field}>
+                    <a href={`#${id(field)}`} onClick={(event) => { event.preventDefault(); document.getElementById(id(field))?.focus(); }}>
+                      {FIELD_LABELS[field]}
+                    </a>: {message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <fieldset className={styles.fieldset} disabled={sending}>
+            <legend className={styles.label}>{FIELD_LABELS.category}</legend>
+            <div className={styles.radios} role="radiogroup" aria-describedby={errors.category ? id("category-error") : undefined}>
+              {REPORT_CATEGORY_IDS.map((value, index) => (
+                <label key={value} className={styles.radio}>
+                  <input
+                    ref={index === 0 ? firstFieldRef : undefined}
+                    id={index === 0 ? id("category") : undefined}
+                    type="radio"
+                    name="category"
+                    value={value}
+                    checked={category === value}
+                    onChange={() => setCategory(value)}
+                  />
+                  {REPORT_CATEGORIES[value]}
+                </label>
+              ))}
+            </div>
+            {errors.category ? <p id={id("category-error")} className={styles.fieldError}>{errors.category}</p> : null}
+          </fieldset>
+
+          {category === "dato" ? (
+            <p className={styles.hint}>
+              Un dato diverso da quello atteso non dimostra da solo spreco, frode o responsabilità.
+              Indica la fonte ufficiale con cui lo confronti: la verifica parte da lì.
+            </p>
+          ) : null}
+
+          <TextField
+            id={id("observed")}
+            label={FIELD_LABELS.observed}
+            value={observed}
+            onChange={setObserved}
+            max={REPORT_LIMITS.observedMax}
+            left={observedLeft}
+            error={errors.observed}
+            disabled={sending}
+            placeholder="Es. il totale della tabella non corrisponde alla somma delle righe"
+          />
+          <TextField
+            id={id("expected")}
+            label={FIELD_LABELS.expected}
+            value={expected}
+            onChange={setExpected}
+            max={REPORT_LIMITS.expectedMax}
+            left={expectedLeft}
+            error={errors.expected}
+            disabled={sending}
+            placeholder="Es. il totale dovrebbe essere uguale alla somma"
+          />
+          <TextField
+            id={id("steps")}
+            label={FIELD_LABELS.steps}
+            value={steps}
+            onChange={setSteps}
+            max={REPORT_LIMITS.stepsMax}
+            left={stepsLeft}
+            error={errors.steps}
+            disabled={sending}
+            placeholder={"1. Apri la pagina\n2. Seleziona…\n3. Osserva…"}
+          />
+
+          <div className={styles.field}>
+            <label htmlFor={id("sourceUrl")} className={styles.label}>
+              {FIELD_LABELS.sourceUrl}{" "}
+              <span className={styles.optional}>{sourceRequired ? "(obbligatoria per contestare un dato)" : "(facoltativa)"}</span>
+            </label>
+            <input
+              id={id("sourceUrl")}
+              type="url"
+              inputMode="url"
+              className={styles.input}
+              value={sourceUrl}
+              onChange={(event) => setSourceUrl(event.target.value)}
+              maxLength={REPORT_LIMITS.sourceUrlMax}
+              placeholder="https://…"
+              disabled={sending}
+              aria-required={sourceRequired}
+              aria-invalid={errors.sourceUrl ? true : undefined}
+              aria-describedby={errors.sourceUrl ? id("sourceUrl-error") : undefined}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            {errors.sourceUrl ? <p id={id("sourceUrl-error")} className={styles.fieldError}>{errors.sourceUrl}</p> : null}
+          </div>
+
+          {/* Honeypot: invisible to people, tempting for bots. */}
+          <div className={styles.honeypot} aria-hidden="true">
+            <label htmlFor={id("website")}>Sito web</label>
+            <input
+              id={id("website")}
+              type="text"
+              name="website"
+              tabIndex={-1}
+              autoComplete="off"
+              value={website}
+              onChange={(event) => setWebsite(event.target.value)}
+            />
+          </div>
+
+          <div className={styles.context}>
+            <strong>Cosa viene allegato automaticamente</strong>
+            <p>
+              Pagina <code>{page?.path ?? "…"}</code>, titolo della pagina, data e ora, dimensione della finestra e
+              versione del browser. Nessun nome, email o indirizzo IP viene salvato nella issue.
+            </p>
+          </div>
+
+          <p className={styles.securityNote}>
+            Hai trovato una vulnerabilità non ancora corretta? Non usare questo modulo: usa il{" "}
+            <a href={SECURITY_ADVISORY_URL} target="_blank" rel="noreferrer">report privato GitHub</a>.
+          </p>
+
+          {submission.state === "failed" ? (
+            <div className={styles.failure} role="alert">
+              <strong>Invio non riuscito</strong>
+              <p>{submission.message}</p>
+              {submission.fallbackUrl ? (
+                <a href={submission.fallbackUrl} target="_blank" rel="noreferrer" className={styles.fallbackLink}>
+                  Apri il modulo GitHub precompilato
+                </a>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className={styles.actions}>
+            <button type="submit" className={styles.primary} disabled={sending} aria-busy={sending}>
+              {sending ? "Invio in corso…" : "Invia la segnalazione pubblica"}
+            </button>
+            <button type="button" className={styles.secondary} onClick={resetAndClose} disabled={sending}>
+              Annulla
+            </button>
+          </div>
+        </form>
+      )}
+    </dialog>
+  );
+}
+
+type TextFieldProps = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  max: number;
+  left: number;
+  error?: string;
+  disabled: boolean;
+  placeholder: string;
+}>;
+
+function TextField({ id, label, value, onChange, max, left, error, disabled, placeholder }: TextFieldProps) {
+  const describedBy = [error ? `${id}-error` : null, `${id}-count`].filter(Boolean).join(" ");
+  return (
+    <div className={styles.field}>
+      <label htmlFor={id} className={styles.label}>{label}</label>
+      <textarea
+        id={id}
+        className={styles.textarea}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        maxLength={max}
+        rows={3}
+        required
+        disabled={disabled}
+        placeholder={placeholder}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+      />
+      <div className={styles.fieldMeta}>
+        {error ? <p id={`${id}-error`} className={styles.fieldError}>{error}</p> : <span />}
+        <span id={`${id}-count`} className={styles.counter}>{left} caratteri disponibili</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/report-problem/report-problem.module.css
+++ b/src/components/report-problem/report-problem.module.css
@@ -1,10 +1,10 @@
 /*
  * "Segnala un problema": one small global control and a native <dialog>.
  *
- * The trigger sits in the bottom-right corner, above the footer's own links,
- * and never grows past a single line so it does not cover table controls or
- * pagination. The dialog is a plain form: same borders, spacing and accent as
- * the rest of the site, nothing floating or animated.
+ * The global trigger is a 44px icon in the bottom-right corner so it stays
+ * tappable without covering charts or table controls. The labelled text lives
+ * in the footer. The dialog is a plain form: same borders, spacing and accent
+ * as the rest of the site, nothing animated.
  */
 
 .floatingTrigger,
@@ -25,14 +25,29 @@
   right: max(var(--space-4), env(safe-area-inset-right));
   bottom: max(var(--space-4), env(safe-area-inset-bottom));
   z-index: 40;
-  padding: 10px 14px;
+  width: 44px;
+  min-width: 44px;
+  padding: 0;
+  justify-content: center;
+  gap: 0;
   border: 1px solid var(--color-neutral-500);
   background: var(--color-raised);
   box-shadow: 0 1px 0 var(--color-neutral-300);
-  white-space: nowrap;
 }
 .floatingTrigger:hover { background: var(--color-neutral-100); color: var(--color-accent-700); }
 .floatingTrigger:focus-visible { outline: 2px solid var(--color-accent-700); outline-offset: 2px; }
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
 
 .inlineTrigger {
   padding: 0;
@@ -223,6 +238,5 @@
 .issueLink { font-weight: 600; color: var(--color-accent-700); }
 
 @media (max-width: 480px) {
-  .floatingTrigger { font-size: 12px; padding: 9px 12px; }
   .header, .form, .success { padding-inline: var(--space-4); }
 }

--- a/src/components/report-problem/report-problem.module.css
+++ b/src/components/report-problem/report-problem.module.css
@@ -1,0 +1,228 @@
+/*
+ * "Segnala un problema": one small global control and a native <dialog>.
+ *
+ * The trigger sits in the bottom-right corner, above the footer's own links,
+ * and never grows past a single line so it does not cover table controls or
+ * pagination. The dialog is a plain form: same borders, spacing and accent as
+ * the rest of the site, nothing floating or animated.
+ */
+
+.floatingTrigger,
+.inlineTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.floatingTrigger {
+  position: fixed;
+  right: max(var(--space-4), env(safe-area-inset-right));
+  bottom: max(var(--space-4), env(safe-area-inset-bottom));
+  z-index: 40;
+  padding: 10px 14px;
+  border: 1px solid var(--color-neutral-500);
+  background: var(--color-raised);
+  box-shadow: 0 1px 0 var(--color-neutral-300);
+  white-space: nowrap;
+}
+.floatingTrigger:hover { background: var(--color-neutral-100); color: var(--color-accent-700); }
+.floatingTrigger:focus-visible { outline: 2px solid var(--color-accent-700); outline-offset: 2px; }
+
+.inlineTrigger {
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  color: var(--color-accent-700);
+  background: transparent;
+  text-decoration: underline;
+  text-underline-offset: .18em;
+}
+.inlineTrigger:hover { color: var(--color-accent-800); }
+
+@media print {
+  .floatingTrigger { display: none; }
+}
+
+/* ── dialog ────────────────────────────────────────────────────────────── */
+
+.dialog {
+  width: min(100% - 2 * var(--space-4), 640px);
+  max-height: min(100dvh - 2 * var(--space-4), 900px);
+  padding: 0;
+  border: 1px solid var(--color-neutral-500);
+  color: var(--color-text);
+  background: var(--color-raised);
+  overflow: auto;
+}
+.dialog::backdrop { background: rgb(32 30 29 / .55); }
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-5) var(--space-5) var(--space-3);
+  border-bottom: 1px solid var(--color-neutral-300);
+}
+.title { margin: 0; font-size: 20px; }
+.intro { margin: var(--space-1) 0 0; font-size: 14px; color: var(--color-neutral-800); max-width: 60ch; }
+.intro strong { color: var(--color-accent-700); }
+
+.close {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  margin: -6px -8px 0 0;
+  border: 1px solid transparent;
+  font: inherit;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--color-neutral-700);
+  background: transparent;
+  cursor: pointer;
+}
+.close:hover { color: var(--color-text); border-color: var(--color-neutral-400); }
+
+.form,
+.success {
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5) var(--space-5);
+}
+
+.fieldset { margin: 0; padding: 0; border: 0; min-inline-size: 0; }
+.field { display: grid; gap: var(--space-1); }
+.label { font-weight: 700; font-size: 14px; }
+.optional { font-weight: 400; color: var(--color-neutral-700); }
+
+.radios { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-4); margin-top: var(--space-1); }
+.radio {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 32px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.radio input { margin: 0; width: 18px; height: 18px; accent-color: var(--color-accent-700); }
+
+.textarea,
+.input {
+  width: 100%;
+  padding: 10px 12px;
+  font: inherit;
+  font-size: 14px;
+  color: var(--color-text);
+  background: var(--color-raised);
+  border: 1px solid var(--color-neutral-400);
+}
+.textarea { min-height: 82px; resize: vertical; }
+.textarea:focus-visible,
+.input:focus-visible { outline: 2px solid var(--color-accent-700); outline-offset: 1px; border-color: var(--color-accent-700); }
+.textarea[aria-invalid="true"],
+.input[aria-invalid="true"] { border-color: var(--color-critical); }
+.textarea::placeholder,
+.input::placeholder { color: var(--color-neutral-600); }
+
+.fieldMeta {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-size: 12px;
+}
+.counter { color: var(--color-neutral-600); white-space: nowrap; }
+.fieldError {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-critical);
+}
+.fieldError::before { content: "⚠ "; }
+
+.hint,
+.context,
+.securityNote {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  font-size: 13px;
+  color: var(--color-neutral-800);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+}
+.context p { margin: var(--space-1) 0 0; }
+.context code { font-family: var(--font-mono); font-size: 12px; word-break: break-all; }
+.securityNote a { color: var(--color-accent-700); }
+
+.errorSummary,
+.failure {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-critical-border);
+  background: var(--color-critical-bg);
+  color: var(--color-text);
+  font-size: 14px;
+}
+.errorSummary strong,
+.failure strong { display: block; color: var(--color-critical); }
+.errorSummary ul { margin: var(--space-2) 0 0; padding-left: 18px; }
+.errorSummary a { color: var(--color-critical); font-weight: 600; }
+.failure p { margin: var(--space-1) 0 0; }
+.fallbackLink { display: inline-block; margin-top: var(--space-2); font-weight: 600; color: var(--color-accent-700); }
+
+.honeypot {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.actions { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-1); }
+.primary,
+.secondary {
+  min-height: 44px;
+  padding: 10px 18px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.primary {
+  color: var(--color-on-strong);
+  background: var(--color-accent-700);
+  border: 1px solid var(--color-accent-700);
+}
+.primary:hover:not(:disabled) { background: var(--color-accent-800); }
+.primary:disabled { opacity: .7; cursor: progress; }
+.secondary {
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-neutral-400);
+}
+.secondary:hover:not(:disabled) { background: var(--color-neutral-200); }
+.primary:focus-visible,
+.secondary:focus-visible { outline: 2px solid var(--color-accent-700); outline-offset: 2px; }
+
+.success { justify-items: start; }
+.success p { margin: 0; max-width: 60ch; }
+.successTitle {
+  padding: var(--space-3) var(--space-4);
+  font-weight: 700;
+  color: var(--color-positive);
+  background: var(--color-positive-bg);
+  border: 1px solid var(--color-positive-border);
+  justify-self: stretch;
+}
+.issueLink { font-weight: 600; color: var(--color-accent-700); }
+
+@media (max-width: 480px) {
+  .floatingTrigger { font-size: 12px; padding: 9px 12px; }
+  .header, .form, .success { padding-inline: var(--space-4); }
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Coffee02Icon, GithubIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { ReportProblemButton } from "@/components/report-problem/report-problem-button";
 import { FOOTER_SITEMAP_GROUPS } from "@/lib/site-navigation";
 import { BUY_ME_A_COFFEE_URL, REPO_URL } from "@/lib/site";
 
@@ -74,6 +75,7 @@ export function SiteFooter({ latestTerritorialCheckLabel }: SiteFooterProps) {
         <nav className="footer-secondary-links" aria-label="Informazioni sul progetto">
           <Link href="/supporter">Chi ci sostiene</Link>
           <Link href="/supporto">Supporto</Link>
+          <ReportProblemButton variant="inline" />
           <Link href="/termini">Termini</Link>
         </nav>
       </div>

--- a/src/lib/http/public-post-guard.ts
+++ b/src/lib/http/public-post-guard.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared guards for public JSON POST endpoints exposed to the browser.
+ *
+ * Every check is fail-closed: a request without a same-site Origin, with a
+ * foreign Host, with a body larger than the declared budget or with a
+ * non-JSON content type is rejected before any business logic runs.
+ */
+
+export const NO_STORE_HEADERS = Object.freeze({
+  "cache-control": "private, no-store",
+  "x-content-type-options": "nosniff",
+});
+
+export function jsonResponse(body: unknown, status = 200, headers?: HeadersInit): Response {
+  return Response.json(body, { status, headers: { ...NO_STORE_HEADERS, ...headers } });
+}
+
+export function normalizedHost(value: string): string | null {
+  const candidate = value.trim().toLocaleLowerCase("en-US").replace(/\.$/u, "");
+  if (!candidate || /[\s/@]/u.test(candidate)) return null;
+  return candidate;
+}
+
+export function isLoopbackHost(value: string): boolean {
+  return /^(?:localhost|127\.0\.0\.1|\[::1\])(?::\d{1,5})?$/u.test(value);
+}
+
+export function allowedHosts(request: Request): Set<string> {
+  const requestUrlHost = normalizedHost(new URL(request.url).host);
+  const configured = [process.env.VERCEL_PROJECT_PRODUCTION_URL, process.env.VERCEL_URL]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map((value) => value.replace(/^https?:\/\//iu, ""))
+    .map(normalizedHost)
+    .filter((value): value is string => value !== null);
+  const allowed = new Set(configured);
+  if (requestUrlHost) allowed.add(requestUrlHost);
+
+  const requestHost = normalizedHost(request.headers.get("host") ?? "");
+  if (requestHost && requestUrlHost && isLoopbackHost(requestHost) && isLoopbackHost(requestUrlHost)) {
+    allowed.add(requestHost);
+  }
+  return allowed;
+}
+
+export type PublicPostGuardOptions = Readonly<{
+  maxRequestBytes: number;
+}>;
+
+/**
+ * Returns a rejection response, or `null` when the request may proceed.
+ */
+export function rejectPublicPost(request: Request, { maxRequestBytes }: PublicPostGuardOptions): Response | null {
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim();
+  if (contentType !== "application/json") {
+    return jsonResponse({ ok: false, error: "Content-Type non supportato" }, 415);
+  }
+
+  const requestHost = normalizedHost(request.headers.get("host") ?? "");
+  if (!requestHost || !allowedHosts(request).has(requestHost)) {
+    return jsonResponse({ ok: false, error: "Host non consentito" }, 403);
+  }
+
+  const origin = request.headers.get("origin");
+  let originUrl: URL;
+  try {
+    originUrl = new URL(origin ?? "");
+  } catch {
+    return jsonResponse({ ok: false, error: "Origin non consentita" }, 403);
+  }
+  const originHost = normalizedHost(originUrl.host);
+  const allowedProtocol = originUrl.protocol === "https:" ||
+    (originUrl.protocol === "http:" && isLoopbackHost(requestHost));
+  if (originHost !== requestHost || !allowedProtocol) {
+    return jsonResponse({ ok: false, error: "Origin non consentita" }, 403);
+  }
+
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/u.test(declaredLength)) {
+      return jsonResponse({ ok: false, error: "Content-Length non valido" }, 400);
+    }
+    if (Number(declaredLength) > maxRequestBytes) {
+      return jsonResponse({ ok: false, error: "Richiesta troppo grande" }, 413);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Reads the body up to `maxRequestBytes`, returning the decoded UTF-8 string
+ * or a ready rejection response.
+ */
+export async function readBoundedBody(
+  request: Request,
+  { maxRequestBytes }: PublicPostGuardOptions,
+): Promise<string | Response> {
+  if (!request.body) return jsonResponse({ ok: false, error: "Corpo richiesta assente" }, 400);
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let aborted = request.signal.aborted;
+  const abortReader = () => {
+    aborted = true;
+    void reader.cancel(request.signal.reason).catch(() => undefined);
+  };
+  if (aborted) {
+    await reader.cancel(request.signal.reason).catch(() => undefined);
+    return jsonResponse({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
+  }
+  request.signal.addEventListener("abort", abortReader, { once: true });
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (aborted) return jsonResponse({ ok: false, error: "Richiesta interrotta o non leggibile" }, 400);
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxRequestBytes) {
+        await reader.cancel("Request body limit exceeded").catch(() => undefined);
+        return jsonResponse({ ok: false, error: "Richiesta troppo grande" }, 413);
+      }
+      chunks.push(value);
+    }
+
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(body);
+    } catch {
+      return jsonResponse({ ok: false, error: "Corpo UTF-8 non valido" }, 400);
+    }
+  } finally {
+    request.signal.removeEventListener("abort", abortReader);
+  }
+}

--- a/src/lib/report/contract.ts
+++ b/src/lib/report/contract.ts
@@ -1,0 +1,302 @@
+/**
+ * Public contract of the "Segnala un problema" form.
+ *
+ * The client sends only what the user typed plus the technical context of the
+ * page. Everything that decides *where* and *how* the issue is created
+ * (repository, labels, title format, body structure) lives on the server and
+ * cannot be influenced by the payload. This module is imported by the browser
+ * too, so it must stay free of secrets and of `server-only` imports.
+ */
+import { z } from "zod";
+import { PUBLIC_SITE_URL, REPO_URL } from "@/lib/site";
+
+export const REPORT_ENDPOINT = "/api/segnalazioni";
+export const SECURITY_ADVISORY_URL = `${REPO_URL}/security/advisories/new`;
+export const REPORT_ISSUE_LABEL = "segnalazione";
+
+export const REPORT_CATEGORIES = Object.freeze({
+  bug: "Bug del sito",
+  dato: "Dato potenzialmente errato",
+  accessibilita: "Accessibilità",
+  altro: "Altro",
+} as const);
+export type ReportCategory = keyof typeof REPORT_CATEGORIES;
+export const REPORT_CATEGORY_IDS = Object.freeze(
+  Object.keys(REPORT_CATEGORIES) as [ReportCategory, ...ReportCategory[]],
+);
+
+export const REPORT_LIMITS = Object.freeze({
+  observedMax: 2_000,
+  expectedMax: 2_000,
+  stepsMax: 2_000,
+  sourceUrlMax: 500,
+  pagePathMax: 300,
+  pageTitleMax: 200,
+  userAgentMax: 300,
+  /** Upper bound of the JSON body accepted by the endpoint, in bytes. */
+  requestBytesMax: 12_288,
+  /** Minimum time a human plausibly needs between opening and sending the form. */
+  minFillMs: 3_000,
+  /** A form opened longer ago than this is considered stale. */
+  maxFillMs: 24 * 60 * 60 * 1_000,
+});
+
+// Control characters (tab excluded), bidi overrides and zero-width characters.
+const INVISIBLE_CHARACTERS =
+  /[\u0000-\u0008\u000B-\u001F\u007F-\u009F\u00AD\u200B-\u200F\u2028-\u202E\u2060-\u2064\uFEFF]/gu;
+
+/**
+ * Normalises free text typed by a person: NFC, no control or invisible
+ * characters, CRLF folded to LF, no trailing spaces, at most one blank line
+ * in a row.
+ */
+export function normalizeUserText(value: string): string {
+  return value
+    .normalize("NFC")
+    .replace(/\r\n?/gu, "\n")
+    .replace(INVISIBLE_CHARACTERS, "")
+    .replace(/[ \t]+$/gmu, "")
+    .replace(/\n{3,}/gu, "\n\n")
+    .trim();
+}
+
+function boundedText(max: number, { required }: { required: boolean }) {
+  const base = z.string().max(max * 4).transform(normalizeUserText);
+  return required
+    ? base.pipe(z.string().min(1, "campo obbligatorio").max(max, `massimo ${max} caratteri`))
+    : base.pipe(z.string().max(max, `massimo ${max} caratteri`));
+}
+
+const publicHttpsUrl = z
+  .string()
+  .max(REPORT_LIMITS.sourceUrlMax, `massimo ${REPORT_LIMITS.sourceUrlMax} caratteri`)
+  .transform((value) => value.trim())
+  .pipe(z.string().min(1).max(REPORT_LIMITS.sourceUrlMax))
+  .refine((value) => {
+    try {
+      const url = new URL(value);
+      return url.protocol === "https:" && url.username === "" && url.password === "" &&
+        !/[\s<>()"'`\\]/u.test(value);
+    } catch {
+      return false;
+    }
+  }, { message: "deve essere un URL https valido" });
+
+/**
+ * Only a path on the canonical site is accepted: the client never sends a
+ * full URL, so an attacker cannot make the issue link to another domain.
+ */
+const sitePagePath = z
+  .string()
+  .max(REPORT_LIMITS.pagePathMax)
+  .refine((value) => {
+    if (!value.startsWith("/") || value.startsWith("//")) return false;
+    if (/[\s<>()"'`\\]/u.test(value)) return false;
+    try {
+      const url = new URL(value, PUBLIC_SITE_URL);
+      return url.origin === PUBLIC_SITE_URL && url.pathname + url.search === value;
+    } catch {
+      return false;
+    }
+  }, { message: "percorso pagina non valido" });
+
+const viewport = z.strictObject({
+  width: z.number().int().min(1).max(20_000),
+  height: z.number().int().min(1).max(20_000),
+});
+
+const isoTimestamp = z
+  .string()
+  .max(40)
+  .refine((value) => Number.isFinite(Date.parse(value)), { message: "timestamp non valido" });
+
+export const reportRequestSchema = z
+  .strictObject({
+    /** UUID chosen by the client; the server uses it to avoid duplicate issues. */
+    clientKey: z.uuid(),
+    category: z.enum(REPORT_CATEGORY_IDS),
+    observed: boundedText(REPORT_LIMITS.observedMax, { required: true }),
+    expected: boundedText(REPORT_LIMITS.expectedMax, { required: true }),
+    steps: boundedText(REPORT_LIMITS.stepsMax, { required: true }),
+    sourceUrl: publicHttpsUrl.optional(),
+    page: z.strictObject({
+      path: sitePagePath,
+      title: boundedText(REPORT_LIMITS.pageTitleMax, { required: false }),
+    }),
+    context: z.strictObject({
+      reportedAt: isoTimestamp,
+      openedAt: isoTimestamp,
+      viewport: viewport.optional(),
+      userAgent: boundedText(REPORT_LIMITS.userAgentMax, { required: false }).optional(),
+    }),
+    /** Honeypot: must stay empty. Bots that fill every field are rejected. */
+    website: z.literal("").optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.category === "dato" && !value.sourceUrl) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["sourceUrl"],
+        message: "per contestare un dato indica il link di una fonte ufficiale",
+      });
+    }
+  });
+
+export type ReportRequest = z.infer<typeof reportRequestSchema>;
+
+export type ReportValidation =
+  | Readonly<{ ok: true; value: ReportRequest }>
+  | Readonly<{ ok: false; message: string }>;
+
+export function parseReportRequest(payload: unknown): ReportValidation {
+  const result = reportRequestSchema.safeParse(payload);
+  if (result.success) return { ok: true, value: result.data };
+  const first = result.error.issues[0];
+  const path = first?.path.map(String).join(".") ?? "";
+  return {
+    ok: false,
+    message: path
+      ? `Campo «${path}» non valido: ${first?.message ?? "valore rifiutato"}`
+      : "Segnalazione non valida",
+  };
+}
+
+/** Timing checks that complement the honeypot. Returns a reason, or `null` when fine. */
+export function timingRejection(context: ReportRequest["context"], now = Date.now()): string | null {
+  const opened = Date.parse(context.openedAt);
+  const reported = Date.parse(context.reportedAt);
+  if (reported < opened) return "Orari della segnalazione incoerenti";
+  if (reported - opened < REPORT_LIMITS.minFillMs) return "Invio troppo rapido";
+  if (now - opened > REPORT_LIMITS.maxFillMs) return "Modulo aperto da troppo tempo: ricarica la pagina";
+  if (reported - now > 5 * 60 * 1_000) return "Orario della segnalazione nel futuro";
+  return null;
+}
+
+/* ── Issue rendering ─────────────────────────────────────────────────────── */
+
+/**
+ * Wraps user text in a fenced block whose fence is longer than any backtick
+ * run inside it. Inside a fence GitHub renders no HTML, no @mentions, no
+ * #references and no links, so the text cannot notify anyone or embed markup.
+ */
+export function fenceUserText(value: string): string {
+  const text = value.length > 0 ? value : "(non indicato)";
+  const longestRun = Math.max(0, ...Array.from(text.matchAll(/`+/gu), (match) => match[0].length));
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}text\n${text}\n${fence}`;
+}
+
+/** Inline text for headings and links: single line, no Markdown/HTML syntax, mentions defused. */
+export function inlineSafe(value: string, max: number): string {
+  const flat = normalizeUserText(value)
+    .replace(/\s+/gu, " ")
+    .replace(/[<>`*_[\]#|\\()]/gu, "")
+    .replace(/@/gu, "＠")
+    .trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+export type IssueDraft = Readonly<{
+  title: string;
+  body: string;
+  labels: readonly string[];
+}>;
+
+export const REPORT_KEY_MARKER = "dvns-report-key";
+
+export function issueMarker(clientKey: string): string {
+  return `<!-- ${REPORT_KEY_MARKER}: ${clientKey} -->`;
+}
+
+function formatRome(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.valueOf())) return "non disponibile";
+  return new Intl.DateTimeFormat("it-IT", {
+    dateStyle: "long",
+    timeStyle: "short",
+    timeZone: "Europe/Rome",
+  }).format(date);
+}
+
+/**
+ * Renders the issue. Title and structure are fixed here; the client can only
+ * fill the user sections, which are all fenced.
+ */
+export function buildIssueDraft(request: ReportRequest): IssueDraft {
+  const category = REPORT_CATEGORIES[request.category];
+  // The path is already restricted by the schema; the title is plain text on
+  // GitHub, so only its length needs bounding here.
+  const pagePath = request.page.path.length > 120 ? `${request.page.path.slice(0, 119)}…` : request.page.path;
+  const pageUrl = `${PUBLIC_SITE_URL}${request.page.path}`;
+  const pageTitle = request.page.title ? inlineSafe(request.page.title, 120) : "";
+  const title = `[Segnalazione] ${category}: ${pagePath}`;
+
+  const source = request.sourceUrl
+    ? `<${request.sourceUrl}>`
+    : request.category === "dato"
+      ? "(non indicata)"
+      : "(non pertinente)";
+
+  const technical = [
+    `- Segnalata il: ${formatRome(request.context.reportedAt)} (Europe/Rome)`,
+    request.context.viewport
+      ? `- Viewport: ${request.context.viewport.width}×${request.context.viewport.height} px`
+      : "- Viewport: non raccolto",
+    request.context.userAgent
+      ? `- Browser: \`${request.context.userAgent.replace(/`/gu, "'")}\``
+      : "- Browser: non raccolto",
+  ].join("\n");
+
+  const lines: Array<string | null> = [
+    issueMarker(request.clientKey),
+    "## Tipo di problema",
+    category,
+    "",
+    "## Pagina",
+    pageTitle ? `[${pageTitle}](${pageUrl})` : `<${pageUrl}>`,
+    "",
+    "## Risultato osservato",
+    fenceUserText(request.observed),
+    "",
+    "## Risultato atteso",
+    fenceUserText(request.expected),
+    "",
+    "## Passaggi per riprodurre",
+    fenceUserText(request.steps),
+    "",
+    "## Fonte ufficiale, se pertinente",
+    source,
+    "",
+    "## Contesto tecnico",
+    technical,
+    "",
+    "> Segnalazione inviata dal form pubblico del sito. Il contenuto inserito dall’utente non è stato verificato.",
+    request.category === "dato"
+      ? "> Un dato contestato non dimostra da solo spreco, frode o responsabilità: va confrontato con la fonte ufficiale."
+      : null,
+  ];
+
+  return {
+    title,
+    body: lines.filter((line): line is string => line !== null).join("\n"),
+    labels: [REPORT_ISSUE_LABEL],
+  };
+}
+
+/** Fallback when the server cannot create the issue: GitHub's own composer, prefilled. */
+export function githubComposerUrl(draft: IssueDraft): string {
+  const params = new URLSearchParams({
+    title: draft.title,
+    body: draft.body.replace(/^<!--[^\n]*-->\n/u, ""),
+    labels: draft.labels.join(","),
+  });
+  return `${REPO_URL}/issues/new?${params.toString()}`;
+}
+
+/* ── Response contract ───────────────────────────────────────────────────── */
+
+export type ReportFailureCode = "invalid_request" | "rate_limited" | "unavailable" | "forbidden";
+
+export type ReportResponse =
+  | Readonly<{ ok: true; issue: Readonly<{ number: number; url: string }>; duplicate: boolean }>
+  | Readonly<{ ok: false; code: ReportFailureCode; message: string; fallbackUrl?: string }>;

--- a/src/lib/report/github.ts
+++ b/src/lib/report/github.ts
@@ -1,0 +1,197 @@
+import "server-only";
+import { createHash, createSign } from "node:crypto";
+import { REPO_URL } from "@/lib/site";
+import { REPORT_ISSUE_LABEL, REPORT_KEY_MARKER, type IssueDraft } from "@/lib/report/contract";
+
+/**
+ * Minimal GitHub App client for the report endpoint.
+ *
+ * The App must be installed on the repository with the single permission
+ * `issues: write`. The installation token is requested with that permission
+ * and that repository only, so even a leaked token cannot reach anything else.
+ * No SDK: two REST calls, a JWT signed with node:crypto, and explicit timeouts.
+ */
+
+const GITHUB_API = "https://api.github.com";
+const REPO_PATH = new URL(REPO_URL).pathname.replace(/^\/+|\/+$/gu, "");
+const TOKEN_SAFETY_MARGIN_MS = 60_000;
+
+export type GitHubIssueRef = Readonly<{ number: number; url: string }>;
+
+export type GitHubAppConfig = Readonly<{
+  appId: string;
+  installationId: string;
+  privateKeyPem: string;
+}>;
+
+export type ReportGitHubOptions = Readonly<{
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+  now?: () => number;
+}>;
+
+export class GitHubUnavailableError extends Error {
+  readonly status: number | null;
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = "GitHubUnavailableError";
+    this.status = status;
+  }
+}
+
+export function readGitHubAppConfig(env: NodeJS.ProcessEnv = process.env): GitHubAppConfig | null {
+  const appId = env.REPORT_GITHUB_APP_ID?.trim();
+  const installationId = env.REPORT_GITHUB_INSTALLATION_ID?.trim();
+  const rawKey = env.REPORT_GITHUB_APP_PRIVATE_KEY?.trim();
+  if (!appId || !installationId || !rawKey) return null;
+  if (!/^\d+$/u.test(appId) || !/^\d+$/u.test(installationId)) return null;
+  // Vercel stores multi-line secrets either verbatim or with escaped newlines.
+  const privateKeyPem = `${(rawKey.includes("\\n") ? rawKey.replace(/\\n/gu, "\n") : rawKey).trim()}\n`;
+  if (!/^-----BEGIN [A-Z ]*PRIVATE KEY-----\n[\s\S]+\n-----END [A-Z ]*PRIVATE KEY-----\n$/u.test(privateKeyPem)) return null;
+  return { appId, installationId, privateKeyPem };
+}
+
+function base64Url(value: Buffer | string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+/** RS256 JWT authenticating the App itself (not an installation). */
+export function signAppJwt(config: GitHubAppConfig, nowMs: number): string {
+  const nowSeconds = Math.floor(nowMs / 1_000);
+  const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64Url(JSON.stringify({
+    iat: nowSeconds - 30,
+    exp: nowSeconds + 5 * 60,
+    iss: config.appId,
+  }));
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${payload}`);
+  const signature = signer.sign(config.privateKeyPem);
+  return `${header}.${payload}.${base64Url(signature)}`;
+}
+
+type InstallationToken = Readonly<{ token: string; expiresAt: number }>;
+
+/** Structural check on GitHub responses: we never trust the shape blindly. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class ReportGitHubClient {
+  readonly #config: GitHubAppConfig;
+  readonly #fetch: typeof fetch;
+  readonly #timeoutMs: number;
+  readonly #now: () => number;
+  #token: InstallationToken | null = null;
+
+  constructor(config: GitHubAppConfig, options: ReportGitHubOptions = {}) {
+    this.#config = config;
+    this.#fetch = options.fetch ?? fetch;
+    this.#timeoutMs = options.timeoutMs ?? 8_000;
+    this.#now = options.now ?? Date.now;
+  }
+
+  async #request(path: string, init: RequestInit & { auth: string }): Promise<Response> {
+    const { auth, ...rest } = init;
+    let response: Response;
+    try {
+      response = await this.#fetch(`${GITHUB_API}${path}`, {
+        ...rest,
+        headers: {
+          accept: "application/vnd.github+json",
+          "x-github-api-version": "2022-11-28",
+          "user-agent": "DoveVannoINostriSoldi-segnalazioni",
+          authorization: auth,
+          ...(rest.body ? { "content-type": "application/json" } : {}),
+        },
+        signal: AbortSignal.timeout(this.#timeoutMs),
+      });
+    } catch {
+      throw new GitHubUnavailableError("GitHub non raggiungibile");
+    }
+    return response;
+  }
+
+  async #installationToken(): Promise<string> {
+    const now = this.#now();
+    if (this.#token && this.#token.expiresAt - TOKEN_SAFETY_MARGIN_MS > now) return this.#token.token;
+
+    const response = await this.#request(
+      `/app/installations/${this.#config.installationId}/access_tokens`,
+      {
+        method: "POST",
+        auth: `Bearer ${signAppJwt(this.#config, now)}`,
+        body: JSON.stringify({
+          repositories: [REPO_PATH.split("/")[1]],
+          permissions: { issues: "write" },
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw new GitHubUnavailableError("Autenticazione GitHub App rifiutata", response.status);
+    }
+    const payload: unknown = await response.json().catch(() => null);
+    if (!isRecord(payload) || typeof payload.token !== "string" || typeof payload.expires_at !== "string") {
+      throw new GitHubUnavailableError("Risposta token GitHub inattesa");
+    }
+    const expiresAt = Date.parse(payload.expires_at);
+    this.#token = { token: payload.token, expiresAt: Number.isFinite(expiresAt) ? expiresAt : now };
+    return payload.token;
+  }
+
+  /**
+   * Looks for an issue already created for this client key. GitHub's list
+   * endpoint (unlike search) is strongly consistent, so a retry seconds after
+   * a timed-out first attempt finds the issue the first attempt created.
+   */
+  async findIssueByKey(clientKey: string, sinceMs: number): Promise<GitHubIssueRef | null> {
+    const token = await this.#installationToken();
+    const since = new Date(sinceMs).toISOString();
+    const query = new URLSearchParams({
+      labels: REPORT_ISSUE_LABEL,
+      state: "all",
+      since,
+      sort: "created",
+      direction: "desc",
+      per_page: "50",
+    });
+    const response = await this.#request(`/repos/${REPO_PATH}/issues?${query}`, {
+      method: "GET",
+      auth: `Bearer ${token}`,
+    });
+    if (!response.ok) throw new GitHubUnavailableError("Lettura issue GitHub fallita", response.status);
+    const payload: unknown = await response.json().catch(() => null);
+    if (!Array.isArray(payload)) throw new GitHubUnavailableError("Risposta issue GitHub inattesa");
+    const marker = `<!-- ${REPORT_KEY_MARKER}: ${clientKey} -->`;
+    for (const item of payload) {
+      if (!isRecord(item) || typeof item.body !== "string") continue;
+      if (item.body.startsWith(marker) && typeof item.number === "number" && typeof item.html_url === "string") {
+        return { number: item.number, url: item.html_url };
+      }
+    }
+    return null;
+  }
+
+  async createIssue(draft: IssueDraft): Promise<GitHubIssueRef> {
+    const token = await this.#installationToken();
+    const response = await this.#request(`/repos/${REPO_PATH}/issues`, {
+      method: "POST",
+      auth: `Bearer ${token}`,
+      body: JSON.stringify({ title: draft.title, body: draft.body, labels: [...draft.labels] }),
+    });
+    if (!response.ok) throw new GitHubUnavailableError("Creazione issue GitHub fallita", response.status);
+    const payload: unknown = await response.json().catch(() => null);
+    if (!isRecord(payload) || typeof payload.number !== "number" || typeof payload.html_url !== "string") {
+      throw new GitHubUnavailableError("Risposta creazione issue inattesa");
+    }
+    if (!payload.html_url.startsWith(`${REPO_URL}/issues/`)) {
+      throw new GitHubUnavailableError("URL issue fuori dal repository atteso");
+    }
+    return { number: payload.number, url: payload.html_url };
+  }
+}
+
+/** Stable, non-reversible key for the per-address limiter. */
+export function hashedLimiterKey(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 32);
+}

--- a/src/lib/report/rate-limit.ts
+++ b/src/lib/report/rate-limit.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory sliding-window limiter.
+ *
+ * Deliberately simple: the site runs on serverless instances without a shared
+ * store, so this protects a single warm instance from bursts and complements
+ * the honeypot, the timing checks and GitHub's own abuse controls. It is not a
+ * durable, global limit — see docs/SEGNALAZIONI.md for the documented gap.
+ */
+
+export type RateLimitRule = Readonly<{ windowMs: number; max: number }>;
+
+export class SlidingWindowLimiter {
+  readonly #hits = new Map<string, number[]>();
+  readonly #rule: RateLimitRule;
+  readonly #maxKeys: number;
+
+  constructor(rule: RateLimitRule, { maxKeys = 5_000 }: { maxKeys?: number } = {}) {
+    this.#rule = rule;
+    this.#maxKeys = maxKeys;
+  }
+
+  /** Records a hit and returns whether it is still within the allowance. */
+  consume(key: string, now = Date.now()): boolean {
+    const floor = now - this.#rule.windowMs;
+    const recent = (this.#hits.get(key) ?? []).filter((timestamp) => timestamp > floor);
+    if (recent.length >= this.#rule.max) {
+      this.#hits.set(key, recent);
+      return false;
+    }
+    recent.push(now);
+    this.#hits.set(key, recent);
+    this.#evict(floor);
+    return true;
+  }
+
+  #evict(floor: number): void {
+    if (this.#hits.size <= this.#maxKeys) return;
+    for (const [key, timestamps] of this.#hits) {
+      if (timestamps.every((timestamp) => timestamp <= floor)) this.#hits.delete(key);
+      if (this.#hits.size <= this.#maxKeys) return;
+    }
+    // Still too many live keys: drop the oldest insertion to bound memory.
+    const oldest = this.#hits.keys().next().value;
+    if (oldest !== undefined) this.#hits.delete(oldest);
+  }
+}
+
+/** First hop of X-Forwarded-For, or null. Never logged: used only as a limiter key. */
+export function clientAddress(request: Request): string | null {
+  const forwarded = request.headers.get("x-forwarded-for");
+  const first = forwarded?.split(",")[0]?.trim();
+  if (first && first.length <= 64 && /^[0-9a-f.:%]+$/iu.test(first)) return first.toLowerCase();
+  const real = request.headers.get("x-real-ip")?.trim();
+  if (real && real.length <= 64 && /^[0-9a-f.:%]+$/iu.test(real)) return real.toLowerCase();
+  return null;
+}

--- a/tests/report-contract.test.mjs
+++ b/tests/report-contract.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const {
+  buildIssueDraft,
+  fenceUserText,
+  githubComposerUrl,
+  inlineSafe,
+  normalizeUserText,
+  parseReportRequest,
+  REPORT_LIMITS,
+  timingRejection,
+} = await import("../src/lib/report/contract.ts");
+
+const NOW = Date.parse("2026-08-30T10:00:00.000Z");
+
+function validPayload(overrides = {}) {
+  return {
+    clientKey: "6f1c2b6e-4d7a-4d61-9a3c-2f1c0b3e9a11",
+    category: "bug",
+    observed: "La tabella mostra un totale diverso dalla somma.",
+    expected: "Il totale deve coincidere con la somma delle righe.",
+    steps: "1. Apri /spese\n2. Guarda il totale",
+    page: { path: "/spese?anno=2025", title: "Spese · DoveVannoINostriSoldi" },
+    context: {
+      reportedAt: new Date(NOW).toISOString(),
+      openedAt: new Date(NOW - 20_000).toISOString(),
+      viewport: { width: 390, height: 844 },
+      userAgent: "Mozilla/5.0 Test",
+    },
+    website: "",
+    ...overrides,
+  };
+}
+
+test("accetta una segnalazione valida e normalizza il testo", () => {
+  const result = parseReportRequest(validPayload({ observed: "  riga\r\n\r\n\r\n\r\nfine​  " }));
+  assert.equal(result.ok, true);
+  assert.equal(result.value.observed, "riga\n\nfine");
+  assert.equal(result.value.website, "");
+});
+
+test("rifiuta campi inattesi: repository, label, assignee o mention non passano", () => {
+  for (const extra of [{ repo: "altro/repo" }, { labels: ["bug"] }, { assignees: ["x"] }, { title: "mio" }]) {
+    const result = parseReportRequest(validPayload(extra));
+    assert.equal(result.ok, false, JSON.stringify(extra));
+  }
+  const nestedExtra = parseReportRequest(validPayload({ page: { path: "/x", title: "t", url: "https://evil.test" } }));
+  assert.equal(nestedExtra.ok, false);
+});
+
+test("rifiuta honeypot compilato, categoria sconosciuta e chiave non UUID", () => {
+  assert.equal(parseReportRequest(validPayload({ website: "https://spam.test" })).ok, false);
+  assert.equal(parseReportRequest(validPayload({ category: "security" })).ok, false);
+  assert.equal(parseReportRequest(validPayload({ clientKey: "abc" })).ok, false);
+});
+
+test("rifiuta testi oltre i limiti e campi obbligatori vuoti", () => {
+  const long = "x".repeat(REPORT_LIMITS.observedMax + 1);
+  assert.equal(parseReportRequest(validPayload({ observed: long })).ok, false);
+  assert.equal(parseReportRequest(validPayload({ steps: "   " })).ok, false);
+  const huge = "x".repeat(REPORT_LIMITS.observedMax * 4 + 1);
+  assert.equal(parseReportRequest(validPayload({ expected: huge })).ok, false);
+});
+
+test("accetta solo percorsi del dominio canonico", () => {
+  assert.equal(parseReportRequest(validPayload({ page: { path: "/spese", title: "" } })).ok, true);
+  for (const path of ["https://evil.test/x", "//evil.test", "spese", "/spese)", "/spese <b>", "/x\\y"]) {
+    assert.equal(parseReportRequest(validPayload({ page: { path, title: "" } })).ok, false, path);
+  }
+});
+
+test("per contestare un dato la fonte ufficiale https è obbligatoria", () => {
+  const missing = parseReportRequest(validPayload({ category: "dato" }));
+  assert.equal(missing.ok, false);
+  assert.match(missing.message, /sourceUrl/);
+  assert.equal(parseReportRequest(validPayload({ category: "dato", sourceUrl: "http://istat.it" })).ok, false);
+  assert.equal(parseReportRequest(validPayload({ category: "dato", sourceUrl: "https://user:pw@istat.it" })).ok, false);
+  assert.equal(parseReportRequest(validPayload({ category: "dato", sourceUrl: "https://www.istat.it/x" })).ok, true);
+});
+
+test("i controlli temporali bloccano invii troppo rapidi, futuri o da moduli stantii", () => {
+  const ok = validPayload().context;
+  assert.equal(timingRejection(ok, NOW), null);
+  assert.match(timingRejection({ ...ok, openedAt: new Date(NOW - 500).toISOString() }, NOW), /rapido/);
+  assert.match(timingRejection({ ...ok, openedAt: new Date(NOW - 2 * REPORT_LIMITS.maxFillMs).toISOString() }, NOW), /troppo tempo/);
+  assert.match(timingRejection({ ...ok, reportedAt: new Date(NOW + 60 * 60_000).toISOString() }, NOW), /futuro/);
+  assert.match(timingRejection({ ...ok, reportedAt: new Date(NOW - 60_000).toISOString(), openedAt: new Date(NOW).toISOString() }, NOW), /incoerenti/);
+});
+
+test("il testo utente finisce in fence che neutralizzano mention, HTML e fence annidate", () => {
+  const fenced = fenceUserText("@octocat guarda <img src=x onerror=alert(1)> ```js\nboom\n```");
+  assert.ok(fenced.startsWith("````text\n"), fenced);
+  assert.ok(fenced.endsWith("\n````"));
+  assert.equal(fenceUserText(""), "```text\n(non indicato)\n```");
+  assert.equal(inlineSafe("Titolo @team <b>#12</b> [x](y)", 80), "Titolo ＠team b12/b xy");
+  assert.equal(normalizeUserText("a‮b"), "ab");
+});
+
+test("titolo e struttura della issue sono decisi dal server", () => {
+  const request = parseReportRequest(validPayload({
+    category: "dato",
+    sourceUrl: "https://www.istat.it/dati",
+    page: { path: "/spese?anno=2025", title: "Spese @admin <script>" },
+  }));
+  assert.equal(request.ok, true);
+  const draft = buildIssueDraft(request.value);
+  assert.equal(draft.title, "[Segnalazione] Dato potenzialmente errato: /spese?anno=2025");
+  assert.deepEqual(draft.labels, ["segnalazione"]);
+  assert.ok(draft.body.startsWith("<!-- dvns-report-key: 6f1c2b6e-4d7a-4d61-9a3c-2f1c0b3e9a11 -->\n## Tipo di problema"));
+  for (const heading of [
+    "## Pagina", "## Risultato osservato", "## Risultato atteso", "## Passaggi per riprodurre",
+    "## Fonte ufficiale, se pertinente", "## Contesto tecnico",
+  ]) {
+    assert.ok(draft.body.includes(`\n${heading}\n`), heading);
+  }
+  assert.ok(draft.body.includes("[Spese ＠admin script](https://www.dovevannoinostrisoldi.com/spese?anno=2025)"));
+  assert.ok(draft.body.includes("<https://www.istat.it/dati>"));
+  assert.ok(draft.body.includes("- Viewport: 390×844 px"));
+  assert.ok(draft.body.includes("non dimostra da solo spreco, frode o responsabilità"));
+  assert.ok(draft.body.includes("Il contenuto inserito dall’utente non è stato verificato."));
+});
+
+test("il composer GitHub di fallback è precompilato senza il marker interno", () => {
+  const request = parseReportRequest(validPayload());
+  const url = new URL(githubComposerUrl(buildIssueDraft(request.value)));
+  assert.equal(url.origin + url.pathname, "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/new");
+  assert.equal(url.searchParams.get("labels"), "segnalazione");
+  assert.match(url.searchParams.get("title"), /^\[Segnalazione\] Bug del sito: \/spese/);
+  assert.ok(!url.searchParams.get("body").includes("dvns-report-key"));
+  assert.ok(url.searchParams.get("body").startsWith("## Tipo di problema"));
+});

--- a/tests/report-github.test.mjs
+++ b/tests/report-github.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { readGitHubAppConfig, ReportGitHubClient, signAppJwt, GitHubUnavailableError } =
+  await import("../src/lib/report/github.ts");
+const { SlidingWindowLimiter, clientAddress } = await import("../src/lib/report/rate-limit.ts");
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const PEM = privateKey.export({ type: "pkcs1", format: "pem" });
+const CONFIG = { appId: "123", installationId: "456", privateKeyPem: PEM };
+
+test("la configurazione è fail-closed e accetta la chiave con newline escapati", () => {
+  assert.equal(readGitHubAppConfig({}), null);
+  assert.equal(readGitHubAppConfig({ REPORT_GITHUB_APP_ID: "1", REPORT_GITHUB_INSTALLATION_ID: "2" }), null);
+  assert.equal(readGitHubAppConfig({
+    REPORT_GITHUB_APP_ID: "abc", REPORT_GITHUB_INSTALLATION_ID: "2", REPORT_GITHUB_APP_PRIVATE_KEY: PEM,
+  }), null);
+  const escaped = readGitHubAppConfig({
+    REPORT_GITHUB_APP_ID: "1",
+    REPORT_GITHUB_INSTALLATION_ID: "2",
+    REPORT_GITHUB_APP_PRIVATE_KEY: PEM.replace(/\n/g, "\\n"),
+  });
+  assert.equal(escaped.privateKeyPem, PEM);
+  assert.equal(readGitHubAppConfig({
+    REPORT_GITHUB_APP_ID: "1", REPORT_GITHUB_INSTALLATION_ID: "2", REPORT_GITHUB_APP_PRIVATE_KEY: PEM,
+  }).privateKeyPem, PEM);
+});
+
+test("il JWT dell'App è RS256, breve e verificabile con la chiave pubblica", () => {
+  const now = Date.parse("2026-08-30T10:00:00Z");
+  const jwt = signAppJwt(CONFIG, now);
+  const [header, payload, signature] = jwt.split(".");
+  assert.deepEqual(JSON.parse(Buffer.from(header, "base64url")), { alg: "RS256", typ: "JWT" });
+  const claims = JSON.parse(Buffer.from(payload, "base64url"));
+  assert.equal(claims.iss, "123");
+  assert.equal(claims.exp - claims.iat, 330);
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(`${header}.${payload}`);
+  assert.equal(verifier.verify(publicKey, Buffer.from(signature, "base64url")), true);
+});
+
+function fakeFetch(handlers) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    const target = new URL(url);
+    const key = `${init.method} ${target.pathname}`;
+    calls.push({ key, init, search: target.searchParams });
+    const handler = handlers[key];
+    if (!handler) throw new Error(`Chiamata inattesa ${key}`);
+    return handler(init, target);
+  };
+  return { fetchImpl, calls };
+}
+
+const jsonResponse = (body, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+test("il token di installazione chiede solo issues:write su questo repository ed è riusato", async () => {
+  const { fetchImpl, calls } = fakeFetch({
+    "POST /app/installations/456/access_tokens": () =>
+      jsonResponse({ token: "ghs_test", expires_at: new Date(Date.now() + 3600_000).toISOString() }),
+    "POST /repos/Italian-Builders-Org/DoveVannoINostriSoldi/issues": () =>
+      jsonResponse({ number: 7, html_url: "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/7" }, 201),
+  });
+  const client = new ReportGitHubClient(CONFIG, { fetch: fetchImpl });
+  const draft = { title: "t", body: "b", labels: ["segnalazione"] };
+  const first = await client.createIssue(draft);
+  const second = await client.createIssue(draft);
+  assert.deepEqual(first, { number: 7, url: "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/7" });
+  assert.deepEqual(second, first);
+
+  const tokenCalls = calls.filter((call) => call.key.startsWith("POST /app/installations"));
+  assert.equal(tokenCalls.length, 1, "il token va riusato finché valido");
+  assert.deepEqual(JSON.parse(tokenCalls[0].init.body), {
+    repositories: ["DoveVannoINostriSoldi"],
+    permissions: { issues: "write" },
+  });
+  assert.match(tokenCalls[0].init.headers.authorization, /^Bearer eyJ/);
+  const issueCall = calls.find((call) => call.key.endsWith("/issues"));
+  assert.equal(issueCall.init.headers.authorization, "Bearer ghs_test");
+  assert.deepEqual(JSON.parse(issueCall.init.body), { title: "t", body: "b", labels: ["segnalazione"] });
+});
+
+test("errori e risposte inattese di GitHub diventano GitHubUnavailableError, mai dati grezzi", async () => {
+  const { fetchImpl } = fakeFetch({
+    "POST /app/installations/456/access_tokens": () => jsonResponse({ message: "Bad credentials" }, 401),
+  });
+  const client = new ReportGitHubClient(CONFIG, { fetch: fetchImpl });
+  await assert.rejects(client.createIssue({ title: "t", body: "b", labels: [] }), (error) => {
+    assert.ok(error instanceof GitHubUnavailableError);
+    assert.equal(error.status, 401);
+    assert.ok(!error.message.includes("Bad credentials"));
+    return true;
+  });
+
+  const foreign = fakeFetch({
+    "POST /app/installations/456/access_tokens": () =>
+      jsonResponse({ token: "ghs", expires_at: new Date(Date.now() + 3600_000).toISOString() }),
+    "POST /repos/Italian-Builders-Org/DoveVannoINostriSoldi/issues": () =>
+      jsonResponse({ number: 1, html_url: "https://github.com/evil/repo/issues/1" }, 201),
+  });
+  await assert.rejects(
+    new ReportGitHubClient(CONFIG, { fetch: foreign.fetchImpl }).createIssue({ title: "t", body: "b", labels: [] }),
+    GitHubUnavailableError,
+  );
+
+  const network = new ReportGitHubClient(CONFIG, { fetch: async () => { throw new TypeError("fetch failed"); } });
+  await assert.rejects(network.createIssue({ title: "t", body: "b", labels: [] }), GitHubUnavailableError);
+});
+
+test("la ricerca per chiave usa la lista issue con label e since e riconosce il marker", async () => {
+  const marker = "<!-- dvns-report-key: 6f1c2b6e-4d7a-4d61-9a3c-2f1c0b3e9a11 -->";
+  const { fetchImpl, calls } = fakeFetch({
+    "POST /app/installations/456/access_tokens": () =>
+      jsonResponse({ token: "ghs", expires_at: new Date(Date.now() + 3600_000).toISOString() }),
+    "GET /repos/Italian-Builders-Org/DoveVannoINostriSoldi/issues": () => jsonResponse([
+      { number: 3, html_url: "https://github.com/x/y/issues/3", body: "altro" },
+      { number: 4, html_url: "https://github.com/x/y/issues/4", body: `${marker}\n## Tipo` },
+    ]),
+  });
+  const client = new ReportGitHubClient(CONFIG, { fetch: fetchImpl });
+  const found = await client.findIssueByKey("6f1c2b6e-4d7a-4d61-9a3c-2f1c0b3e9a11", Date.parse("2026-08-29T10:00:00Z"));
+  assert.deepEqual(found, { number: 4, url: "https://github.com/x/y/issues/4" });
+  const list = calls.find((call) => call.key.startsWith("GET"));
+  assert.equal(list.search.get("labels"), "segnalazione");
+  assert.equal(list.search.get("since"), "2026-08-29T10:00:00.000Z");
+  assert.equal(await client.findIssueByKey("00000000-0000-4000-8000-000000000000", 0), null);
+});
+
+test("il limitatore a finestra scorrevole conta per chiave e dimentica gli accessi vecchi", () => {
+  const limiter = new SlidingWindowLimiter({ windowMs: 1_000, max: 2 });
+  assert.equal(limiter.consume("a", 0), true);
+  assert.equal(limiter.consume("a", 100), true);
+  assert.equal(limiter.consume("a", 200), false);
+  assert.equal(limiter.consume("b", 200), true);
+  assert.equal(limiter.consume("a", 1_101), true);
+});
+
+test("l'indirizzo client viene letto dal primo hop di X-Forwarded-For e validato", () => {
+  const make = (headers) => new Request("https://x.test", { headers });
+  assert.equal(clientAddress(make({ "x-forwarded-for": "203.0.113.9, 10.0.0.1" })), "203.0.113.9");
+  assert.equal(clientAddress(make({ "x-forwarded-for": "2001:DB8::1" })), "2001:db8::1");
+  assert.equal(clientAddress(make({ "x-forwarded-for": "<script>" })), null);
+  assert.equal(clientAddress(make({})), null);
+});

--- a/tests/report-route.test.mjs
+++ b/tests/report-route.test.mjs
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { POST } = await import("../src/app/api/segnalazioni/route.ts");
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const PEM = privateKey.export({ type: "pkcs1", format: "pem" });
+const ISSUES_PATH = "/repos/Italian-Builders-Org/DoveVannoINostriSoldi/issues";
+const ISSUE_URL = (number) => `https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/${number}`;
+
+let addressCounter = 0;
+function freshAddress() {
+  addressCounter += 1;
+  return `203.0.113.${addressCounter}`;
+}
+
+function payload(overrides = {}) {
+  const now = Date.now();
+  return {
+    clientKey: randomUUID(),
+    category: "bug",
+    observed: "Il totale non torna.",
+    expected: "Il totale deve coincidere.",
+    steps: "1. Apri la pagina\n2. Confronta",
+    page: { path: "/spese", title: "Spese" },
+    context: {
+      reportedAt: new Date(now).toISOString(),
+      openedAt: new Date(now - 15_000).toISOString(),
+      viewport: { width: 1280, height: 800 },
+      userAgent: "Mozilla/5.0 Test",
+    },
+    website: "",
+    ...overrides,
+  };
+}
+
+function request(body, { headers = {}, url = "https://example.test/api/segnalazioni", address = freshAddress() } = {}) {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: new URL(url).origin,
+      Host: new URL(url).host,
+      "X-Forwarded-For": address,
+      ...headers,
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+function configure(installationId = "999") {
+  process.env.REPORT_GITHUB_APP_ID = "42";
+  process.env.REPORT_GITHUB_INSTALLATION_ID = installationId;
+  process.env.REPORT_GITHUB_APP_PRIVATE_KEY = PEM;
+}
+
+function unconfigure() {
+  delete process.env.REPORT_GITHUB_APP_ID;
+  delete process.env.REPORT_GITHUB_INSTALLATION_ID;
+  delete process.env.REPORT_GITHUB_APP_PRIVATE_KEY;
+}
+
+/** Records every GitHub call; throws on anything unexpected so a leak is loud. */
+function installGitHub({ existing = [], createStatus = 201, tokenStatus = 201 } = {}) {
+  const calls = [];
+  let nextNumber = 100;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === "string" ? input : input.url);
+    assert.equal(url.origin, "https://api.github.com", "solo GitHub può essere contattato");
+    const key = `${init.method ?? "GET"} ${url.pathname}`;
+    calls.push({ key, body: init.body ? JSON.parse(init.body) : null, headers: init.headers });
+    const json = (body, status) => new Response(JSON.stringify(body), { status });
+    if (key.startsWith("POST /app/installations/")) {
+      if (tokenStatus !== 201) return json({ message: "denied" }, tokenStatus);
+      return json({ token: "ghs_test", expires_at: new Date(Date.now() + 3600_000).toISOString() }, 201);
+    }
+    if (key === `GET ${ISSUES_PATH}`) return json(existing, 200);
+    if (key === `POST ${ISSUES_PATH}`) {
+      if (createStatus !== 201) return json({ message: "boom" }, createStatus);
+      nextNumber += 1;
+      return json({ number: nextNumber, html_url: ISSUE_URL(nextNumber) }, 201);
+    }
+    throw new Error(`Chiamata GitHub inattesa: ${key}`);
+  };
+  return {
+    calls,
+    created: () => calls.filter((call) => call.key === `POST ${ISSUES_PATH}`),
+    restore: () => { globalThis.fetch = originalFetch; },
+  };
+}
+
+function withoutGitHub() {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error("Nessuna chiamata esterna attesa"); };
+  return () => { globalThis.fetch = originalFetch; };
+}
+
+test("rifiuta content type, origin e host non consentiti prima di ogni altra cosa", async () => {
+  const restore = withoutGitHub();
+  try {
+    configure();
+    assert.equal((await POST(request(payload(), { headers: { "Content-Type": "text/plain" } }))).status, 415);
+    assert.equal((await POST(request(payload(), { headers: { Origin: "https://attacker.test" } }))).status, 403);
+    assert.equal((await POST(request(payload(), { headers: { Host: "other.test" } }))).status, 403);
+    const noOrigin = new Request("https://example.test/api/segnalazioni", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Host: "example.test" },
+      body: JSON.stringify(payload()),
+    });
+    assert.equal((await POST(noOrigin)).status, 403);
+  } finally {
+    restore();
+    unconfigure();
+  }
+});
+
+test("rifiuta payload sovradimensionati, JSON rotto e campi inattesi senza contattare GitHub", async () => {
+  const restore = withoutGitHub();
+  try {
+    configure();
+    const big = await POST(request(payload({ observed: "x".repeat(20_000) })));
+    assert.equal(big.status, 413);
+    const declared = await POST(request(payload(), { headers: { "Content-Length": "999999" } }));
+    assert.equal(declared.status, 413);
+    const broken = await POST(request("{nope"));
+    assert.equal(broken.status, 400);
+    assert.equal((await broken.json()).code, "invalid_request");
+
+    for (const bad of [
+      payload({ labels: ["urgent"] }),
+      payload({ repository: "evil/repo" }),
+      payload({ assignees: ["someone"] }),
+      payload({ page: { path: "https://evil.test/", title: "" } }),
+      payload({ category: "dato" }),
+      payload({ website: "http://spam.test" }),
+    ]) {
+      const response = await POST(request(bad));
+      assert.equal(response.status, 400, JSON.stringify(bad));
+      const body = await response.json();
+      assert.equal(body.ok, false);
+      assert.equal(body.code, "invalid_request");
+      assert.equal(body.fallbackUrl, undefined, "nessun fallback per input rifiutati");
+    }
+  } finally {
+    restore();
+    unconfigure();
+  }
+});
+
+test("rifiuta invii troppo rapidi (time-trap) e moduli stantii", async () => {
+  const restore = withoutGitHub();
+  try {
+    configure();
+    const now = Date.now();
+    const fast = await POST(request(payload({
+      context: { reportedAt: new Date(now).toISOString(), openedAt: new Date(now - 200).toISOString() },
+    })));
+    assert.equal(fast.status, 400);
+    assert.match((await fast.json()).message, /rapido/);
+    const stale = await POST(request(payload({
+      context: { reportedAt: new Date(now).toISOString(), openedAt: new Date(now - 48 * 3600_000).toISOString() },
+    })));
+    assert.equal(stale.status, 400);
+  } finally {
+    restore();
+    unconfigure();
+  }
+});
+
+test("senza credenziali risponde 503 con il composer GitHub precompilato e conserva i dati", async () => {
+  const restore = withoutGitHub();
+  try {
+    unconfigure();
+    const response = await POST(request(payload({ observed: "Testo da conservare" })));
+    assert.equal(response.status, 503);
+    const body = await response.json();
+    assert.equal(body.ok, false);
+    assert.equal(body.code, "unavailable");
+    const fallback = new URL(body.fallbackUrl);
+    assert.equal(fallback.pathname, "/Italian-Builders-Org/DoveVannoINostriSoldi/issues/new");
+    assert.ok(fallback.searchParams.get("body").includes("Testo da conservare"));
+    assert.equal(fallback.searchParams.get("labels"), "segnalazione");
+  } finally {
+    restore();
+  }
+});
+
+test("un invio valido crea una sola issue e restituisce numero e URL", async () => {
+  const github = installGitHub();
+  try {
+    configure("1001");
+    const response = await POST(request(payload()));
+    assert.equal(response.status, 201);
+    assert.equal(response.headers.get("cache-control"), "private, no-store");
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.duplicate, false);
+    assert.equal(body.issue.number, 101);
+    assert.equal(body.issue.url, ISSUE_URL(101));
+    assert.equal(github.created().length, 1);
+    const created = github.created()[0].body;
+    assert.deepEqual(created.labels, ["segnalazione"]);
+    assert.match(created.title, /^\[Segnalazione\] Bug del sito: \/spese$/);
+    assert.ok(created.body.startsWith("<!-- dvns-report-key: "));
+    assert.ok(!JSON.stringify(github.calls).includes(PEM.slice(40, 80)), "la chiave privata non lascia il server");
+    for (const call of github.calls) assert.equal(call.headers.authorization.startsWith("Bearer "), true);
+  } finally {
+    github.restore();
+    unconfigure();
+  }
+});
+
+test("retry con la stessa chiave non crea duplicati (memoria dell'istanza)", async () => {
+  const github = installGitHub();
+  try {
+    configure("1002");
+    const body = payload();
+    const first = await POST(request(body));
+    const second = await POST(request(body));
+    assert.equal(first.status, 201);
+    assert.equal(second.status, 200);
+    const secondBody = await second.json();
+    assert.equal(secondBody.duplicate, true);
+    assert.equal(secondBody.issue.url, (await first.json()).issue.url);
+    assert.equal(github.created().length, 1);
+  } finally {
+    github.restore();
+    unconfigure();
+  }
+});
+
+test("una issue già esistente su GitHub con lo stesso marker viene riusata", async () => {
+  const key = randomUUID();
+  const github = installGitHub({
+    existing: [{ number: 55, html_url: ISSUE_URL(55), body: `<!-- dvns-report-key: ${key} -->\n## Tipo` }],
+  });
+  try {
+    configure("1003");
+    const response = await POST(request(payload({ clientKey: key })));
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(body, { ok: true, issue: { number: 55, url: ISSUE_URL(55) }, duplicate: true });
+    assert.equal(github.created().length, 0);
+  } finally {
+    github.restore();
+    unconfigure();
+  }
+});
+
+test("se GitHub fallisce risponde 503 con fallback e non espone dettagli del provider", async () => {
+  const originalError = console.error;
+  const logged = [];
+  console.error = (...args) => logged.push(args.join(" "));
+  const github = installGitHub({ createStatus: 500 });
+  try {
+    configure("1004");
+    const response = await POST(request(payload({ observed: "contenuto riservato al form" })));
+    assert.equal(response.status, 503);
+    const body = await response.json();
+    assert.equal(body.code, "unavailable");
+    assert.ok(body.fallbackUrl.startsWith("https://github.com/"));
+    assert.ok(!JSON.stringify(body).includes("boom"));
+    assert.equal(logged.length, 1);
+    assert.ok(!logged[0].includes("contenuto riservato"), "il contenuto non finisce nei log");
+    assert.match(logged[0], /HTTP 500/);
+  } finally {
+    console.error = originalError;
+    github.restore();
+    unconfigure();
+  }
+
+  const denied = installGitHub({ tokenStatus: 401 });
+  try {
+    configure("1005");
+    const response = await POST(request(payload()));
+    assert.equal(response.status, 503);
+    assert.equal(denied.created().length, 0);
+  } finally {
+    denied.restore();
+    unconfigure();
+  }
+});
+
+test("oltre il limite per indirizzo risponde 429 senza contattare GitHub", async () => {
+  const github = installGitHub();
+  try {
+    configure("1006");
+    const address = "198.51.100.7";
+    for (let index = 0; index < 3; index += 1) {
+      assert.equal((await POST(request(payload(), { address }))).status, 201);
+    }
+    const limited = await POST(request(payload(), { address }));
+    assert.equal(limited.status, 429);
+    assert.equal(limited.headers.get("retry-after"), "600");
+    const body = await limited.json();
+    assert.equal(body.code, "rate_limited");
+    assert.ok(body.fallbackUrl.startsWith("https://github.com/"));
+    assert.equal(github.created().length, 3);
+  } finally {
+    github.restore();
+    unconfigure();
+  }
+});


### PR DESCRIPTION
## Cosa cambia

Closes #197.

Ogni pagina pubblica ha un pulsante «Segnala un problema» (layout radice, in basso a destra; variante inline nel footer e in /supporto). Apre un dialog che raccoglie una segnalazione strutturata e, a invio riuscito, crea una issue pubblica in questo repository restituendo numero e link.

## UI (`src/components/report-problem/`)

- Trigger client minimale; dialog, schema e stili caricati con `next/dynamic` solo alla prima attivazione.
- `<dialog>` nativo: focus iniziale, focus trap, Esc, ritorno del focus al pulsante. Portal su `<body>`.
- Campi: categoria (bug del sito, dato potenzialmente errato, accessibilità, altro), cosa è successo, cosa ti aspettavi, passaggi per riprodurre, fonte ufficiale (obbligatoria per contestare un dato, con promemoria che il dato non dimostra spreco, frode o responsabilità).
- Avviso esplicito che la issue è pubblica e vieta dati personali/credenziali; rimando al report privato GitHub per le vulnerabilità.
- Errori collegati ai campi (`aria-invalid`, `aria-describedby`, riepilogo `role="alert"`), nessun doppio submit, conferma leggibile senza colore.
- Contesto tecnico allegato e dichiarato nel form: path pagina, titolo, data/ora, viewport, user agent. Nessun nome, email, IP.

Contratto (`src/lib/report/contract.ts`)

- Schema zod strict: chiavi extra rifiutate (labels, assignees, repository, title…), lunghezze massime, body ≤ 12 KB, path solo sul dominio canonico, URL fonte solo https senza credenziali, honeypot website.
- Titolo [Segnalazione] <categoria>: <pagina> e struttura del corpo decisi dal server, come da issue.
- Testo utente in fence Markdown con fence più lunga di ogni run di backtick: niente HTML, @mention, #ref o link interpretati. Titolo pagina ripulito inline.

Endpoint POST `/api/segnalazioni`

- Guardie HTTP condivise estratte in `src/lib/http/public-post-guard.ts `(Content-Type, Host, Origin same-site, Content-Length, body limitato) e riusate da /api/assistant (nessun cambio di comportamento, test esistenti verdi).
- Time-trap apertura→invio (≥3 s, ≤24 h), rate limit per indirizzo (hash SHA-256, 3/10 min) e per istanza (30/10 min), Retry-After.
- Idempotenza: clientKey UUID generato dal browser; memoria d'istanza + marker <!-- dvns-report-key --> cercato nelle issue con label segnalazione delle ultime 24 h (lista issue, consistente). Retry/doppio click/timeout → stessa issue, duplicate: true.
- Fallback: 503 con fallbackUrl verso il composer GitHub precompilato se l'App non è configurata o GitHub fallisce; il form conserva i dati.
- Log: solo classe errore e stato HTTP upstream, mai il contenuto.

Client GitHub (src/lib/report/github.ts)

- GitHub App: JWT RS256 con node:crypto, token di installazione richiesto con permissions: `{ issues: "write" }` e repositories: [DoveVannoINostriSoldi], cache fino a 60 s dalla scadenza, timeout 8 s. Nessun SDK. Verifica che l'URL della issue creata appartenga al repository.

## Documentazione

`docs/SEGNALAZIONI.md` (contratto, sicurezza, attivazione), `/supporto`, `/privacy`, `SECURITY.md`, `README.md`, `.env.example`.

## Sicurezza e limiti dichiarati

- Credenziale solo server-side, minimo privilegio. Senza env → endpoint fail-closed (503 + composer).
- Rate limit non durevole: in-memory per istanza serverless (nessuno store condiviso nel progetto). Limite globale effettivo = GitHub + 30×istanze.
- Anti-bot senza challenge esterno: honeypot + time-trap + rate limit. Scelta per evitare script di terze parti e modifiche alla CSP.
- Redis per rate limit/idempotenza e Cloudflare Turnstile sono predisponibili come follow-up: il limitatore è isolato in `src/lib/report/rate-limit.ts` e lo schema accetta estensioni controllate. Da valutare dai maintainer dopo il primo periodo in produzione.
- Fuori scope come da issue: allegati, nome/email, vulnerabilità, modifica issue esistenti, classificazione automatica.

## Attivazione (post-merge, richiede permessi org)

1. Creare una GitHub App con permesso Issues: Read and write, senza webhook, installata solo su questo repository.
2. Impostare su Vercel REPORT_GITHUB_APP_ID, REPORT_GITHUB_INSTALLATION_ID, REPORT_GITHUB_APP_PRIVATE_KEY.
3. Creare la label segnalazione (l'App la crea comunque alla prima issue).
4. Inviare una segnalazione di prova da produzione e chiuderla.