### PR TITLE
fix(ui): make responsive navigation scroll controls usable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -373,7 +373,23 @@ nav li a { text-decoration: none; }
   display: block;
 }
 
-.nav-scroll-hint { display: none; }
+.nav-scroll-control {
+  display: none;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-height: 42px;
+  padding: 8px 0;
+  border: 0;
+  color: var(--color-neutral-600);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.nav-scroll-control:hover { color: var(--color-accent-700); }
 
 /* ── page shells ────────────────────────────────────────────────────────── */
 
@@ -718,7 +734,8 @@ main { display: block; }
     overflow-x: clip;
     overflow-y: visible;
   }
-  .nav-row[data-menu-open="true"] .nav-scroll-hint { display: none; }
+  .nav-scroll-control { display: inline-flex; }
+  .nav-row[data-menu-open="true"] .nav-scroll-control { display: none; }
   .primary-nav {
     overflow-x: auto;
     scrollbar-width: none;
@@ -802,15 +819,12 @@ main { display: block; }
   .primary-nav { scrollbar-width: thin; }
   .primary-nav::-webkit-scrollbar { display: block; height: 3px; }
   .primary-nav::-webkit-scrollbar-thumb { background: var(--color-neutral-400); }
-  .nav-scroll-hint {
+  .nav-scroll-control {
     display: inline-flex;
-    align-items: center;
-    gap: 3px;
-    flex: none;
-    color: var(--color-neutral-600);
-    font-size: 11px;
-    font-weight: 700;
-    white-space: nowrap;
+    min-width: 44px;
+  }
+  .nav-scroll-control-backward {
+    order: -1;
   }
   .footer-sitemap-columns {
     column-count: 2;

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -8,6 +8,7 @@ import { HeaderSearch } from "@/components/header-search";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown01Icon,
+  ArrowLeft01Icon,
   ArrowRight01Icon,
   GithubIcon,
 } from "@hugeicons/core-free-icons";
@@ -53,6 +54,10 @@ function NavigationSearchSync({
 function NavigationContent({ pathname, currentSearch }: NavigationContentProps) {
   const navigationRef = useRef<HTMLElement>(null);
   const activeLinkRef = useRef<HTMLAnchorElement>(null);
+  const [navigationScroll, setNavigationScroll] = useState({
+    backward: false,
+    forward: false,
+  });
   /**
    * Exactly one submenu may be open. Hover, focus and the caret all write the
    * same state so CSS never opens a second panel through :hover/:focus-within
@@ -78,6 +83,43 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
     (href: string) => setOpenMenu({ href, pathname, search: currentSearch }),
     [currentSearch, pathname],
   );
+
+  const updateNavigationScroll = useCallback(() => {
+    const navigation = navigationRef.current;
+    if (!navigation) return;
+    const maxScrollLeft = Math.max(0, navigation.scrollWidth - navigation.clientWidth);
+    const next = {
+      backward: navigation.scrollLeft > 4,
+      forward: navigation.scrollLeft < maxScrollLeft - 4,
+    };
+    setNavigationScroll((current) => (
+      current.backward === next.backward && current.forward === next.forward ? current : next
+    ));
+  }, []);
+
+  const scrollNavigation = useCallback((direction: "backward" | "forward") => {
+    const navigation = navigationRef.current;
+    if (!navigation) return;
+    const maxScrollLeft = Math.max(0, navigation.scrollWidth - navigation.clientWidth);
+    const distance = Math.max(160, Math.round(navigation.clientWidth * 0.75));
+    const nextScrollLeft = navigation.scrollLeft + (direction === "forward" ? distance : -distance);
+    navigation.scrollLeft = Math.max(0, Math.min(maxScrollLeft, nextScrollLeft));
+  }, []);
+
+  useLayoutEffect(() => {
+    const navigation = navigationRef.current;
+    if (!navigation) return;
+    updateNavigationScroll();
+    navigation.addEventListener("scroll", updateNavigationScroll, { passive: true });
+    window.addEventListener("resize", updateNavigationScroll);
+    const resizeObserver = new ResizeObserver(updateNavigationScroll);
+    resizeObserver.observe(navigation);
+    return () => {
+      navigation.removeEventListener("scroll", updateNavigationScroll);
+      window.removeEventListener("resize", updateNavigationScroll);
+      resizeObserver.disconnect();
+    };
+  }, [updateNavigationScroll]);
 
   useEffect(() => {
     const navigation = navigationRef.current;
@@ -261,10 +303,28 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
             })}
           </ul>
         </nav>
-        <span className="nav-scroll-hint" aria-hidden="true">
-          Scorri
-          <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.8} />
-        </span>
+        {navigationScroll.backward ? (
+          <button
+            type="button"
+            className="nav-scroll-control nav-scroll-control-backward"
+            aria-label="Scorri la navigazione verso sinistra"
+            onClick={() => scrollNavigation("backward")}
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} size={14} strokeWidth={1.8} aria-hidden="true" />
+            <span aria-hidden="true">Indietro</span>
+          </button>
+        ) : null}
+        {navigationScroll.forward ? (
+          <button
+            type="button"
+            className="nav-scroll-control nav-scroll-control-forward"
+            aria-label="Scorri la navigazione verso destra"
+            onClick={() => scrollNavigation("forward")}
+          >
+            <span aria-hidden="true">Scorri</span>
+            <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
     </header>
   );

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -55,6 +55,12 @@ test("a submenu can be opened without a pointer that can hover", async () => {
   assert.doesNotMatch(navigationComponent, /▾|Scorri →/);
   assert.match(navigationComponent, /event\.key === "Escape"/);
   assert.match(navigationComponent, /document\.addEventListener\("pointerdown", dismissOutside\)/);
+  assert.match(navigationComponent, /className="nav-scroll-control nav-scroll-control-forward"/);
+  assert.match(navigationComponent, /className="nav-scroll-control nav-scroll-control-backward"/);
+  assert.match(navigationComponent, /navigation\.scrollLeft = Math\.max\(0, Math\.min\(maxScrollLeft, nextScrollLeft\)\)/);
+  assert.match(globalsCss, /\.nav-scroll-control \{/);
+  assert.match(globalsCss, /@media \(max-width: 1320px\)[\s\S]*?\.nav-scroll-control \{ display: inline-flex; \}/);
+  assert.match(globalsCss, /\.nav-row\[data-menu-open="true"\] \.nav-scroll-control \{ display: none; \}/);
   // Open state carries the path it was opened on, so a completed navigation
   // closes the menu without a setState in an effect.
   assert.match(navigationComponent, /openMenu\?\.pathname === pathname/);


### PR DESCRIPTION
## Cosa cambia

Rende la navigazione primaria orizzontale realmente utilizzabile quando il viewport è più stretto del menu:

- sostituisce l indicatore statico `Scorri` con controlli accessibili avanti/indietro;
- aggiorna la visibilità dei controlli su scroll, resize e ResizeObserver;
- mantiene il menu a tendina e il comportamento mobile esistente;
- evita overflow orizzontale del documento.

## Verifica

- `npm run ci:static`
- `npm run build`
- `node --experimental-strip-types --test tests/site-navigation.test.mjs`
- verifica browser a 426px: scroll avanti/indietro funzionante e nessun overflow del body.