### PR TITLE
fix(ui): togli Indietro e Scorri dal menu su touch

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -94,9 +94,10 @@ async function assertResponsiveShell(page, label, width) {
     }),
   );
   if (width <= 900) {
-    assert.ok(
-      scrollControls.every((control) => !control.visible),
-      `${label}: Indietro/Scorri visibili su mobile`,
+    assert.equal(
+      scrollControls.length,
+      0,
+      `${label}: Indietro/Scorri ancora nel DOM su mobile`,
     );
     const navOverflow = await page.evaluate(() => {
       const row = document.querySelector(".nav-row");
@@ -722,6 +723,7 @@ async function runScenario(browser, {
   label,
   mediaFeatures,
   pathname,
+  touch = false,
   validate,
   width,
 }) {
@@ -731,6 +733,15 @@ async function runScenario(browser, {
   let thrown;
 
   try {
+    if (touch) {
+      await page.setViewport({
+        width,
+        height: 900,
+        deviceScaleFactor: 1,
+        hasTouch: true,
+        isMobile: true,
+      });
+    }
     if (mediaFeatures) await page.emulateMediaFeatures(mediaFeatures);
     await navigate(page, { url: requestedUrl, label });
     await assertResponsiveShell(page, label, width);
@@ -1479,6 +1490,8 @@ try {
         }).length,
       );
       assert.equal(visibleScrollControls, 0, "Menu mobile: Indietro/Scorri ancora visibili");
+      const scrollControlCount = await page.$$eval(".nav-scroll-control", (buttons) => buttons.length);
+      assert.equal(scrollControlCount, 0, "Menu mobile: Indietro/Scorri ancora nel DOM");
 
       const scrolled = await page.evaluate(() => {
         const navigation = document.querySelector(".primary-nav");
@@ -1505,6 +1518,34 @@ try {
     },
   });
   completed.push("Menu mobile senza Indietro/Scorri 390px");
+
+  await runScenario(browser, {
+    label: "Menu touch senza Indietro/Scorri 1024px",
+    pathname: "/",
+    width: 1024,
+    touch: true,
+    validate: async (page) => {
+      const scrollControlCount = await page.$$eval(".nav-scroll-control", (buttons) => buttons.length);
+      assert.equal(scrollControlCount, 0, "Menu touch 1024px: Indietro/Scorri ancora nel DOM");
+      const scrolled = await page.evaluate(() => {
+        const navigation = document.querySelector(".primary-nav");
+        if (!navigation) return null;
+        const before = navigation.scrollLeft;
+        navigation.scrollLeft = Math.min(
+          navigation.scrollWidth - navigation.clientWidth,
+          before + 120,
+        );
+        return {
+          after: navigation.scrollLeft,
+          overflow: navigation.scrollWidth - navigation.clientWidth,
+        };
+      });
+      assert.ok(scrolled, "Menu touch 1024px: navigazione primaria assente");
+      assert.ok(scrolled.overflow > 4, "Menu touch 1024px: la riga non ha contenuto da scorrere");
+      assert.ok(scrolled.after > 0, "Menu touch 1024px: lo scorrimento al tocco non sposta la riga");
+    },
+  });
+  completed.push("Menu touch senza Indietro/Scorri 1024px");
 
   for (const width of [320, 390, 768, 1024, 1280, 1600]) {
     const label = `Debito pubblico ${width}px`;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -802,6 +802,14 @@ main { display: block; }
   }
 }
 
+@media (max-width: 1320px) and (hover: none) {
+  .nav-scroll-control { display: none; }
+}
+
+@media (max-width: 1320px) and (pointer: coarse) {
+  .nav-scroll-control { display: none; }
+}
+
 @media (max-width: 1000px) {
   :root { --gutter: 20px; }
   .header-search { width: 260px; }

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -3,7 +3,15 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { HeaderSearch } from "@/components/header-search";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -24,6 +32,24 @@ type NavigationContentProps = Readonly<{
   pathname: string;
   currentSearch: string | null;
 }>;
+
+/** Mouse on a viewport wide enough that swipe is not the primary way to pan. */
+const MOUSE_NAV_SCROLL_CONTROLS_QUERY =
+  "(hover: hover) and (pointer: fine) and (min-width: 901px)";
+
+function subscribeMouseNavScrollControls(onChange: () => void) {
+  const media = window.matchMedia(MOUSE_NAV_SCROLL_CONTROLS_QUERY);
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
+}
+
+function useMouseNavScrollControls() {
+  return useSyncExternalStore(
+    subscribeMouseNavScrollControls,
+    () => window.matchMedia(MOUSE_NAV_SCROLL_CONTROLS_QUERY).matches,
+    () => false,
+  );
+}
 
 export function Navigation() {
   const pathname = usePathname();
@@ -58,6 +84,7 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
     backward: false,
     forward: false,
   });
+  const showScrollControls = useMouseNavScrollControls();
   /**
    * Exactly one submenu may be open. Hover, focus and the caret all write the
    * same state so CSS never opens a second panel through :hover/:focus-within
@@ -303,7 +330,7 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
             })}
           </ul>
         </nav>
-        {navigationScroll.backward ? (
+        {showScrollControls && navigationScroll.backward ? (
           <button
             type="button"
             className="nav-scroll-control nav-scroll-control-backward"
@@ -314,7 +341,7 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
             <span aria-hidden="true">Indietro</span>
           </button>
         ) : null}
-        {navigationScroll.forward ? (
+        {showScrollControls && navigationScroll.forward ? (
           <button
             type="button"
             className="nav-scroll-control nav-scroll-control-forward"

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -62,11 +62,25 @@ test("a submenu can be opened without a pointer that can hover", async () => {
   assert.match(navigationComponent, /document\.addEventListener\("pointerdown", dismissOutside\)/);
   assert.match(navigationComponent, /className="nav-scroll-control nav-scroll-control-forward"/);
   assert.match(navigationComponent, /className="nav-scroll-control nav-scroll-control-backward"/);
+  assert.match(navigationComponent, /useSyncExternalStore/);
+  assert.match(
+    navigationComponent,
+    /\(hover: hover\) and \(pointer: fine\) and \(min-width: 901px\)/,
+  );
+  assert.match(navigationComponent, /showScrollControls && navigationScroll\.forward/);
   assert.match(navigationComponent, /navigation\.scrollLeft = Math\.max\(0, Math\.min\(maxScrollLeft, nextScrollLeft\)\)/);
   assert.match(globalsCss, /\.nav-scroll-control \{/);
   assert.match(globalsCss, /@media \(max-width: 1320px\)[\s\S]*?\.nav-scroll-control \{ display: inline-flex; \}/);
   assert.match(globalsCss, /\.nav-row\[data-menu-open="true"\] \.nav-scroll-control \{ display: none; \}/);
   assert.match(globalsCss, /@media \(max-width: 900px\)[\s\S]*?\.nav-scroll-control \{ display: none; \}/);
+  assert.match(
+    globalsCss,
+    /@media \(max-width: 1320px\) and \(hover: none\)[\s\S]*?\.nav-scroll-control \{ display: none; \}/,
+  );
+  assert.match(
+    globalsCss,
+    /@media \(max-width: 1320px\) and \(pointer: coarse\)[\s\S]*?\.nav-scroll-control \{ display: none; \}/,
+  );
   assert.doesNotMatch(
     globalsCss,
     /@media \(max-width: 620px\)[\s\S]*?\.nav-scroll-control \{\s*display: inline-flex/,
@@ -98,6 +112,8 @@ test("mobile dropdown taps use stable, hit-testable navigation geometry", () => 
   assert.match(navigationTouchTargetSource, /navigation\.scrollLeft/);
   assert.match(browserCoreSource, /await waitForStableNavigationTouchTarget\(page, toggle\)/);
   assert.match(browserCoreSource, /const toggleBox = await toggle\.boundingBox\(\)/);
+  assert.match(browserCoreSource, /Menu touch senza Indietro\/Scorri 1024px/);
+  assert.match(browserCoreSource, /touch: true/);
 });
 
 test("browser copy guard matches limit and offset as whole words", () => {


### PR DESCRIPTION
## Summary
- #235 nascondeva Indietro/Scorri solo sotto i 900px. Su iPhone in orizzontale (oltre 900px) e su iPad restavano visibili sul sito pubblico.
- Ora i due pulsanti non vengono proprio renderizzati su touch: restano solo con mouse e viewport da 901px in su.
- La riga del menu continua a scorrere col dito.

## Test plan
- [ ] Telefono 390px: niente Indietro/Scorri nel DOM, il menu scorre al tocco.
- [ ] iPhone landscape ~932px e iPad 1024px: stessi pulsanti assenti.
- [ ] Desktop stretto con mouse (~1100px): Scorri resta se la riga non ci sta.
- [ ] CI `required` verde.


Made with [Cursor](https://cursor.com)