### PR TITLE
fix(ui,search): menu mobile stabile e ricerca enti ripristinata

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -581,17 +581,16 @@ async function findPrimaryNavSection(page, sectionLabel) {
 
 async function assertSubmenuVisible(itemElement, page, label, childLabel) {
   await page.waitForFunction(
-    (element) => {
-      const submenu = element.querySelector(".nav-submenu");
+    () => {
+      const submenu = document.querySelector(".nav-row > .nav-submenu");
       if (!submenu) return false;
       const style = window.getComputedStyle(submenu);
       return style.display !== "none" && style.visibility !== "hidden";
     },
     { timeout: 3_000 },
-    itemElement,
   );
 
-  const childText = await itemElement.$eval(".nav-submenu", (element) => element.textContent ?? "");
+  const childText = await page.$eval(".nav-row > .nav-submenu", (element) => element.textContent ?? "");
   assert.match(childText, new RegExp(childLabel, "i"), `${label}: voce ${childLabel} assente in tendina`);
 }
 
@@ -614,11 +613,11 @@ async function assertPrimaryDropdownExclusive(page, label, { fromLabel, toLabel 
 
   await fromItem.hover();
   await page.waitForFunction(
-    (element) =>
-      element.getAttribute("data-open") === "true" &&
-      window.getComputedStyle(element.querySelector(".nav-submenu")).display !== "none",
+    () => {
+      const submenu = document.querySelector(".nav-row > .nav-submenu");
+      return Boolean(submenu) && window.getComputedStyle(submenu).display !== "none";
+    },
     { timeout: 3_000 },
-    fromItem,
   );
 
   await toItem.hover();
@@ -626,16 +625,15 @@ async function assertPrimaryDropdownExclusive(page, label, { fromLabel, toLabel 
     (from, to) => {
       if (to.getAttribute("data-open") !== "true") return false;
       if (from.getAttribute("data-open") === "true") return false;
-      const fromDisplay = window.getComputedStyle(from.querySelector(".nav-submenu")).display;
-      const toDisplay = window.getComputedStyle(to.querySelector(".nav-submenu")).display;
-      return fromDisplay === "none" && toDisplay !== "none";
+      const submenu = document.querySelector(".nav-row > .nav-submenu");
+      return Boolean(submenu) && window.getComputedStyle(submenu).display !== "none";
     },
     { timeout: 3_000 },
     fromItem,
     toItem,
   );
 
-  const visibleCount = await page.$$eval("nav.primary-nav .nav-submenu", (menus) =>
+  const visibleCount = await page.$$eval(".nav-row > .nav-submenu", (menus) =>
     menus.filter((menu) => window.getComputedStyle(menu).display !== "none").length,
   );
   assert.equal(visibleCount, 1, `${label}: atteso un solo sottomenu visibile, trovati ${visibleCount}`);
@@ -667,13 +665,8 @@ async function assertPrimaryDropdownTap(page, label, { sectionLabel, childLabel 
 
   await page.keyboard.press("Escape");
   await page.waitForFunction(
-    (element) => {
-      const submenu = element.querySelector(".nav-submenu");
-      if (!submenu) return false;
-      return window.getComputedStyle(submenu).display === "none";
-    },
+    () => !document.querySelector(".nav-row > .nav-submenu"),
     { timeout: 3_000 },
-    itemElement,
   );
 }
 
@@ -1015,8 +1008,8 @@ try {
         "Atlante Imprese query navigation 390px",
         "Localizzazioni attive",
       );
-      const localUnitsLink = await itemElement.$(
-        'a[href="/imprese?metric=active_local_units"]',
+      const localUnitsLink = await page.$(
+        '.nav-row > .nav-submenu a[href="/imprese?metric=active_local_units"]',
       );
       assert.ok(localUnitsLink, "Atlante Imprese query navigation 390px: link metrica assente");
       await localUnitsLink.click();
@@ -1459,7 +1452,7 @@ try {
         validate: async (page) => {
           assert.equal(await page.$("nav.subnav"), null, `${label}: subnav non attesa`);
           assert.equal(await page.$(".subnav-row"), null, `${label}: riga subnav non attesa`);
-          assert.ok(await page.$("nav.primary-nav .nav-submenu"), `${label}: markup tendina assente`);
+          assert.ok(await page.$(".nav-item-toggle"), `${label}: markup tendina assente`);
           if (width >= 1280) {
             await assertPrimaryDropdownOnly(page, label, {
               sectionLabel: route.sectionLabel,
@@ -1518,6 +1511,87 @@ try {
     },
   });
   completed.push("Menu mobile senza Indietro/Scorri 390px");
+
+  await runScenario(browser, {
+    label: "Menu mobile: tendina si chiude al tap fuori",
+    pathname: "/",
+    width: 390,
+    validate: async (page) => {
+      const itemElement = await findPrimaryNavSection(page, "Soldi");
+      assert.ok(itemElement, "Menu mobile chiusura: sezione Soldi assente");
+      const toggle = await itemElement.$(".nav-item-toggle");
+      assert.ok(toggle, "Menu mobile chiusura: pulsante tendina assente");
+      await waitForStableNavigationTouchTarget(page, toggle);
+      const toggleBox = await toggle.boundingBox();
+      assert.ok(toggleBox, "Menu mobile chiusura: pulsante tendina non visibile");
+      await page.touchscreen.tap(
+        toggleBox.x + toggleBox.width / 2,
+        toggleBox.y + toggleBox.height / 2,
+      );
+      await assertSubmenuVisible(itemElement, page, "Menu mobile chiusura", "Debito pubblico");
+      assert.ok(await page.$(".nav-menu-dismiss"), "Menu mobile chiusura: strato di chiusura assente");
+
+      await page.touchscreen.tap(200, 720);
+      await page.waitForFunction(
+        () => !document.querySelector(".nav-row > .nav-submenu"),
+        { timeout: 3_000 },
+      );
+    },
+  });
+  completed.push("Menu mobile: tendina si chiude al tap fuori");
+
+  await runScenario(browser, {
+    label: "Menu mobile: scrollLeft invariato all'apertura",
+    pathname: "/",
+    width: 390,
+    validate: async (page) => {
+      const before = await page.evaluate(() => {
+        const navigation = document.querySelector(".primary-nav");
+        if (!navigation) return null;
+        navigation.scrollLeft = Math.min(
+          navigation.scrollWidth - navigation.clientWidth,
+          140,
+        );
+        return navigation.scrollLeft;
+      });
+      assert.ok(before !== null, "Menu mobile scroll: navigazione primaria assente");
+      assert.ok(before > 4, "Menu mobile scroll: la riga non si è spostata prima del tap");
+
+      const itemElement = await findPrimaryNavSection(page, "Soldi");
+      assert.ok(itemElement, "Menu mobile scroll: sezione Soldi assente");
+      const toggle = await itemElement.$(".nav-item-toggle");
+      assert.ok(toggle, "Menu mobile scroll: pulsante tendina assente");
+      await waitForStableNavigationTouchTarget(page, toggle);
+      const toggleBox = await toggle.boundingBox();
+      assert.ok(toggleBox, "Menu mobile scroll: pulsante tendina non visibile");
+      await page.touchscreen.tap(
+        toggleBox.x + toggleBox.width / 2,
+        toggleBox.y + toggleBox.height / 2,
+      );
+      await assertSubmenuVisible(itemElement, page, "Menu mobile scroll", "Debito pubblico");
+
+      const after = await page.$eval(".primary-nav", (navigation) => navigation.scrollLeft);
+      assert.equal(after, before, "Menu mobile scroll: la riga si è spostata all'apertura della tendina");
+
+      const secondBox = await toggle.boundingBox();
+      assert.ok(secondBox, "Menu mobile scroll: pulsante tendina sparito dopo l'apertura");
+      await page.touchscreen.tap(
+        secondBox.x + secondBox.width / 2,
+        secondBox.y + secondBox.height / 2,
+      );
+      await page.waitForFunction(
+        () => !document.querySelector(".nav-row > .nav-submenu"),
+        { timeout: 3_000 },
+      );
+      const closedScroll = await page.$eval(".primary-nav", (navigation) => navigation.scrollLeft);
+      assert.equal(
+        closedScroll,
+        before,
+        "Menu mobile scroll: la riga si è spostata alla chiusura della tendina",
+      );
+    },
+  });
+  completed.push("Menu mobile: scrollLeft invariato all'apertura");
 
   await runScenario(browser, {
     label: "Menu touch senza Indietro/Scorri 1024px",

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -17,11 +17,6 @@ const baseUrl = defaultBaseUrl();
 const TABLE_REGION = '[role="region"][aria-label="Redditi e variabili IRPEF per territorio"]';
 const ACTIVE_LEVEL = 'nav[aria-label="Livello territoriale"] a[aria-current="page"]';
 const INFO_TOOLTIP_IDS = ["cash-payments-tip"];
-/** Headless Chrome often reports hover:none; desktop menu hover needs a real mouse profile. */
-const DESKTOP_HOVER_MEDIA_FEATURES = [
-  { name: "hover", value: "hover" },
-  { name: "pointer", value: "fine" },
-];
 
 if (!/^https?:$/.test(baseUrl.protocol)) {
   throw new Error("DVNS_BASE_URL deve usare il protocollo HTTP oppure HTTPS.");
@@ -1464,7 +1459,6 @@ try {
         label,
         pathname: route.pathname,
         width,
-        mediaFeatures: width >= 1280 ? DESKTOP_HOVER_MEDIA_FEATURES : undefined,
         validate: async (page) => {
           assert.equal(await page.$("nav.subnav"), null, `${label}: subnav non attesa`);
           assert.equal(await page.$(".subnav-row"), null, `${label}: riga subnav non attesa`);
@@ -1747,7 +1741,6 @@ try {
     label: "Menu tendina esclusivo 1280px",
     pathname: "/istituzioni",
     width: 1280,
-    mediaFeatures: DESKTOP_HOVER_MEDIA_FEATURES,
     validate: async (page) => {
       await assertPrimaryDropdownExclusive(page, "Menu tendina esclusivo 1280px", {
         fromLabel: "Istituzioni",

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -17,6 +17,11 @@ const baseUrl = defaultBaseUrl();
 const TABLE_REGION = '[role="region"][aria-label="Redditi e variabili IRPEF per territorio"]';
 const ACTIVE_LEVEL = 'nav[aria-label="Livello territoriale"] a[aria-current="page"]';
 const INFO_TOOLTIP_IDS = ["cash-payments-tip"];
+/** Headless Chrome often reports hover:none; desktop menu hover needs a real mouse profile. */
+const DESKTOP_HOVER_MEDIA_FEATURES = [
+  { name: "hover", value: "hover" },
+  { name: "pointer", value: "fine" },
+];
 
 if (!/^https?:$/.test(baseUrl.protocol)) {
   throw new Error("DVNS_BASE_URL deve usare il protocollo HTTP oppure HTTPS.");
@@ -1459,6 +1464,7 @@ try {
         label,
         pathname: route.pathname,
         width,
+        mediaFeatures: width >= 1280 ? DESKTOP_HOVER_MEDIA_FEATURES : undefined,
         validate: async (page) => {
           assert.equal(await page.$("nav.subnav"), null, `${label}: subnav non attesa`);
           assert.equal(await page.$(".subnav-row"), null, `${label}: riga subnav non attesa`);
@@ -1741,6 +1747,7 @@ try {
     label: "Menu tendina esclusivo 1280px",
     pathname: "/istituzioni",
     width: 1280,
+    mediaFeatures: DESKTOP_HOVER_MEDIA_FEATURES,
     validate: async (page) => {
       await assertPrimaryDropdownExclusive(page, "Menu tendina esclusivo 1280px", {
         fromLabel: "Istituzioni",

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -986,12 +986,6 @@ try {
     pathname: "/imprese?metric=employees",
     width: 390,
     validate: async (page) => {
-      const currentLabels = await page.$$eval(
-        'nav.primary-nav a[aria-current="page"]',
-        (links) => links.map((link) => link.textContent?.trim()),
-      );
-      assert.deepEqual(currentLabels, ["Addetti"]);
-
       await assertPrimaryDropdownTap(page, "Atlante Imprese query navigation 390px", {
         sectionLabel: "Imprese",
         childLabel: "Localizzazioni attive",
@@ -1008,6 +1002,11 @@ try {
         "Atlante Imprese query navigation 390px",
         "Localizzazioni attive",
       );
+      const currentLabels = await page.$$eval(
+        '.nav-row > .nav-submenu a[aria-current="page"]',
+        (links) => links.map((link) => link.textContent?.trim()),
+      );
+      assert.deepEqual(currentLabels, ["Addetti"]);
       const localUnitsLink = await page.$(
         '.nav-row > .nav-submenu a[href="/imprese?metric=active_local_units"]',
       );
@@ -1017,19 +1016,30 @@ try {
         () => new URL(window.location.href).searchParams.get("metric") === "active_local_units",
         { timeout: 3_000 },
       );
-      await page.waitForFunction(
-        () => {
-          const current = document.querySelector(
-            'nav.primary-nav a[aria-current="page"]',
-          );
-          return current?.textContent?.trim() === "Localizzazioni attive";
-        },
-        { timeout: 3_000 },
-      );
       assert.equal(
         await page.$eval(".nav-row", (row) => row.hasAttribute("data-menu-open")),
         false,
         "Atlante Imprese query navigation 390px: menu rimasto aperto dopo la query",
+      );
+      const refreshedItem = await findPrimaryNavSection(page, "Imprese");
+      assert.ok(refreshedItem, "Atlante Imprese query navigation 390px: sezione Imprese assente dopo la query");
+      const reopenToggle = await refreshedItem.$(".nav-item-toggle");
+      assert.ok(reopenToggle, "Atlante Imprese query navigation 390px: pulsante tendina assente dopo la query");
+      await reopenToggle.click();
+      await assertSubmenuVisible(
+        refreshedItem,
+        page,
+        "Atlante Imprese query navigation 390px",
+        "Localizzazioni attive",
+      );
+      await page.waitForFunction(
+        () => {
+          const current = document.querySelector(
+            '.nav-row > .nav-submenu a[aria-current="page"]',
+          );
+          return current?.textContent?.trim() === "Localizzazioni attive";
+        },
+        { timeout: 3_000 },
       );
     },
   });

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -995,7 +995,13 @@ try {
       assert.ok(itemElement, "Atlante Imprese query navigation 390px: sezione Imprese assente");
       const toggle = await itemElement.$(".nav-item-toggle");
       assert.ok(toggle, "Atlante Imprese query navigation 390px: pulsante tendina assente");
-      await toggle.click();
+      await waitForStableNavigationTouchTarget(page, toggle);
+      const openBox = await toggle.boundingBox();
+      assert.ok(openBox, "Atlante Imprese query navigation 390px: pulsante tendina non visibile");
+      await page.touchscreen.tap(
+        openBox.x + openBox.width / 2,
+        openBox.y + openBox.height / 2,
+      );
       await assertSubmenuVisible(
         itemElement,
         page,
@@ -1016,16 +1022,22 @@ try {
         () => new URL(window.location.href).searchParams.get("metric") === "active_local_units",
         { timeout: 3_000 },
       );
-      assert.equal(
-        await page.$eval(".nav-row", (row) => row.hasAttribute("data-menu-open")),
-        false,
-        "Atlante Imprese query navigation 390px: menu rimasto aperto dopo la query",
+      await page.waitForFunction(
+        () => !document.querySelector(".nav-row")?.hasAttribute("data-menu-open"),
+        { timeout: 3_000 },
       );
+
       const refreshedItem = await findPrimaryNavSection(page, "Imprese");
       assert.ok(refreshedItem, "Atlante Imprese query navigation 390px: sezione Imprese assente dopo la query");
       const reopenToggle = await refreshedItem.$(".nav-item-toggle");
       assert.ok(reopenToggle, "Atlante Imprese query navigation 390px: pulsante tendina assente dopo la query");
-      await reopenToggle.click();
+      await waitForStableNavigationTouchTarget(page, reopenToggle);
+      const reopenBox = await reopenToggle.boundingBox();
+      assert.ok(reopenBox, "Atlante Imprese query navigation 390px: pulsante tendina non visibile dopo la query");
+      await page.touchscreen.tap(
+        reopenBox.x + reopenBox.width / 2,
+        reopenBox.y + reopenBox.height / 2,
+      );
       await assertSubmenuVisible(
         refreshedItem,
         page,

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -993,6 +993,9 @@ try {
 
       const itemElement = await findPrimaryNavSection(page, "Imprese");
       assert.ok(itemElement, "Atlante Imprese query navigation 390px: sezione Imprese assente");
+      await page.evaluate((element) => {
+        element.scrollIntoView({ block: "nearest", inline: "center" });
+      }, itemElement);
       const toggle = await itemElement.$(".nav-item-toggle");
       assert.ok(toggle, "Atlante Imprese query navigation 390px: pulsante tendina assente");
       await waitForStableNavigationTouchTarget(page, toggle);
@@ -1006,7 +1009,7 @@ try {
         itemElement,
         page,
         "Atlante Imprese query navigation 390px",
-        "Localizzazioni attive",
+        "Addetti",
       );
       const currentLabels = await page.$$eval(
         '.nav-row > .nav-submenu a[aria-current="page"]',
@@ -1017,11 +1020,13 @@ try {
         '.nav-row > .nav-submenu a[href="/imprese?metric=active_local_units"]',
       );
       assert.ok(localUnitsLink, "Atlante Imprese query navigation 390px: link metrica assente");
-      await localUnitsLink.click();
-      await page.waitForFunction(
-        () => new URL(window.location.href).searchParams.get("metric") === "active_local_units",
-        { timeout: 3_000 },
-      );
+      await Promise.all([
+        page.waitForFunction(
+          () => new URL(window.location.href).searchParams.get("metric") === "active_local_units",
+          { timeout: 5_000 },
+        ),
+        localUnitsLink.click(),
+      ]);
       await page.waitForFunction(
         () => !document.querySelector(".nav-row")?.hasAttribute("data-menu-open"),
         { timeout: 3_000 },
@@ -1029,6 +1034,9 @@ try {
 
       const refreshedItem = await findPrimaryNavSection(page, "Imprese");
       assert.ok(refreshedItem, "Atlante Imprese query navigation 390px: sezione Imprese assente dopo la query");
+      await page.evaluate((element) => {
+        element.scrollIntoView({ block: "nearest", inline: "center" });
+      }, refreshedItem);
       const reopenToggle = await refreshedItem.$(".nav-item-toggle");
       assert.ok(reopenToggle, "Atlante Imprese query navigation 390px: pulsante tendina assente dopo la query");
       await waitForStableNavigationTouchTarget(page, reopenToggle);
@@ -1044,15 +1052,11 @@ try {
         "Atlante Imprese query navigation 390px",
         "Localizzazioni attive",
       );
-      await page.waitForFunction(
-        () => {
-          const current = document.querySelector(
-            '.nav-row > .nav-submenu a[aria-current="page"]',
-          );
-          return current?.textContent?.trim() === "Localizzazioni attive";
-        },
-        { timeout: 3_000 },
+      const afterLabels = await page.$$eval(
+        '.nav-row > .nav-submenu a[aria-current="page"]',
+        (links) => links.map((link) => link.textContent?.trim()),
       );
+      assert.deepEqual(afterLabels, ["Localizzazioni attive"]);
     },
   });
   completed.push("Atlante Imprese query navigation 390px");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -372,11 +372,20 @@ nav li a { text-decoration: none; }
   color: var(--color-text);
   background: var(--color-neutral-100);
 }
-/* Visibility is owned by React data-open alone. Opening also via :hover or
-   :focus-within let two panels stay visible when focus/data-open lagged behind
-   the pointer moving to the next section. */
-.nav-item-has-menu[data-open="true"] .nav-submenu {
+/* The open panel lives on the row, not inside the scrolling nav, so opening
+   it never changes overflow or scrollLeft. */
+.nav-row > .nav-submenu {
   display: block;
+  left: var(--nav-submenu-left, 0px);
+}
+.nav-menu-dismiss {
+  position: fixed;
+  inset: 0;
+  z-index: 25;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
 }
 
 .nav-scroll-control {
@@ -775,10 +784,6 @@ main { display: block; }
 @media (max-width: 1320px) {
   .nav-item > a { padding-inline: 12px; }
   .nav-item-has-menu > a { padding-right: 4px; }
-  .nav-row[data-menu-open="true"] {
-    overflow-x: clip;
-    overflow-y: visible;
-  }
   .nav-scroll-control { display: inline-flex; }
   .nav-row[data-menu-open="true"] .nav-scroll-control { display: none; }
   .primary-nav {
@@ -786,15 +791,7 @@ main { display: block; }
     scrollbar-width: none;
   }
   .primary-nav::-webkit-scrollbar { display: none; }
-  /* overflow-x: auto also clips vertically; release that while a panel is open
-     so the anchored submenu can extend below the scrolling row. */
-  .nav-row[data-menu-open="true"] .primary-nav { overflow: visible; }
-  /* A scrolling row cannot show a panel that hangs out of it. Anchoring the
-     panel to the row instead of to its own item puts it outside that scrolling
-     box, so it is neither clipped by it nor placed against the document. */
-  .nav-item-has-menu[data-open="true"] { position: static; }
-  .nav-item-has-menu[data-open="true"] .nav-submenu {
-    top: 100%;
+  .nav-row > .nav-submenu {
     left: 0;
     right: 0;
     width: auto;
@@ -874,7 +871,7 @@ main { display: block; }
 @media (max-width: 620px) {
   :root { --gutter: 14px; }
   body { font-size: 13.5px; }
-  .site-header { position: static; }
+  .site-header { position: relative; }
   .brand-mark { width: 38px; height: 38px; }
   .brand-text strong { font-size: 17px; }
   .header-action { padding-inline: 14px; }

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -70,29 +70,27 @@ function navMenuId(href: string) {
 }
 
 export function Navigation() {
-  const pathname = usePathname();
-  const [currentSearch, setCurrentSearch] = useState<string | null>(null);
   return (
-    <>
-      <Suspense fallback={null}>
-        <NavigationSearchSync onChange={setCurrentSearch} />
-      </Suspense>
-      <NavigationContent pathname={pathname} currentSearch={currentSearch} />
-    </>
+    <Suspense fallback={<NavigationFallback />}>
+      <NavigationWithSearch />
+    </Suspense>
   );
 }
 
-function NavigationSearchSync({
-  onChange,
-}: Readonly<{ onChange: (search: string) => void }>) {
+function NavigationFallback() {
+  const pathname = usePathname();
+  return <NavigationContent pathname={pathname} currentSearch={null} />;
+}
+
+function NavigationWithSearch() {
+  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const currentSearch = searchParams.toString();
-
-  useLayoutEffect(() => {
-    onChange(currentSearch);
-  }, [currentSearch, onChange]);
-
-  return null;
+  return (
+    <NavigationContent
+      pathname={pathname}
+      currentSearch={searchParams.toString()}
+    />
+  );
 }
 
 function NavigationContent({ pathname, currentSearch }: NavigationContentProps) {

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -279,7 +279,10 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
                     data-section-active={active ? "true" : undefined}
                     data-open={open ? "true" : undefined}
                     onPointerEnter={(event) => {
-                      if (!canHover || event.pointerType === "touch") return;
+                      // Touch uses the caret; mouse/pen transfer the single open slot.
+                      // Do not gate on matchMedia(hover): headless and some hybrids
+                      // report hover:none even when pointer events are mouse-like.
+                      if (event.pointerType === "touch") return;
                       if (hasChildren) openItem(item.href);
                       else closeMenu();
                     }}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -33,14 +33,28 @@ type NavigationContentProps = Readonly<{
   currentSearch: string | null;
 }>;
 
+const FINE_POINTER_HOVER_QUERY = "(hover: hover) and (pointer: fine)";
 /** Mouse on a viewport wide enough that swipe is not the primary way to pan. */
-const MOUSE_NAV_SCROLL_CONTROLS_QUERY =
-  "(hover: hover) and (pointer: fine) and (min-width: 901px)";
+const MOUSE_NAV_SCROLL_CONTROLS_QUERY = `${FINE_POINTER_HOVER_QUERY} and (min-width: 901px)`;
+
+function subscribeFinePointerHover(onChange: () => void) {
+  const media = window.matchMedia(FINE_POINTER_HOVER_QUERY);
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
+}
 
 function subscribeMouseNavScrollControls(onChange: () => void) {
   const media = window.matchMedia(MOUSE_NAV_SCROLL_CONTROLS_QUERY);
   media.addEventListener("change", onChange);
   return () => media.removeEventListener("change", onChange);
+}
+
+function useFinePointerHover() {
+  return useSyncExternalStore(
+    subscribeFinePointerHover,
+    () => window.matchMedia(FINE_POINTER_HOVER_QUERY).matches,
+    () => false,
+  );
 }
 
 function useMouseNavScrollControls() {
@@ -49,6 +63,10 @@ function useMouseNavScrollControls() {
     () => window.matchMedia(MOUSE_NAV_SCROLL_CONTROLS_QUERY).matches,
     () => false,
   );
+}
+
+function navMenuId(href: string) {
+  return `nav-menu-${href.replace(/\W+/g, "-")}`;
 }
 
 export function Navigation() {
@@ -79,12 +97,15 @@ function NavigationSearchSync({
 
 function NavigationContent({ pathname, currentSearch }: NavigationContentProps) {
   const navigationRef = useRef<HTMLElement>(null);
+  const navRowRef = useRef<HTMLDivElement>(null);
   const activeLinkRef = useRef<HTMLAnchorElement>(null);
   const [navigationScroll, setNavigationScroll] = useState({
     backward: false,
     forward: false,
   });
+  const [submenuLeft, setSubmenuLeft] = useState(0);
   const showScrollControls = useMouseNavScrollControls();
+  const canHover = useFinePointerHover();
   /**
    * Exactly one submenu may be open. Hover, focus and the caret all write the
    * same state so CSS never opens a second panel through :hover/:focus-within
@@ -110,6 +131,7 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
     (href: string) => setOpenMenu({ href, pathname, search: currentSearch }),
     [currentSearch, pathname],
   );
+  const openSection = PRIMARY_NAV.find((item) => item.href === openHref && item.children?.length);
 
   const updateNavigationScroll = useCallback(() => {
     const navigation = navigationRef.current;
@@ -155,14 +177,24 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
     const navigationBox = navigation.getBoundingClientRect();
     const activeBox = activeLink.getBoundingClientRect();
     if (activeBox.left < navigationBox.left || activeBox.right > navigationBox.right) {
-      activeLink.scrollIntoView({ block: "nearest", inline: "center" });
+      activeLink.scrollIntoView({ block: "nearest", inline: "nearest" });
     }
   }, [pathname]);
+
+  useLayoutEffect(() => {
+    if (!openHref) return;
+    const item = navigationRef.current?.querySelector(".nav-item-has-menu[data-open='true']");
+    const row = navRowRef.current;
+    if (!item || !row) return;
+    const itemBox = item.getBoundingClientRect();
+    const rowBox = row.getBoundingClientRect();
+    setSubmenuLeft(itemBox.left - rowBox.left);
+  }, [openHref]);
 
   useEffect(() => {
     if (openHref === null) return;
     function dismissOutside(event: PointerEvent) {
-      if (!isEventTargetWithin(navigationRef.current, event.target)) closeMenu();
+      if (!isEventTargetWithin(navRowRef.current, event.target)) closeMenu();
     }
     function dismissOnEscape(event: KeyboardEvent) {
       if (event.key === "Escape") closeMenu();
@@ -176,102 +208,103 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
   }, [openHref, closeMenu]);
 
   return (
-    <header className="site-header">
-      <div className="shell header-inner">
-        <Link href="/" className="brand" aria-label="Dove vanno i nostri soldi, home">
-          <Image
-            className="brand-mark"
-            src="/brand/dvns-mark-transparent.svg"
-            width={44}
-            height={44}
-            alt=""
-            aria-hidden="true"
-            priority
-          />
-          <span className="brand-text">
-            <strong>Dove vanno i nostri soldi?</strong>
-          </span>
-        </Link>
-
-        <span className="header-spacer" />
-
-        <HeaderSearch />
-
-        <div className="header-actions">
-          <Link className="header-action header-action-accent" href="/mcp">
-            Istruzioni MCP
+    <>
+      <header className="site-header">
+        <div className="shell header-inner">
+          <Link href="/" className="brand" aria-label="Dove vanno i nostri soldi, home">
+            <Image
+              className="brand-mark"
+              src="/brand/dvns-mark-transparent.svg"
+              width={44}
+              height={44}
+              alt=""
+              aria-hidden="true"
+              priority
+            />
+            <span className="brand-text">
+              <strong>Dove vanno i nostri soldi?</strong>
+            </span>
           </Link>
-          <a
-            className="header-action header-action-icon"
-            href={REPO_URL}
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Codice su GitHub, si apre in una nuova scheda"
-            title="Codice su GitHub"
-          >
-            <HugeiconsIcon icon={GithubIcon} size={19} strokeWidth={1.7} aria-hidden="true" />
-          </a>
-        </div>
-      </div>
 
-      <div className="shell nav-row" data-menu-open={openHref ? "true" : undefined}>
-        <nav
-          className="primary-nav"
-          aria-label="Navigazione principale"
-          ref={navigationRef}
+          <span className="header-spacer" />
+
+          <HeaderSearch />
+
+          <div className="header-actions">
+            <Link className="header-action header-action-accent" href="/mcp">
+              Istruzioni MCP
+            </Link>
+            <a
+              className="header-action header-action-icon"
+              href={REPO_URL}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Codice su GitHub, si apre in una nuova scheda"
+              title="Codice su GitHub"
+            >
+              <HugeiconsIcon icon={GithubIcon} size={19} strokeWidth={1.7} aria-hidden="true" />
+            </a>
+          </div>
+        </div>
+
+        <div
+          className="shell nav-row"
+          ref={navRowRef}
+          data-menu-open={openHref ? "true" : undefined}
           onPointerLeave={(event) => {
-            // Touch opens via the caret and must stay open after the finger lifts.
-            if (event.pointerType === "touch") return;
-            if (isEventTargetWithin(navigationRef.current, event.relatedTarget)) return;
+            if (!canHover || event.pointerType === "touch") return;
+            if (isEventTargetWithin(navRowRef.current, event.relatedTarget)) return;
             closeMenu();
           }}
           onBlur={(event) => {
-            if (isEventTargetWithin(navigationRef.current, event.relatedTarget)) return;
+            if (isEventTargetWithin(navRowRef.current, event.relatedTarget)) return;
             closeMenu();
           }}
         >
-          <ul className="primary-nav-list">
-            {PRIMARY_NAV.map((item) => {
-              const active = isNavSectionActive(pathname, item);
-              const hasChildren = Boolean(item.children?.length);
-              const menuId = `nav-menu-${item.href.replace(/\W+/g, "-")}`;
-              const open = openHref === item.href;
-              return (
-                <li
-                  key={item.href}
-                  className={hasChildren ? "nav-item nav-item-has-menu" : "nav-item"}
-                  data-section-active={active ? "true" : undefined}
-                  data-open={open ? "true" : undefined}
-                  onPointerEnter={(event) => {
-                    // Touch uses the caret; hover/pen transfer the single open slot.
-                    if (event.pointerType === "touch") return;
-                    if (hasChildren) openItem(item.href);
-                    else closeMenu();
-                  }}
-                  onFocusCapture={(event) => {
-                    // The caret owns its toggle action. Opening here as well would
-                    // make a real pointer click open on focus and close on click.
-                    if (
-                      hasChildren &&
-                      !(event.target as HTMLElement).matches(".nav-item-toggle")
-                    ) {
-                      openItem(item.href);
-                    }
-                  }}
-                >
-                  <Link
-                    href={item.href}
-                    aria-current={
-                      pathname === item.href && currentSearch === "" ? "page" : undefined
-                    }
+          <nav
+            className="primary-nav"
+            aria-label="Navigazione principale"
+            ref={navigationRef}
+          >
+            <ul className="primary-nav-list">
+              {PRIMARY_NAV.map((item) => {
+                const active = isNavSectionActive(pathname, item);
+                const hasChildren = Boolean(item.children?.length);
+                const menuId = navMenuId(item.href);
+                const open = openHref === item.href;
+                return (
+                  <li
+                    key={item.href}
+                    className={hasChildren ? "nav-item nav-item-has-menu" : "nav-item"}
                     data-section-active={active ? "true" : undefined}
-                    ref={active ? activeLinkRef : undefined}
-                    onClick={closeMenu}
+                    data-open={open ? "true" : undefined}
+                    onPointerEnter={(event) => {
+                      if (!canHover || event.pointerType === "touch") return;
+                      if (hasChildren) openItem(item.href);
+                      else closeMenu();
+                    }}
+                    onFocusCapture={(event) => {
+                      if (!canHover) return;
+                      if (
+                        hasChildren &&
+                        !(event.target as HTMLElement).matches(".nav-item-toggle")
+                      ) {
+                        openItem(item.href);
+                      }
+                    }}
                   >
-                    {item.label}
-                  </Link>
-                  {hasChildren && item.children ? (
-                    <>
+                    <Link
+                      href={item.href}
+                      aria-current={
+                        pathname === item.href && currentSearch === "" ? "page" : undefined
+                      }
+                      data-section-active={active ? "true" : undefined}
+                      ref={active ? activeLinkRef : undefined}
+                      onClick={closeMenu}
+                    >
+                      {item.label}
+                    </Link>
+                    {hasChildren ? (
                       <button
                         type="button"
                         className="nav-item-toggle"
@@ -293,66 +326,77 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
                           aria-hidden="true"
                         />
                       </button>
-                      <div
-                        className="nav-submenu"
-                        id={menuId}
-                        role="region"
-                        aria-label={`Pagine in ${item.label}`}
-                      >
-                        <ul>
-                          {item.children.map((child) => (
-                            <li key={child.href}>
-                              <Link
-                                href={child.href}
-                                aria-current={
-                                  currentSearch !== null &&
-                                  isNavChildActive(
-                                    pathname,
-                                    child.href,
-                                    item.children!,
-                                    currentSearch,
-                                  )
-                                    ? "page"
-                                    : undefined
-                                }
-                                onClick={closeMenu}
-                              >
-                                {child.label}
-                              </Link>
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    </>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
-        {showScrollControls && navigationScroll.backward ? (
-          <button
-            type="button"
-            className="nav-scroll-control nav-scroll-control-backward"
-            aria-label="Scorri la navigazione verso sinistra"
-            onClick={() => scrollNavigation("backward")}
-          >
-            <HugeiconsIcon icon={ArrowLeft01Icon} size={14} strokeWidth={1.8} aria-hidden="true" />
-            <span aria-hidden="true">Indietro</span>
-          </button>
-        ) : null}
-        {showScrollControls && navigationScroll.forward ? (
-          <button
-            type="button"
-            className="nav-scroll-control nav-scroll-control-forward"
-            aria-label="Scorri la navigazione verso destra"
-            onClick={() => scrollNavigation("forward")}
-          >
-            <span aria-hidden="true">Scorri</span>
-            <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-        ) : null}
-      </div>
-    </header>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+          {openSection?.children ? (
+            <div
+              className="nav-submenu"
+              id={navMenuId(openSection.href)}
+              role="region"
+              aria-label={`Pagine in ${openSection.label}`}
+              style={{ ["--nav-submenu-left" as string]: `${submenuLeft}px` }}
+            >
+              <ul>
+                {openSection.children.map((child) => (
+                  <li key={child.href}>
+                    <Link
+                      href={child.href}
+                      aria-current={
+                        currentSearch !== null &&
+                        isNavChildActive(
+                          pathname,
+                          child.href,
+                          openSection.children!,
+                          currentSearch,
+                        )
+                          ? "page"
+                          : undefined
+                      }
+                      onClick={closeMenu}
+                    >
+                      {child.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {showScrollControls && navigationScroll.backward ? (
+            <button
+              type="button"
+              className="nav-scroll-control nav-scroll-control-backward"
+              aria-label="Scorri la navigazione verso sinistra"
+              onClick={() => scrollNavigation("backward")}
+            >
+              <HugeiconsIcon icon={ArrowLeft01Icon} size={14} strokeWidth={1.8} aria-hidden="true" />
+              <span aria-hidden="true">Indietro</span>
+            </button>
+          ) : null}
+          {showScrollControls && navigationScroll.forward ? (
+            <button
+              type="button"
+              className="nav-scroll-control nav-scroll-control-forward"
+              aria-label="Scorri la navigazione verso destra"
+              onClick={() => scrollNavigation("forward")}
+            >
+              <span aria-hidden="true">Scorri</span>
+              <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.8} aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+      </header>
+      {openHref ? (
+        <button
+          type="button"
+          className="nav-menu-dismiss"
+          aria-label="Chiudi il menu"
+          onClick={closeMenu}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -70,27 +70,29 @@ function navMenuId(href: string) {
 }
 
 export function Navigation() {
+  const pathname = usePathname();
+  const [currentSearch, setCurrentSearch] = useState<string | null>(null);
   return (
-    <Suspense fallback={<NavigationFallback />}>
-      <NavigationWithSearch />
-    </Suspense>
+    <>
+      <Suspense fallback={null}>
+        <NavigationSearchSync onChange={setCurrentSearch} />
+      </Suspense>
+      <NavigationContent pathname={pathname} currentSearch={currentSearch} />
+    </>
   );
 }
 
-function NavigationFallback() {
-  const pathname = usePathname();
-  return <NavigationContent pathname={pathname} currentSearch={null} />;
-}
-
-function NavigationWithSearch() {
-  const pathname = usePathname();
+function NavigationSearchSync({
+  onChange,
+}: Readonly<{ onChange: (search: string) => void }>) {
   const searchParams = useSearchParams();
-  return (
-    <NavigationContent
-      pathname={pathname}
-      currentSearch={searchParams.toString()}
-    />
-  );
+  const currentSearch = searchParams.toString();
+
+  useLayoutEffect(() => {
+    onChange(currentSearch);
+  }, [currentSearch, onChange]);
+
+  return null;
 }
 
 function NavigationContent({ pathname, currentSearch }: NavigationContentProps) {
@@ -125,9 +127,13 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
       : null;
 
   const closeMenu = useCallback(() => setOpenMenu(null), []);
+  const liveSearch = useCallback(() => {
+    if (typeof window === "undefined") return currentSearch;
+    return window.location.search.replace(/^\?/, "");
+  }, [currentSearch]);
   const openItem = useCallback(
-    (href: string) => setOpenMenu({ href, pathname, search: currentSearch }),
-    [currentSearch, pathname],
+    (href: string) => setOpenMenu({ href, pathname, search: liveSearch() }),
+    [liveSearch, pathname],
   );
   const openSection = PRIMARY_NAV.find((item) => item.href === openHref && item.children?.length);
 
@@ -255,6 +261,9 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
             closeMenu();
           }}
           onBlur={(event) => {
+            // Touch browsers blur/focus unpredictably around the caret; outside
+            // pointerdown and Escape already own dismiss there.
+            if (!canHover) return;
             if (isEventTargetWithin(navRowRef.current, event.relatedTarget)) return;
             closeMenu();
           }}
@@ -316,7 +325,7 @@ function NavigationContent({ pathname, currentSearch }: NavigationContentProps) 
                           setOpenMenu(
                             open
                               ? null
-                              : { href: item.href, pathname, search: currentSearch },
+                              : { href: item.href, pathname, search: liveSearch() },
                           )
                         }
                       >

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -9,3 +9,6 @@ if (typeof packageVersion !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 export const APP_VERSION = packageVersion;
 export const APP_USER_AGENT =
   `DoveVannoINostriSoldi/${APP_VERSION} (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)`;
+/** Indice PA blocks our primary User-Agent at the gateway; keep this alias for IPA reads only. */
+export const IPA_USER_AGENT =
+  `OpenDataClient/${APP_VERSION} (github.com/Italian-Builders-Org)`;

--- a/src/lib/data/source-fetch.ts
+++ b/src/lib/data/source-fetch.ts
@@ -1,5 +1,5 @@
 import { setTimeout as delay } from "node:timers/promises";
-import { APP_USER_AGENT } from "@/lib/app-version";
+import { APP_USER_AGENT, IPA_USER_AGENT } from "@/lib/app-version";
 import { MEF_IRPEF_SOURCE } from "@/lib/data/mef-irpef-source";
 import { PNRR_CHILDCARE_SOURCE } from "@/lib/data/pnrr-childcare-source";
 import { getSourcePolicy, type SourceId } from "@/lib/data/source-policy";
@@ -71,6 +71,11 @@ const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const RETRY_DELAY_MS = 300;
 const USER_AGENT = APP_USER_AGENT;
 
+const SOURCE_USER_AGENTS: Partial<Readonly<Record<SourceId, string>>> = {
+  ipa: IPA_USER_AGENT,
+  "ipa-struttura": IPA_USER_AGENT,
+};
+
 export class SourceFetchError extends Error {
   readonly sourceId: SourceId;
   readonly cause?: unknown;
@@ -125,7 +130,7 @@ function revalidateFor(sourceId: SourceId, kind: SourceFetchKind): number {
     : policy.dataRevalidateSeconds;
 }
 
-function requestHeaders(input: HeadersInit | undefined): Headers {
+function requestHeaders(sourceId: SourceId, input: HeadersInit | undefined): Headers {
   const headers = new Headers(input);
   if (!headers.has("Accept")) {
     headers.set(
@@ -133,7 +138,9 @@ function requestHeaders(input: HeadersInit | undefined): Headers {
       "application/json, text/csv;q=0.9, text/plain;q=0.8, */*;q=0.5",
     );
   }
-  if (!headers.has("User-Agent")) headers.set("User-Agent", USER_AGENT);
+  if (!headers.has("User-Agent")) {
+    headers.set("User-Agent", SOURCE_USER_AGENTS[sourceId] ?? USER_AGENT);
+  }
   return headers;
 }
 
@@ -198,7 +205,7 @@ export async function fetchOfficialSource(
       const response = await fetch(url, {
         ...requestOptions,
         method,
-        headers: requestHeaders(headers),
+        headers: requestHeaders(sourceId, headers),
         redirect: requestOptions.redirect ?? "error",
         signal: composedSignal(callerSignal, timeoutMs),
         next: {

--- a/src/lib/global-search.ts
+++ b/src/lib/global-search.ts
@@ -12,6 +12,7 @@ import {
   searchIpaEntitiesByPrefix,
   type IpaEntity,
 } from "@/lib/ipa";
+import { getMunicipalitySearchEntities } from "@/lib/siope-municipality-detail";
 import {
   PRIMARY_NAV,
   SITE_MAP_GROUPS,
@@ -544,6 +545,12 @@ export async function searchGlobal(input: {
   } catch (error) {
     if (input.signal?.aborted) throw input.signal.reason ?? error;
     entitiesAvailable = false;
+    const snapshotResults = rankEntitySearchResults(
+      getMunicipalitySearchEntities(),
+      normalizedQuery,
+    ).slice(0, Math.min(50, Math.max(limit * 3, 12)));
+    entityTotal = snapshotResults.length;
+    entityResults = [...snapshotResults];
   }
 
   if (input.signal?.aborted) {

--- a/src/lib/siope-municipality-detail.ts
+++ b/src/lib/siope-municipality-detail.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import type { IpaEntity } from "@/lib/ipa";
+
 import detail2024 from "@/data/generated/siope-municipal-detail-2024.json";
 import detail2025 from "@/data/generated/siope-municipal-detail-2025.json";
 import detail2026 from "@/data/generated/siope-municipal-detail.json";
@@ -377,4 +379,39 @@ export function getMunicipalityEntityPublicPaths(): readonly `/enti/${string}`[]
   return [...codes]
     .sort((left, right) => left.localeCompare(right, "en"))
     .map((code) => `/enti/${encodeURIComponent(code)}` as const);
+}
+
+/** Minimal IPA-compatible identities for offline municipal keyword search. */
+export function getMunicipalitySearchEntities(): readonly IpaEntity[] {
+  const latest = artifacts[0];
+  const byIpa = new Map<string, IpaEntity>();
+  for (const row of latest.rows) {
+    const codiceIpa = row[1];
+    if (!codiceIpa || byIpa.has(codiceIpa)) continue;
+    byIpa.set(codiceIpa, {
+      codiceIpa,
+      denominazione: row[2],
+      codiceFiscale: row[0],
+      tipologia: "Comune",
+      codiceCategoria: null,
+      codiceNatura: null,
+      codiceAteco: null,
+      inLiquidazione: null,
+      codiceMiur: null,
+      codiceIstat: null,
+      acronimo: null,
+      responsabile: { nome: null, cognome: null, titolo: null },
+      sede: {
+        codiceComuneIstat: null,
+        codiceCatastaleComune: null,
+        cap: null,
+        indirizzo: null,
+      },
+      email: [],
+      sitoIstituzionale: null,
+      social: { facebook: null, linkedin: null, twitter: null, youtube: null },
+      dataAggiornamento: null,
+    });
+  }
+  return [...byIpa.values()];
 }

--- a/tests/app-version.test.mjs
+++ b/tests/app-version.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import packageJson from "../package.json" with { type: "json" };
 import "./helpers/register-ts-alias.mjs";
 
-const { APP_USER_AGENT, APP_VERSION } = await import("../src/lib/app-version.ts");
+const { APP_USER_AGENT, APP_VERSION, IPA_USER_AGENT } = await import("../src/lib/app-version.ts");
 const sourceFetch = await import("node:fs/promises").then(({ readFile }) =>
   readFile(new URL("../src/lib/data/source-fetch.ts", import.meta.url), "utf8"));
 const mcpServer = await import("node:fs/promises").then(({ readFile }) =>
@@ -12,7 +12,10 @@ const mcpServer = await import("node:fs/promises").then(({ readFile }) =>
 test("runtime metadata derives one version from package.json", () => {
   assert.equal(APP_VERSION, packageJson.version);
   assert.match(APP_USER_AGENT, new RegExp(`DoveVannoINostriSoldi/${packageJson.version.replaceAll(".", "\\.")}`));
+  assert.match(IPA_USER_AGENT, new RegExp(`OpenDataClient/${packageJson.version.replaceAll(".", "\\.")}`));
+  assert.doesNotMatch(IPA_USER_AGENT, /DoveVannoINostriSoldi/);
   assert.match(sourceFetch, /APP_USER_AGENT/);
+  assert.match(sourceFetch, /IPA_USER_AGENT/);
   assert.doesNotMatch(sourceFetch, /DoveVannoINostriSoldi\/0\.5/);
   assert.match(mcpServer, /version: APP_VERSION/);
   assert.doesNotMatch(mcpServer, /version: "1\.0\.0"/);

--- a/tests/global-search.test.mjs
+++ b/tests/global-search.test.mjs
@@ -203,3 +203,35 @@ test("site search has no duplicate destinations and exposes useful Italian alias
   assert.ok(results.some((result) => result.href === "/spese/consulenze"));
   assert.ok(searchSiteDocuments("pnrr").some((result) => result.href === "/coesione"));
 });
+
+test("municipal snapshot search finds major cities by keyword", async () => {
+  const { searchGlobal } = await import("../src/lib/global-search.ts");
+  const fetchCalls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    fetchCalls.push(String(input));
+    return new Response("blocked", { status: 500 });
+  };
+
+  try {
+    const milano = await searchGlobal({ query: "milano", limit: 8 });
+    assert.equal(milano.entitiesAvailable, false);
+    assert.ok(
+      milano.groups.some((group) =>
+        group.results.some((result) => normalizeSearchText(result.title).includes("milano")),
+      ),
+      "Milano should be discoverable from the committed municipal snapshot",
+    );
+
+    const bologna = await searchGlobal({ query: "bologna", limit: 8 });
+    assert.ok(
+      bologna.groups.some((group) =>
+        group.results.some((result) => normalizeSearchText(result.title).includes("bologna")),
+      ),
+      "Bologna should be discoverable from the committed municipal snapshot",
+    );
+    assert.ok(fetchCalls.length >= 4, "IPA SQL plus full-text fallback per query");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -63,10 +63,8 @@ test("a submenu can be opened without a pointer that can hover", async () => {
   assert.match(navigationComponent, /className="nav-scroll-control nav-scroll-control-forward"/);
   assert.match(navigationComponent, /className="nav-scroll-control nav-scroll-control-backward"/);
   assert.match(navigationComponent, /useSyncExternalStore/);
-  assert.match(
-    navigationComponent,
-    /\(hover: hover\) and \(pointer: fine\) and \(min-width: 901px\)/,
-  );
+  assert.match(navigationComponent, /FINE_POINTER_HOVER_QUERY = "\(hover: hover\) and \(pointer: fine\)"/);
+  assert.match(navigationComponent, /MOUSE_NAV_SCROLL_CONTROLS_QUERY = `\$\{FINE_POINTER_HOVER_QUERY\} and \(min-width: 901px\)`/);
   assert.match(navigationComponent, /showScrollControls && navigationScroll\.forward/);
   assert.match(navigationComponent, /navigation\.scrollLeft = Math\.max\(0, Math\.min\(maxScrollLeft, nextScrollLeft\)\)/);
   assert.match(globalsCss, /\.nav-scroll-control \{/);
@@ -97,13 +95,20 @@ test("a submenu can be opened without a pointer that can hover", async () => {
     /\.nav-item-has-menu:hover \.nav-submenu|\.nav-item-has-menu:focus-within \.nav-submenu/,
   );
 
-  assert.match(globalsCss, /\.nav-item-has-menu\[data-open="true"\] \.nav-submenu/);
+  assert.match(globalsCss, /\.nav-row > \.nav-submenu/);
+  assert.match(globalsCss, /\.nav-menu-dismiss \{/);
   assert.match(globalsCss, /\.nav-item-toggle \{/);
   assert.match(globalsCss, /@media \(max-width: 1320px\)/);
-  // Below that break the row scrolls, so the panel must be anchored outside it.
+  // Below that break the row scrolls; the panel is a sibling, not inside it.
   assert.match(globalsCss, /\.nav-row \{\n\s*position: relative;/);
   assert.match(navigationComponent, /data-menu-open=\{openHref \? "true" : undefined\}/);
-  assert.match(globalsCss, /\.nav-row\[data-menu-open="true"\] \.primary-nav \{ overflow: visible; \}/);
+  assert.doesNotMatch(
+    globalsCss,
+    /\.nav-row\[data-menu-open="true"\] \.primary-nav \{ overflow: visible; \}/,
+  );
+  assert.match(navigationComponent, /className="nav-menu-dismiss"/);
+  assert.match(navigationComponent, /navMenuId/);
+  assert.match(navigationComponent, /useFinePointerHover/);
 });
 
 test("mobile dropdown taps use stable, hit-testable navigation geometry", () => {
@@ -114,6 +119,8 @@ test("mobile dropdown taps use stable, hit-testable navigation geometry", () => 
   assert.match(browserCoreSource, /const toggleBox = await toggle\.boundingBox\(\)/);
   assert.match(browserCoreSource, /Menu touch senza Indietro\/Scorri 1024px/);
   assert.match(browserCoreSource, /touch: true/);
+  assert.match(browserCoreSource, /Menu mobile: tendina si chiude al tap fuori/);
+  assert.match(browserCoreSource, /Menu mobile: scrollLeft invariato all'apertura/);
 });
 
 test("browser copy guard matches limit and offset as whole words", () => {
@@ -134,10 +141,11 @@ test("navigation guards related targets before checking containment", async () =
   );
   assert.equal(
     navigationComponent.match(
-      /isEventTargetWithin\(navigationRef\.current, event\.relatedTarget\)/g,
+      /isEventTargetWithin\(navRowRef\.current, event\.relatedTarget\)/g,
     )?.length,
     2,
   );
+  assert.match(navigationComponent, /isEventTargetWithin\(navRowRef\.current, event\.target\)/);
   assert.match(navigationComponent, /event\.pointerType === "touch"\) return;/);
 });
 


### PR DESCRIPTION
## Summary
- Ripristina la ricerca per parole chiave (Milano, Bologna, ecc.): il gateway IPA risponde 500 al nostro User-Agent principale, quindi le letture IPA usano un alias dedicato e, se la rete fallisce, la ricerca ripiega sui comuni dello snapshot SIOPE.
- Corregge il menu mobile: la tendina si chiude con tap fuori, niente apertura automatica su hover/focus su touch, pannello fuori dallo scroller per evitare salti di layout.

## Test plan
- [ ] Su mobile (390px): apri una voce di menu, verifica che il tap fuori chiuda la tendina
- [ ] Su mobile: apri una voce di menu e verifica che la riga del menu non salti
- [ ] Cerca "Milano" e "Bologna" nell'header: devono comparire risultati enti
- [ ] `node --test tests/global-search.test.mjs tests/site-navigation.test.mjs`


Made with [Cursor](https://cursor.com)