### PR TITLE
fix(enti): jump link Comunali a 44px per touch

### DIFF
--- a/src/app/enti/[codice]/scheda.module.css
+++ b/src/app/enti/[codice]/scheda.module.css
@@ -69,7 +69,7 @@
 .sectionNav a {
   display: inline-flex;
   align-items: center;
-  min-height: 36px;
+  min-height: 44px;
   padding: 0 12px;
   border: 1px solid var(--color-neutral-300);
   color: var(--color-neutral-800);


### PR DESCRIPTION
## Summary
- Porta i jump link della scheda Comune da 36px a 44px di altezza minima, allineati ai target touch usati altrove.

## Test plan
- [ ] Scheda Comune (es. `/enti/c_f205`) a 390px: jump nav tappabile
- [ ] `tests/territory-metrics.test.mjs` (no-radius) invariato


Made with [Cursor](https://cursor.com)