### PR TITLE
fix(enti): non esporre più i 429 di Indice PA come errore di pagina

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -4,6 +4,7 @@ import {
   GLOBAL_SEARCH_MAX_LIMIT,
   GLOBAL_SEARCH_MIN_QUERY_LENGTH,
   searchGlobal,
+  searchGlobalLocalFallback,
 } from "@/lib/global-search";
 
 export const runtime = "nodejs";
@@ -32,6 +33,17 @@ function errorResponse(message: string, status = 400): Response {
   );
 }
 
+function searchJson(body: unknown): Response {
+  return Response.json(body, {
+    headers: {
+      // Search is interactive and backed by a changing public registry. Avoid
+      // replaying a stale empty prefix result from the browser or an edge cache.
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
 export async function GET(request: Request) {
   const params = new URL(request.url).searchParams;
   const query = params.get("q")?.trim() ?? "";
@@ -47,33 +59,24 @@ export async function GET(request: Request) {
     );
   }
   if (query.length > 0 && query.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-    return Response.json(
-      {
-        ok: true,
-        query,
-        groups: [],
-        total: 0,
-        hasMore: false,
-        staticTotal: 0,
-        entityTotal: 0,
-        entitiesAvailable: true,
-      },
-      {
-        headers: {
-          "Cache-Control": "no-store",
-          "X-Content-Type-Options": "nosniff",
-        },
-      },
-    );
+    return searchJson({
+      ok: true,
+      query,
+      groups: [],
+      total: 0,
+      hasMore: false,
+      staticTotal: 0,
+      entityTotal: 0,
+      entitiesAvailable: true,
+    });
   }
 
-  const result = await searchGlobal({ query, limit, signal: request.signal });
-  return Response.json(result, {
-    headers: {
-      // Search is interactive and backed by a changing public registry. Avoid
-      // replaying a stale empty prefix result from the browser or an edge cache.
-      "Cache-Control": "no-store",
-      "X-Content-Type-Options": "nosniff",
-    },
-  });
+  try {
+    const result = await searchGlobal({ query, limit, signal: request.signal });
+    return searchJson(result);
+  } catch (error) {
+    if (request.signal.aborted) throw error;
+    // Never let an unexpected IPA/runtime failure become HTTP 429/5xx here.
+    return searchJson(searchGlobalLocalFallback({ query, limit }));
+  }
 }

--- a/src/app/cerca/page.tsx
+++ b/src/app/cerca/page.tsx
@@ -7,6 +7,7 @@ import {
   GLOBAL_SEARCH_MAX_QUERY_LENGTH,
   GLOBAL_SEARCH_MIN_QUERY_LENGTH,
   searchGlobal,
+  searchGlobalLocalFallback,
 } from "@/lib/global-search";
 import styles from "./cerca.module.css";
 
@@ -30,10 +31,14 @@ function first(value: string | string[] | undefined): string {
 export default async function SearchPage({ searchParams }: SearchPageProps) {
   const params = await searchParams;
   const query = first(params.q).trim().slice(0, GLOBAL_SEARCH_MAX_QUERY_LENGTH);
-  const result =
-    query.length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH
-      ? await searchGlobal({ query, limit: GLOBAL_SEARCH_DEFAULT_LIMIT * 2 })
-      : null;
+  let result = null;
+  if (query.length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+    try {
+      result = await searchGlobal({ query, limit: GLOBAL_SEARCH_DEFAULT_LIMIT * 2 });
+    } catch {
+      result = searchGlobalLocalFallback({ query, limit: GLOBAL_SEARCH_DEFAULT_LIMIT * 2 });
+    }
+  }
 
   return (
     <main className="shell page">

--- a/src/app/enti/[codice]/page.tsx
+++ b/src/app/enti/[codice]/page.tsx
@@ -84,7 +84,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   try {
     const entity = await getIpaEntityByCode(normalizedCode);
-    if (!entity) return { title: "Ente non trovato" };
+    if (!entity) return { title: "Ente non trovato", robots: entityRobots };
 
     return {
       title: entity.denominazione,
@@ -92,7 +92,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       robots: entityRobots,
     };
   } catch {
-    return { title: "Ente", robots: entityRobots };
+    // Avoid a second live IPA round-trip on failure: the page body already
+    // handles snapshot/ANAC fallback without turning upstream 429 into metadata errors.
+    return {
+      title: `Ente ${normalizedCode}`,
+      robots: entityRobots,
+    };
   }
 }
 

--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -11,7 +11,7 @@ import {
   type SearchResult,
 } from "@/lib/global-search-contract";
 
-const DEBOUNCE_MS = 200;
+const DEBOUNCE_MS = 400;
 const SUGGESTION_LIMIT = 8;
 
 function flattenResults(response: GlobalSearchResponse | null): readonly SearchResult[] {

--- a/src/lib/data/source-fetch.ts
+++ b/src/lib/data/source-fetch.ts
@@ -22,6 +22,17 @@ type SourceFetchOptions = Omit<NextFetchOptions, "next" | "signal" | "cache"> & 
   maxRetries?: number;
   /** Cannot exceed the source policy. Floor is 1 second. */
   timeoutMs?: number;
+  /**
+   * `revalidate` (default) uses Next data cache tags.
+   * `no-store` is for interactive UI paths: avoids associating upstream 4xx/5xx
+   * (especially 429) with the document response in the App Router.
+   */
+  cacheMode?: "revalidate" | "no-store";
+  /**
+   * When true, non-OK HTTP statuses cancel the body and throw SourceFetchError
+   * instead of returning the Response. Prefer this for Server Components.
+   */
+  rejectHttpError?: boolean;
 };
 
 const ALLOWED_HOSTS: Readonly<Record<SourceId, readonly string[]>> = {
@@ -79,17 +90,29 @@ const SOURCE_USER_AGENTS: Partial<Readonly<Record<SourceId, string>>> = {
 export class SourceFetchError extends Error {
   readonly sourceId: SourceId;
   readonly cause?: unknown;
+  readonly httpStatus?: number;
 
   constructor(
     message: string,
     sourceId: SourceId,
     cause?: unknown,
+    httpStatus?: number,
   ) {
     super(message);
     this.name = "SourceFetchError";
     this.sourceId = sourceId;
     this.cause = cause;
+    this.httpStatus = httpStatus;
   }
+}
+
+/** True when the upstream asked us to back off (do not issue a second IPA call). */
+export function isUpstreamOverloadedError(error: unknown): boolean {
+  if (error instanceof SourceFetchError) {
+    return error.httpStatus === 429 || error.httpStatus === 503;
+  }
+  if (!(error instanceof Error)) return false;
+  return /\bHTTP (429|503)\b/.test(error.message);
 }
 
 function assertOfficialUrl(sourceId: SourceId, rawUrl: string): URL {
@@ -171,6 +194,8 @@ export async function fetchOfficialSource(
   const cacheTags = [...new Set([...policy.tags, ...(options.tags ?? [])])];
   const requestedRevalidate = options.revalidateSeconds ?? revalidateFor(sourceId, kind);
   const revalidate = Math.max(1, Math.trunc(requestedRevalidate));
+  const cacheMode = options.cacheMode ?? "revalidate";
+  const rejectHttpError = options.rejectHttpError === true;
 
   const {
     kind: _kind,
@@ -178,6 +203,8 @@ export async function fetchOfficialSource(
     tags: _tags,
     maxRetries: _maxRetries,
     timeoutMs: _timeoutMs,
+    cacheMode: _cacheMode,
+    rejectHttpError: _rejectHttpError,
     signal: callerSignal,
     headers,
     ...requestOptions
@@ -187,6 +214,8 @@ export async function fetchOfficialSource(
   void _tags;
   void _maxRetries;
   void _timeoutMs;
+  void _cacheMode;
+  void _rejectHttpError;
 
   const method = (requestOptions.method ?? "GET").toUpperCase();
   if (method !== "GET" && method !== "HEAD") {
@@ -208,18 +237,33 @@ export async function fetchOfficialSource(
         headers: requestHeaders(sourceId, headers),
         redirect: requestOptions.redirect ?? "error",
         signal: composedSignal(callerSignal, timeoutMs),
-        next: {
-          revalidate,
-          tags: cacheTags,
-        },
+        ...(cacheMode === "no-store"
+          ? { cache: "no-store" as const }
+          : {
+              next: {
+                revalidate,
+                tags: cacheTags,
+              },
+            }),
       });
 
       if (!RETRYABLE_STATUS.has(response.status) || attempt === retries) {
+        if (rejectHttpError && !response.ok) {
+          const status = response.status;
+          await response.body?.cancel().catch(() => undefined);
+          throw new SourceFetchError(
+            `Fonte ${sourceId} HTTP ${status}`,
+            sourceId,
+            undefined,
+            status,
+          );
+        }
         return response;
       }
 
       await response.body?.cancel();
     } catch (error) {
+      if (error instanceof SourceFetchError) throw error;
       lastError = error;
       if (callerSignal?.aborted) throw callerSignal.reason;
       if (attempt === retries) {

--- a/src/lib/global-search.ts
+++ b/src/lib/global-search.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/ipa";
 import { municipalityName } from "@/lib/municipality-name";
 import { getMunicipalitySearchEntities } from "@/lib/siope-municipality-detail";
+import { isUpstreamOverloadedError } from "@/lib/data/source-fetch";
 import {
   PRIMARY_NAV,
   SITE_MAP_GROUPS,
@@ -606,6 +607,46 @@ function emptyResponse(query: string, entitiesAvailable = true): GlobalSearchRes
   };
 }
 
+/** Local-only search used when IPA must not be contacted again (overload/abort recovery). */
+export function searchGlobalLocalFallback(input: {
+  query: string;
+  limit?: number;
+}): GlobalSearchResponse {
+  const query = input.query.trim().slice(0, GLOBAL_SEARCH_MAX_QUERY_LENGTH);
+  const normalizedQuery = normalizeSearchText(query);
+  if (normalizedQuery.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+    return emptyResponse(query, false);
+  }
+
+  const limit = safeLimit(input.limit);
+  const staticResults = searchSiteDocuments(query);
+  const entityLimit = Math.min(50, Math.max(limit * 3, 12));
+  const municipalityResults = rankEntitySearchResults(
+    getMunicipalitySearchEntities(),
+    normalizedQuery,
+  ).slice(0, entityLimit);
+
+  const byHref = new Map<string, SearchResult>();
+  for (const result of [...staticResults, ...municipalityResults]) {
+    const existing = byHref.get(result.href);
+    if (!existing || compareResults(result, existing) < 0) byHref.set(result.href, result);
+  }
+  const combined = [...byHref.values()].sort(compareResults);
+  const visible = combined.slice(0, limit);
+  const total = staticResults.length + municipalityResults.length;
+
+  return {
+    ok: true,
+    query,
+    groups: groupResults(visible),
+    total,
+    hasMore: total > visible.length,
+    staticTotal: staticResults.length,
+    entityTotal: municipalityResults.length,
+    entitiesAvailable: false,
+  };
+}
+
 function safeLimit(value: number | undefined): number {
   if (!Number.isFinite(value)) return GLOBAL_SEARCH_DEFAULT_LIMIT;
   return Math.min(Math.max(Math.trunc(value as number), 1), GLOBAL_SEARCH_MAX_LIMIT);
@@ -644,8 +685,10 @@ export async function searchGlobal(input: {
       });
     } catch (error) {
       if (input.signal?.aborted) throw input.signal.reason ?? error;
+      // 429/503: do not issue a second IPA call; fail closed to local municipalities.
+      if (isUpstreamOverloadedError(error)) throw error;
       // Keep the existing full-text adapter as a fail-safe when the optional
-      // SQL search endpoint is unavailable upstream.
+      // SQL search endpoint is unavailable upstream for other reasons.
       entitySearch = await searchIpaEntities({
         query: normalizedQuery,
         limit: entityLimit,

--- a/src/lib/ipa-stats.ts
+++ b/src/lib/ipa-stats.ts
@@ -50,11 +50,11 @@ export async function getIpaTypeDistribution(limit = 8): Promise<{
     kind: "data",
     headers: { Accept: "application/json" },
     tags: ["dataset:ipa-enti", "view:ipa-types"],
+    maxRetries: 0,
+    timeoutMs: 4_000,
+    cacheMode: "no-store",
+    rejectHttpError: true,
   });
-
-  if (!response.ok) {
-    throw new Error(`IPA SQL upstream HTTP ${response.status}`);
-  }
 
   const payload = (await response.json()) as SqlResponse;
   if (!payload.success || !Array.isArray(payload.result?.records)) {

--- a/src/lib/ipa-structure.ts
+++ b/src/lib/ipa-structure.ts
@@ -68,9 +68,11 @@ async function fetchRecords(
     headers: { Accept: "application/json" },
     tags: ["dataset:ipa-structure", `entity:${codiceIpa}`],
     signal,
+    maxRetries: 0,
+    timeoutMs: 4_000,
+    cacheMode: "no-store",
+    rejectHttpError: true,
   });
-
-  if (!response.ok) throw new Error(`IPA struttura upstream HTTP ${response.status}`);
 
   const payload = (await response.json()) as DatastoreResponse;
   if (!payload.success || !Array.isArray(payload.result?.records)) {

--- a/src/lib/ipa.ts
+++ b/src/lib/ipa.ts
@@ -238,13 +238,12 @@ async function datastoreRequest(
     headers: { Accept: "application/json" },
     signal,
     tags: ["dataset:ipa-enti"],
-    maxRetries: fetchOptions.maxRetries,
-    timeoutMs: fetchOptions.timeoutMs,
+    maxRetries: fetchOptions.maxRetries ?? 0,
+    timeoutMs: fetchOptions.timeoutMs ?? 4_000,
+    // Interactive entity/search paths must not let upstream 429 become the page status.
+    cacheMode: "no-store",
+    rejectHttpError: true,
   });
-
-  if (!response.ok) {
-    throw new Error(`IPA upstream HTTP ${response.status}`);
-  }
 
   const payload = (await response.json()) as CkanDatastoreResponse;
 
@@ -336,11 +335,11 @@ export async function searchIpaEntitiesByPrefix(options: {
     headers: { Accept: "application/json" },
     signal: options.signal,
     tags: ["dataset:ipa-enti", "view:global-search"],
+    maxRetries: 0,
+    timeoutMs: 4_000,
+    cacheMode: "no-store",
+    rejectHttpError: true,
   });
-
-  if (!response.ok) {
-    throw new Error(`IPA SQL upstream HTTP ${response.status}`);
-  }
 
   const payload = (await response.json()) as CkanSqlResponse;
   if (!payload.success || !Array.isArray(payload.result?.records)) {

--- a/tests/global-search-route.test.mjs
+++ b/tests/global-search-route.test.mjs
@@ -71,6 +71,31 @@ test("query vuota o di un carattere non chiama IPA", async () => {
   assert.equal(fetchCalls.length, 0);
 });
 
+test("su 429 IPA non ripete il fallback full-text e resta HTTP 200", async () => {
+  fetchCalls.length = 0;
+  globalThis.fetch = async (input, init = {}) => {
+    fetchCalls.push({ input: String(input), init });
+    return new Response("Too Many Requests", { status: 429 });
+  };
+
+  const response = await GET(request("?q=asl&limit=8"));
+  assert.equal(response.status, 200);
+  assertErrorHeaders(response);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.entitiesAvailable, false);
+  assert.equal(fetchCalls.length, 1, "un 429 non deve aprire il secondo adapter IPA");
+  assert.ok(fetchCalls[0].input.includes("datastore_search_sql"));
+
+  globalThis.fetch = async (input, init = {}) => {
+    fetchCalls.push({ input: String(input), init });
+    return new Response(JSON.stringify({ success: false }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+});
+
 test("il fallback IPA resta una risposta controllata e riceve il signal", async () => {
   fetchCalls.length = 0;
   const response = await GET(request("?q=Roma&limit=8"));

--- a/tests/header-search.test.mjs
+++ b/tests/header-search.test.mjs
@@ -19,6 +19,7 @@ test("la ricerca usa la query rifilata e riparte anche per variazioni di spaziat
     headerSearch,
     /const showDropdown = open && trimmedQuery\.length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH;/,
   );
+  assert.match(headerSearch, /const DEBOUNCE_MS = 400;/);
 
   for (const rawQuery of ["  Roma", "Roma  ", "  Roma  "]) {
     assert.equal(rawQuery.trim(), "Roma");

--- a/tests/source-fetch-ipa-interactive.test.mjs
+++ b/tests/source-fetch-ipa-interactive.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const {
+  SourceFetchError,
+  fetchOfficialSource,
+  isUpstreamOverloadedError,
+} = await import("../src/lib/data/source-fetch.ts");
+
+test("rejectHttpError throws SourceFetchError without returning a 429 Response", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("slow down", { status: 429 });
+
+  try {
+    await assert.rejects(
+      () =>
+        fetchOfficialSource(
+          "ipa",
+          "https://www.indicepa.gov.it/ipa-dati/api/3/action/datastore_search?resource_id=d09adf99-dc10-4349-8c53-27b1e5aa97b6&limit=0",
+          { cacheMode: "no-store", rejectHttpError: true, maxRetries: 0, timeoutMs: 1000 },
+        ),
+      (error) => {
+        assert.ok(error instanceof SourceFetchError);
+        assert.equal(error.httpStatus, 429);
+        assert.equal(isUpstreamOverloadedError(error), true);
+        return true;
+      },
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("no-store interactive fetches do not attach a Next revalidate cache policy", async () => {
+  const originalFetch = globalThis.fetch;
+  /** @type {RequestInit | undefined} */
+  let seenInit;
+  globalThis.fetch = async (_input, init = {}) => {
+    seenInit = init;
+    return new Response(JSON.stringify({ success: true, result: { records: [], total: 0 } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const response = await fetchOfficialSource(
+      "ipa",
+      "https://www.indicepa.gov.it/ipa-dati/api/3/action/datastore_search?resource_id=d09adf99-dc10-4349-8c53-27b1e5aa97b6&limit=0",
+      { cacheMode: "no-store", maxRetries: 0, timeoutMs: 1000 },
+    );
+    assert.equal(response.status, 200);
+    assert.equal(seenInit?.cache, "no-store");
+    assert.equal(seenInit?.next, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- IPA / struttura / stats in percorsi interattivi usano `cacheMode: \"no-store\"` + `rejectHttpError`: un 429 upstream non diventa più lo status della pagina Next.
- Ricerca: su 429/503 niente secondo adapter IPA; `/api/search` e `/cerca` restano HTTP 200 con comuni locali e `entitiesAvailable: false`.
- Autocomplete header: debounce 200→400ms per ridurre la pressione su Indice PA.

## Test plan
- [x] `tests/source-fetch-ipa-interactive.test.mjs`
- [x] `tests/global-search-route.test.mjs` (incluso caso 429 → 1 sola fetch, status 200)
- [x] `tests/header-search.test.mjs`
- [ ] Produzione: cercare `asl`, aprire `/enti/asl_fg` — mai pagina nuda «Too Many Requests»; al massimo notice IPA / snapshot ANAC
- [ ] Comuni (`/enti/c_f205`) restano ok

Made with [Cursor](https://cursor.com)