### PR TITLE
docs: inventario degli snapshot per il refresh automatico

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,13 @@ npm run test:snapshots  # generated-artifact registry + offline artifact checks
 contratti fail-closed) una sola volta.
 
 `test:snapshots` valida il registro degli artifact generati
-(`scripts/ci/generated-artifacts.json`), esegue i controlli offline `--check`
-unici per ogni artifact, verifica la pulizia del worktree e rileva file
-generati non registrati. Non riesegue la suite ETL.
+(`scripts/ci/generated-artifacts.json`), controlla che
+[docs/SOURCE_SNAPSHOT_INVENTORY.md](docs/SOURCE_SNAPSHOT_INVENTORY.md) sia
+allineato al registro, esegue i controlli offline `--check` unici per ogni
+artifact, verifica la pulizia del worktree e rileva file generati non
+registrati. Non riesegue la suite ETL. Se il registro o un workflow di refresh
+cambiano, rigenera l'inventario con
+`python3 scripts/ci/source-snapshot-inventory.py --write`.
 
 ### Limite di trust: PR vs fonti ufficiali
 

--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -14,6 +14,18 @@ L'obiettivo operativo è diverso: **rilevare ogni nuovo rilascio ufficiale il pr
 6. Nessun endpoint interno di refresh accetta URL arbitrari.
 7. La cache è segmentata per source tag, in modo da invalidare una fonte senza svuotare tutto il sito.
 
+## Inventario degli snapshot
+
+L'elenco operativo degli snapshot committati è in
+[SOURCE_SNAPSHOT_INVENTORY.md](SOURCE_SNAPSHOT_INVENTORY.md): periodo nello
+snapshot, URL ufficiale, controlli, workflow, modo di aggiornamento e rollback.
+È generato dal registro `scripts/ci/generated-artifacts.json`. Un inventario
+stale fallisce la CI.
+
+Questo risponde a [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189)
+prima di automatizzare una fonte alla volta. Non sostituisce la tabella delle
+cadenze qui sotto.
+
 ## Componenti
 
 ### `source-policy.ts`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,7 +44,7 @@ Come usare questo file:
 | Iniziativa | Copertura | Implementabile | Effort | Issue / PR | Dove | Prossimo passo |
 |---|---|---|---|---|---|---|
 | Navigazione semplice e mobile stabile | Parziale su `main` ([#205](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/205) mergiata) | Sì | Medio | Nessuna issue aperta dedicata | `src/components/navigation.tsx`, `/controlli`, `/dati` | Test di comprensione e regressioni visive su route reali a 390, 768 e 1280 px. Feedback: X-028, X-047, T-005, T-019, T-020, T-032, T-034. |
-| Freschezza uniforme e refresh automatico | Policy e health parziali; refresh non è ancora un job periodico | Sì | Alto | [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189) aperta | [FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md) | Inventario fonte per fonte, fallimento visibile, timestamp pubblico. Non chiamare «live» un polling. Feedback: T-001, T-024, X-117. |
+| Freschezza uniforme e refresh automatico | Inventario snapshot committato; 7 fonti già in PR automatica del data bot; le altre restano rilevamento, cache o manuali | Sì | Alto | [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189) aperta | [SOURCE_SNAPSHOT_INVENTORY.md](SOURCE_SNAPSHOT_INVENTORY.md), [FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md) | Prossima slice: una sola fonte ancora manuale sul publisher (branch dedicato, PR, mai push su `main`). Feedback: T-001, T-024, X-117. |
 | Benchmark appalti davvero comparabili | Contratti ANAC parziali su `main` ([#204](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/204), [#208](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/208)) | Sì | Alto | [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185) aperta; [#183](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/183) TED, da valutare a parte | `/appalti`, `/confronti`, `docs/research/ANAC_*` | Unità, quantità e categoria comparabile; bloccare i confronti deboli. Feedback: X-072, X-077, X-091, T-004, A-004. |
 | Drill-down e confronto territoriale | Territori, IRPEF, OpenCivitas e schede ente già su `main` | Sì | Alto | [#130](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/130) aperta | `/territori`, `/enti/[codice]` | Completare Provincia/ASL dove la fonte lo consente; peer con denominatore coerente. Non inventare residui fiscali comunali. Feedback: X-019, X-066, X-097, X-104, T-012. |
 
@@ -97,6 +97,8 @@ Come usare questo file:
 |---|---|---|
 | [#219](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/219) HHI e Top 1/Top 10 sugli appalti ente | Aperta, in conflitto con `main` | Slice di [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185). Non mergiare finché rebase e `required` non sono verdi. |
 | [#211](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/211) ESLint 10 | Aperta | Dipendenza; `eslint-plugin-react` non è pronto. Non è una riga di prodotto. |
+| [#219](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/219) HHI appalti | Aperta, CI rossa | Slice successiva di [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185); rebase e `production` restano a Roberto. |
+| [#235](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/235) menu mobile | Aperta, CI verde, branch indietro rispetto a `main` | Nasconde Indietro/Scorri sotto i 900px. Da rebase e merge. |
 
 ## Issue aperte senza riga sopra
 

--- a/docs/SOURCE_SNAPSHOT_INVENTORY.md
+++ b/docs/SOURCE_SNAPSHOT_INVENTORY.md
@@ -1,0 +1,86 @@
+# Inventario degli snapshot pubblicati
+
+Inventario operativo richiesto da [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189).
+Non è la cadenza dichiarata dalla fonte: quella resta in
+[FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md).
+Qui si vede, per ogni artefatto committato: periodo nello snapshot,
+URL ufficiale, controlli, workflow, modo di aggiornamento e rollback.
+
+Questo file è generato da `scripts/ci/source-snapshot-inventory.py`.
+Dopo una modifica al registro o a un workflow di refresh:
+
+```bash
+python3 scripts/ci/source-snapshot-inventory.py --write
+```
+
+## Criterio di completamento
+
+Un aggiornamento nuovo deve essere rilevato, rigenerato, validato e
+proposto in PR senza modifiche manuali. Un errore della fonte deve
+fallire in modo visibile, senza pubblicare dati parziali. Nessun
+workflow scrive su `main`.
+
+## Riepilogo
+
+- Artefatti nel registro: 34
+- PR automatica: 7 (data bot, branch `automation/data/*`, PR)
+- solo rilevamento: 3 (controlla l'upstream, non pubblica)
+- invalidazione cache: 3 (invalida tag, non tocca gli snapshot)
+- manuale: 21 (PR umana dopo revisione)
+
+## Rollback per modo
+
+- **PR automatica.** Chiudere o revertire la PR del data bot. `main` resta sull'ultimo snapshot valido. Nessun push diretto su `main`.
+- **solo rilevamento.** Il job fallisce e non riscrive i file. Resta pubblicato lo snapshot già committato.
+- **invalidazione cache.** Non pubblica snapshot. Se il job fallisce la cache resta quella precedente fino al prossimo tentativo.
+- **manuale.** PR umana dopo revisione di hash, schema e periodo. Rollback: revert del merge.
+
+Responsabile operativo dei refresh automatici: GitHub App data bot
+(`DATA_BOT_APP_CLIENT_ID` nell'environment `source-operations`).
+La revisione e il merge restano umani.
+
+## Artefatti
+
+| Artefatto | Periodo nello snapshot | Osservazione | URL ufficiale | Controllo DVNS | Workflow | Modo | Validazione |
+|---|---|---|---|---|---|---|---|
+| `anac-awardees-coverage` | 2026-01-23 | 2026-08-30T18:30:00Z | https://dati.anticorruzione.it/opendata/dataset/aggiudicatari | nessuno | nessuno | manuale | `python3 scripts/etl/anac_awardees_coverage.py --check` |
+| `anac-entity-procurement-coverage` | 2026-08-06T07:31:40Z | 2026-08-30T21:30:00Z | https://dati.anticorruzione.it/opendata/dataset/stazioni-appaltanti | nessuno | nessuno | manuale | `python3 scripts/etl/anac_entity_procurement_coverage.py --check` |
+| `anac-entity-procurement-page` | non dichiarato nello snapshot | 2026-08-31T14:49:08Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/anac_entity_procurement_page.py --check` |
+| `consulenti-pubblici` | 2026 | 2026-08-25T13:30:46Z | https://consulentipubblici.dfp.gov.it/progetto | `37 */6 * * *` | `.github/workflows/consulenti-refresh.yml` | PR automatica | `python scripts/etl/consulenti_snapshot.py --check` |
+| `cpt-regional-fiscal` | non dichiarato nello snapshot | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | suite ETL |
+| `indire-pnrr-assignments` | aggiornamento aprile 2026 | 2026-08-23 | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/indire_pnrr_assignments.py --validate-committed` |
+| `inps-civil-invalidity` | non dichiarato nello snapshot | 2026-08-20T22:30:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
+| `inps-pensions-osservatorio` | non dichiarato nello snapshot | 2026-09-01T12:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
+| `integrated-catalog` | non dichiarato nello snapshot | 2026-08-23T00:00:00Z | non dichiarato nel registro | solo workflow_dispatch | `.github/workflows/source-refresh.yml` | invalidazione cache | suite ETL |
+| `integrated-rows` | non dichiarato nello snapshot | non dichiarato | non dichiarato nel registro | solo workflow_dispatch | `.github/workflows/source-refresh.yml` | invalidazione cache | suite ETL |
+| `istat-municipality-geography` | 31/12/2022 | 2026-08-25T00:00:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/istat_municipality_geography.py --validate-committed` |
+| `istat-regions-2024` | 2024 | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/istat_regions_account.py --validate-committed` |
+| `mef-irpef-2024` | 2024 | non dichiarato | https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?tree=2025 | `17 6 * * 1` | `.github/workflows/mef-irpef-refresh.yml` | solo rilevamento | `python scripts/etl/mef_irpef_municipal_snapshot.py --check` |
+| `mef-participations` | 2023-12-31 | 2026-08-20T10:12:54.480623Z | https://www.de.mef.gov.it/it/attivita_istituzionali/partecipazioni_pubbliche/open_data_partecipazioni/index.html | `23 5 * * *` | `.github/workflows/mef-participations-refresh.yml` | PR automatica | `python scripts/etl/mef_participations_snapshot.py --check` |
+| `openbdap-budget-law` | non dichiarato nello snapshot | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --check` |
+| `opencivitas-2022` | 2022 | 2026-08-20T12:35:16Z | https://www.opencivitas.it/it/open-data | `23 4 * * *` | `.github/workflows/opencivitas-refresh.yml` | PR automatica | `python scripts/etl/opencivitas_snapshot.py --check` |
+| `opencoesione` | 2026-04-30 | 2026-08-20T08:51:13+00:00 | https://opencoesione.gov.it/it/api/aggregati/ | `17 */6 * * *` | `.github/workflows/opencoesione-refresh.yml` | PR automatica | `python scripts/etl/opencoesione_snapshot.py --check` |
+| `parliament` | non dichiarato nello snapshot | 2026-08-20T14:00:00.000Z | non dichiarato nel registro | `37 */6 * * *` | `.github/workflows/parliament-sources.yml` | solo rilevamento | `python scripts/etl/parliament_sources.py --check` |
+| `pcm-financial-2024` | 2024 | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/pcm_financial_account.py --check` |
+| `pnrr-childcare` | 2026-06-13 | 2026-08-21T12:15:00Z | https://www.italiadomani.gov.it/content/sogei-ng/it/it/catalogo-open-data.html | `37 5 * * 1` | `.github/workflows/pnrr-childcare-refresh.yml` | solo rilevamento | `python scripts/etl/pnrr_childcare_snapshot.py --check` |
+| `government-scorecard` | 2024 | 2026-08-29T23:11:43Z | https://economy-finance.ec.europa.eu/economic-research-and-databases/economic-databases/ameco-database/download-annual-data-set-macro-economic-database-ameco_en | `37 7 * * 2` | `.github/workflows/government-scorecard-refresh.yml` | PR automatica | `python3 scripts/ci/check-government-scorecard-artifacts.py` |
+| `public-debt` | 2026-06-30 | 2026-08-24T09:41:59Z | https://www.bancaditalia.it/pubblicazioni/finanza-pubblica/index.html | `17 6 * * *` | `.github/workflows/public-debt-refresh.yml` | PR automatica | `python scripts/etl/public_debt_snapshot.py --check` |
+| `rgs-consulting-payments` | non dichiarato nello snapshot | 2026-08-22T00:00:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | suite ETL |
+| `rgs-ministries-2025` | 2025 | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/rgs_ministries_account.py --validate-committed` |
+| `rgs-state-budget-territorial-2023` | 2023 | 2026-08-22T00:00:00Z | https://bdap-opendata.rgs.mef.gov.it/content/2023-distribuzione-territoriale-della-spesa-del-bilancio-dello-stato-spesa-statale?metadati=showall | nessuno | nessuno | manuale | suite ETL |
+| `siope-municipal` | 2026 | 2026-08-25T03:31:23+00:00 | https://www.siope.it/documenti/siope2/open/last | `29 4 * * *` | `.github/workflows/siope-refresh.yml` | PR automatica | `python scripts/etl/siope_municipal_snapshot.py --check` |
+| `ssn-cce-2024` | 2024 | 2026-08-22T00:00:00Z | https://bdap-opendata.rgs.mef.gov.it/content/2024-modello-di-rilevazione-del-conto-economico-degli-enti-del-ssn | nessuno | nessuno | manuale | `python scripts/etl/ssn_cce_snapshot.py --check` |
+| `vive-roma-restoration` | non dichiarato nello snapshot | 2026-08-22 | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
+| `company-atlas` | 2026-08-11 | 2026-08-26T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `node scripts/etl/company_atlas_snapshot.mjs --check` |
+| `istat-pensions-2012-2022` | 2012-2022 | non dichiarato | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_pensions_snapshot.py --check` |
+| `istat-enterprise-turnover` | 2024 | 2026-08-26T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/istat_enterprise_turnover.py --check` |
+| `education-atlas` | 2026-02-23 | 2026-08-27T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/education_atlas_snapshot.py --check` |
+| `source-ledger-proofs` | non dichiarato nello snapshot | 2026-08-23T00:00:00Z | non dichiarato nel registro | solo workflow_dispatch | `.github/workflows/source-refresh.yml` | invalidazione cache | suite ETL |
+| `investigative-explorer-incarichi` | non dichiarato nello snapshot | 2026-08-26T21:45:23Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/investigative_explorer_build.py --check --output src/data/generated/investigative-explorer-incarichi.json` |
+
+## Prossimo passo
+
+Automatizzare una sola fonte ancora in modo **manuale**, usando il
+publisher già gestito: branch dedicato, artefatti verificati, PR
+automatica, mai push su `main`. Non aprire un workflow unico che
+aggiorna tutto.

--- a/scripts/ci/source-snapshot-inventory.py
+++ b/scripts/ci/source-snapshot-inventory.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Build the published-snapshot inventory from the generated-artifact registry.
+
+Francesco asked for this inventory in issue #189 before automating sources one
+at a time. The markdown is generated, not hand-edited: a stale doc fails CI.
+
+Usage:
+    python3 scripts/ci/source-snapshot-inventory.py --write
+    python3 scripts/ci/source-snapshot-inventory.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = ROOT / "scripts" / "ci" / "generated-artifacts.json"
+DOC_PATH = ROOT / "docs" / "SOURCE_SNAPSHOT_INVENTORY.md"
+MAX_SNAPSHOT_BYTES = 2_000_000
+CRON_RE = re.compile(r"cron:\s*[\"']([^\"']+)[\"']")
+PUBLISH_RE = re.compile(r"uses:\s*\./\.github/actions/publish-data-refresh")
+HEAD_FIELD_RE = re.compile(
+    r'"(referenceDate|referenceYear|referencePeriod|latestYear|year|taxYear|'
+    r'generatedAt|observedAt|acquiredAt|retrievedAt|publishedAt|extractionDate|'
+    r'dataThrough|observedThrough|sourceDate|updatedAt)"\s*:\s*(?:"([^"]+)"|(\d+))'
+)
+
+MODE_PR = "PR automatica"
+MODE_DETECT = "solo rilevamento"
+MODE_CACHE = "invalidazione cache"
+MODE_MANUAL = "manuale"
+
+ROLLBACK = {
+    MODE_PR: (
+        "Chiudere o revertire la PR del data bot. `main` resta sull'ultimo "
+        "snapshot valido. Nessun push diretto su `main`."
+    ),
+    MODE_DETECT: (
+        "Il job fallisce e non riscrive i file. Resta pubblicato lo snapshot "
+        "già committato."
+    ),
+    MODE_CACHE: (
+        "Non pubblica snapshot. Se il job fallisce la cache resta quella "
+        "precedente fino al prossimo tentativo."
+    ),
+    MODE_MANUAL: (
+        "PR umana dopo revisione di hash, schema e periodo. Rollback: revert "
+        "del merge."
+    ),
+}
+
+
+def load_registry() -> dict[str, Any]:
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path) -> Any | None:
+    if not path.is_file():
+        return None
+    try:
+        if path.stat().st_size <= MAX_SNAPSHOT_BYTES:
+            return json.loads(path.read_text(encoding="utf-8"))
+        head = path.read_bytes()[:16_384].decode("utf-8", "replace")
+        payload: dict[str, Any] = {}
+        for match in HEAD_FIELD_RE.finditer(head):
+            payload.setdefault(match.group(1), match.group(2) or match.group(3))
+        return payload or None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def format_value(value: Any) -> str | None:
+    if value is None or value is False:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(int(value) if isinstance(value, float) and value.is_integer() else value)
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if isinstance(value, dict):
+        start = value.get("from") or value.get("start") or value.get("min")
+        end = value.get("to") or value.get("end") or value.get("max")
+        if start is not None and end is not None:
+            return f"{start}-{end}"
+        date = value.get("referenceDate") or value.get("date")
+        if isinstance(date, str) and date.strip():
+            return date.strip()
+    if isinstance(value, list) and value and all(isinstance(item, (int, str)) for item in value):
+        return ", ".join(str(item) for item in value[:6])
+    return None
+
+
+def pick_period(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    for key in (
+        "referenceDate",
+        "referencePeriod",
+        "referenceYear",
+        "period",
+        "latestYear",
+        "year",
+        "taxYear",
+        "publishedAt",
+        "extractionDate",
+        "dataThrough",
+        "observedThrough",
+        "sourceDate",
+        "updatedAt",
+        "sourceLastModified",
+    ):
+        formatted = format_value(payload.get(key))
+        if formatted:
+            return formatted
+    for nested_key in ("stock", "coverage", "source", "scope", "freshness", "meta"):
+        nested = payload.get(nested_key)
+        if isinstance(nested, dict):
+            found = pick_period(nested)
+            if found:
+                return found
+    sources = payload.get("sources")
+    if isinstance(sources, dict):
+        dates = []
+        for source in sources.values():
+            if not isinstance(source, dict):
+                continue
+            for key in ("updatedAt", "observedThrough", "referencePeriod", "referenceDate", "release"):
+                formatted = format_value(source.get(key))
+                if formatted:
+                    dates.append(formatted)
+                    break
+        if dates:
+            return max(dates)
+    inputs = payload.get("inputs")
+    if isinstance(inputs, dict):
+        dates = []
+        for entry in inputs.values():
+            if isinstance(entry, dict):
+                formatted = format_value(entry.get("sourceLastModified") or entry.get("referenceDate"))
+                if formatted:
+                    dates.append(formatted)
+        if dates:
+            return max(dates)
+    return None
+
+
+def pick_observed(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    for key in ("observedAt", "acquiredAt", "generatedAt", "retrievedAt", "catalogObservedAt"):
+        formatted = format_value(payload.get(key))
+        if formatted:
+            return formatted
+    sources = payload.get("sources")
+    if isinstance(sources, dict):
+        for source in sources.values():
+            if isinstance(source, dict):
+                formatted = format_value(source.get("retrievedAt") or source.get("observedAt"))
+                if formatted:
+                    return formatted
+    return None
+
+
+def period_from_spec(artifact: dict[str, Any]) -> str | None:
+    spec_path = artifact.get("sourceSpec")
+    if not isinstance(spec_path, str):
+        return None
+    spec = load_json(ROOT / spec_path)
+    if not isinstance(spec, dict):
+        return None
+    found = pick_period(spec)
+    if found:
+        return found
+    observed = spec.get("catalogObservedAt") or spec.get("catalogMetadataModifiedAt")
+    return format_value(observed)
+
+
+def snapshot_dates(artifact: dict[str, Any]) -> tuple[str, str]:
+    period = None
+    observed = None
+    preferred: list[Path] = []
+    rest: list[Path] = []
+    for relative in artifact.get("files") or []:
+        path = ROOT / relative
+        if path.is_dir():
+            meta = path / "meta.json"
+            if meta.is_file():
+                preferred.append(meta)
+            continue
+        if "meta" in path.name:
+            preferred.append(path)
+        else:
+            rest.append(path)
+    for path in preferred + rest:
+        payload = load_json(path)
+        if payload is None:
+            continue
+        period = period or pick_period(payload)
+        observed = observed or pick_observed(payload)
+        if period and observed:
+            break
+    period = period or period_from_spec(artifact)
+    return period or "non dichiarato nello snapshot", observed or "non dichiarato"
+
+
+def official_url(artifact: dict[str, Any]) -> str:
+    publication = artifact.get("publication") or {}
+    url = publication.get("upstreamUrl")
+    if isinstance(url, str) and url.startswith("https://"):
+        return url
+    spec_path = artifact.get("sourceSpec")
+    if isinstance(spec_path, str):
+        spec = load_json(ROOT / spec_path)
+        if isinstance(spec, dict):
+            for key in ("landingUrl", "sourceUrl", "datasetPageUrl", "catalogUrl"):
+                value = spec.get(key)
+                if isinstance(value, str) and value.startswith("https://"):
+                    return value
+            inputs = spec.get("inputs")
+            if isinstance(inputs, dict):
+                for entry in inputs.values():
+                    if not isinstance(entry, dict):
+                        continue
+                    for key in ("datasetPageUrl", "resourcePageUrl", "url", "landingUrl"):
+                        value = entry.get(key)
+                        if isinstance(value, str) and value.startswith("https://"):
+                            return value
+            source = spec.get("source")
+            if isinstance(source, dict):
+                landing = source.get("landingUrl")
+                if isinstance(landing, str) and landing.startswith("https://"):
+                    return landing
+    return "non dichiarato nel registro"
+
+
+def workflow_schedule(relative: str | None) -> str:
+    if not relative:
+        return "nessuno"
+    path = ROOT / relative
+    if not path.is_file():
+        return "workflow assente"
+    text = path.read_text(encoding="utf-8")
+    found = CRON_RE.findall(text)
+    if not found:
+        return "solo workflow_dispatch"
+    unique = []
+    for item in found:
+        if item not in unique:
+            unique.append(item)
+    return "; ".join(f"`{item}`" for item in unique)
+
+
+def classify_mode(artifact: dict[str, Any]) -> str:
+    workflow = artifact.get("refreshWorkflow")
+    if workflow == ".github/workflows/source-refresh.yml":
+        return MODE_CACHE
+    if isinstance(workflow, str) and workflow:
+        path = ROOT / workflow
+        text = path.read_text(encoding="utf-8") if path.is_file() else ""
+        if artifact.get("publication") and PUBLISH_RE.search(text):
+            return MODE_PR
+        return MODE_DETECT
+    return MODE_MANUAL
+
+
+def validation_label(artifact: dict[str, Any]) -> str:
+    offline = artifact.get("offlineCheck") or {}
+    command = offline.get("command")
+    covered = offline.get("coveredBy")
+    if isinstance(command, str) and command.strip():
+        return f"`{command}`"
+    if covered == "etl-suite":
+        return "suite ETL"
+    if covered == "node-tests":
+        return "test Node"
+    return "non dichiarato"
+
+
+def markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def render_markdown(registry: dict[str, Any] | None = None) -> str:
+    registry = registry or load_registry()
+    artifacts = list(registry.get("artifacts") or [])
+    rows = []
+    counts = {MODE_PR: 0, MODE_DETECT: 0, MODE_CACHE: 0, MODE_MANUAL: 0}
+    for artifact in artifacts:
+        mode = classify_mode(artifact)
+        counts[mode] = counts.get(mode, 0) + 1
+        period, observed = snapshot_dates(artifact)
+        workflow = artifact.get("refreshWorkflow") or "nessuno"
+        rows.append(
+            {
+                "id": artifact.get("id", ""),
+                "owner": artifact.get("owner", ""),
+                "mode": mode,
+                "period": period,
+                "observed": observed,
+                "url": official_url(artifact),
+                "schedule": workflow_schedule(artifact.get("refreshWorkflow")),
+                "workflow": workflow if isinstance(workflow, str) else "nessuno",
+                "validation": validation_label(artifact),
+                "verification": artifact.get("verificationMode", ""),
+            }
+        )
+
+    lines = [
+        "# Inventario degli snapshot pubblicati",
+        "",
+        "Inventario operativo richiesto da [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189).",
+        "Non è la cadenza dichiarata dalla fonte: quella resta in",
+        "[FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md).",
+        "Qui si vede, per ogni artefatto committato: periodo nello snapshot,",
+        "URL ufficiale, controlli, workflow, modo di aggiornamento e rollback.",
+        "",
+        "Questo file è generato da `scripts/ci/source-snapshot-inventory.py`.",
+        "Dopo una modifica al registro o a un workflow di refresh:",
+        "",
+        "```bash",
+        "python3 scripts/ci/source-snapshot-inventory.py --write",
+        "```",
+        "",
+        "## Criterio di completamento",
+        "",
+        "Un aggiornamento nuovo deve essere rilevato, rigenerato, validato e",
+        "proposto in PR senza modifiche manuali. Un errore della fonte deve",
+        "fallire in modo visibile, senza pubblicare dati parziali. Nessun",
+        "workflow scrive su `main`.",
+        "",
+        "## Riepilogo",
+        "",
+        f"- Artefatti nel registro: {len(rows)}",
+        f"- {MODE_PR}: {counts[MODE_PR]} (data bot, branch `automation/data/*`, PR)",
+        f"- {MODE_DETECT}: {counts[MODE_DETECT]} (controlla l'upstream, non pubblica)",
+        f"- {MODE_CACHE}: {counts[MODE_CACHE]} (invalida tag, non tocca gli snapshot)",
+        f"- {MODE_MANUAL}: {counts[MODE_MANUAL]} (PR umana dopo revisione)",
+        "",
+        "## Rollback per modo",
+        "",
+    ]
+    for mode in (MODE_PR, MODE_DETECT, MODE_CACHE, MODE_MANUAL):
+        lines.append(f"- **{mode}.** {ROLLBACK[mode]}")
+    lines.extend(
+        [
+            "",
+            "Responsabile operativo dei refresh automatici: GitHub App data bot",
+            "(`DATA_BOT_APP_CLIENT_ID` nell'environment `source-operations`).",
+            "La revisione e il merge restano umani.",
+            "",
+            "## Artefatti",
+            "",
+            "| Artefatto | Periodo nello snapshot | Osservazione | URL ufficiale | Controllo DVNS | Workflow | Modo | Validazione |",
+            "|---|---|---|---|---|---|---|---|",
+        ]
+    )
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                markdown_cell(part)
+                for part in (
+                    f"`{row['id']}`",
+                    row["period"],
+                    row["observed"],
+                    row["url"],
+                    row["schedule"],
+                    f"`{row['workflow']}`" if row["workflow"] != "nessuno" else "nessuno",
+                    row["mode"],
+                    row["validation"],
+                )
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Prossimo passo",
+            "",
+            "Automatizzare una sola fonte ancora in modo **manuale**, usando il",
+            "publisher già gestito: branch dedicato, artefatti verificati, PR",
+            "automatica, mai push su `main`. Non aprire un workflow unico che",
+            "aggiorna tutto.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_doc() -> Path:
+    DOC_PATH.write_text(render_markdown(), encoding="utf-8")
+    return DOC_PATH
+
+
+def check_doc() -> None:
+    expected = render_markdown()
+    if not DOC_PATH.is_file():
+        raise SystemExit(f"missing {DOC_PATH.relative_to(ROOT)}; run with --write")
+    actual = DOC_PATH.read_text(encoding="utf-8")
+    if actual != expected:
+        raise SystemExit(
+            f"{DOC_PATH.relative_to(ROOT)} is stale; run "
+            "python3 scripts/ci/source-snapshot-inventory.py --write"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--write", action="store_true", help="Regenerate the committed inventory.")
+    group.add_argument("--check", action="store_true", help="Fail if the committed inventory is stale.")
+    args = parser.parse_args()
+    if args.write:
+        path = write_doc()
+        print(path.relative_to(ROOT))
+        return 0
+    check_doc()
+    print(f"{DOC_PATH.relative_to(ROOT)} is current")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -536,6 +536,16 @@ def main() -> int:
     errors.extend(validate_schema(registry))
     errors.extend(validate_references(registry))
     errors.extend(detect_unregistered_files(registry))
+    inventory_check = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "ci" / "source-snapshot-inventory.py"), "--check"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if inventory_check.returncode != 0:
+        errors.append(
+            (inventory_check.stderr or inventory_check.stdout or "snapshot inventory is stale").strip()
+        )
 
     if errors:
         print(f"\n❌ Registry validation failed ({len(errors)} error(s)):\n", file=sys.stderr)

--- a/tests/etl/test_source_snapshot_inventory.py
+++ b/tests/etl/test_source_snapshot_inventory.py
@@ -1,0 +1,28 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ci" / "source-snapshot-inventory.py"
+DOC = ROOT / "docs" / "SOURCE_SNAPSHOT_INVENTORY.md"
+
+
+class SourceSnapshotInventoryTests(unittest.TestCase):
+    def test_inventory_is_generated_from_the_registry(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("#189", text)
+        self.assertIn("PR automatica", text)
+        self.assertIn("solo rilevamento", text)
+        self.assertIn("manuale", text)
+        self.assertIn("`siope-municipal`", text)
+        self.assertIn("workflow scrive su `main`", text)
+        self.assertNotRegex(text, r"[—–]")


### PR DESCRIPTION
## Summary
- Prima slice di #189: inventario operativo di tutti gli snapshot committati, generato dal registro e non scritto a mano.
- Per ogni artefatto: periodo, URL ufficiale se noto, cron, workflow, modo (PR automatica / solo rilevamento / cache / manuale), validazione e rollback.
- Oggi: 7 fonti già in PR del data bot, 3 solo rilevamento, 3 invalidazione cache, 21 ancora manuali. Prossima slice: una sola fonte manuale sul publisher, mai un workflow unico.

## Test plan
- [ ] `python3 scripts/ci/source-snapshot-inventory.py --check`
- [ ] `python3 scripts/ci/validate-generated-artifacts.py`
- [ ] `python3 -m unittest tests.etl.test_source_snapshot_inventory`
- [ ] Dopo un cambio al registro, `--write` aggiorna `docs/SOURCE_SNAPSHOT_INVENTORY.md` e CI fallisce se manca.
- [ ] CI `required` verde.


Made with [Cursor](https://cursor.com)