### PR TITLE
fix(ui): nascondi Indietro/Scorri nel menu su mobile

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -79,6 +79,42 @@ async function assertResponsiveShell(page, label, width) {
   assert.equal(navigationState.notePresent, false, `${label}: nota fonti ridondante ancora presente`);
   assert.ok(navigationState.navigationLeft >= 0, `${label}: navigazione fuori viewport a sinistra`);
   assert.ok(navigationState.navigationRight <= width + 1, `${label}: navigazione fuori viewport a destra`);
+
+  const scrollControls = await page.evaluate(() =>
+    [...document.querySelectorAll(".nav-scroll-control")].map((element) => {
+      const style = window.getComputedStyle(element);
+      const box = element.getBoundingClientRect();
+      return {
+        visible:
+          style.display !== "none" &&
+          style.visibility !== "hidden" &&
+          box.width > 0 &&
+          box.height > 0,
+      };
+    }),
+  );
+  if (width <= 900) {
+    assert.ok(
+      scrollControls.every((control) => !control.visible),
+      `${label}: Indietro/Scorri visibili su mobile`,
+    );
+    const navOverflow = await page.evaluate(() => {
+      const row = document.querySelector(".nav-row");
+      const navigation = document.querySelector(".primary-nav");
+      if (!navigation) return null;
+      return {
+        menuOpen: row?.getAttribute("data-menu-open") === "true",
+        overflowX: window.getComputedStyle(navigation).overflowX,
+      };
+    });
+    assert.ok(navOverflow, `${label}: navigazione primaria assente`);
+    if (!navOverflow.menuOpen) {
+      assert.ok(
+        navOverflow.overflowX === "auto" || navOverflow.overflowX === "scroll",
+        `${label}: la riga del menu non scorre al tocco`,
+      );
+    }
+  }
 }
 
 async function assertCohesionTracePanelContrast(page, label) {
@@ -1429,6 +1465,46 @@ try {
       completed.push(label);
     }
   }
+
+  await runScenario(browser, {
+    label: "Menu mobile senza Indietro/Scorri 390px",
+    pathname: "/",
+    width: 390,
+    validate: async (page) => {
+      const visibleScrollControls = await page.$$eval(".nav-scroll-control", (buttons) =>
+        buttons.filter((button) => {
+          const style = window.getComputedStyle(button);
+          const box = button.getBoundingClientRect();
+          return style.display !== "none" && box.width > 0 && box.height > 0;
+        }).length,
+      );
+      assert.equal(visibleScrollControls, 0, "Menu mobile: Indietro/Scorri ancora visibili");
+
+      const scrolled = await page.evaluate(() => {
+        const navigation = document.querySelector(".primary-nav");
+        if (!navigation) return null;
+        const before = navigation.scrollLeft;
+        navigation.scrollLeft = Math.min(
+          navigation.scrollWidth - navigation.clientWidth,
+          before + 120,
+        );
+        return {
+          before,
+          after: navigation.scrollLeft,
+          overflow: navigation.scrollWidth - navigation.clientWidth,
+        };
+      });
+      assert.ok(scrolled, "Menu mobile: navigazione primaria assente");
+      assert.ok(scrolled.overflow > 4, "Menu mobile: la riga non ha contenuto da scorrere");
+      assert.ok(scrolled.after > scrolled.before, "Menu mobile: lo scorrimento al tocco non sposta la riga");
+
+      await assertPrimaryDropdownTap(page, "Menu mobile senza Indietro/Scorri 390px", {
+        sectionLabel: "Soldi",
+        childLabel: "Debito pubblico",
+      });
+    },
+  });
+  completed.push("Menu mobile senza Indietro/Scorri 390px");
 
   for (const width of [320, 390, 768, 1024, 1280, 1600]) {
     const label = `Debito pubblico ${width}px`;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -834,6 +834,8 @@ main { display: block; }
   .brand { flex: 1; min-width: 0; }
   .brand-text strong { font-size: 19px; }
   .header-search { order: 3; width: 100%; }
+  /* Touch already pans the row. Extra Indietro/Scorri buttons steal space. */
+  .nav-scroll-control { display: none; }
   .footer-sitemap-columns {
     column-count: 2;
     column-gap: var(--space-4);
@@ -873,13 +875,6 @@ main { display: block; }
   .primary-nav { scrollbar-width: thin; }
   .primary-nav::-webkit-scrollbar { display: block; height: 3px; }
   .primary-nav::-webkit-scrollbar-thumb { background: var(--color-neutral-400); }
-  .nav-scroll-control {
-    display: inline-flex;
-    min-width: 44px;
-  }
-  .nav-scroll-control-backward {
-    order: -1;
-  }
   .footer-sitemap-columns {
     column-count: 2;
     column-gap: var(--space-4);

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -66,6 +66,11 @@ test("a submenu can be opened without a pointer that can hover", async () => {
   assert.match(globalsCss, /\.nav-scroll-control \{/);
   assert.match(globalsCss, /@media \(max-width: 1320px\)[\s\S]*?\.nav-scroll-control \{ display: inline-flex; \}/);
   assert.match(globalsCss, /\.nav-row\[data-menu-open="true"\] \.nav-scroll-control \{ display: none; \}/);
+  assert.match(globalsCss, /@media \(max-width: 900px\)[\s\S]*?\.nav-scroll-control \{ display: none; \}/);
+  assert.doesNotMatch(
+    globalsCss,
+    /@media \(max-width: 620px\)[\s\S]*?\.nav-scroll-control \{\s*display: inline-flex/,
+  );
   // Open state carries the path it was opened on, so a completed navigation
   // closes the menu without a setState in an effect.
   assert.match(navigationComponent, /openMenu\?\.pathname === pathname/);


### PR DESCRIPTION
## Summary
- Su viewport fino a 900px i pulsanti Indietro/Scorri della navigazione primaria spariscono: il menu si scorre già al tocco e i due controlli rubano spazio.
- Resta la riga scrollabile (e la scrollbar sottile sotto i 620px). Tra 901px e 1320px i pulsanti restano per chi usa il mouse.
- E2e: a 390px su home, pagella e debito i controlli non sono visibili, la riga si sposta con lo scroll, la tendina Soldi si apre al tap.

## Test plan
- [ ] Telefono 390px: header senza Indietro/Scorri, il menu scorre col dito.
- [ ] Tap sulla freccia di Soldi: si apre Debito pubblico, niente overflow orizzontale.
- [ ] Tablet/desktop stretti (circa 1100px): i pulsanti restano se la riga non ci sta.
- [ ] CI `required` verde.


Made with [Cursor](https://cursor.com)