### PR TITLE
fix(enti): stop crawlers indexing unique appalti URLs

### DIFF
--- a/src/app/enti/[codice]/appalti/page.tsx
+++ b/src/app/enti/[codice]/appalti/page.tsx
@@ -356,12 +356,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { codice } = await params;
   const normalizedCode = decodeEntityProcurementRouteCode(codice);
   if (!normalizedCode) notFound();
-  try {
-    const entity = await getIpaEntityByCode(normalizedCode);
-    return { title: "Appalti · " + (entity?.denominazione ?? normalizedCode) };
-  } catch {
-    return { title: "Appalti · " + normalizedCode };
-  }
+  return {
+    title: "Appalti · " + normalizedCode,
+    robots: { index: false, follow: false },
+  };
 }
 
 export default async function EntityProcurementPage({ params, searchParams }: PageProps) {

--- a/src/lib/public-discovery.ts
+++ b/src/lib/public-discovery.ts
@@ -130,7 +130,9 @@ export function publicRobots(siteUrl: string): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: "/api/",
+      // Unique entity procurement URLs miss the CDN on every hit. MCP and
+      // humans still reach them; crawlers should not enumerate them.
+      disallow: ["/api/", "/enti/*/appalti"],
     },
     sitemap: `${siteUrl}/sitemap.xml`,
   };

--- a/tests/anac-entity-procurement-page.test.mjs
+++ b/tests/anac-entity-procurement-page.test.mjs
@@ -446,11 +446,18 @@ test("UI keeps scope, rankings, official CIG links and no later indicators", () 
   assert.match(detail, /Perimetro temporale/);
   assert.match(detail, /verifyLiveFiscalCode: false/);
   assert.match(detail, /Indice PA non risponde/);
+  assert.match(detail, /robots:\s*\{\s*index:\s*false,\s*follow:\s*false\s*\}/);
   assert.match(detail, /maxDuration = 15/);
   const entityPage = readFileSync(new URL("../src/app/enti/[codice]/page.tsx", import.meta.url), "utf8");
   assert.match(entityPage, /Anagrafica IPA non disponibile/);
   assert.doesNotMatch(entityPage, /Impossibile interrogare la fonte IPA/);
-  assert.match(detail, /entity\?\.denominazione \?\? normalizedCode/);
+  const metadataFn = detail.slice(
+    detail.indexOf("export async function generateMetadata"),
+    detail.indexOf("export default async function"),
+  );
+  assert.match(metadataFn, /title: "Appalti · " \+ normalizedCode/);
+  assert.doesNotMatch(metadataFn, /getIpaEntityByCode/);
+  assert.match(detail, /entity\?\.denominazione \|\| normalizedCode/);
   assert.match(detail, /nameVariants > 1/);
   assert.match(`${section}\n${detail}`, /codici fiscali degli operatori/);
   assert.match(detail, /caption/);

--- a/tests/public-discovery.test.mjs
+++ b/tests/public-discovery.test.mjs
@@ -117,10 +117,12 @@ test("robots permits public pages without blocking Next assets", () => {
   assert.deepEqual(robots.rules, {
     userAgent: "*",
     allow: "/",
-    disallow: "/api/",
+    disallow: ["/api/", "/enti/*/appalti"],
   });
   assert.equal(robots.sitemap, `${PUBLIC_SITE_URL}/sitemap.xml`);
   assert.equal(robots.rules.disallow.includes("/_next/"), false);
+  assert.equal(robots.rules.disallow.includes("/mcp"), false);
+  assert.equal(robots.rules.disallow.includes("/api/mcp"), false);
 });
 
 test("llms discovery paths are indexable and resolve to public pages", async () => {


### PR DESCRIPTION
## Summary
- I crawler stanno enumerando migliaia di URL uniche `/enti/{codice}/appalti` (anche con codici inventati). Ogni hit è `force-dynamic` e `cache=MISS`, ed è la voce dominante del compute Vercel. MCP non c'entra: resta raggiungibile su `/mcp` e `/api/mcp`.
- `robots.txt` ora disallows `/enti/*/appalti` (non `/mcp` né un extra su `/api/mcp`, già coperto da `/api/`). La pagina appalti ente esce dall'indice (`noindex, nofollow`) e `generateMetadata` non chiama più IPA: una sola lookup IPA nel render, non due.
- Sul progetto Vercel è già live una regola WAF **enti-appalti-crawl-cap**: 40 req/60s per IP solo sul path appalti ente, azione 429. La regola MCP resta in **log** (60/min), così gli agenti non vengono tagliati al bordo.

## Test plan
- [ ] `node --test tests/public-discovery.test.mjs tests/anac-entity-procurement-page.test.mjs`
- [ ] Dopo il merge, aprire una scheda `/enti/{codice}/appalti` da browser: pagina ok, titolo con codice IPA, nessun 429 a ritmo umano
- [ ] `curl -sI https://www.dovevannoinostrisoldi.com/robots.txt` contiene `Disallow: /enti/*/appalti` e non blocca `/mcp`
- [ ] Un POST MCP (`/api/mcp`) continua a rispondere; nessun 429 WAF su MCP
- [ ] In Vercel Observability, le invocazioni `/enti/[codice]/appalti` da crawler scendono (429 WAF non fatturati)


Made with [Cursor](https://cursor.com)