### PR TITLE
feat(education): add year-over-year trend chart

### DIFF
--- a/src/app/istruzione/education-trend-chart.module.css
+++ b/src/app/istruzione/education-trend-chart.module.css
@@ -1,0 +1,71 @@
+.figure {
+  margin: 14px 0 0;
+}
+
+.chart {
+  width: 100%;
+  height: 240px;
+  min-height: 220px;
+}
+
+.figure figcaption {
+  margin-top: 8px;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.tooltip {
+  min-width: 175px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-neutral-400);
+  color: var(--color-on-strong);
+  background: var(--color-text);
+  box-shadow: var(--shadow-md);
+}
+
+.tooltip > strong {
+  display: block;
+  color: var(--color-on-strong);
+  font-size: 12px;
+}
+
+.tooltip dl {
+  display: grid;
+  gap: 5px;
+  margin: 8px 0 0;
+}
+
+.tooltip dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tooltip dt {
+  color: var(--color-on-strong-muted);
+  font-size: 11px;
+}
+
+.tooltip dd {
+  margin: 0;
+  color: var(--color-on-strong);
+  font-size: 11px;
+  font-weight: 700;
+  text-align: right;
+}
+
+.empty {
+  display: grid;
+  min-height: 220px;
+  place-items: center;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  text-align: center;
+}
+
+@media (max-width: 520px) {
+  .chart {
+    height: 220px;
+  }
+}

--- a/src/app/istruzione/education-trend-chart.tsx
+++ b/src/app/istruzione/education-trend-chart.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { ChartDataTable } from "@/components/charts/chart-data-table";
+import { percent } from "@/lib/format";
+import styles from "./education-trend-chart.module.css";
+
+type EducationTrendPoint = Readonly<{
+  period: string;
+  periodLabel: string;
+  value: number | null;
+  femaleCount: number | null;
+}>;
+
+type ChartPoint = EducationTrendPoint & { students: number | null };
+
+const exactStudents = new Intl.NumberFormat("it-IT", {
+  maximumFractionDigits: 0,
+  useGrouping: "always",
+});
+
+function compactStudents(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    return `${(value / 1_000_000).toLocaleString("it-IT", { maximumFractionDigits: 1 })} mln`;
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${(value / 1_000).toLocaleString("it-IT", { maximumFractionDigits: 0 })} mila`;
+  }
+  return exactStudents.format(value);
+}
+
+function exactStudentLabel(value: number | null): string {
+  return value === null ? "n.d." : `${exactStudents.format(value)} studenti`;
+}
+
+function femaleLabel(point: EducationTrendPoint): string {
+  if (point.femaleCount === null || point.value === null || point.value === 0) return "n.d.";
+  const share = (point.femaleCount / point.value) * 100;
+  return `${exactStudents.format(point.femaleCount)} (${percent(share)})`;
+}
+
+function periodRangeLabel(points: readonly EducationTrendPoint[]): string {
+  const first = points[0]?.periodLabel;
+  const last = points.at(-1)?.periodLabel;
+  if (!first || !last) return "per gli anni disponibili";
+  if (first === last) return `nell'anno scolastico ${first}`;
+  return `dal ${first} al ${last}`;
+}
+
+function TooltipContent({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartPoint }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+
+  return (
+    <div className={styles.tooltip}>
+      <strong>{point.periodLabel}</strong>
+      <dl>
+        <div>
+          <dt>Studenti osservati</dt>
+          <dd>{exactStudentLabel(point.value)}</dd>
+        </div>
+        <div>
+          <dt>Ragazze</dt>
+          <dd>{femaleLabel(point)}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export function EducationTrendChart({
+  data,
+}: {
+  data: readonly EducationTrendPoint[];
+}) {
+  const chartData: ChartPoint[] = data.map((point) => ({
+    ...point,
+    students: point.value,
+  }));
+  const periodRange = periodRangeLabel(chartData);
+
+  if (!chartData.some((point) => point.value !== null)) {
+    return <div className={styles.empty}>Trend non disponibile per il perimetro selezionato.</div>;
+  }
+
+  return (
+    <figure className={styles.figure} aria-labelledby="education-trend-chart-title">
+      <div className={styles.chart} role="img" aria-label={`Studenti osservati per anno scolastico ${periodRange}`}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={chartData}
+            margin={{ top: 12, right: 12, bottom: 4, left: 4 }}
+            accessibilityLayer
+          >
+            <CartesianGrid vertical={false} stroke="var(--color-neutral-300)" />
+            <XAxis
+              dataKey="periodLabel"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+            />
+            <YAxis
+              axisLine={false}
+              tickLine={false}
+              width={62}
+              domain={[0, "auto"]}
+              tick={{ fill: "var(--color-neutral-600)", fontSize: 11 }}
+              tickFormatter={compactStudents}
+            />
+            <Tooltip
+              isAnimationActive={false}
+              cursor={{ stroke: "var(--color-neutral-400)" }}
+              content={<TooltipContent />}
+            />
+            <Line
+              type="monotone"
+              dataKey="students"
+              stroke="var(--chart-primary)"
+              strokeWidth={2.5}
+              dot={{ r: 3, fill: "var(--chart-primary)", stroke: "var(--color-raised)", strokeWidth: 2 }}
+              activeDot={{ r: 5, fill: "var(--chart-primary)", stroke: "var(--color-raised)", strokeWidth: 2 }}
+              connectNulls={false}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <figcaption id="education-trend-chart-title">
+        Studenti osservati nel perimetro selezionato. Il confronto descrive la serie pubblicata dal MIM, non un andamento della qualità scolastica.
+      </figcaption>
+      <ChartDataTable
+        label="Trend degli studenti osservati per anno scolastico"
+        columns={["Studenti osservati", "Ragazze"]}
+        rows={chartData.map((point) => ({
+          label: point.periodLabel,
+          values: [exactStudentLabel(point.value), femaleLabel(point)],
+        }))}
+      />
+    </figure>
+  );
+}

--- a/src/app/istruzione/istruzione.module.css
+++ b/src/app/istruzione/istruzione.module.css
@@ -87,18 +87,6 @@
 .attribution { margin: 14px 0 0; color: var(--color-neutral-600); font-size: 10px; line-height: 1.45; }
 .note { margin: 12px 0 0; color: var(--color-neutral-600); font-size: 11px; line-height: 1.45; }
 
-.trendRail {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
-  margin-top: 14px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--color-neutral-300);
-}
-.trendPoint { display: grid; gap: 3px; min-width: 0; padding: 10px 8px; background: var(--color-neutral-100); border-top: 3px solid var(--color-accent-300); }
-.trendPoint span { color: var(--color-neutral-600); font-size: 10px; letter-spacing: .05em; text-transform: uppercase; }
-.trendPoint strong { color: var(--color-accent-900); font-size: 20px; letter-spacing: -.04em; font-variant-numeric: tabular-nums; }
-.trendPoint small { color: var(--color-neutral-600); font-size: 10px; }
 .trendDelta { margin: 12px 0 0; color: var(--color-neutral-700); font-size: 12px; }
 .trendDelta strong { color: var(--color-accent-700); }
 
@@ -125,10 +113,6 @@
   .heroMeta { align-items: flex-start; text-align: left; }
   .dashboardGrid { grid-template-columns: 1fr; }
   .dashboardGrid > .column:last-child { grid-column: auto; display: flex; }
-}
-
-@media (max-width: 480px) {
-  .trendRail { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 360px) {

--- a/src/app/istruzione/page.tsx
+++ b/src/app/istruzione/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { CompanyAtlasMap } from "@/components/company-atlas-map";
 import { EducationAtlasFilters } from "@/components/education-atlas-filters";
+import { EducationTrendChart } from "./education-trend-chart";
 import { integer, longDate, percent } from "@/lib/format";
 import {
   EDUCATION_ATLAS_ALL,
@@ -216,15 +217,7 @@ export default async function EducationAtlasPage({
             </div>
             {hasTrendData ? (
               <>
-                <div className={styles.trendRail}>
-                  {view.trend.map((point) => (
-                    <div className={styles.trendPoint} key={point.period}>
-                      <span>{point.periodLabel}</span>
-                      <strong>{compactStudents(point.value)}</strong>
-                      <small>{genderShare(point.femaleCount, point.value)} ragazze</small>
-                    </div>
-                  ))}
-                </div>
+                <EducationTrendChart data={view.trend} />
                 <p className={styles.trendDelta}>
                   Ultimo confronto: <strong>{signedPercent(currentTrend?.value ?? null, previousTrend?.value ?? null)}</strong> rispetto all&apos;anno precedente.
                 </p>

--- a/tests/education-atlas.test.mjs
+++ b/tests/education-atlas.test.mjs
@@ -110,6 +110,14 @@ test("education trend and regional view keep missing territories explicit", () =
   assert.equal(national.regionPoints.find((region) => region.code === "04")?.value, null);
   assert.equal(national.regionPoints.filter((region) => region.value !== null).length, 18);
   assert.equal(national.trend.length, 3);
+  assert.deepEqual(
+    national.trend.map(({ period, periodLabel, value }) => ({ period, periodLabel, value })),
+    [
+      { period: "202223", periodLabel: "2022/23", value: 2_650_266 },
+      { period: "202324", periodLabel: "2023/24", value: 2_639_838 },
+      { period: "202425", periodLabel: "2024/25", value: 2_632_660 },
+    ],
+  );
   assert.equal(national.addressRanking.length, 14);
   assert.ok(national.pathwayBreakdown[0].value > 0);
 
@@ -183,4 +191,35 @@ test("education period choices stay visible and keyboard-operable", async () => 
   assert.doesNotMatch(component, /<select[\s\S]*?data-education-filter="period"/);
   assert.match(css, /\.periodOptions button \{[\s\S]*?min-height: 42px;/);
   assert.match(css, /\.periodOptions button:focus-visible/);
+});
+
+test("education trend exposes the year-over-year series as a chart with an exact data table", async () => {
+  const [page, chart, css] = await Promise.all([
+    readFile(new URL("../src/app/istruzione/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/istruzione/education-trend-chart.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/app/istruzione/education-trend-chart.module.css", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(page, /import \{ EducationTrendChart \} from "\.\/education-trend-chart"/);
+  assert.match(page, /<EducationTrendChart data=\{view\.trend\} \/>/);
+  assert.match(chart, /^"use client";/);
+  assert.match(chart, /<LineChart/);
+  assert.match(chart, /data=\{chartData\}/);
+  assert.match(chart, /dataKey="periodLabel"/);
+  assert.match(chart, /dataKey="students"/);
+  assert.match(chart, /ChartDataTable/);
+  assert.match(chart, /Studenti osservati per anno scolastico/);
+  assert.match(chart, /exactStudentLabel\(point\.value\)/);
+  assert.match(chart, /value === null \? "n\.d\."/);
+  assert.match(chart, /percent\(share\)/);
+  assert.match(chart, /isAnimationActive=\{false\}/);
+  assert.match(chart, /role="img"/);
+  assert.match(chart, /periodRangeLabel\(chartData\)/);
+  assert.doesNotMatch(chart, /dal 2022\/23 al 2024\/25/);
+  assert.match(chart, /<Tooltip[\s\S]*content=\{<TooltipContent \/>\}/);
+  assert.match(chart, /rows=\{chartData\.map/);
+  assert.match(chart, /var\(--chart-primary\)/);
+  assert.match(css, /var\(--color-on-strong\)/);
+  assert.match(css, /\.chart \{[\s\S]*height: 240px;/);
+  assert.match(css, /@media \(max-width: 520px\)[\s\S]*\.chart \{[\s\S]*height: 220px;/);
 });


### PR DESCRIPTION
## Cosa cambia

Aggiunge alla sezione `Istruzione` una visualizzazione lineare dell andamento anno su anno degli studenti osservati:

- usa la serie MIM già presente nello snapshot (2022/23, 2023/24, 2024/25);
- mantiene il confronto numerico e la variazione rispetto all anno precedente;
- aggiunge tooltip leggibile e tabella dati esatti accessibile;
- chiarisce che la serie descrive il perimetro osservato, non la qualità scolastica;
- non modifica fonte, snapshot o contratto dati.

## Verifica

- `npm run ci:static`
- `npm run build`
- `node --experimental-strip-types --test tests/education-atlas.test.mjs`
- verifica browser a 426px: grafico leggibile, tabella accessibile e nessun overflow del body.