### PR TITLE
feat(data): aggiorna l'Atlante Imprese con il data bot

### DIFF
--- a/.github/workflows/company-atlas-refresh.yml
+++ b/.github/workflows/company-atlas-refresh.yml
@@ -1,0 +1,39 @@
+name: Atlante Imprese snapshot
+
+on:
+  schedule:
+    - cron: "41 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: company-atlas-snapshot
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: refresh
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: source-operations
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22.23.2"
+      - name: Refresh official aggregate snapshot
+        run: node scripts/etl/company_atlas_snapshot.mjs
+      - name: Validate offline snapshot
+        run: node scripts/etl/company_atlas_snapshot.mjs --check
+      - name: Publish generated data
+        uses: ./.github/actions/publish-data-refresh
+        with:
+          artifact-id: company-atlas
+          app-client-id: ${{ vars.DATA_BOT_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.DATA_BOT_APP_PRIVATE_KEY }}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,7 +44,7 @@ Come usare questo file:
 | Iniziativa | Copertura | Implementabile | Effort | Issue / PR | Dove | Prossimo passo |
 |---|---|---|---|---|---|---|
 | Navigazione semplice e mobile stabile | Parziale su `main` ([#205](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/205) mergiata) | Sì | Medio | Nessuna issue aperta dedicata | `src/components/navigation.tsx`, `/controlli`, `/dati` | Test di comprensione e regressioni visive su route reali a 390, 768 e 1280 px. Feedback: X-028, X-047, T-005, T-019, T-020, T-032, T-034. |
-| Freschezza uniforme e refresh automatico | Inventario snapshot committato; 7 fonti già in PR automatica del data bot; le altre restano rilevamento, cache o manuali | Sì | Alto | [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189) aperta | [SOURCE_SNAPSHOT_INVENTORY.md](SOURCE_SNAPSHOT_INVENTORY.md), [FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md) | Prossima slice: una sola fonte ancora manuale sul publisher (branch dedicato, PR, mai push su `main`). Feedback: T-001, T-024, X-117. |
+| Freschezza uniforme e refresh automatico | Inventario snapshot committato; publisher del data bot su 8 fonti incluso Atlante Imprese | Sì | Alto | [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189) aperta | [SOURCE_SNAPSHOT_INVENTORY.md](SOURCE_SNAPSHOT_INVENTORY.md), [FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md) | Prossima slice: un'altra fonte ancora manuale, una alla volta. Il trimestre addetti dell'Atlante resta pinnato all'URL 2026-Q2. Feedback: T-001, T-024, X-117. |
 | Benchmark appalti davvero comparabili | Contratti ANAC parziali su `main` ([#204](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/204), [#208](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/208)) | Sì | Alto | [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185) aperta; [#183](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/183) TED, da valutare a parte | `/appalti`, `/confronti`, `docs/research/ANAC_*` | Unità, quantità e categoria comparabile; bloccare i confronti deboli. Feedback: X-072, X-077, X-091, T-004, A-004. |
 | Drill-down e confronto territoriale | Territori, IRPEF, OpenCivitas e schede ente già su `main` | Sì | Alto | [#130](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/130) aperta | `/territori`, `/enti/[codice]` | Completare Provincia/ASL dove la fonte lo consente; peer con denominatore coerente. Non inventare residui fiscali comunali. Feedback: X-019, X-066, X-097, X-104, T-012. |
 
@@ -95,10 +95,9 @@ Come usare questo file:
 
 | PR | Stato letto | Nota per la roadmap |
 |---|---|---|
-| [#219](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/219) HHI e Top 1/Top 10 sugli appalti ente | Aperta, in conflitto con `main` | Slice di [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185). Non mergiare finché rebase e `required` non sono verdi. |
-| [#211](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/211) ESLint 10 | Aperta | Dipendenza; `eslint-plugin-react` non è pronto. Non è una riga di prodotto. |
-| [#219](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/219) HHI appalti | Aperta, CI rossa | Slice successiva di [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185); rebase e `production` restano a Roberto. |
-| [#235](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/235) menu mobile | Aperta, CI verde, branch indietro rispetto a `main` | Nasconde Indietro/Scorri sotto i 900px. Da rebase e merge. |
+| [#219](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/219) HHI e Top 1/Top 10 sugli appalti ente | Aperta, in conflitto con `main` | Slice di [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185). Rebase e `required` restano a Roberto. |
+| [#211](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/211) ESLint 10 | Aperta | Dipendenza; `eslint-plugin-react` non è pronto. Non mergiare. |
+| [#235](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/235) menu mobile | Aperta, rebase su `main` | Nasconde Indietro/Scorri sotto i 900px. Merge quando `required` è verde. |
 
 ## Issue aperte senza riga sopra
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,7 +43,7 @@ Come usare questo file:
 
 | Iniziativa | Copertura | Implementabile | Effort | Issue / PR | Dove | Prossimo passo |
 |---|---|---|---|---|---|---|
-| Navigazione semplice e mobile stabile | Parziale su `main` ([#205](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/205) mergiata) | Sì | Medio | Nessuna issue aperta dedicata | `src/components/navigation.tsx`, `/controlli`, `/dati` | Test di comprensione e regressioni visive su route reali a 390, 768 e 1280 px. Feedback: X-028, X-047, T-005, T-019, T-020, T-032, T-034. |
+| Navigazione semplice e mobile stabile | Parziale su `main` ([#205](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/205) e [#235](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/235) mergiate) | Sì | Medio | Nessuna issue aperta dedicata | `src/components/navigation.tsx`, `/controlli`, `/dati` | Test di comprensione e regressioni visive su route reali a 390, 768 e 1280 px. Feedback: X-028, X-047, T-005, T-019, T-020, T-032, T-034. |
 | Freschezza uniforme e refresh automatico | Inventario snapshot committato; publisher del data bot su 8 fonti incluso Atlante Imprese | Sì | Alto | [#189](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/189) aperta | [SOURCE_SNAPSHOT_INVENTORY.md](SOURCE_SNAPSHOT_INVENTORY.md), [FRESHNESS_AND_REFRESH.md](FRESHNESS_AND_REFRESH.md) | Prossima slice: un'altra fonte ancora manuale, una alla volta. Il trimestre addetti dell'Atlante resta pinnato all'URL 2026-Q2. Feedback: T-001, T-024, X-117. |
 | Benchmark appalti davvero comparabili | Contratti ANAC parziali su `main` ([#204](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/204), [#208](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/208)) | Sì | Alto | [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185) aperta; [#183](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/183) TED, da valutare a parte | `/appalti`, `/confronti`, `docs/research/ANAC_*` | Unità, quantità e categoria comparabile; bloccare i confronti deboli. Feedback: X-072, X-077, X-091, T-004, A-004. |
 | Drill-down e confronto territoriale | Territori, IRPEF, OpenCivitas e schede ente già su `main` | Sì | Alto | [#130](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/130) aperta | `/territori`, `/enti/[codice]` | Completare Provincia/ASL dove la fonte lo consente; peer con denominatore coerente. Non inventare residui fiscali comunali. Feedback: X-019, X-066, X-097, X-104, T-012. |
@@ -97,7 +97,6 @@ Come usare questo file:
 |---|---|---|
 | [#219](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/219) HHI e Top 1/Top 10 sugli appalti ente | Aperta, in conflitto con `main` | Slice di [#185](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/issues/185). Rebase e `required` restano a Roberto. |
 | [#211](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/211) ESLint 10 | Aperta | Dipendenza; `eslint-plugin-react` non è pronto. Non mergiare. |
-| [#235](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/pull/235) menu mobile | Aperta, rebase su `main` | Nasconde Indietro/Scorri sotto i 900px. Merge quando `required` è verde. |
 
 ## Issue aperte senza riga sopra
 

--- a/docs/SOURCE_SNAPSHOT_INVENTORY.md
+++ b/docs/SOURCE_SNAPSHOT_INVENTORY.md
@@ -23,10 +23,10 @@ workflow scrive su `main`.
 ## Riepilogo
 
 - Artefatti nel registro: 34
-- PR automatica: 7 (data bot, branch `automation/data/*`, PR)
+- PR automatica: 8 (data bot, branch `automation/data/*`, PR)
 - solo rilevamento: 3 (controlla l'upstream, non pubblica)
 - invalidazione cache: 3 (invalida tag, non tocca gli snapshot)
-- manuale: 21 (PR umana dopo revisione)
+- manuale: 20 (PR umana dopo revisione)
 
 ## Rollback per modo
 
@@ -71,7 +71,7 @@ La revisione e il merge restano umani.
 | `siope-municipal` | 2026 | 2026-08-25T03:31:23+00:00 | https://www.siope.it/documenti/siope2/open/last | `29 4 * * *` | `.github/workflows/siope-refresh.yml` | PR automatica | `python scripts/etl/siope_municipal_snapshot.py --check` |
 | `ssn-cce-2024` | 2024 | 2026-08-22T00:00:00Z | https://bdap-opendata.rgs.mef.gov.it/content/2024-modello-di-rilevazione-del-conto-economico-degli-enti-del-ssn | nessuno | nessuno | manuale | `python scripts/etl/ssn_cce_snapshot.py --check` |
 | `vive-roma-restoration` | non dichiarato nello snapshot | 2026-08-22 | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
-| `company-atlas` | 2026-08-11 | 2026-08-26T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `node scripts/etl/company_atlas_snapshot.mjs --check` |
+| `company-atlas` | 2026-08-11 | 2026-08-26T00:00:00+02:00 | https://opendata.marche.camcom.it/data/Stock-Imprese-Attive-Italia.json | `41 5 * * *` | `.github/workflows/company-atlas-refresh.yml` | PR automatica | `node scripts/etl/company_atlas_snapshot.mjs --check` |
 | `istat-pensions-2012-2022` | 2012-2022 | non dichiarato | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_pensions_snapshot.py --check` |
 | `istat-enterprise-turnover` | 2024 | 2026-08-26T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/istat_enterprise_turnover.py --check` |
 | `education-atlas` | 2026-02-23 | 2026-08-27T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/education_atlas_snapshot.py --check` |

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -775,8 +775,19 @@
         "command": "node scripts/etl/company_atlas_snapshot.mjs",
         "requiresNetworkInput": true
       },
-      "refreshWorkflow": null,
-      "trustModel": "The committed snapshot is derived from three official CC BY 4.0 aggregate releases. The offline check validates schema, provenance, exact 20-region and ATECO coverage, workforce all-bucket aggregation, null coverage, release totals, duplicate protection and the aggregate-only boundary; a future refresh must be reviewed before publication."
+      "refreshWorkflow": ".github/workflows/company-atlas-refresh.yml",
+      "publication": {
+        "branch": "automation/data/company-atlas",
+        "commitTitle": "chore(data): refresh Atlante Imprese snapshot",
+        "prTitle": "data: refresh Atlante Imprese snapshot",
+        "upstreamUrl": "https://opendata.marche.camcom.it/data/Stock-Imprese-Attive-Italia.json",
+        "upstreamUrls": [
+          "https://opendata.marche.camcom.it/data/Stock-Imprese-Attive-Italia.json",
+          "https://opendata.marche.camcom.it/data/2026-Q2-Addetti-Localizzazioni-Attive-Italia.csv",
+          "https://opendata.marche.camcom.it/data/Stock-Imprese-Attive-Italia-Valore-Produzione.json"
+        ]
+      },
+      "trustModel": "Scheduled workflow creates a bot-authored managed PR candidate from the official CCIAA Marche / InfoCamere aggregate releases; review and PR-side validation govern publication. A new workforce quarter is not accepted until its URL and release totals are updated in the generator."
     },
     {
       "id": "istat-pensions-2012-2022",

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -42,6 +42,7 @@ VALID_COVERAGE = frozenset({"standalone", "etl-suite", "node-tests"})
 GENERATED_EXTENSIONS = frozenset({".json", ".jsonl", ".jsonl.gz", ".ts"})
 PUBLICATION_IDS = frozenset(
     {
+        "company-atlas",
         "consulenti-pubblici",
         "government-scorecard",
         "mef-participations",

--- a/scripts/etl/company_atlas_snapshot.mjs
+++ b/scripts/etl/company_atlas_snapshot.mjs
@@ -109,9 +109,24 @@ const REGION_SOURCE_NAMES = Object.freeze({
 
 const LICENSE = "CC BY 4.0";
 const ATECO_VERSION = "ATECO 2025";
-const OBSERVED_AT = process.argv.find((arg) => arg.startsWith("--observed-at="))?.split("=", 2)[1]
+const OBSERVED_AT_OVERRIDE = process.argv.find((arg) => arg.startsWith("--observed-at="))?.split("=", 2)[1]
   ?? process.env.COMPANY_ATLAS_OBSERVED_AT
-  ?? new Date().toISOString();
+  ?? null;
+
+function latestSourceTimestamp(values) {
+  const timestamps = values
+    .map((value) => {
+      if (value == null || value === "") return null;
+      const parsed = Date.parse(value);
+      return Number.isNaN(parsed) ? null : new Date(parsed).toISOString();
+    })
+    .filter(Boolean)
+    .sort();
+  if (timestamps.length === 0) {
+    throw new Error("Nessuna data di aggiornamento fonte valida");
+  }
+  return timestamps[timestamps.length - 1];
+}
 
 function categoryCodes(dataset, dimensionId) {
   const category = dataset.dimension[dimensionId].category;
@@ -177,7 +192,7 @@ async function fetchText(url) {
   return response.text();
 }
 
-function sourceRecord({ id, label, url, updatedAt, cadence, coverage, caveat }) {
+function sourceRecord({ id, label, url, updatedAt, observedAt, cadence, coverage, caveat }) {
   return {
     id,
     label,
@@ -185,7 +200,7 @@ function sourceRecord({ id, label, url, updatedAt, cadence, coverage, caveat }) 
     publisher: "CCIAA Marche su dati InfoCamere",
     license: LICENSE,
     updatedAt,
-    observedAt: OBSERVED_AT,
+    observedAt,
     cadence,
     coverage,
     caveat,
@@ -582,9 +597,12 @@ export async function buildSnapshot() {
     expectedSectorCodes: active.sectors.map((sector) => sector.code),
   });
   const production = normalizeProductionValue(productionValue);
+  const generatedAt = OBSERVED_AT_OVERRIDE
+    ?? latestSourceTimestamp([active.updatedAt, workforce.updatedAt, production.updatedAt]);
+  const latestActivePeriod = active.periods.at(-1)?.id;
   const snapshot = {
     schemaVersion: 1,
-    generatedAt: OBSERVED_AT,
+    generatedAt,
     observationType: "aggregate",
     geographyVersion: "regioni ISTAT allineate ai codici territoriali usati dalla fonte",
     atecoVersion: ATECO_VERSION,
@@ -594,8 +612,11 @@ export async function buildSnapshot() {
         label: "Imprese attive · stock mensile",
         url: SOURCE_URLS.activeStock,
         updatedAt: active.updatedAt,
+        observedAt: generatedAt,
         cadence: "mensile",
-        coverage: "Sedi di impresa attive per regione, settore ATECO 2025 e mese; ultimo periodo 31/07/2026.",
+        coverage: latestActivePeriod
+          ? `Sedi di impresa attive per regione, settore ATECO 2025 e mese; ultimo periodo ${latestActivePeriod}.`
+          : "Sedi di impresa attive per regione, settore ATECO 2025 e mese.",
         caveat: "Conta sedi di impresa attive, non ricavi e non gruppi societari.",
       }),
       workforce: sourceRecord({
@@ -603,6 +624,7 @@ export async function buildSnapshot() {
         label: "Addetti e localizzazioni attive · trimestre",
         url: SOURCE_URLS.workforce,
         updatedAt: workforce.updatedAt,
+        observedAt: generatedAt,
         cadence: "trimestrale",
         coverage: "Tutte le righe sono bucket ATECO osservati distinti; la pipeline somma i bucket provinciali a regione × sezione ATECO senza scartare i livelli più specifici.",
         caveat: "Le posizioni previdenziali attive sono conteggiate nel trimestre precedente a quello indicato, a partire dalla fornitura INPS: il dato non rappresenta il livello di occupazione nel territorio e non è direttamente comparabile con ISTAT/ASIA. Le localizzazioni attive comprendono sedi di impresa e unità locali non cessate.",
@@ -612,6 +634,7 @@ export async function buildSnapshot() {
         label: "Fasce di valore della produzione · bilanci",
         url: SOURCE_URLS.productionValue,
         updatedAt: production.updatedAt,
+        observedAt: generatedAt,
         cadence: "annuale",
         coverage: "Numero di sedi attive obbligate al deposito del bilancio per fascia, regione e settore; periodo 31/12/2025.",
         caveat: "Il valore della produzione non è fatturato o ricavi esatti; la fonte lo deriva dai bilanci depositati.",

--- a/tests/company-atlas.test.mjs
+++ b/tests/company-atlas.test.mjs
@@ -33,8 +33,8 @@ test("the generated company atlas snapshot is aggregate-only and schema-valid", 
   assert.equal(parsed.regions.length, 20);
   assert.ok(parsed.sectors.length >= 10);
   assert.equal(parsed.productionBands.length, 10);
-  assert.equal(parsed.observations.length, 12_880);
-  assert.equal(parsed.generatedAt, "2026-08-26T00:00:00+02:00");
+  assert.ok(parsed.observations.length >= 12_880);
+  assert.match(parsed.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
 
   // Assert every region has valid 2-digit code and name
   for (const region of parsed.regions) {

--- a/tests/etl/test_publish_data_refresh.py
+++ b/tests/etl/test_publish_data_refresh.py
@@ -31,6 +31,7 @@ class PublishDataRefreshTests(TestCase):
         self.assertEqual(
             set(publications),
             {
+                "company-atlas",
                 "consulenti-pubblici",
                 "government-scorecard",
                 "mef-participations",
@@ -43,6 +44,7 @@ class PublishDataRefreshTests(TestCase):
         self.assertEqual(
             {item["branch"] for item in publications.values()},
             {
+                "automation/data/company-atlas",
                 "automation/data/consulenti",
                 "automation/data/government-scorecard",
                 "automation/data/mef-participations",

--- a/tests/etl/test_workflow_governance.py
+++ b/tests/etl/test_workflow_governance.py
@@ -8,7 +8,9 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 
 class WorkflowGovernanceTests(unittest.TestCase):
     SOURCE_WORKFLOWS = {
+        "company-atlas-refresh.yml": "company-atlas",
         "consulenti-refresh.yml": "consulenti-pubblici",
+        "government-scorecard-refresh.yml": "government-scorecard",
         "opencivitas-refresh.yml": "opencivitas-2022",
         "opencoesione-refresh.yml": "opencoesione",
         "mef-participations-refresh.yml": "mef-participations",


### PR DESCRIPTION
## Summary
- Seconda slice di #189: l'Atlante Imprese entra nel publisher già gestito. Job giornaliero, branch `automation/data/company-atlas`, PR del bot, mai push su `main`.
- Lo snapshot usa la data di aggiornamento della fonte, non l'orologio del runner: se i tre file ufficiali non cambiano, non si apre una PR vuota.
- Un nuovo trimestre addetti non entra da solo: restano URL e totali 2026-Q2, fail-closed.

## Test plan
- [ ] `node scripts/etl/company_atlas_snapshot.mjs --check`
- [ ] `python3 scripts/ci/validate-generated-artifacts.py`
- [ ] `python3 -m unittest tests.etl.test_workflow_governance tests.etl.test_publish_data_refresh tests.etl.test_source_snapshot_inventory`
- [ ] Inventario: `company-atlas` in modo PR automatica.
- [ ] Dopo il merge, un `workflow_dispatch` su `company-atlas-refresh.yml` apre una PR solo se lo stock mensile è cambiato.
- [ ] CI `required` verde.


Made with [Cursor](https://cursor.com)