### PR TITLE
fix(governi): fonti accanto ai numeri e lettura mobile

### DIFF
--- a/src/app/governi/[id]/page.tsx
+++ b/src/app/governi/[id]/page.tsx
@@ -297,7 +297,7 @@ export default async function GovernmentDetailPage({ params }: GovernmentPagePro
         )}
       </section>
 
-      <GovernmentArchive id="altri-governi" selectedGovernmentId={government.id} />
+      <GovernmentArchive id="altri-governi" selectedGovernmentId={government.id} ameco={sources.ameco} />
 
       <section className={styles.comparisonCallout} aria-labelledby="confronta-governo">
         <div>

--- a/src/app/governi/current-government-overview.module.css
+++ b/src/app/governi/current-government-overview.module.css
@@ -149,8 +149,53 @@
   line-height: 1;
 }
 
-.signalValues > div + div strong {
-  font-size: clamp(20px, 2vw, 26px);
+.signalValues small {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.35;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
+}
+
+.signalCaveat {
+  min-height: 0 !important;
+  margin: -4px 0 12px !important;
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.chartHint,
+.sourceLine,
+.computedNote {
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.chartHint {
+  margin: -4px 0 8px;
+}
+
+.sourceLine {
+  margin-top: 8px;
+  overflow-wrap: anywhere;
+}
+
+.sourceLine a,
+.computedNote a {
+  font-weight: 750;
+}
+
+.computedNote {
+  padding: 12px 18px 0;
+  color: var(--color-neutral-300);
+}
+
+.computedNote a {
+  color: var(--color-accent-300);
 }
 
 .signalChart {
@@ -227,7 +272,6 @@
   color: var(--color-on-strong);
   font-size: 11px;
   font-weight: 800;
-  white-space: nowrap;
 }
 
 .summary {
@@ -621,7 +665,16 @@
   }
 
   .summaryStats {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
+  }
+
+  .summaryStats > div {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-neutral-700);
+  }
+
+  .summaryStats > div:last-child {
+    border-bottom: 0;
   }
 
   .robustnessStrip {
@@ -667,6 +720,52 @@
   .liveBoundary {
     align-items: start;
     flex-direction: column;
+  }
+
+  .signalValues {
+    grid-template-columns: 1fr;
+  }
+
+  .signalValues > div + div {
+    padding: 13px 0 0;
+    border-left: 0;
+    border-top: 1px solid var(--color-neutral-300);
+    text-align: left;
+  }
+
+  .signalCardHeading {
+    flex-wrap: wrap;
+  }
+
+  .signalCardHeading > span {
+    white-space: normal;
+  }
+
+  .valueRow {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .currentValue {
+    max-width: none;
+    padding: 13px 0 0;
+    border-left: 0;
+    border-top: 1px solid var(--color-neutral-200);
+    text-align: left;
+  }
+
+  .cardFooter {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cardFooter > b {
+    text-align: left;
+  }
+
+  .computedNote {
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .indicatorCard > p {

--- a/src/app/governi/current-government-overview.tsx
+++ b/src/app/governi/current-government-overview.tsx
@@ -2,7 +2,7 @@ import type { GovernmentCurrentSignalsView } from "@/lib/government-current-sign
 import { ChartDataTable } from "@/components/charts/chart-data-table";
 import { CurrentGovernmentSignals } from "./current-government-signals";
 import { GovernmentIndicatorChart } from "./government-indicator-chart";
-import { formatScore, rawChangeLabel, relativeChangeLabel, sourceValue } from "./government-scorecard-format";
+import { formatScore, italySourceCodes, rawChangeLabel, relativeChangeLabel, sourceValue } from "./government-scorecard-format";
 import styles from "./current-government-overview.module.css";
 
 type CountryKey = "italy" | "france" | "germany" | "spain";
@@ -36,6 +36,12 @@ type Calculation = Readonly<{
     label: string;
     checks: readonly unknown[];
   }>;
+}>;
+
+export type AmecoCitation = Readonly<{
+  release: string;
+  landingUrl: string;
+  observedThrough: number;
 }>;
 
 const INDICATOR_COPY: Readonly<Record<string, { label: string; group: string; question: string }>> = {
@@ -94,6 +100,14 @@ function improvement(indicator: Indicator, point: Indicator["series"][number], c
     : direction * (point[country] - start);
 }
 
+function levelChange(indicator: Indicator, point: Indicator["series"][number], country: CountryKey) {
+  const start = indicator.series[0]?.[country];
+  if (start == null) return 0;
+  return indicator.transformation === "log-change"
+    ? 100 * (Math.log(point[country]) - Math.log(start))
+    : point[country] - start;
+}
+
 function sparklinePoints(values: readonly number[], minimum: number, maximum: number) {
   const range = maximum - minimum || 1;
   return values.map((value, index) => {
@@ -104,6 +118,12 @@ function sparklinePoints(values: readonly number[], minimum: number, maximum: nu
 }
 
 function TrendSparkline({ indicator }: { indicator: Indicator }) {
+  const italyLevel = indicator.series.map((point) => levelChange(indicator, point, "italy"));
+  const peersLevel = indicator.series.map((point) => median([
+    levelChange(indicator, point, "france"),
+    levelChange(indicator, point, "germany"),
+    levelChange(indicator, point, "spain"),
+  ]));
   const italy = indicator.series.map((point) => improvement(indicator, point, "italy"));
   const peers = indicator.series.map((point) => median([
     improvement(indicator, point, "france"),
@@ -116,7 +136,7 @@ function TrendSparkline({ indicator }: { indicator: Indicator }) {
 
   return (
     <>
-      <svg className={styles.sparkline} viewBox="0 0 240 64" role="img" aria-label={`${indicator.label}: andamento dal ${indicator.series[0]?.year} al ${indicator.series.at(-1)?.year}, Italia e mediana dei peer`}>
+      <svg className={styles.sparkline} viewBox="0 0 240 64" role="img" aria-label={`${indicator.label}: andamento dal ${indicator.series[0]?.year} al ${indicator.series.at(-1)?.year}, Italia e mediana dei peer. Nel grafico verso l’alto significa miglioramento.`}>
         <line x1="8" x2="232" y1={zeroY} y2={zeroY} className={styles.zeroLine} />
         <polyline points={sparklinePoints(peers, minimum, maximum)} className={styles.peerLine} />
         <polyline points={sparklinePoints(italy, minimum, maximum)} className={styles.italyLine} />
@@ -125,14 +145,15 @@ function TrendSparkline({ indicator }: { indicator: Indicator }) {
         <span>Periodo del grafico</span>
         <strong>{indicator.series[0]?.year} → {indicator.series.at(-1)?.year}</strong>
       </div>
+      <p className={styles.chartHint}>Nel grafico verso l’alto significa miglioramento, anche se il livello scende.</p>
       <ChartDataTable
-        label={`${indicator.label}: andamento annuale di Italia e mediana di Francia, Germania e Spagna`}
-        columns={["Italia · variazione", "Mediana peer · variazione"]}
+        label={`${indicator.label}: variazione di livello annuale di Italia e mediana di Francia, Germania e Spagna; stesso segno della variazione nel mandato`}
+        columns={["Italia · variazione di livello", "Mediana peer · variazione di livello"]}
         rows={indicator.series.map((point, index) => ({
           label: `Anno ${point.year}`,
           values: [
-            relativeChangeLabel({ relativeChange: italy[index] ?? 0, transformation: indicator.transformation }),
-            relativeChangeLabel({ relativeChange: peers[index] ?? 0, transformation: indicator.transformation }),
+            relativeChangeLabel({ relativeChange: italyLevel[index] ?? 0, transformation: indicator.transformation }),
+            relativeChangeLabel({ relativeChange: peersLevel[index] ?? 0, transformation: indicator.transformation }),
           ],
         }))}
       />
@@ -147,7 +168,11 @@ function comparisonLabel(indicator: Indicator) {
     maximumFractionDigits: 1,
   });
   if (Math.abs(indicator.relativeChange) < 0.05) return "In linea con i peer";
-  return `${indicator.relativeChange > 0 ? "Meglio" : "Peggio"} dei peer di ${distance}${suffix}`;
+  const peer = `${indicator.relativeChange > 0 ? "Meglio" : "Peggio"} dei peer di ${distance}${suffix}`;
+  if (indicator.orientedChange < -MOVEMENT_EPSILON && indicator.relativeChange > MOVEMENT_EPSILON) {
+    return `${peer}. Il livello italiano è sceso, i peer di più`;
+  }
+  return peer;
 }
 
 function currentValueLabel(indicator: Indicator) {
@@ -169,10 +194,12 @@ export function CurrentGovernmentOverview({
   governmentName,
   calculation,
   currentSignals,
+  ameco,
 }: {
   governmentName: string;
   calculation: Calculation;
   currentSignals: GovernmentCurrentSignalsView;
+  ameco: AmecoCitation;
 }) {
   const improved = calculation.indicators.filter((indicator) => indicator.orientedChange >= MOVEMENT_EPSILON).length;
   const aheadOfPeers = calculation.indicators.filter((indicator) => indicator.relativeChange >= MOVEMENT_EPSILON).length;
@@ -231,6 +258,10 @@ export function CurrentGovernmentOverview({
             </dd>
           </div>
         </dl>
+        <p className={styles.computedNote}>
+          Il risultato, lo stress test e i conteggi sui sei indicatori sono un indice calcolato dal sito con AMECO {ameco.release} (osservati al {ameco.observedThrough}). Non è un voto pubblicato dalla Commissione.{" "}
+          <a href={ameco.landingUrl} target="_blank" rel="noreferrer">Dataset AMECO <span aria-hidden="true">↗</span></a>
+        </p>
 
         <div className={styles.indicatorGrid}>
           {calculation.indicators.map((indicator) => {
@@ -270,6 +301,11 @@ export function CurrentGovernmentOverview({
                   <span>Era {sourceValue(indicator.baselineValue, indicator.id)}</span>
                   <b data-peer={peerPosition}>{comparisonLabel(indicator)}</b>
                 </div>
+                <p className={styles.sourceLine}>
+                  <a href={ameco.landingUrl} target="_blank" rel="noreferrer">
+                    Fonte: AMECO · {italySourceCodes(indicator.sourceCodes)} · {ameco.release}
+                  </a>
+                </p>
               </article>
             );
           })}

--- a/src/app/governi/current-government-signals.tsx
+++ b/src/app/governi/current-government-signals.tsx
@@ -102,16 +102,27 @@ export function CurrentGovernmentSignals({ data }: { data: GovernmentCurrentSign
               <span>{signal.latestAnnualRate > 0 ? "12 mesi: in aumento" : signal.latestAnnualRate < 0 ? "12 mesi: in calo" : "12 mesi: stabili"}</span>
             </div>
             <p>{signal.question}</p>
+            {signal.id === "housing-energy" ? (
+              <p className={styles.signalCaveat}>Include affitti e utenze. Il calo dal 2022 è trainato dall’energia, non solo dagli affitti.</p>
+            ) : null}
             <div className={styles.signalValues}>
-              <div><span>Da {monthLabel(data.startPeriod)} · %</span><strong>{signedPercent(signal.cumulativeChange)}</strong></div>
-              <div><span>Ultimi 12 mesi · %</span><strong>{signedPercent(signal.latestAnnualRate)}</strong></div>
+              <div>
+                <span>Da {monthLabel(data.startPeriod)} · %</span>
+                <strong>{signedPercent(signal.cumulativeChange)}</strong>
+                <small>Fonte: {data.source.owner} · {data.source.datasetCode}</small>
+              </div>
+              <div>
+                <span>Ultimi 12 mesi · %</span>
+                <strong>{signedPercent(signal.latestAnnualRate)}</strong>
+                <small>Fonte: {data.source.owner} · {data.source.datasetCode}</small>
+              </div>
             </div>
             <SignalChart signal={signal} startPeriod={data.startPeriod} latestPeriod={data.latestPeriod} source={data.source} />
             <div className={styles.signalPeer}>
               <span>Mediana peer: {signedPercent(signal.peerMedianCumulativeChange)}</span>
               <b>Italia {signedPoints(signal.cumulativeDistanceFromPeers)} vs peer</b>
             </div>
-            <small>Unità: variazione percentuale (%) dell’indice armonizzato. Fonte: <a href={data.source.landingUrl} target="_blank" rel="noreferrer">{data.source.owner} · {data.source.datasetCode}</a>. {signal.limitations}</small>
+            <small>Unità: variazione percentuale (%) dell’indice armonizzato, base 2025=100. Fonte: <a href={data.source.landingUrl} target="_blank" rel="noreferrer">{data.source.owner} · {data.source.datasetCode}</a>. {signal.limitations}</small>
           </article>
         ))}
       </div>

--- a/src/app/governi/governi.module.css
+++ b/src/app/governi/governi.module.css
@@ -1185,7 +1185,6 @@
 
 .dataBoundary a {
   font-weight: 800;
-  white-space: nowrap;
 }
 
 .pageJumps {
@@ -1288,6 +1287,18 @@
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+.forecastSource {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.forecastSource a {
+  font-weight: 750;
 }
 
 .forecastCompact li {
@@ -1515,7 +1526,8 @@
     grid-template-columns: 1fr auto 1fr;
   }
 
-  .forecastCompact ul {
+  .forecastCompact ul,
+  .forecastSource {
     grid-column: 1 / -1;
   }
 
@@ -1646,7 +1658,16 @@
   }
 
   .governmentBars li {
-    grid-template-columns: minmax(120px, .8fr) minmax(120px, 1.2fr) 42px;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+  }
+
+  .governmentBar {
+    grid-column: 1 / -1;
+  }
+
+  .governmentBars li > small {
+    grid-column: 1 / -1;
   }
 
   .governmentBarLabel {

--- a/src/app/governi/government-archive.tsx
+++ b/src/app/governi/government-archive.tsx
@@ -3,7 +3,15 @@ import { getGovernmentScorecardView } from "@/lib/government-scorecard";
 import { formatScore } from "./government-scorecard-format";
 import styles from "./governi.module.css";
 
-export function GovernmentArchive({ id, selectedGovernmentId }: { id: string; selectedGovernmentId: string }) {
+export function GovernmentArchive({
+  id,
+  selectedGovernmentId,
+  ameco,
+}: {
+  id: string;
+  selectedGovernmentId: string;
+  ameco: Readonly<{ release: string; landingUrl: string }>;
+}) {
   const data = getGovernmentScorecardView();
 
   return (
@@ -13,7 +21,10 @@ export function GovernmentArchive({ id, selectedGovernmentId }: { id: string; se
         <b aria-hidden="true">Apri l’archivio</b>
       </summary>
       <div className={styles.explorerBody}>
-        <p className={styles.explorerIntro}>Ogni nome apre la scheda completa del governo. Le barre usano lo stesso paniere; “ND” indica che la finestra annuale non è sufficiente.</p>
+        <p className={styles.explorerIntro}>
+          Ogni nome apre la scheda completa del governo. Le barre e i numeri sono un indice calcolato da AMECO {ameco.release}, non un voto della Commissione. “ND” indica che la finestra annuale non è sufficiente.{" "}
+          <a href={ameco.landingUrl} target="_blank" rel="noreferrer">Fonte: AMECO <span aria-hidden="true">↗</span></a>
+        </p>
         <ol className={styles.governmentBars}>
           {[...data.governments].reverse().map((government) => (
             <li key={government.id} data-current={government.id === selectedGovernmentId || undefined}>

--- a/src/app/governi/government-scorecard-format.ts
+++ b/src/app/governi/government-scorecard-format.ts
@@ -24,3 +24,7 @@ export function sourceValue(value: number, indicatorId: string) {
   const suffix = indicatorId === "real_compensation" ? " indice" : indicatorId === "real_gdp_per_capita" ? " mila € 2020" : "%";
   return `${value.toLocaleString("it-IT", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}${suffix}`;
 }
+
+export function italySourceCodes(sourceCodes: Readonly<Record<"italy", readonly string[]>>) {
+  return sourceCodes.italy.join(", ");
+}

--- a/src/app/governi/page.tsx
+++ b/src/app/governi/page.tsx
@@ -32,7 +32,7 @@ export default function GovernmentsPage() {
 
       <section aria-label="Dati del governo attualmente in carica">
         {currentScore ? (
-          <CurrentGovernmentOverview governmentName={current.name} calculation={currentScore} currentSignals={currentSignals} />
+          <CurrentGovernmentOverview governmentName={current.name} calculation={currentScore} currentSignals={currentSignals} ameco={data.sources.ameco} />
         ) : (
           <div className="notice warning-notice">
             <strong>{current.name}: risultato non disponibile.</strong>
@@ -61,19 +61,26 @@ export default function GovernmentsPage() {
                 <div>
                   <span>Risultato osservato</span>
                   <strong>{currentScore ? score(currentScore.score) : "n.d."}<small>/100</small></strong>
-                  <small>fino al {data.sources.ameco.observedThrough}</small>
+                  <small>Indice calcolato da AMECO fino al {data.sources.ameco.observedThrough}</small>
                 </div>
                 <span className={styles.forecastArrow} aria-hidden="true">→</span>
                 <div>
                   <span>Scenario al {forecast.endYear}</span>
                   <strong>{score(forecast.score)}<small>/100</small></strong>
-                  <small>se le stime si realizzano</small>
+                  <small>Previsione AMECO {data.sources.ameco.release}, non osservata</small>
                 </div>
                 <ul>
                   {forecast.indicators.slice(0, 3).map((indicator) => (
-                    <li key={indicator.id}><span>{indicator.label}</span><strong>{sourceValue(indicator.endValue, indicator.id)}</strong></li>
+                    <li key={indicator.id}>
+                      <span>{indicator.label}</span>
+                      <strong>{sourceValue(indicator.endValue, indicator.id)}</strong>
+                    </li>
                   ))}
                 </ul>
+                <p className={styles.forecastSource}>
+                  Fonte dei tre valori {forecast.endYear}: AMECO {data.sources.ameco.release}.{" "}
+                  <a href={data.sources.ameco.landingUrl} target="_blank" rel="noreferrer">Dataset AMECO <span aria-hidden="true">↗</span></a>
+                </p>
               </div>
             ) : <p>Scenario non disponibile.</p>}
           </div>
@@ -108,7 +115,11 @@ export default function GovernmentsPage() {
           <article>
             <span>Traiettoria precedente</span>
             {current.inheritance.trend.status === "scored" ? (
-              <><h3>{score(current.inheritance.trend.score)}/100</h3><p>Andamento nei due anni precedenti, mostrato separatamente dal risultato del governo attuale.</p></>
+              <>
+                <h3>{score(current.inheritance.trend.score)}/100</h3>
+                <p>Andamento nei due anni precedenti, mostrato separatamente dal risultato del governo attuale. Indice calcolato da AMECO {data.sources.ameco.release}, stessa formula.</p>
+                <p><a href={data.sources.ameco.landingUrl} target="_blank" rel="noreferrer">Fonte: AMECO <span aria-hidden="true">↗</span></a></p>
+              </>
             ) : <><h3>Non calcolabile</h3><p>{current.inheritance.trend.reason}</p></>}
           </article>
           <article>
@@ -166,7 +177,7 @@ export default function GovernmentsPage() {
         </div>
       </section>
 
-      <GovernmentArchive id="confronto-governi" selectedGovernmentId={current.id} />
+      <GovernmentArchive id="confronto-governi" selectedGovernmentId={current.id} ameco={data.sources.ameco} />
 
       <section className={styles.comparisonCallout} id="confronto-diretto" aria-labelledby="confronto-title">
         <div>

--- a/tests/government-scorecard-accessibility.test.mjs
+++ b/tests/government-scorecard-accessibility.test.mjs
@@ -37,6 +37,7 @@ test("current monthly signal charts expose a source-aware table and derive dates
 test("current overview mini charts have a keyboard-readable data table", () => {
   assert.match(currentOverview, /function TrendSparkline/);
   assert.match(currentOverview, /<ChartDataTable/);
-  assert.match(currentOverview, /Mediana peer · variazione/);
+  assert.match(currentOverview, /Mediana peer · variazione di livello/);
   assert.match(currentOverview, /relativeChangeLabel/);
+  assert.match(currentOverview, /levelChange/);
 });

--- a/tests/government-scorecard-ui.test.mjs
+++ b/tests/government-scorecard-ui.test.mjs
@@ -22,7 +22,7 @@ test("government scorecard is server-first and opens on the current government",
   assert.doesNotMatch(page, /^"use client"/);
   assert.match(page, /Economia italiana: cosa sta migliorando e cosa no/);
   assert.match(page, /getGovernmentCurrentSignalsView/);
-  assert.match(page, /<CurrentGovernmentOverview governmentName=\{current\.name\} calculation=\{currentScore\} currentSignals=\{currentSignals\} \/>/);
+  assert.match(page, /<CurrentGovernmentOverview governmentName=\{current\.name\} calculation=\{currentScore\} currentSignals=\{currentSignals\} ameco=\{data\.sources\.ameco\} \/>/);
   assert.match(page, /Risultati annuali al \{data\.sources\.ameco\.observedThrough\} · prezzi a \{currentSignals\.latestPeriod\}/);
   assert.match(page, /I sei indicatori annuali permettono lo storico/);
   assert.match(page, /<CitizenScoreModel \/>/);
@@ -46,7 +46,7 @@ test("page keeps current data first, then inheritance, context, actions, archive
     assert.ok(next > cursor, heading);
     cursor = next;
   }
-  assert.match(page, /<GovernmentArchive id="confronto-governi" selectedGovernmentId=\{current\.id\} \/>/);
+  assert.match(page, /<GovernmentArchive id="confronto-governi" selectedGovernmentId=\{current\.id\} ameco=\{data\.sources\.ameco\} \/>/);
   assert.match(page, /<details className=\{styles\.explorer\} id="metodo-dati">/);
   assert.match(page, /non un dato osservato e non un risultato anticipato/);
   assert.doesNotMatch(page, /Il confronto con i peer non è lo spread/);
@@ -77,7 +77,18 @@ test("current overview turns all six indicators into readable trends and peer co
   assert.match(currentOverview, /Lo zero è il \{baselineYear\}/);
   assert.match(currentOverview, /<GovernmentIndicatorChart indicators=\{indicators\} \/>/);
   assert.match(currentOverview, /role="img"/);
-  assert.match(currentOverview, /<CurrentGovernmentSignals data=\{currentSignals\} \/>/);
+  assert.match(currentOverview, /Fonte: AMECO/);
+  assert.match(currentOverview, /italySourceCodes\(indicator\.sourceCodes\)/);
+  assert.match(currentOverview, /indice calcolato dal sito/);
+  assert.match(currentOverview, /function levelChange/);
+  assert.match(currentOverview, /Italia · variazione di livello/);
+  assert.match(currentOverview, /Nel grafico verso l’alto significa miglioramento/);
+  assert.match(currentOverview, /Il livello italiano è sceso, i peer di più/);
+  assert.match(currentSignals, /Include affitti e utenze/);
+  assert.match(currentSignals, /Fonte: \{data\.source\.owner\}/);
+  assert.match(governmentArchive, /indice calcolato da AMECO/);
+  assert.match(page, /Previsione AMECO/);
+  assert.match(page, /Fonte: AMECO/);
   assert.match(page, /indicators=\{currentScore\.indicators\}/);
   assert.match(page, /baselineYear=\{currentScore\.baselineYear\}/);
   assert.ok(page.indexOf("Scegli due governi e sovrapponi i dati") < page.indexOf("<CurrentGovernmentPeerComparison"));
@@ -131,6 +142,7 @@ test("page exposes raw values, peers, missing-score reasons and official sources
 
 test("every government links to a dedicated five-part assessment", () => {
   assert.match(governmentArchive, /href=\{`\/governi\/\$\{government\.id\}`\}/);
+  assert.match(detail, /<GovernmentArchive id="altri-governi" selectedGovernmentId=\{government\.id\} ameco=\{sources\.ameco\} \/>/);
   for (const heading of ["Cosa ha ereditato", "In quale situazione ha governato", "Cosa ha fatto per intervenire", "Risultati osservati e situazione lasciata", "Cosa i dati non dimostrano"]) {
     assert.match(detail, new RegExp(heading));
   }
@@ -192,6 +204,9 @@ test("page is discoverable, progressive and responsive", () => {
   assert.match(overviewStyles, /\.indicatorGrid/);
   assert.match(overviewStyles, /\.liveGrid/);
   assert.match(overviewStyles, /@media \(max-width: 700px\)/);
+  assert.match(overviewStyles, /\.summaryStats \{[\s\S]*grid-template-columns: 1fr/);
+  assert.match(overviewStyles, /\.valueRow \{[\s\S]*flex-direction: column/);
+  assert.match(styles, /\.governmentBars li \{[\s\S]*grid-template-columns: 1fr auto/);
   assert.doesNotMatch(styles, /color-neutral-950/);
   assert.match(overviewStyles, /\.summary[\s\S]*background: var\(--color-text\)/);
   assert.doesNotMatch(`${styles}\n${overviewStyles}`, /font-size:\s*[89]px/);


### PR DESCRIPTION
## Summary
- Ogni cifra della pagella cita la fonte accanto: AMECO e codice serie sulle 6 card, Eurostat sui prezzi, «indice calcolato» su risultato/archivio/scenario.
- Le tabelle sotto le card usano la variazione di livello (disoccupazione 2024: −1,6, come il mandato), non il miglioramento orientato.
- Layout mobile: una colonna per i KPI, valori impilati, archivio a due colonne, niente overflow a 390px.

## Test plan
- [ ] `/governi` a 390px: niente scroll orizzontale, fonti visibili sotto ogni numero.
- [ ] Card Disoccupazione: «Variazione nel mandato −1,6 punti» e tabella 2024 −1,6 punti.
- [ ] Card Casa/energia: nota che il calo è trainato dall’energia.
- [ ] Card Investimenti se peggiora ma batte i peer: «Il livello italiano è sceso, i peer di più».
- [ ] Archivi e scenario 2027: etichetta indice/previsione AMECO, non voto della Commissione.
- [ ] CI `required` verde.


Made with [Cursor](https://cursor.com)