### PR TITLE
fix(budget): classify current OpenBDAP CSV outage

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -11,6 +11,7 @@ import {
   scenarioIdFromLabel,
   waitForServer,
 } from "./harness.mjs";
+import { waitForStableNavigationTouchTarget } from "./navigation-touch-target.mjs";
 
 const baseUrl = defaultBaseUrl();
 const TABLE_REGION = '[role="region"][aria-label="Redditi e variabili IRPEF per territorio"]';
@@ -614,6 +615,7 @@ async function assertPrimaryDropdownTap(page, label, { sectionLabel, childLabel 
   const toggle = await itemElement.$(".nav-item-toggle");
   assert.ok(toggle, `${label}: pulsante tendina assente`);
 
+  await waitForStableNavigationTouchTarget(page, toggle);
   const toggleBox = await toggle.boundingBox();
   assert.ok(toggleBox, `${label}: pulsante tendina non visibile`);
   await page.touchscreen.tap(

--- a/scripts/browser/navigation-touch-target.mjs
+++ b/scripts/browser/navigation-touch-target.mjs
@@ -1,0 +1,88 @@
+const STABLE_FOR_MS = 100;
+const MIN_STABLE_FRAMES = 2;
+
+/**
+ * Wait until a mobile primary-navigation target can be tapped at a stable point.
+ * The caller must read boundingBox() after this wait and immediately use those
+ * coordinates for the input event; this helper deliberately does not sleep
+ * without checking the target and its scroll-container geometry.
+ */
+export async function waitForStableNavigationTouchTarget(page, element, { timeout = 3_000 } = {}) {
+  await page.waitForFunction(
+    async (candidate, stability) => {
+      const sameSnapshot = (first, second) => {
+        if (!first || !second) return false;
+        return [
+          "x",
+          "y",
+          "width",
+          "height",
+          "navigationX",
+          "navigationWidth",
+          "navigationClientWidth",
+          "navigationScrollWidth",
+          "scrollLeft",
+        ].every((key) => Math.abs(first[key] - second[key]) <= 0.25);
+      };
+
+      const readSnapshot = () => {
+        if (!candidate.isConnected) return null;
+
+        const rect = candidate.getBoundingClientRect();
+        const navigation = candidate.closest(".primary-nav");
+        const navigationRect = navigation?.getBoundingClientRect();
+        const style = window.getComputedStyle(candidate);
+        if (
+          !navigation ||
+          !navigationRect ||
+          rect.width <= 0 ||
+          rect.height <= 0 ||
+          style.display === "none" ||
+          style.visibility === "hidden" ||
+          style.pointerEvents === "none"
+        ) {
+          return null;
+        }
+
+        const hit = document.elementFromPoint(
+          rect.left + rect.width / 2,
+          rect.top + rect.height / 2,
+        );
+        if (!hit || (hit !== candidate && !candidate.contains(hit))) return null;
+
+        return {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+          navigationX: navigationRect.x,
+          navigationWidth: navigationRect.width,
+          navigationClientWidth: navigation.clientWidth,
+          navigationScrollWidth: navigation.scrollWidth,
+          scrollLeft: navigation.scrollLeft,
+        };
+      };
+
+      let previous = readSnapshot();
+      if (!previous) return false;
+
+      const stableSince = performance.now();
+      let stableFrames = 0;
+      while (
+        stableFrames < stability.minStableFrames ||
+        performance.now() - stableSince < stability.stableForMs
+      ) {
+        await new Promise((resolve) => window.requestAnimationFrame(resolve));
+        const current = readSnapshot();
+        if (!sameSnapshot(previous, current)) return false;
+        previous = current;
+        stableFrames += 1;
+      }
+
+      return true;
+    },
+    { timeout },
+    element,
+    { stableForMs: STABLE_FOR_MS, minStableFrames: MIN_STABLE_FRAMES },
+  );
+}

--- a/src/lib/bdap-legge-bilancio.ts
+++ b/src/lib/bdap-legge-bilancio.ts
@@ -195,6 +195,15 @@ function throwForTemporaryHttpFailure(response: Response, operation: string): vo
   }
 }
 
+// OpenBDAP has emitted both messages for the same missing-attachment failure:
+// the shorter form is the current live response, while the longer form is
+// retained for compatibility with older gateway responses. Other JSON errors
+// must remain fail-closed instead of silently switching to the snapshot.
+const KNOWN_CSV_ATTACHMENT_OUTAGE_MESSAGES = new Set([
+  "Cannot convert data to csv",
+  "Cannot convert data to csv. Attachment not found",
+]);
+
 function text(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const cleaned = value.trim();
@@ -365,7 +374,8 @@ async function fetchDatasetRows(
         };
         if (
           payload.success === false &&
-          payload.error?.message === "Cannot convert data to csv. Attachment not found"
+          typeof payload.error?.message === "string" &&
+          KNOWN_CSV_ATTACHMENT_OUTAGE_MESSAGES.has(payload.error.message)
         ) {
           throw new BudgetLawSourceTemporarilyUnavailableError(
             "OpenBDAP non ha reso disponibile l'allegato CSV richiesto",

--- a/tests/bdap-legge-bilancio.test.mjs
+++ b/tests/bdap-legge-bilancio.test.mjs
@@ -545,7 +545,44 @@ test("the budget-law route falls back to the verified snapshot when OpenBDAP is 
   }
 });
 
-test("the known OpenBDAP attachment-conversion outage uses the snapshot", async () => {
+test("known OpenBDAP attachment-conversion outages use the snapshot", async () => {
+  const outageMessages = [
+    "Cannot convert data to csv",
+    "Cannot convert data to csv. Attachment not found",
+  ];
+
+  for (const message of outageMessages) {
+    resetBudgetLawMissionSeriesCacheForTests();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      const url = new URL(input.toString());
+      if (url.pathname.endsWith("/package_search")) {
+        return new Response(
+          JSON.stringify({ success: true, result: { results: [packageFixture()] } }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ success: false, error: { message } }),
+        { headers: { "content-type": "application/json" } },
+      );
+    };
+    try {
+      const response = await getBudgetLawRoute(
+        new NextRequest("https://example.test/api/spese/stato/legge-bilancio?anni=20"),
+      );
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.dataMode, "snapshot");
+      assert.deepEqual(body.years, [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      resetBudgetLawMissionSeriesCacheForTests();
+    }
+  }
+});
+
+test("an unrelated OpenBDAP CSV JSON error fails closed", async () => {
   resetBudgetLawMissionSeriesCacheForTests();
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input) => {
@@ -559,19 +596,16 @@ test("the known OpenBDAP attachment-conversion outage uses the snapshot", async 
     return new Response(
       JSON.stringify({
         success: false,
-        error: { message: "Cannot convert data to csv. Attachment not found" },
+        error: { message: "Database unavailable while converting data to csv" },
       }),
       { headers: { "content-type": "application/json" } },
     );
   };
   try {
-    const response = await getBudgetLawRoute(
-      new NextRequest("https://example.test/api/spese/stato/legge-bilancio?anni=20"),
+    await assert.rejects(
+      getBudgetLawMissionSeries(),
+      /OpenBDAP non ha restituito un CSV per il dataset Legge di Bilancio/,
     );
-    assert.equal(response.status, 200);
-    const body = await response.json();
-    assert.equal(body.dataMode, "snapshot");
-    assert.deepEqual(body.years, [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]);
   } finally {
     globalThis.fetch = originalFetch;
     resetBudgetLawMissionSeriesCacheForTests();

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -8,6 +8,11 @@ const navigationSource = fs.readFileSync(
   new URL("../src/lib/site-navigation.ts", import.meta.url),
   "utf8",
 );
+const browserCoreSource = fs.readFileSync(new URL("../scripts/browser/core.mjs", import.meta.url), "utf8");
+const navigationTouchTargetSource = fs.readFileSync(
+  new URL("../scripts/browser/navigation-touch-target.mjs", import.meta.url),
+  "utf8",
+);
 const layoutSource = fs.readFileSync(new URL("../src/app/layout.tsx", import.meta.url), "utf8");
 const globalsCss = fs.readFileSync(new URL("../src/app/globals.css", import.meta.url), "utf8");
 
@@ -80,6 +85,14 @@ test("a submenu can be opened without a pointer that can hover", async () => {
   assert.match(globalsCss, /\.nav-row \{\n\s*position: relative;/);
   assert.match(navigationComponent, /data-menu-open=\{openHref \? "true" : undefined\}/);
   assert.match(globalsCss, /\.nav-row\[data-menu-open="true"\] \.primary-nav \{ overflow: visible; \}/);
+});
+
+test("mobile dropdown taps use stable, hit-testable navigation geometry", () => {
+  assert.match(navigationTouchTargetSource, /export async function waitForStableNavigationTouchTarget/);
+  assert.match(navigationTouchTargetSource, /window\.requestAnimationFrame/);
+  assert.match(navigationTouchTargetSource, /navigation\.scrollLeft/);
+  assert.match(browserCoreSource, /await waitForStableNavigationTouchTarget\(page, toggle\)/);
+  assert.match(browserCoreSource, /const toggleBox = await toggle\.boundingBox\(\)/);
 });
 
 test("navigation guards related targets before checking containment", async () => {


### PR DESCRIPTION
## Summary

- Classify OpenBDAP's current HTTP 200 JSON response, `Cannot convert data to csv`, as the known temporary missing-CSV-attachment outage.
- Retain compatibility with the legacy `Cannot convert data to csv. Attachment not found` response.
- Keep unrelated JSON and schema errors fail-closed; the fallback remains the verified committed snapshot.

## Why

The production gate on `main` was failing in the budget-law browser scenario because the live CSV endpoint returned JSON instead of CSV. The adapter treated the known outage as a permanent error, so the page rendered its unavailable-data alert and the treemap selector was absent.

## Validation

- Targeted budget-law tests: 20/20 passed, including both outage variants and an unrelated-error negative case.
- Production build, lint, typecheck, design, brand, action-pin and generated-artifact checks passed.
- Browser core passed all scenarios, including budget-law sharing at 390px, 768px and 1280px.
- The original treemap repro passed at 390px and 1280px; 20 repeated runs at each width passed (40/40).
- Full Node and ETL suites completed; their sandbox-only loopback/timing failures were rerun in isolation with network permissions and passed.

## Browser harness race

- The mobile dropdown helper now waits for the target and primary-navigation geometry, scroll position and center hit-test to remain stable for at least two animation frames and 100 ms before rereading the bounding box for `touchscreen.tap`.
- The exact `/debito` 390px repro passed 20/20 at CPU1x and 20/20 at CPU4x without a pre-tap delay.
- The complete browser-core suite passed again against a fresh production server after this harness fix.

## Relation to #206

This is a prerequisite fix for the pre-existing production required-gate failure observed on `main` while validating #206. It is independent of #206 and #207 feature changes and does not modify either checkout.
