### PR TITLE
feat(ui): nel footer il sito è supportato da Manto Venture

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -1741,6 +1741,7 @@ try {
           [".footer-actions a[href='/privacy']", "Privacy"],
           [".footer-secondary-links a[href='/termini']", "Termini"],
           [".footer-secondary-links a[href='/supporter']", "Chi ci sostiene"],
+          [".footer-makers a[href='https://mantoventure.com']", "Manto Venture"],
           [".footer-social a[href='https://www.instagram.com/dovevannoinostrisoldi/']", "Instagram"],
           [".footer-social a[href='https://x.com/DVNSoldi']", "X"],
         ];

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -459,6 +459,15 @@ main { display: block; }
 }
 .footer-makers a,
 .footer-secondary-links a { display: inline-flex; align-items: center; min-height: 32px; }
+.footer-backer {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--color-neutral-300);
+}
+.footer-backer a { min-height: 32px; }
 .footer-link {
   display: inline-flex;
   align-items: center;
@@ -836,6 +845,10 @@ main { display: block; }
   .footer-credits { grid-template-columns: minmax(0, 1fr); gap: var(--space-2); }
   .footer-actions,
   .footer-secondary-links { justify-content: flex-start; }
+  .footer-backer {
+    padding-left: 0;
+    border-left: 0;
+  }
   .footer-support {
     flex-direction: column;
     align-items: flex-start;

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -12,6 +12,12 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { ReportProblemButton } from "@/components/report-problem/report-problem-button";
 import { FOOTER_SITEMAP_GROUPS } from "@/lib/site-navigation";
 import { BUY_ME_A_COFFEE_URL, REPO_URL, SOCIAL_LINKS } from "@/lib/site";
+import { SITE_SUPPORTERS } from "@/lib/supporters";
+
+const MANTO_VENTURE = SITE_SUPPORTERS.find((supporter) => supporter.name === "Manto Venture");
+if (!MANTO_VENTURE?.href) {
+  throw new Error("Manto Venture deve avere un URL pubblico nel footer");
+}
 
 const SOCIAL_ICONS = {
   threads: ThreadsIcon,
@@ -106,6 +112,12 @@ export function SiteFooter({ latestTerritorialCheckLabel }: SiteFooterProps) {
           <a href="https://x.com/fragiannicola" target="_blank" rel="noreferrer">@fragiannicola</a>
           <span aria-hidden="true">·</span>
           <a href="https://x.com/dom_gag_96" target="_blank" rel="noreferrer">@dom_gag_96</a>
+          <span className="footer-backer">
+            <span className="footer-credit">Supportata da</span>
+            <a href={MANTO_VENTURE.href} target="_blank" rel="noreferrer">
+              {MANTO_VENTURE.name}
+            </a>
+          </span>
         </div>
         <nav className="footer-secondary-links" aria-label="Informazioni sul progetto">
           <Link href="/supporter">Chi ci sostiene</Link>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -14,10 +14,15 @@ import { FOOTER_SITEMAP_GROUPS } from "@/lib/site-navigation";
 import { BUY_ME_A_COFFEE_URL, REPO_URL, SOCIAL_LINKS } from "@/lib/site";
 import { SITE_SUPPORTERS } from "@/lib/supporters";
 
-const MANTO_VENTURE = SITE_SUPPORTERS.find((supporter) => supporter.name === "Manto Venture");
-if (!MANTO_VENTURE?.href) {
-  throw new Error("Manto Venture deve avere un URL pubblico nel footer");
+function mantoVentureSupporter() {
+  const supporter = SITE_SUPPORTERS.find((item) => item.name === "Manto Venture");
+  if (!supporter?.href) {
+    throw new Error("Manto Venture deve avere un URL pubblico nel footer");
+  }
+  return supporter;
 }
+
+const MANTO_VENTURE = mantoVentureSupporter();
 
 const SOCIAL_ICONS = {
   threads: ThreadsIcon,

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -219,6 +219,10 @@ test("supporters page lists the current acknowledgements", async () => {
   assert.match(footer, /href="\/supporter"/);
   assert.match(footer, /BUY_ME_A_COFFEE_URL/);
   assert.match(footer, /Buy me an AI compute/);
+  assert.match(footer, /SITE_SUPPORTERS/);
+  assert.match(footer, /Supportata da/);
+  assert.match(footer, /MANTO_VENTURE\.href/);
+  assert.match(supporters, /href: "https:\/\/mantoventure\.com"/);
   assert.match(site, /BUY_ME_A_COFFEE_URL = "https:\/\/www\.buymeacoffee\.com\/dovevannoinostrisoldi"/);
   assert.match(site, /https:\/\/www\.threads\.com\/@dovevannoinostrisoldi/);
   assert.match(site, /https:\/\/www\.facebook\.com\/profile\.php\?id=61593922084084/);
@@ -232,6 +236,7 @@ test("supporters page lists the current acknowledgements", async () => {
   assert.match(globals, /\.footer-support-action \{/);
   assert.match(globals, /\.footer-social \{/);
   assert.match(globals, /\.footer-social \.footer-link \{[\s\S]*?min-height:\s*44px/);
+  assert.match(globals, /\.footer-backer \{/);
   assert.doesNotMatch(footer, /cdnjs\.buymeacoffee\.com/);
   assert.match(navigationSource, /href: "\/supporter", label: "Chi ci sostiene"/);
 });


### PR DESCRIPTION
## Summary
- Nel footer, accanto a «Fatto da», compare «Supportata da Manto Venture» con link a https://mantoventure.com.
- Usa lo stesso URL già in `/supporter`, senza duplicarlo.

## Test plan
- [x] Home: il credito è visibile a 390 e 1280 px, senza overflow orizzontale.
- [x] Il link apre https://mantoventure.com in una nuova scheda.
- [ ] Controllare anche una pagina interna (es. `/spese/pensioni`) e mobile reale.


Made with [Cursor](https://cursor.com)