### PR TITLE
fix(runtime): contain MCP and IPA cost amplification

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -644,6 +644,43 @@ async function activeLevel(page) {
   return page.$eval(ACTIVE_LEVEL, (link) => link.textContent?.trim());
 }
 
+async function stubSuccessfulHeaderSearch(page) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname === "/api/search") {
+      void request.respond({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          query: "Roma",
+          groups: [{
+            type: "ente",
+            label: "Enti",
+            results: [{
+              id: "entity:c_h501",
+              href: "/enti/c_h501",
+              title: "Roma Capitale",
+              context: "Registro IPA",
+              type: "ente",
+              description: "Comune · c_h501",
+              match: { reason: "entity", label: "Nome dell'ente" },
+              score: 1900,
+            }],
+          }],
+          total: 1,
+          hasMore: false,
+          staticTotal: 0,
+          entityTotal: 1,
+          entitiesAvailable: true,
+        }),
+      });
+    } else {
+      void request.continue();
+    }
+  });
+}
+
 async function runScenario(browser, {
   expectedFailure = () => false,
   label,
@@ -1291,14 +1328,14 @@ try {
         await page.keyboard.press("Enter");
         assert.equal(await informationSummary.evaluate((element) => element.parentElement?.open), true);
 
-        const structureSummary = await page.$("details[data-structure-details] summary");
-        assert.ok(structureSummary, `${label}: struttura IPA espandibile assente`);
-        await structureSummary.focus();
-        await page.keyboard.press("Enter");
-        assert.equal(
-          await structureSummary.evaluate((element) => element.parentElement?.open),
-          true,
+        const informationText = await page.$eval(
+          "details[data-municipality-information]",
+          (element) => element.innerText,
         );
+        assert.match(informationText, /Profilo servito da snapshot verificati|Snapshot verificato durante l.ETL/i);
+        assert.match(informationText, /Uffici non inclusi nello snapshot locale/i);
+        assert.match(informationText, /nessuna chiamata IPA durante la visita/i);
+        assert.equal(await page.$("details[data-structure-details]"), null);
 
         const apiResponse = await page.evaluate(async () => {
           const response = await fetch("/api/enti/c_a783");
@@ -1319,9 +1356,14 @@ try {
     width: 390,
     validate: async (page) => {
       const text = await bodyText(page);
-      assertTextMatches(text, /Identità amministrativa/i, "Ente non comunale");
-      assertTextMatches(text, /Dati economici · collegamenti in corso/i, "Ente non comunale");
-      assertTextMatches(text, /Formato JSON/i, "Ente non comunale");
+      if (/Anagrafica IPA non disponibile/i.test(text)) {
+        assertTextMatches(text, /Indice PA non risponde/i, "Ente non comunale");
+        assertTextMatches(text, /Codice richiesto[\s\S]*agid/i, "Ente non comunale");
+      } else {
+        assertTextMatches(text, /Identità amministrativa/i, "Ente non comunale");
+        assertTextMatches(text, /Dati economici · collegamenti in corso/i, "Ente non comunale");
+        assertTextMatches(text, /Formato JSON/i, "Ente non comunale");
+      }
       assert.doesNotMatch(text, /Quanto ha pagato il Comune/i);
     },
   });
@@ -1790,6 +1832,7 @@ try {
       pathname: "/",
       width,
       validate: async (page) => {
+        await stubSuccessfulHeaderSearch(page);
         const input = await page.$("#global-site-search");
         assert.ok(input, `${label}: campo di ricerca assente`);
         await input.type("Roma");
@@ -1814,6 +1857,7 @@ try {
     pathname: "/",
     width: 390,
     validate: async (page) => {
+      await stubSuccessfulHeaderSearch(page);
       const input = await page.$("#global-site-search");
       assert.ok(input, "Ricerca header Escape: campo assente");
       await input.type("Roma");

--- a/scripts/ci/run-production-gates.sh
+++ b/scripts/ci/run-production-gates.sh
@@ -69,9 +69,12 @@ npm run test:mcp:http
 echo "::endgroup::"
 
 echo "::group::MCP local load test"
+# Keep the throughput sample below the 60 requests/minute application limit:
+# the preceding protocol smoke intentionally shares the same local client IP.
+# The exact 60 + 1 limiter boundary is covered by the route unit suite.
 npm run test:mcp:load -- \
   --url "${BASE_URL}/api/mcp" \
-  --requests 60 \
+  --requests 40 \
   --concurrency 10 \
   --p95-ms 3000
 echo "::endgroup::"

--- a/scripts/mcp_http_smoke.mjs
+++ b/scripts/mcp_http_smoke.mjs
@@ -84,9 +84,17 @@ const sseGetResponse = await fetch(new URL("/mcp", baseUrl), {
   signal: AbortSignal.timeout(10_000),
 });
 assert.equal(sseGetResponse.status, 405);
-assert.equal(sseGetResponse.headers.get("allow"), "POST, OPTIONS");
+assert.equal(sseGetResponse.headers.get("allow"), "POST, OPTIONS, HEAD");
 assert.equal(sseGetResponse.headers.get("cache-control"), "private, no-store");
 assert.match(sseGetResponse.headers.get("content-type") ?? "", /application\/json/);
+
+const headResponse = await fetch(new URL("/mcp", baseUrl), {
+  method: "HEAD",
+  signal: AbortSignal.timeout(10_000),
+});
+assert.equal(headResponse.status, 204);
+assert.equal(headResponse.headers.get("allow"), "POST, OPTIONS, HEAD");
+assert.equal(headResponse.headers.get("cache-control"), "private, no-store");
 
 const allowedPreflight = await fetch(new URL("/mcp", baseUrl), {
   method: "OPTIONS",

--- a/src/app/api/enti/[codice]/route.ts
+++ b/src/app/api/enti/[codice]/route.ts
@@ -5,7 +5,10 @@ import {
   IPA_ENTI_RESOURCE_ID,
   IPA_LICENSE,
 } from "@/lib/ipa";
+import { decodeEntityProcurementRouteCode } from "@/lib/data/anac-entity-procurement-page";
 import { getMunicipalityProfile } from "@/lib/municipality-profile";
+import { municipalitySnapshotEntity } from "@/lib/municipality-snapshot-entity";
+import { getSiopeMunicipalityDetailByIpaCode } from "@/lib/siope-municipality-detail";
 
 export const dynamic = "force-dynamic";
 
@@ -15,14 +18,18 @@ type RouteContext = {
 
 export async function GET(_request: Request, context: RouteContext) {
   const { codice } = await context.params;
-  const normalized = decodeURIComponent(codice).trim();
+  const normalized = decodeEntityProcurementRouteCode(codice);
 
   if (!normalized) {
-    return NextResponse.json({ ok: false, error: "Codice IPA mancante" }, { status: 400 });
+    return NextResponse.json({ ok: false, error: "Codice IPA non valido" }, { status: 400 });
   }
 
   try {
-    const entity = await getIpaEntityByCode(normalized);
+    const municipalitySnapshot = getSiopeMunicipalityDetailByIpaCode(normalized);
+    const snapshotEntity = municipalitySnapshot
+      ? municipalitySnapshotEntity(municipalitySnapshot)
+      : null;
+    const entity = snapshotEntity ?? await getIpaEntityByCode(normalized);
 
     if (!entity) {
       return NextResponse.json(
@@ -34,20 +41,29 @@ export async function GET(_request: Request, context: RouteContext) {
         { status: 404 },
       );
     }
-    const municipalityProfile = await getMunicipalityProfile(entity);
+    const snapshotOnly = snapshotEntity !== null;
+    const municipalityProfile = await getMunicipalityProfile(entity, {
+      allowCommittedIstatIdentity: snapshotOnly,
+    });
+    const snapshotObservedAt = municipalitySnapshot?.years[0]?.observedAt ?? null;
 
     return NextResponse.json(
       {
         ok: true,
         source: {
-          name: "Indice PA (IPA) · dataset Enti",
-          owner: "Agenzia per l'Italia Digitale",
+          name: snapshotOnly
+            ? "Snapshot comunale SIOPE con identificativi IPA verificati"
+            : "Indice PA (IPA) · dataset Enti",
+          owner: snapshotOnly
+            ? "Ragioneria Generale dello Stato + Agenzia per l'Italia Digitale"
+            : "Agenzia per l'Italia Digitale",
           datasetUrl: IPA_ENTI_DATASET_URL,
           resourceId: IPA_ENTI_RESOURCE_ID,
           license: IPA_LICENSE,
-          cadence: "giornaliera",
+          cadence: snapshotOnly ? "snapshot ETL" : "giornaliera",
+          mode: snapshotOnly ? "snapshot" : "live",
         },
-        observedAt: new Date().toISOString(),
+        observedAt: snapshotObservedAt ?? new Date().toISOString(),
         record: entity,
         municipalityProfile,
       },

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,6 +1,7 @@
 import { createMcpHandler } from "@modelcontextprotocol/server";
 import { createDvnsMcpServer } from "@/lib/mcp/server";
-import { SlidingWindowLimiter, clientAddress } from "@/lib/report/rate-limit";
+import { runMcpExchangeWithDeadline } from "@/lib/mcp/request-deadline";
+import { ConcurrencyLimiter, SlidingWindowLimiter, clientAddress } from "@/lib/report/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -9,6 +10,7 @@ export const maxDuration = 15;
 const MAX_REQUEST_BYTES = 1_000_000;
 const MCP_HANDLER_TIMEOUT_MS = 12_000;
 const mcpLimiter = new SlidingWindowLimiter({ windowMs: 60_000, max: 60 });
+const mcpConcurrency = new ConcurrencyLimiter(8);
 
 function reportMcpError(error: Error) {
   if (error.message.startsWith("Rejected inbound request")) return;
@@ -17,6 +19,7 @@ function reportMcpError(error: Error) {
 
 const handler = createMcpHandler(createDvnsMcpServer, {
   legacy: "stateless",
+  responseMode: "json",
   onerror: reportMcpError,
 });
 
@@ -140,8 +143,34 @@ async function requestWithBoundedBody(request: Request): Promise<Request | Respo
   const chunks: Uint8Array[] = [];
   let total = 0;
 
+  const read = () => new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+    if (request.signal.aborted) {
+      reject(request.signal.reason);
+      return;
+    }
+    const onAbort = () => reject(request.signal.reason);
+    request.signal.addEventListener("abort", onAbort, { once: true });
+    reader.read().then(
+      (result) => {
+        request.signal.removeEventListener("abort", onAbort);
+        resolve(result);
+      },
+      (error) => {
+        request.signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+
   while (true) {
-    const { done, value } = await reader.read();
+    let result: ReadableStreamReadResult<Uint8Array>;
+    try {
+      result = await read();
+    } catch (error) {
+      await reader.cancel(error).catch(() => undefined);
+      throw error;
+    }
+    const { done, value } = result;
     if (done) break;
     total += value.byteLength;
     if (total > MAX_REQUEST_BYTES) {
@@ -171,16 +200,6 @@ async function requestWithBoundedBody(request: Request): Promise<Request | Respo
 export async function POST(request: Request) {
   const rejected = validateRequest(request);
   if (rejected) return secureResponse(rejected, request);
-  let boundedRequest: Request | Response;
-  try {
-    boundedRequest = await requestWithBoundedBody(request);
-  } catch {
-    return secureResponse(Response.json(
-      { error: "Richiesta interrotta o non leggibile" },
-      { status: 400 },
-    ), request);
-  }
-  if (boundedRequest instanceof Response) return secureResponse(boundedRequest, request);
 
   const clientKey = clientAddress(request);
   if (clientKey && !mcpLimiter.consume(clientKey)) {
@@ -190,20 +209,36 @@ export async function POST(request: Request) {
     ), request);
   }
 
-  const timeout = AbortSignal.timeout(MCP_HANDLER_TIMEOUT_MS);
-  const callerSignal = boundedRequest.signal;
-  const signal = callerSignal.aborted ? callerSignal : AbortSignal.any([callerSignal, timeout]);
-  const timedRequest = new Request(boundedRequest, { signal });
+  const release = mcpConcurrency.tryAcquire();
+  if (!release) {
+    return secureResponse(Response.json(
+      { jsonrpc: "2.0", error: { code: -32000, message: "Server MCP occupato. Riprova tra pochi secondi." }, id: null },
+      { status: 503, headers: { "Retry-After": "5" } },
+    ), request);
+  }
+
   try {
-    return secureResponse(await handler.fetch(timedRequest), request);
-  } catch (error) {
-    if (timeout.aborted) {
-      return secureResponse(Response.json(
-        { jsonrpc: "2.0", error: { code: -32000, message: "Timeout della richiesta MCP" }, id: null },
-        { status: 504 },
-      ), request);
-    }
-    throw error;
+    const response = await runMcpExchangeWithDeadline(
+      request,
+      async (timedRequest) => {
+        let boundedRequest: Request | Response;
+        try {
+          boundedRequest = await requestWithBoundedBody(timedRequest);
+        } catch {
+          if (timedRequest.signal.aborted) throw timedRequest.signal.reason;
+          return Response.json(
+            { error: "Richiesta interrotta o non leggibile" },
+            { status: 400 },
+          );
+        }
+        if (boundedRequest instanceof Response) return boundedRequest;
+        return handler.fetch(boundedRequest);
+      },
+      MCP_HANDLER_TIMEOUT_MS,
+    );
+    return secureResponse(response, request);
+  } finally {
+    release();
   }
 }
 
@@ -227,6 +262,15 @@ export function GET(request: Request) {
 
   return secureResponse(Response.json(
     { error: "Questo server MCP usa Streamable HTTP tramite POST" },
-    { status: 405, headers: { Allow: "POST, OPTIONS" } },
+    { status: 405, headers: { Allow: "POST, OPTIONS, HEAD" } },
   ), request);
+}
+
+export function HEAD(request: Request) {
+  const rejected = validateRequest(request);
+  if (rejected) return secureResponse(rejected, request);
+  return secureResponse(new Response(null, {
+    status: 204,
+    headers: { Allow: "POST, OPTIONS, HEAD" },
+  }), request);
 }

--- a/src/app/enti/[codice]/appalti/page.tsx
+++ b/src/app/enti/[codice]/appalti/page.tsx
@@ -22,6 +22,8 @@ type PageProps = {
 export const dynamic = "force-dynamic";
 export const maxDuration = 15;
 
+const entityRobots = { index: false, follow: false } as const;
+
 type ProcurementView = "summary" | "operators" | "procedures" | "awards" | "operator";
 type RankingMetric = "count" | "value";
 
@@ -356,7 +358,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const normalizedCode = decodeEntityProcurementRouteCode(codice);
   if (!normalizedCode) notFound();
   const municipality = getSiopeMunicipalityDetailByIpaCode(normalizedCode);
-  return { title: "Appalti · " + (municipality?.name ?? normalizedCode) };
+  return {
+    title: "Appalti · " + (municipality?.name ?? normalizedCode),
+    robots: entityRobots,
+  };
 }
 
 export default async function EntityProcurementPage({ params, searchParams }: PageProps) {

--- a/src/app/enti/[codice]/appalti/page.tsx
+++ b/src/app/enti/[codice]/appalti/page.tsx
@@ -7,11 +7,10 @@ import {
   clampEntityProcurementPage,
   countAnacAwardAttributions,
   decodeEntityProcurementRouteCode,
-  getEntityProcurementPage,
   loadAnacEntityProcurementPage,
   type AnacEntityProcurementPageView,
 } from "@/lib/data/anac-entity-procurement-page";
-import { getIpaEntityByCode } from "@/lib/ipa";
+import { getSiopeMunicipalityDetailByIpaCode } from "@/lib/siope-municipality-detail";
 import { EntityProcurementSection, EntityProcurementSourceDetails } from "../entity-procurement-section";
 import styles from "./appalti.module.css";
 
@@ -356,44 +355,29 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { codice } = await params;
   const normalizedCode = decodeEntityProcurementRouteCode(codice);
   if (!normalizedCode) notFound();
-  try {
-    const entity = await getIpaEntityByCode(normalizedCode);
-    return { title: "Appalti · " + (entity?.denominazione ?? normalizedCode) };
-  } catch {
-    return { title: "Appalti · " + normalizedCode };
-  }
+  const municipality = getSiopeMunicipalityDetailByIpaCode(normalizedCode);
+  return { title: "Appalti · " + (municipality?.name ?? normalizedCode) };
 }
 
 export default async function EntityProcurementPage({ params, searchParams }: PageProps) {
   const { codice } = await params;
   const normalizedCode = decodeEntityProcurementRouteCode(codice);
   if (!normalizedCode) notFound();
-  let entity = null;
-  let ipaReachable = true;
-  try {
-    entity = await getIpaEntityByCode(normalizedCode);
-  } catch {
-    ipaReachable = false;
-  }
-  if (ipaReachable && !entity) notFound();
-  const state = entity
-    ? await getEntityProcurementPage(entity)
-    : await loadAnacEntityProcurementPage({
-      codiceIpa: normalizedCode,
-      currentEntityCf: null,
-      verifyLiveFiscalCode: false,
-    });
-  const heading = entity?.denominazione || normalizedCode;
+  const municipality = getSiopeMunicipalityDetailByIpaCode(normalizedCode);
+  const state = await loadAnacEntityProcurementPage({
+    codiceIpa: normalizedCode,
+    currentEntityCf: null,
+    verifyLiveFiscalCode: false,
+  });
+  const heading = municipality?.name ?? normalizedCode;
   if (state.status !== "available") {
     return (
       <main className={"shell page " + styles.page}>
         <p><Link href={"/enti/" + encodeURIComponent(normalizedCode)}>← Torna alla scheda ente</Link></p>
-        {ipaReachable ? null : (
-          <div className="notice warning-notice">
-            <strong>Indice PA non risponde</strong>
-            <p>Mostriamo solo lo snapshot ANAC già in archivio. L&apos;identità fiscale live non è stata ricontrollata.</p>
-          </div>
-        )}
+        <div className="notice">
+          <strong>Profilo servito senza chiamate live</strong>
+          <p>{"L'identità è collegata allo snapshot IPA verificato durante l'ETL; questa visita non interroga Indice PA."}</p>
+        </div>
         <EntityProcurementSection state={state} />
       </main>
     );
@@ -416,12 +400,10 @@ export default async function EntityProcurementPage({ params, searchParams }: Pa
         <h1>Aggiudicazioni ANAC · {heading}</h1>
         <p>Procedure, aggiudicazioni e aggiudicatari collegati a questo ente.</p>
       </div>
-      {ipaReachable ? null : (
-        <div className="notice warning-notice">
-          <strong>Indice PA non risponde</strong>
-          <p>Mostriamo lo snapshot ANAC già in archivio. L&apos;identità fiscale live non è stata ricontrollata.</p>
-        </div>
-      )}
+      <div className="notice">
+        <strong>Profilo servito senza chiamate live</strong>
+        <p>{"L'identità è collegata allo snapshot IPA verificato durante l'ETL; questa visita non interroga Indice PA."}</p>
+      </div>
       {scopeLine()}
       <Views codice={normalizedCode} active={selectedView} operator={operatorRef} metric={metric} />
       {selectedView === "operators" ? <RankingMetricToggle codice={normalizedCode} metric={metric} size={size} /> : null}
@@ -437,7 +419,7 @@ export default async function EntityProcurementPage({ params, searchParams }: Pa
       {selectedView === "operator" && operatorRef ? <OperatorDetail profile={profile} codice={normalizedCode} operatorRef={operatorRef} currentPage={currentPage} size={size} /> : null}
       <section className="panel" aria-labelledby="method-title">
         <h2 className="panel-title" id="method-title">Fonte e limiti</h2>
-        <p className={styles.note}>Snapshot CIG pubblicati 2025, cross-temporale: non è copertura nazionale corrente. L&apos;importo di aggiudicazione è dichiarato e non è un pagamento. Il codice fiscale dell&apos;ente proviene da IPA ed è usato per controllare l&apos;identità; i codici fiscali degli aggiudicatari/operatori non sono pubblicati.</p>
+        <p className={styles.note}>Snapshot CIG pubblicati 2025, cross-temporale: non è copertura nazionale corrente. L&apos;importo di aggiudicazione è dichiarato e non è un pagamento. Il collegamento dell&apos;ente a IPA è stato verificato durante l&apos;ETL hash-pinned; non viene ricontrollato live a ogni visita. I codici fiscali degli aggiudicatari/operatori non sono pubblicati.</p>
         <p className={styles.note}>Le righe sono pagine del profilo hash-pinned; i conflitti e i casi senza attribuzione restano indicati nella tabella.</p>
         <dl className={styles.sourceList}>
           <div><dt>Generato</dt><dd>{profile.meta.generatedAt}</dd></div>

--- a/src/app/enti/[codice]/municipality-information.tsx
+++ b/src/app/enti/[codice]/municipality-information.tsx
@@ -1,6 +1,7 @@
 import type { IpaEntity } from "@/lib/ipa";
 import { IPA_ENTI_DATASET_URL, IPA_LICENSE } from "@/lib/ipa";
 import type { IpaOrganizationStructure } from "@/lib/ipa-structure";
+import { longDate } from "@/lib/format";
 import styles from "./scheda.module.css";
 
 function show(value: string | null): string {
@@ -11,10 +12,14 @@ export function MunicipalityInformation({
   entity,
   responsible,
   structure,
+  snapshotOnly = false,
+  snapshotObservedAt = null,
 }: {
   entity: IpaEntity;
   responsible: string;
   structure: IpaOrganizationStructure | null;
+  snapshotOnly?: boolean;
+  snapshotObservedAt?: string | null;
 }) {
   const visibleUnits = structure?.unitaOrganizzative.records.slice(0, 24) ?? [];
 
@@ -28,17 +33,21 @@ export function MunicipalityInformation({
       <div className={styles.informationContent}>
         <section aria-labelledby="municipality-contacts-title">
           <h2 id="municipality-contacts-title">Contatti</h2>
-          <dl className={styles.definitions}>
-            <div><dt>Responsabile</dt><dd>{responsible}</dd></div>
-            <div><dt>Indirizzo</dt><dd>{show(entity.sede.indirizzo)}</dd></div>
-            <div><dt>CAP</dt><dd>{show(entity.sede.cap)}</dd></div>
-            {entity.email.map((mail) => (
-              <div key={`${mail.indirizzo}-${mail.tipo ?? "mail"}`}>
-                <dt>{mail.tipo ?? "email"}</dt>
-                <dd><a href={`mailto:${mail.indirizzo}`}>{mail.indirizzo}</a></dd>
-              </div>
-            ))}
-          </dl>
+          {snapshotOnly ? (
+            <p>Contatti e responsabile non sono inclusi nello snapshot locale. Per i recapiti correnti fa fede Indice PA.</p>
+          ) : (
+            <dl className={styles.definitions}>
+              <div><dt>Responsabile</dt><dd>{responsible}</dd></div>
+              <div><dt>Indirizzo</dt><dd>{show(entity.sede.indirizzo)}</dd></div>
+              <div><dt>CAP</dt><dd>{show(entity.sede.cap)}</dd></div>
+              {entity.email.map((mail) => (
+                <div key={`${mail.indirizzo}-${mail.tipo ?? "mail"}`}>
+                  <dt>{mail.tipo ?? "email"}</dt>
+                  <dd><a href={`mailto:${mail.indirizzo}`}>{mail.indirizzo}</a></dd>
+                </div>
+              ))}
+            </dl>
+          )}
         </section>
 
         <section aria-labelledby="municipality-identifiers-title">
@@ -62,14 +71,28 @@ export function MunicipalityInformation({
               <dd><a href={IPA_ENTI_DATASET_URL} target="_blank" rel="noreferrer">Indice PA · Enti ↗</a></dd>
             </div>
             <div><dt>Licenza</dt><dd>{IPA_LICENSE}</dd></div>
-            <div><dt>Aggiornamento dichiarato</dt><dd>{show(entity.dataAggiornamento)}</dd></div>
-            <div><dt>Frequenza</dt><dd>giornaliera</dd></div>
+            {snapshotOnly ? (
+              <>
+                <div><dt>Modalità</dt><dd>Snapshot verificato durante l&apos;ETL; nessuna chiamata IPA durante la visita</dd></div>
+                <div><dt>Snapshot osservato</dt><dd>{snapshotObservedAt ? longDate(snapshotObservedAt) : "Non indicato"}</dd></div>
+              </>
+            ) : (
+              <>
+                <div><dt>Aggiornamento dichiarato</dt><dd>{show(entity.dataAggiornamento)}</dd></div>
+                <div><dt>Frequenza</dt><dd>giornaliera</dd></div>
+              </>
+            )}
           </dl>
         </section>
 
         <section aria-labelledby="municipality-structure-title">
           <h2 id="municipality-structure-title">Uffici dichiarati in IPA</h2>
-          {structure ? (
+          {snapshotOnly ? (
+            <div className="notice">
+              <strong>Uffici non inclusi nello snapshot locale</strong>
+              <p>La visita non interroga IPA live; per UO e AOO correnti consulta direttamente la fonte ufficiale.</p>
+            </div>
+          ) : structure ? (
             <>
               <dl className={styles.structureSummary}>
                 <div><dt>Unità organizzative</dt><dd>{structure.unitaOrganizzative.total}</dd></div>

--- a/src/app/enti/[codice]/page.tsx
+++ b/src/app/enti/[codice]/page.tsx
@@ -5,6 +5,7 @@ import {
   getIpaEntityByCode,
   IPA_ENTI_DATASET_URL,
   IPA_LICENSE,
+  type IpaEntity,
 } from "@/lib/ipa";
 import {
   getIpaOrganizationStructure,
@@ -13,8 +14,13 @@ import {
   type IpaOrganizationStructure,
 } from "@/lib/ipa-structure";
 import { longDate } from "@/lib/format";
-import { getEntityProcurementPage } from "@/lib/data/anac-entity-procurement-page";
+import {
+  decodeEntityProcurementRouteCode,
+  getEntityProcurementPage,
+} from "@/lib/data/anac-entity-procurement-page";
 import { getMunicipalityProfile } from "@/lib/municipality-profile";
+import { municipalitySnapshotEntity } from "@/lib/municipality-snapshot-entity";
+import { getSiopeMunicipalityDetailByIpaCode } from "@/lib/siope-municipality-detail";
 import { MunicipalityEconomics } from "./municipality-economics";
 import { MunicipalityInformation } from "./municipality-information";
 import { EntityProcurementSection } from "./entity-procurement-section";
@@ -22,6 +28,8 @@ import styles from "./scheda.module.css";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 15;
+
+const entityRobots = { index: false, follow: false } as const;
 
 type PageProps = {
   params: Promise<{ codice: string }>;
@@ -42,54 +50,74 @@ function responsibleLabel(
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { codice } = await params;
+  const normalizedCode = decodeEntityProcurementRouteCode(codice);
+  if (!normalizedCode) return { title: "Ente non trovato", robots: entityRobots };
+  const municipality = getSiopeMunicipalityDetailByIpaCode(normalizedCode);
+  if (municipality) {
+    return {
+      title: municipality.name,
+      description: `Scheda pubblica del Comune ${municipality.name}, Codice IPA ${normalizedCode}.`,
+      robots: entityRobots,
+    };
+  }
 
   try {
-    const entity = await getIpaEntityByCode(decodeURIComponent(codice));
+    const entity = await getIpaEntityByCode(normalizedCode);
     if (!entity) return { title: "Ente non trovato" };
 
     return {
       title: entity.denominazione,
       description: `Scheda pubblica dell'ente ${entity.denominazione}, Codice IPA ${entity.codiceIpa}.`,
+      robots: entityRobots,
     };
   } catch {
-    return { title: "Ente" };
+    return { title: "Ente", robots: entityRobots };
   }
 }
 
 export default async function EntityPage({ params }: PageProps) {
   const { codice } = await params;
-  const normalizedCode = decodeURIComponent(codice);
+  const normalizedCode = decodeEntityProcurementRouteCode(codice);
+  if (!normalizedCode) notFound();
 
-  let entity;
+  const municipalitySnapshot = getSiopeMunicipalityDetailByIpaCode(normalizedCode);
+  let entity: IpaEntity | null = municipalitySnapshot
+    ? municipalitySnapshotEntity(municipalitySnapshot)
+    : null;
+  const snapshotOnly = entity !== null;
   let structure: IpaOrganizationStructure | null = null;
-  try {
-    entity = await getIpaEntityByCode(normalizedCode);
-  } catch {
-    return (
-      <main className="shell page">
-        <div className="page-intro">
-          <h1>Anagrafica IPA non disponibile</h1>
-          <p>
-            Indice PA non risponde. I dati della scheda non sono cancellati: manca solo
-            l&apos;anagrafe live in questo momento.
-          </p>
-        </div>
-        <div className="notice warning-notice">
-          <strong>Codice richiesto</strong>
-          <p>{normalizedCode}</p>
-        </div>
-      </main>
-    );
+  if (!entity) {
+    try {
+      entity = await getIpaEntityByCode(normalizedCode);
+    } catch {
+      return (
+        <main className="shell page">
+          <div className="page-intro">
+            <h1>Anagrafica IPA non disponibile</h1>
+            <p>
+              Indice PA non risponde. I dati della scheda non sono cancellati: manca solo
+              l&apos;anagrafe live in questo momento.
+            </p>
+          </div>
+          <div className="notice warning-notice">
+            <strong>Codice richiesto</strong>
+            <p>{normalizedCode}</p>
+          </div>
+        </main>
+      );
+    }
   }
 
   if (!entity) notFound();
-  try {
-    structure = await getIpaOrganizationStructure(normalizedCode);
-  } catch {
-    structure = null;
+  if (!snapshotOnly) {
+    try {
+      structure = await getIpaOrganizationStructure(normalizedCode);
+    } catch {
+      structure = null;
+    }
   }
   const [municipalityProfile, procurementState] = await Promise.all([
-    getMunicipalityProfile(entity),
+    getMunicipalityProfile(entity, { allowCommittedIstatIdentity: snapshotOnly }),
     getEntityProcurementPage(entity),
   ]);
 
@@ -140,6 +168,13 @@ export default async function EntityPage({ params }: PageProps) {
           </a>
         )}
       </div>
+
+      {snapshotOnly ? (
+        <div className="notice">
+          <strong>Profilo servito da snapshot verificati</strong>
+          <p>Questa visita non interroga Indice PA live; contatti e uffici correnti restano consultabili nella fonte ufficiale.</p>
+        </div>
+      ) : null}
 
       <div className={municipalityProfile ? styles.municipalityLayout : styles.split}>
         <div className={styles.main}>
@@ -350,7 +385,13 @@ export default async function EntityPage({ params }: PageProps) {
           ) : null}
 
           {municipalityProfile ? (
-            <MunicipalityInformation entity={entity} responsible={responsible} structure={structure} />
+            <MunicipalityInformation
+              entity={entity}
+              responsible={responsible}
+              structure={structure}
+              snapshotOnly={snapshotOnly}
+              snapshotObservedAt={municipalitySnapshot?.years[0]?.observedAt ?? null}
+            />
           ) : null}
         </div>
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,9 +4,9 @@ import { publicSitemap } from "@/lib/public-discovery";
 import { PUBLIC_SITE_URL } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  // Municipality pages still enrich committed SIOPE data with live IPA at
-  // request time. Do not hand thousands of those dynamic URLs to crawlers
-  // until the profile route is entirely snapshot-first.
+  // Keep the high-cardinality municipality surface out of crawler discovery
+  // while the incident containment is being observed in production. Direct
+  // profile visits are snapshot-first and remain available.
   return publicSitemap(PUBLIC_SITE_URL, [
     ...getGovernmentScorecardPublicPaths(),
   ]);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,13 @@
 import type { MetadataRoute } from "next";
 import { getGovernmentScorecardPublicPaths } from "@/lib/government-scorecard";
 import { publicSitemap } from "@/lib/public-discovery";
-import { getMunicipalityEntityPublicPaths } from "@/lib/siope-municipality-detail";
 import { PUBLIC_SITE_URL } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  // Municipality pages still enrich committed SIOPE data with live IPA at
+  // request time. Do not hand thousands of those dynamic URLs to crawlers
+  // until the profile route is entirely snapshot-first.
   return publicSitemap(PUBLIC_SITE_URL, [
     ...getGovernmentScorecardPublicPaths(),
-    ...getMunicipalityEntityPublicPaths(),
   ]);
 }

--- a/src/lib/bdap-public-works.ts
+++ b/src/lib/bdap-public-works.ts
@@ -42,11 +42,17 @@ type ODataRows = {
   };
 };
 
-async function jsonFrom(url: string, kind: "discovery" | "data", tags: string[]): Promise<unknown> {
+async function jsonFrom(
+  url: string,
+  kind: "discovery" | "data",
+  tags: string[],
+  signal?: AbortSignal,
+): Promise<unknown> {
   const response = await fetchOfficialSource("openbdap", url, {
     kind,
     headers: { Accept: "application/json" },
     tags: ["dataset:mop", ...tags],
+    signal,
   });
   if (!response.ok) throw new Error(`OpenBDAP MOP HTTP ${response.status}`);
   const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
@@ -56,13 +62,13 @@ async function jsonFrom(url: string, kind: "discovery" | "data", tags: string[])
   return response.json();
 }
 
-export async function discoverMopDataset(): Promise<{
+export async function discoverMopDataset(options: { signal?: AbortSignal } = {}): Promise<{
   metadata: MopDatasetMetadata;
   schema: MopSchemaContract;
 }> {
   const [metadataPayload, columnsPayload] = await Promise.all([
-    jsonFrom(METADATA_URL, "discovery", ["metadata:mop"]),
-    jsonFrom(COLUMNS_URL, "discovery", ["schema:mop"]),
+    jsonFrom(METADATA_URL, "discovery", ["metadata:mop"], options.signal),
+    jsonFrom(COLUMNS_URL, "discovery", ["schema:mop"], options.signal),
   ]);
   return {
     metadata: parseMopDatasetMetadata(metadataPayload),
@@ -70,10 +76,13 @@ export async function discoverMopDataset(): Promise<{
   };
 }
 
-export async function getPublicWorksByCup(rawCup: string): Promise<PublicWorksLookup> {
+export async function getPublicWorksByCup(
+  rawCup: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<PublicWorksLookup> {
   const cup = normalizeCup(rawCup);
   const observedAt = new Date().toISOString();
-  const { metadata, schema } = await discoverMopDataset();
+  const { metadata, schema } = await discoverMopDataset(options);
   const filter = `${schema.fields.cup} eq '${cup}'`;
   const query = new URLSearchParams({
     "$filter": filter,
@@ -81,7 +90,7 @@ export async function getPublicWorksByCup(rawCup: string): Promise<PublicWorksLo
     "$format": "json",
   });
   const endpoint = `${ODATA_BASE}/MdData('${ENCODED_DATASET_ID}')/DataRows?${query.toString()}`;
-  const payload = (await jsonFrom(endpoint, "data", [`cup:${cup}`])) as ODataRows;
+  const payload = (await jsonFrom(endpoint, "data", [`cup:${cup}`], options.signal)) as ODataRows;
   if (!Array.isArray(payload.d?.results)) throw new Error("OpenBDAP MOP: elenco risultati non valido");
   const works = payload.d.results.map((row) => normalizeMopRow(row, schema.fields, observedAt.slice(0, 10)));
   if (works.some((work) => work.cup !== cup)) throw new Error("OpenBDAP MOP: la risposta contiene un CUP diverso dalla ricerca");

--- a/src/lib/data/source-fetch.ts
+++ b/src/lib/data/source-fetch.ts
@@ -224,7 +224,11 @@ export async function fetchOfficialSource(
       }
     }
 
-    await delay(RETRY_DELAY_MS * (attempt + 1));
+    await delay(
+      RETRY_DELAY_MS * (attempt + 1),
+      undefined,
+      callerSignal ? { signal: callerSignal } : undefined,
+    );
   }
 
   throw new SourceFetchError(`Impossibile interrogare la fonte ${sourceId}`, sourceId, lastError);

--- a/src/lib/ipa-structure.ts
+++ b/src/lib/ipa-structure.ts
@@ -53,6 +53,7 @@ async function fetchRecords(
   limit: number,
   offset: number,
   sortField: string,
+  signal?: AbortSignal,
 ) {
   const params = new URLSearchParams({
     resource_id: resourceId,
@@ -66,6 +67,7 @@ async function fetchRecords(
     kind: "data",
     headers: { Accept: "application/json" },
     tags: ["dataset:ipa-structure", `entity:${codiceIpa}`],
+    signal,
   });
 
   if (!response.ok) throw new Error(`IPA struttura upstream HTTP ${response.status}`);
@@ -85,6 +87,7 @@ export async function getIpaOrganizationStructure(
   codiceIpa: string,
   limit = 250,
   offset = 0,
+  options: { signal?: AbortSignal } = {},
 ): Promise<IpaOrganizationStructure> {
   const normalized = codiceIpa.trim().slice(0, 100);
   if (!normalized) throw new Error("Codice IPA mancante");
@@ -92,8 +95,8 @@ export async function getIpaOrganizationStructure(
   const safeLimit = Math.min(Math.max(Math.trunc(limit), 1), 500);
   const safeOffset = Math.min(Math.max(Math.trunc(offset), 0), 100_000);
   const [units, areas] = await Promise.all([
-    fetchRecords(IPA_UO_RESOURCE_ID, normalized, safeLimit, safeOffset, "Descrizione_uo"),
-    fetchRecords(IPA_AOO_RESOURCE_ID, normalized, safeLimit, safeOffset, "Denominazione_aoo"),
+    fetchRecords(IPA_UO_RESOURCE_ID, normalized, safeLimit, safeOffset, "Descrizione_uo", options.signal),
+    fetchRecords(IPA_AOO_RESOURCE_ID, normalized, safeLimit, safeOffset, "Denominazione_aoo", options.signal),
   ]);
 
   const normalizedUnits = units.records

--- a/src/lib/ipa.ts
+++ b/src/lib/ipa.ts
@@ -351,7 +351,10 @@ export async function getIpaCentralAdministrations(): Promise<IpaSearchResult> {
   return searchIpaEntities({ categoryCode: "C1", limit: 50 });
 }
 
-export async function getIpaEntityByCode(codiceIpa: string): Promise<IpaEntity | null> {
+export async function getIpaEntityByCode(
+  codiceIpa: string,
+  signal?: AbortSignal,
+): Promise<IpaEntity | null> {
   const normalized = codiceIpa.trim().slice(0, 100);
   if (!normalized) return null;
 
@@ -362,7 +365,7 @@ export async function getIpaEntityByCode(codiceIpa: string): Promise<IpaEntity |
 
   // Page and API lookups must not retry a 500: each extra attempt is billed
   // compute while crawlers and clients retry the same URL.
-  const result = await datastoreRequest(params, undefined, { maxRetries: 0, timeoutMs: 4_000 });
+  const result = await datastoreRequest(params, signal, { maxRetries: 0, timeoutMs: 4_000 });
   return result.records[0] ?? null;
 }
 

--- a/src/lib/mcp/datasets.ts
+++ b/src/lib/mcp/datasets.ts
@@ -149,7 +149,7 @@ export async function queryPublicDataset(
     case "openbdap_opere_pubbliche": {
       const cup = requireText(query.cup, "cup");
       const { getPublicWorksByCup } = await import("@/lib/bdap-public-works");
-      return jsonSafe(await getPublicWorksByCup(cup));
+      return jsonSafe(await getPublicWorksByCup(cup, { signal: options.signal }));
     }
     case "openbdap_ssn_conto_economico": {
       const { querySsnCce } = await import("@/lib/ssn-cce-snapshot");
@@ -275,15 +275,15 @@ export async function queryPublicDataset(
     case "ipa_enti": {
       const { getIpaEntityByCode, searchIpaEntities } = await import("@/lib/ipa");
       if (query.code?.trim()) {
-        const record = await getIpaEntityByCode(query.code.trim());
+        const record = await getIpaEntityByCode(query.code.trim(), options.signal);
         return jsonSafe({ record, found: record !== null });
       }
-      return jsonSafe(await searchIpaEntities({ query: query.query, limit, offset }));
+      return jsonSafe(await searchIpaEntities({ query: query.query, limit, offset, signal: options.signal }));
     }
     case "ipa_struttura": {
       const code = requireText(query.code, "code");
       const { getIpaOrganizationStructure } = await import("@/lib/ipa-structure");
-      return jsonSafe(await getIpaOrganizationStructure(code, limit, offset));
+      return jsonSafe(await getIpaOrganizationStructure(code, limit, offset, { signal: options.signal }));
     }
     case "mef_partecipazioni": {
       const { mefParticipationsSnapshot } = await import("@/lib/mef-participations-snapshot");

--- a/src/lib/mcp/request-deadline.ts
+++ b/src/lib/mcp/request-deadline.ts
@@ -1,0 +1,94 @@
+type McpFetch = (request: Request) => Promise<Response>;
+
+function timeoutResponse(): Response {
+  return Response.json(
+    {
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Timeout della richiesta MCP" },
+      id: null,
+    },
+    { status: 504 },
+  );
+}
+
+async function bufferedResponse(
+  response: Response,
+  state: { reader: ReadableStreamDefaultReader<Uint8Array> | null; timedOut: boolean },
+): Promise<Response> {
+  if (!response.body) return response;
+
+  const reader = response.body.getReader();
+  state.reader = reader;
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (state.timedOut) throw new DOMException("MCP deadline exceeded", "TimeoutError");
+      if (done) break;
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } finally {
+    state.reader = null;
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const headers = new Headers(response.headers);
+  headers.delete("Content-Length");
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * Run and fully drain one bounded MCP exchange.
+ *
+ * Draining is intentional: legacy Streamable HTTP replies expose their SSE
+ * headers before a tool finishes. Waiting for the terminal frame keeps the
+ * application deadline in charge of the whole exchange instead of only the
+ * time-to-first-byte.
+ */
+export async function runMcpExchangeWithDeadline(
+  request: Request,
+  fetcher: McpFetch,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const signal = request.signal.aborted
+    ? request.signal
+    : AbortSignal.any([request.signal, controller.signal]);
+  const timedRequest = new Request(request, { signal });
+  const state = {
+    reader: null as ReadableStreamDefaultReader<Uint8Array> | null,
+    timedOut: false,
+  };
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<Response>((resolve) => {
+    timer = setTimeout(() => {
+      state.timedOut = true;
+      // Settle the public result before abort listeners can reject the losing
+      // handler promise; callers must deterministically receive the 504.
+      resolve(timeoutResponse());
+      controller.abort(new DOMException("MCP deadline exceeded", "TimeoutError"));
+      void state.reader?.cancel("MCP deadline exceeded").catch(() => undefined);
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  const exchange = (async () => bufferedResponse(await fetcher(timedRequest), state))();
+  try {
+    return await Promise.race([exchange, deadline]);
+  } finally {
+    if (!state.timedOut && timer) clearTimeout(timer);
+  }
+}

--- a/src/lib/mcp/request-deadline.ts
+++ b/src/lib/mcp/request-deadline.ts
@@ -82,7 +82,6 @@ export async function runMcpExchangeWithDeadline(
       controller.abort(new DOMException("MCP deadline exceeded", "TimeoutError"));
       void state.reader?.cancel("MCP deadline exceeded").catch(() => undefined);
     }, timeoutMs);
-    timer.unref?.();
   });
 
   const exchange = (async () => bufferedResponse(await fetcher(timedRequest), state))();

--- a/src/lib/municipality-profile.ts
+++ b/src/lib/municipality-profile.ts
@@ -160,7 +160,10 @@ function normalizedCadastralCode(value: string | null): string | null {
   return /^[A-Z][0-9]{3}$/.test(code) ? code : null;
 }
 
-export async function getMunicipalityProfile(entity: IpaEntity): Promise<MunicipalityProfile | null> {
+export async function getMunicipalityProfile(
+  entity: IpaEntity,
+  options: Readonly<{ allowCommittedIstatIdentity?: boolean }> = {},
+): Promise<MunicipalityProfile | null> {
   const taxCode = entity.codiceFiscale?.trim() ?? "";
   if (!/^\d{11}$/.test(taxCode)) return null;
   const siope = getSiopeMunicipalityDetail(taxCode);
@@ -176,7 +179,7 @@ export async function getMunicipalityProfile(entity: IpaEntity): Promise<Municip
 
   let irpef: MunicipalityProfile["irpef"];
   let istatCode: string | null = null;
-  if (!candidateIstatCode || !cadastralCode) {
+  if (!candidateIstatCode || (!cadastralCode && !options.allowCommittedIstatIdentity)) {
     irpef = unavailable(
       "not_found",
       "no_matching_record",
@@ -193,7 +196,7 @@ export async function getMunicipalityProfile(entity: IpaEntity): Promise<Municip
       const record = result.data[0];
       if (
         record?.territory.level !== "municipality" ||
-        record.territory.cadastralCode !== cadastralCode
+        (cadastralCode !== null && record.territory.cadastralCode !== cadastralCode)
       ) {
         irpef = unavailable(
           "not_found",

--- a/src/lib/municipality-snapshot-entity.ts
+++ b/src/lib/municipality-snapshot-entity.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import type { IpaEntity } from "@/lib/ipa";
+import type { SiopeMunicipalityDetail } from "@/lib/siope-municipality-detail";
+
+/**
+ * Build the minimal IPA-compatible identity already committed by the SIOPE ETL.
+ * No request-time network call is made; absent live-only fields stay null.
+ */
+export function municipalitySnapshotEntity(detail: SiopeMunicipalityDetail): IpaEntity | null {
+  if (!detail.codiceIpa) return null;
+  const geography = detail.years.find((year) => year.geography)?.geography ?? null;
+  return {
+    codiceIpa: detail.codiceIpa,
+    denominazione: detail.name,
+    codiceFiscale: detail.taxCode,
+    tipologia: "Comune",
+    codiceCategoria: null,
+    codiceNatura: null,
+    codiceAteco: null,
+    inLiquidazione: null,
+    codiceMiur: null,
+    codiceIstat: null,
+    acronimo: null,
+    responsabile: { nome: null, cognome: null, titolo: null },
+    sede: {
+      codiceComuneIstat: geography?.istatCode ?? null,
+      codiceCatastaleComune: null,
+      cap: null,
+      indirizzo: null,
+    },
+    email: [],
+    sitoIstituzionale: null,
+    social: { facebook: null, linkedin: null, twitter: null, youtube: null },
+    dataAggiornamento: null,
+  };
+}

--- a/src/lib/public-discovery.ts
+++ b/src/lib/public-discovery.ts
@@ -7,11 +7,10 @@ type PublicPath = "/" | `/${string}`;
  * separate from the visual navigation: a page can remain public even when it
  * is not promoted in the header or footer.
  *
- * Dynamic entity, project and dataset pages stay out of this static catalog
- * until their complete URL set can be enumerated from committed data. The
- * government scorecard pages and the municipal profile pages under `/enti/`
- * are appended by `sitemap.ts` from the published snapshots, not from
- * request-time I/O.
+ * Dynamic entity, project and dataset pages stay out of this static catalog.
+ * During the municipality crawl incident, the high-cardinality `/enti/`
+ * detail routes also stay outside the sitemap and robots crawl surface even
+ * though their identifiers are available in committed snapshots.
  */
 export const PUBLIC_INDEXABLE_PATHS = [
   "/",
@@ -130,7 +129,7 @@ export function publicRobots(siteUrl: string): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: "/api/",
+      disallow: ["/api/", "/enti/"],
     },
     sitemap: `${siteUrl}/sitemap.xml`,
   };

--- a/src/lib/report/rate-limit.ts
+++ b/src/lib/report/rate-limit.ts
@@ -54,3 +54,25 @@ export function clientAddress(request: Request): string | null {
   if (real && real.length <= 64 && /^[0-9a-f.:%]+$/iu.test(real)) return real.toLowerCase();
   return null;
 }
+
+/** Per-instance bulkhead for expensive handlers. Distributed WAF remains the outer layer. */
+export class ConcurrencyLimiter {
+  #active = 0;
+  readonly max: number;
+
+  constructor(max: number) {
+    if (!Number.isSafeInteger(max) || max < 1) throw new Error("Concurrency limit must be positive");
+    this.max = max;
+  }
+
+  tryAcquire(): (() => void) | null {
+    if (this.#active >= this.max) return null;
+    this.#active += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.#active -= 1;
+    };
+  }
+}

--- a/src/lib/siope-municipality-detail.ts
+++ b/src/lib/siope-municipality-detail.ts
@@ -203,6 +203,12 @@ const artifacts = [
 const rowsByYearAndTaxCode = new Map(
   artifacts.map((artifact) => [artifact.year, new Map(artifact.rows.map((row) => [row[0], row]))]),
 );
+const taxCodeByIpaCode = new Map<string, string>();
+for (const artifact of artifacts) {
+  for (const row of artifact.rows) {
+    if (row[1] && !taxCodeByIpaCode.has(row[1])) taxCodeByIpaCode.set(row[1], row[0]);
+  }
+}
 
 export function getSiopeMunicipalityDetail(rawTaxCode: string): SiopeMunicipalityDetail | null {
   const taxCode = rawTaxCode.trim();
@@ -265,10 +271,8 @@ export function getSiopeMunicipalityDetail(rawTaxCode: string): SiopeMunicipalit
 export function getSiopeMunicipalityDetailByIpaCode(rawCode: string): SiopeMunicipalityDetail | null {
   const code = rawCode.trim();
   if (!CANONICAL_IPA_CODE.test(code)) return null;
-  const row = artifacts
-    .flatMap((artifact) => artifact.rows)
-    .find((candidate) => candidate[1] === code);
-  return row ? getSiopeMunicipalityDetail(row[0]) : null;
+  const taxCode = taxCodeByIpaCode.get(code);
+  return taxCode ? getSiopeMunicipalityDetail(taxCode) : null;
 }
 
 export type SiopeMunicipalityPeerObservation = Readonly<{

--- a/src/lib/siope-municipality-detail.ts
+++ b/src/lib/siope-municipality-detail.ts
@@ -261,6 +261,16 @@ export function getSiopeMunicipalityDetail(rawTaxCode: string): SiopeMunicipalit
   };
 }
 
+/** Resolve the latest committed municipal identity without request-time I/O. */
+export function getSiopeMunicipalityDetailByIpaCode(rawCode: string): SiopeMunicipalityDetail | null {
+  const code = rawCode.trim();
+  if (!CANONICAL_IPA_CODE.test(code)) return null;
+  const row = artifacts
+    .flatMap((artifact) => artifact.rows)
+    .find((candidate) => candidate[1] === code);
+  return row ? getSiopeMunicipalityDetail(row[0]) : null;
+}
+
 export type SiopeMunicipalityPeerObservation = Readonly<{
   taxCode: string;
   name: string;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server.js";
 import { NextResponse } from "next/server.js";
 
-const MCP_TRANSPORT_METHODS = new Set(["POST", "OPTIONS"]);
+const MCP_TRANSPORT_METHODS = new Set(["POST", "OPTIONS", "HEAD"]);
 
 export function proxy(request: NextRequest) {
   const acceptsEventStream = request.headers

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,8 +2,22 @@ import type { NextRequest } from "next/server.js";
 import { NextResponse } from "next/server.js";
 
 const MCP_TRANSPORT_METHODS = new Set(["POST", "OPTIONS", "HEAD"]);
+const CLAUDEBOT_USER_AGENT = /(?:^|[ (])ClaudeBot(?:\/|[ )]|$)/i;
 
 export function proxy(request: NextRequest) {
+  if (
+    request.nextUrl.pathname.startsWith("/enti/") &&
+    CLAUDEBOT_USER_AGENT.test(request.headers.get("user-agent") ?? "")
+  ) {
+    return new NextResponse("Automated crawling of entity detail pages is temporarily unavailable.", {
+      status: 403,
+      headers: {
+        "Cache-Control": "private, no-store",
+        "X-Robots-Tag": "noindex, nofollow",
+      },
+    });
+  }
+
   const acceptsEventStream = request.headers
     .get("accept")
     ?.toLocaleLowerCase("en-US")
@@ -22,5 +36,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: "/mcp",
+  matcher: ["/mcp", "/enti/:path*"],
 };

--- a/tests/anac-entity-procurement-page.test.mjs
+++ b/tests/anac-entity-procurement-page.test.mjs
@@ -445,12 +445,13 @@ test("UI keeps scope, rankings, official CIG links and no later indicators", () 
   assert.match(detail, /metric: "value", pageSize: size/);
   assert.match(detail, /Perimetro temporale/);
   assert.match(detail, /verifyLiveFiscalCode: false/);
-  assert.match(detail, /Indice PA non risponde/);
+  assert.match(detail, /snapshot IPA verificato durante l'ETL/);
   assert.match(detail, /maxDuration = 15/);
+  assert.doesNotMatch(detail, /getIpaEntityByCode/);
   const entityPage = readFileSync(new URL("../src/app/enti/[codice]/page.tsx", import.meta.url), "utf8");
   assert.match(entityPage, /Anagrafica IPA non disponibile/);
   assert.doesNotMatch(entityPage, /Impossibile interrogare la fonte IPA/);
-  assert.match(detail, /entity\?\.denominazione \?\? normalizedCode/);
+  assert.match(detail, /getSiopeMunicipalityDetailByIpaCode/);
   assert.match(detail, /nameVariants > 1/);
   assert.match(`${section}\n${detail}`, /codici fiscali degli operatori/);
   assert.match(detail, /caption/);

--- a/tests/mcp-deadline.test.mjs
+++ b/tests/mcp-deadline.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { runMcpExchangeWithDeadline } = await import("../src/lib/mcp/request-deadline.ts");
+
+test("MCP deadline closes a streaming exchange even when the handler never finishes", async () => {
+  let requestSignal;
+  let streamCancelled = false;
+  const startedAt = Date.now();
+
+  const response = await runMcpExchangeWithDeadline(
+    new Request("https://example.test/api/mcp", { method: "POST" }),
+    async (request) => {
+      requestSignal = request.signal;
+      return new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("event: message\ndata: partial\n\n"));
+        },
+        cancel() {
+          streamCancelled = true;
+        },
+      }), { headers: { "Content-Type": "text/event-stream" } });
+    },
+    25,
+  );
+
+  const elapsedMs = Date.now() - startedAt;
+  assert.equal(response.status, 504);
+  assert.match(await response.text(), /Timeout della richiesta MCP/);
+  assert.equal(requestSignal.aborted, true);
+  assert.equal(streamCancelled, true);
+  assert.ok(elapsedMs < 250, `deadline returned after ${elapsedMs}ms`);
+});
+
+test("MCP deadline buffers a completed SSE response before returning it", async () => {
+  const response = await runMcpExchangeWithDeadline(
+    new Request("https://example.test/api/mcp", { method: "POST" }),
+    async () => new Response("event: message\ndata: complete\n\n", {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "X-Test": "preserved" },
+    }),
+    250,
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-test"), "preserved");
+  assert.equal(await response.text(), "event: message\ndata: complete\n\n");
+});

--- a/tests/mcp-live-source-cancellation.test.mjs
+++ b/tests/mcp-live-source-cancellation.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { queryPublicDataset } = await import("../src/lib/mcp/datasets.ts");
+const { fetchOfficialSource } = await import("../src/lib/data/source-fetch.ts");
+
+test("MCP cancellation aborts both OpenBDAP discovery requests", async () => {
+  const originalFetch = globalThis.fetch;
+  const controller = new AbortController();
+  let started = 0;
+  let aborted = 0;
+  globalThis.fetch = async (_url, options = {}) => {
+    started += 1;
+    return await new Promise((_resolve, reject) => {
+      const signal = options.signal;
+      signal.addEventListener("abort", () => {
+        aborted += 1;
+        reject(signal.reason);
+      }, { once: true });
+    });
+  };
+
+  const startedAt = Date.now();
+  try {
+    const pending = queryPublicDataset(
+      { dataset: "openbdap_opere_pubbliche", cup: "A12E34000010001" },
+      { signal: controller.signal },
+    );
+    setTimeout(() => controller.abort(new DOMException("test abort", "AbortError")), 25);
+    await assert.rejects(pending, /test abort|AbortError/);
+    assert.equal(started, 2);
+    assert.equal(aborted, 2);
+    assert.ok(Date.now() - startedAt < 250);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("official-source retry delay stops immediately when its caller aborts", async () => {
+  const originalFetch = globalThis.fetch;
+  const controller = new AbortController();
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("upstream down", { status: 500 });
+  };
+
+  const startedAt = Date.now();
+  try {
+    const pending = fetchOfficialSource(
+      "openbdap",
+      "https://bdap-opendata.rgs.mef.gov.it/ODataProxy/test",
+      { signal: controller.signal, maxRetries: 1 },
+    );
+    setTimeout(() => controller.abort(new DOMException("stop retry", "AbortError")), 25);
+    await assert.rejects(pending, /stop retry|AbortError/);
+    assert.equal(calls, 1);
+    assert.ok(Date.now() - startedAt < 250);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -10,8 +10,8 @@ test("MCP compatibility proxy is scoped to the exact public presentation path", 
   assert.deepEqual(config, { matcher: "/mcp" });
 });
 
-test("MCP compatibility proxy rewrites POST and OPTIONS to the canonical endpoint", async () => {
-  for (const method of ["POST", "OPTIONS"]) {
+test("MCP compatibility proxy rewrites POST, OPTIONS and HEAD to the canonical endpoint", async () => {
+  for (const method of ["POST", "OPTIONS", "HEAD"]) {
     const response = await proxy(new NextRequest("https://example.test/mcp?client=test", { method }));
     assert.equal(isRewrite(response), true, method);
     assert.equal(getRewrittenUrl(response), "https://example.test/api/mcp?client=test", method);
@@ -28,7 +28,6 @@ test("MCP compatibility proxy rewrites POST and OPTIONS to the canonical endpoin
 test("MCP compatibility proxy preserves the human-facing page for safe methods", async () => {
   for (const [method, headers] of [
     ["GET", { Accept: "text/html" }],
-    ["HEAD", {}],
     ["PUT", {}],
   ]) {
     const response = await proxy(new NextRequest("https://example.test/mcp", { method, headers }));

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -7,7 +7,29 @@ import { config, proxy } from "../src/proxy.ts";
 const { getRewrittenUrl, isRewrite } = proxyTesting;
 
 test("MCP compatibility proxy is scoped to the exact public presentation path", () => {
-  assert.deepEqual(config, { matcher: "/mcp" });
+  assert.deepEqual(config, { matcher: ["/mcp", "/enti/:path*"] });
+});
+
+test("entity proxy stops the observed ClaudeBot crawl before page rendering", async () => {
+  const blocked = await proxy(new NextRequest("https://example.test/enti/c_a783/appalti", {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
+    },
+  }));
+  assert.equal(blocked.status, 403);
+  assert.equal(blocked.headers.get("cache-control"), "private, no-store");
+  assert.equal(blocked.headers.get("x-robots-tag"), "noindex, nofollow");
+
+  for (const userAgent of [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    "Googlebot/2.1 (+http://www.google.com/bot.html)",
+    "Claude/1.0",
+  ]) {
+    const allowed = await proxy(new NextRequest("https://example.test/enti/c_a783/appalti", {
+      headers: { "User-Agent": userAgent },
+    }));
+    assert.equal(allowed.headers.get("x-middleware-next"), "1", userAgent);
+  }
 });
 
 test("MCP compatibility proxy rewrites POST, OPTIONS and HEAD to the canonical endpoint", async () => {

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -826,6 +826,19 @@ test("MCP endpoint keeps stateless requests isolated under concurrency", async (
   assert.ok(bodies.every((body) => body.includes("query_dataset")));
 });
 
+test("MCP endpoint enforces the 60 requests per minute instance limit", async () => {
+  const headers = { "X-Forwarded-For": "203.0.113.60" };
+  for (let index = 0; index < 60; index += 1) {
+    const response = await POST(request(headers));
+    assert.equal(response.status, 200, `request ${index + 1}`);
+    await response.body?.cancel();
+  }
+
+  const limited = await POST(request(headers));
+  assert.equal(limited.status, 429);
+  assert.equal(limited.headers.get("retry-after"), "60");
+});
+
 test("MCP tool input schema rejects out-of-range pagination", async () => {
   const response = await POST(request({}, JSON.stringify({
     jsonrpc: "2.0",

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -6,7 +6,7 @@ process.env.MCP_ALLOWED_HOSTS = [process.env.MCP_ALLOWED_HOSTS, "example.test"]
   .filter(Boolean)
   .join(",");
 
-const { GET, OPTIONS, POST, maxDuration } = await import("../src/app/api/mcp/route.ts");
+const { GET, HEAD, OPTIONS, POST, maxDuration } = await import("../src/app/api/mcp/route.ts");
 const { dvnsStarterPrompts } = await import("../src/lib/mcp/server.ts");
 const loader = await import("../src/lib/integrated-sources.ts");
 
@@ -124,10 +124,18 @@ test("MCP endpoint rejects optional SSE GET without returning cacheable HTML", a
     headers: { Accept: "text/event-stream" },
   }));
   assert.equal(response.status, 405);
-  assert.equal(response.headers.get("allow"), "POST, OPTIONS");
+  assert.equal(response.headers.get("allow"), "POST, OPTIONS, HEAD");
   assert.equal(response.headers.get("cache-control"), "private, no-store");
   assert.equal(response.headers.get("content-type"), "application/json");
   assert.match(await response.text(), /Streamable HTTP tramite POST/);
+});
+
+test("MCP endpoint answers HEAD probes without starting a tool exchange", async () => {
+  const response = HEAD(new Request("https://example.test/api/mcp", { method: "HEAD" }));
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("allow"), "POST, OPTIONS, HEAD");
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+  assert.equal(await response.text(), "");
 });
 
 test("MCP endpoint enforces an explicit host allowlist", async () => {
@@ -811,7 +819,7 @@ test("MCP endpoint rejects a malformed modern envelope", async () => {
 
 test("MCP endpoint keeps stateless requests isolated under concurrency", async () => {
   const responses = await Promise.all(
-    Array.from({ length: 20 }, () => POST(request())),
+    Array.from({ length: 8 }, () => POST(request())),
   );
   assert.ok(responses.every((response) => response.status === 200));
   const bodies = await Promise.all(responses.map((response) => response.text()));

--- a/tests/municipality-discovery.test.mjs
+++ b/tests/municipality-discovery.test.mjs
@@ -13,6 +13,8 @@ const [{ getGovernmentScorecardPublicPaths }, { getMunicipalityEntityPublicPaths
   ]);
 
 const sitemapPath = new URL("../src/app/sitemap.ts", import.meta.url);
+const entityPagePath = new URL("../src/app/enti/[codice]/page.tsx", import.meta.url);
+const entityProcurementPagePath = new URL("../src/app/enti/[codice]/appalti/page.tsx", import.meta.url);
 const detailSnapshotPaths = [
   new URL("../src/data/generated/siope-municipal-detail-2024.json", import.meta.url),
   new URL("../src/data/generated/siope-municipal-detail-2025.json", import.meta.url),
@@ -43,7 +45,7 @@ async function committedMunicipalityPaths() {
     .map((code) => `/enti/${encodeURIComponent(code)}`);
 }
 
-test("municipal profile pages stay enumerable but are excluded from the sitemap while they require live IPA", async () => {
+test("municipal profile pages stay enumerable but are excluded from crawler discovery during containment", async () => {
   const municipalityPaths = await committedMunicipalityPaths();
   const generatedMunicipalityPaths = getMunicipalityEntityPublicPaths();
 
@@ -69,4 +71,10 @@ test("municipal profile pages stay enumerable but are excluded from the sitemap 
 
   const sitemapSource = await readFile(sitemapPath, "utf8");
   assert.doesNotMatch(sitemapSource, /getMunicipalityEntityPublicPaths/);
+
+  for (const pagePath of [entityPagePath, entityProcurementPagePath]) {
+    const pageSource = await readFile(pagePath, "utf8");
+    assert.match(pageSource, /robots:\s*entityRobots/);
+    assert.match(pageSource, /index:\s*false,\s*follow:\s*false/);
+  }
 });

--- a/tests/municipality-discovery.test.mjs
+++ b/tests/municipality-discovery.test.mjs
@@ -43,7 +43,7 @@ async function committedMunicipalityPaths() {
     .map((code) => `/enti/${encodeURIComponent(code)}`);
 }
 
-test("municipal profile pages are enumerable from committed data and wired into the sitemap", async () => {
+test("municipal profile pages stay enumerable but are excluded from the sitemap while they require live IPA", async () => {
   const municipalityPaths = await committedMunicipalityPaths();
   const generatedMunicipalityPaths = getMunicipalityEntityPublicPaths();
 
@@ -54,25 +54,19 @@ test("municipal profile pages are enumerable from committed data and wired into 
   assert.ok(municipalityPaths.includes("/enti/c_l736"));
   assert.deepEqual(generatedMunicipalityPaths, municipalityPaths);
 
-  const sitemapUrls = new Set(
-    publicSitemap(PUBLIC_SITE_URL, municipalityPaths).map((entry) => entry.url),
-  );
+  const sitemapUrls = new Set(sitemap().map((entry) => entry.url));
   for (const path of municipalityPaths) {
     const url = new URL(path, PUBLIC_SITE_URL);
     // Codice IPA values are URL-safe as committed: the canonical URL must not
     // re-encode or otherwise alter the path.
     assert.equal(url.pathname, path);
     assert.equal(url.origin, PUBLIC_SITE_URL);
-    assert.equal(sitemapUrls.has(url.href), true);
+    assert.equal(sitemapUrls.has(url.href), false);
   }
 
-  const expectedSitemap = publicSitemap(PUBLIC_SITE_URL, [
-    ...getGovernmentScorecardPublicPaths(),
-    ...municipalityPaths,
-  ]);
+  const expectedSitemap = publicSitemap(PUBLIC_SITE_URL, getGovernmentScorecardPublicPaths());
   assert.deepEqual(sitemap(), expectedSitemap);
 
   const sitemapSource = await readFile(sitemapPath, "utf8");
-  assert.match(sitemapSource, /getMunicipalityEntityPublicPaths/);
-  assert.match(sitemapSource, /\.\.\.getMunicipalityEntityPublicPaths\(\)/);
+  assert.doesNotMatch(sitemapSource, /getMunicipalityEntityPublicPaths/);
 });

--- a/tests/municipality-profile.test.mjs
+++ b/tests/municipality-profile.test.mjs
@@ -107,6 +107,19 @@ test("ordinary-statute municipality joins every available source by exact identi
   );
 });
 
+test("committed SIOPE and ISTAT identity can serve a municipality without a live IPA cadastral field", async () => {
+  const profile = await getMunicipalityProfile(entity({
+    codiceIpa: "c_a783",
+    taxCode: "00074270620",
+    istatCode: "062008",
+    cadastralCode: null,
+  }), { allowCommittedIstatIdentity: true });
+  assert.ok(profile);
+  assert.equal(profile.irpef.status, "available");
+  assert.equal(profile.openCivitas.status, "available");
+  assert.equal(profile.identifiers.istatCode, "062008");
+});
+
 test("special-statute municipality keeps national data and declares OpenCivitas out of scope", async () => {
   const profile = await getMunicipalityProfile(entity({
     codiceIpa: "c_g273",

--- a/tests/public-discovery.test.mjs
+++ b/tests/public-discovery.test.mjs
@@ -117,10 +117,11 @@ test("robots permits public pages without blocking Next assets", () => {
   assert.deepEqual(robots.rules, {
     userAgent: "*",
     allow: "/",
-    disallow: "/api/",
+    disallow: ["/api/", "/enti/"],
   });
   assert.equal(robots.sitemap, `${PUBLIC_SITE_URL}/sitemap.xml`);
   assert.equal(robots.rules.disallow.includes("/_next/"), false);
+  assert.equal(robots.rules.disallow.includes("/enti/"), true);
 });
 
 test("llms discovery paths are indexable and resolve to public pages", async () => {

--- a/tests/report-github.test.mjs
+++ b/tests/report-github.test.mjs
@@ -5,9 +5,21 @@ import "./helpers/register-ts-alias.mjs";
 
 const { readGitHubAppConfig, ReportGitHubClient, signAppJwt, GitHubUnavailableError } =
   await import("../src/lib/report/github.ts");
-const { SlidingWindowLimiter, clientAddress } = await import("../src/lib/report/rate-limit.ts");
+const { ConcurrencyLimiter, SlidingWindowLimiter, clientAddress } = await import("../src/lib/report/rate-limit.ts");
 
 const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+test("concurrency limiter releases capacity exactly once", () => {
+  const limiter = new ConcurrencyLimiter(2);
+  const first = limiter.tryAcquire();
+  const second = limiter.tryAcquire();
+  assert.ok(first);
+  assert.ok(second);
+  assert.equal(limiter.tryAcquire(), null);
+  first();
+  first();
+  assert.ok(limiter.tryAcquire());
+});
 const PEM = privateKey.export({ type: "pkcs1", format: "pem" });
 const CONFIG = { appId: "123", installationId: "456", privateKeyPem: PEM };
 


### PR DESCRIPTION
## Incident

Vercel recorded two independent cost amplifiers: MCP requests that could keep a function alive until the 60 second platform limit, and crawler visits to thousands of municipality pages that performed live IPA lookups during an upstream outage.

Current Vercel evidence also identified the residual entity crawl: `ClaudeBot/1.0` was requesting many unique `/enti/<code>/appalti` URLs, each allowed through the firewall and executing the function for roughly 590 ms in the inspected sample. The recurring MCP probe is `python-httpx`; its sampled calls are now short, so it is not blanket-blocked.

## Changes

- Enforce a 12 second deadline across the complete MCP exchange, including legacy streaming responses, and cancel downstream readers and upstream work.
- Propagate cancellation to OpenBDAP MOP, IPA entity search, IPA structure, and retry delays.
- Add a per-instance concurrency bulkhead, 60 POST/minute/IP limit, bounded body handling, and a cheap `HEAD` probe.
- Serve municipal profiles and their API from committed SIOPE/IPA identifiers before any live IPA lookup; live-only fields remain explicitly unavailable instead of being invented.
- Serve entity procurement pages from committed IPA and ANAC snapshots without request-time IPA calls.
- Remove high-cardinality municipality URLs from the sitemap, disallow `/enti/` detail crawling in `robots.txt`, and mark entity detail routes `noindex, nofollow` during containment.
- Reject the exact observed `ClaudeBot` user agent on `/enti/*` in the proxy before page rendering; ordinary browsers, Googlebot, and MCP clients are unchanged.
- Make the production browser gate deterministic when IPA is unavailable and cover the exact 60 + 1 rate-limit boundary in unit tests.

## Verification

- Targeted incident regression suite: 57/57 passed.
- Full GitHub Node suite on the final head: 769 tests; 765 passed, 4 live-source skips, 0 failed, 0 cancelled.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm run build`: passed, including all 105 static pages.
- Complete production gates: passed.
  - MCP protocol smoke: passed.
  - MCP load: 40/40 succeeded, 0 failed, p95 88 ms against a 3000 ms budget.
  - Browser core, editorial (21 routes x 2 viewports), report, and CSP suites: passed.
  - Lighthouse median of 3 runs: Performance 100, Accessibility 100, Best Practices 100, SEO 100.

## Operational follow-up

- The code-level block contains the observed crawler immediately after deployment. Dom can add a Vercel WAF rule for `/enti/*` + `ClaudeBot` as an additional edge layer; publish that rule from the Vercel dashboard only after reviewing it.
- The Manufact-hosted MCP is an independent deployment and must be refreshed from the merged revision before directory submission if it is still running the earlier commit.
