### PR TITLE
fix(search): evita che i 429 IPA diventino pagine Too Many Requests

### DIFF
--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -11,8 +11,18 @@ import {
   type SearchResult,
 } from "@/lib/global-search-contract";
 
-const DEBOUNCE_MS = 400;
+const DEBOUNCE_MS = 600;
 const SUGGESTION_LIMIT = 8;
+const CLIENT_SEARCH_CACHE_LIMIT = 24;
+
+const clientSearchCache = new Map<string, GlobalSearchResponse>();
+
+function rememberClientSearch(query: string, payload: GlobalSearchResponse): void {
+  clientSearchCache.set(query, payload);
+  if (clientSearchCache.size <= CLIENT_SEARCH_CACHE_LIMIT) return;
+  const oldest = clientSearchCache.keys().next().value;
+  if (oldest !== undefined) clientSearchCache.delete(oldest);
+}
 
 function flattenResults(response: GlobalSearchResponse | null): readonly SearchResult[] {
   return response?.groups.flatMap((group) => group.results) ?? [];
@@ -43,6 +53,15 @@ export function HeaderSearch() {
       return;
     }
 
+    const cached = clientSearchCache.get(effectQuery);
+    if (cached) {
+      setResponse(cached);
+      setActiveIndex(-1);
+      setSearchError(false);
+      setLoading(false);
+      return;
+    }
+
     const timer = setTimeout(() => {
       const controller = new AbortController();
       abortRef.current = controller;
@@ -57,6 +76,7 @@ export function HeaderSearch() {
         })
         .then((payload) => {
           if (requestId !== requestIdRef.current || payload.ok !== true) return;
+          rememberClientSearch(effectQuery, payload);
           setResponse(payload);
           setActiveIndex(-1);
           setSearchError(false);

--- a/src/components/header-search.tsx
+++ b/src/components/header-search.tsx
@@ -53,16 +53,18 @@ export function HeaderSearch() {
       return;
     }
 
-    const cached = clientSearchCache.get(effectQuery);
-    if (cached) {
-      setResponse(cached);
-      setActiveIndex(-1);
-      setSearchError(false);
-      setLoading(false);
-      return;
-    }
-
     const timer = setTimeout(() => {
+      if (requestId !== requestIdRef.current) return;
+
+      const cached = clientSearchCache.get(effectQuery);
+      if (cached) {
+        setResponse(cached);
+        setActiveIndex(-1);
+        setSearchError(false);
+        setLoading(false);
+        return;
+      }
+
       const controller = new AbortController();
       abortRef.current = controller;
       setLoading(true);

--- a/src/lib/data/source-fetch.ts
+++ b/src/lib/data/source-fetch.ts
@@ -1,3 +1,5 @@
+import http from "node:http";
+import https from "node:https";
 import { setTimeout as delay } from "node:timers/promises";
 import { APP_USER_AGENT, IPA_USER_AGENT } from "@/lib/app-version";
 import { MEF_IRPEF_SOURCE } from "@/lib/data/mef-irpef-source";
@@ -109,10 +111,95 @@ export class SourceFetchError extends Error {
 /** True when the upstream asked us to back off (do not issue a second IPA call). */
 export function isUpstreamOverloadedError(error: unknown): boolean {
   if (error instanceof SourceFetchError) {
-    return error.httpStatus === 429 || error.httpStatus === 503;
+    return (
+      error.httpStatus === 429
+      || error.httpStatus === 500
+      || error.httpStatus === 502
+      || error.httpStatus === 503
+      || error.httpStatus === 504
+    );
   }
   if (!(error instanceof Error)) return false;
-  return /\bHTTP (429|503)\b/.test(error.message);
+  return /\bHTTP (429|500|502|503|504)\b/.test(error.message);
+}
+
+/**
+ * Interactive `no-store` paths must not use Next's patched `fetch`: an upstream
+ * 429/5xx Response can still be associated with the App Router document status
+ * and surface as Vercel's "Too Many Requests" page even after we throw locally.
+ * Node's http(s) client keeps that status off the flight response.
+ *
+ * Tests that mock `globalThis.fetch` set `DVNS_SOURCE_FETCH_USE_GLOBAL=1`.
+ */
+function shouldBypassNextFetch(cacheMode: "revalidate" | "no-store"): boolean {
+  if (cacheMode !== "no-store") return false;
+  return process.env.DVNS_SOURCE_FETCH_USE_GLOBAL !== "1";
+}
+
+function fetchViaNodeHttp(
+  url: URL,
+  init: Readonly<{
+    method: string;
+    headers: Headers;
+    signal?: AbortSignal;
+  }>,
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    if (init.signal?.aborted) {
+      reject(init.signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+      return;
+    }
+
+    const transport = url.protocol === "https:" ? https : http;
+    const requestHeaders: Record<string, string> = {};
+    init.headers.forEach((value, key) => {
+      requestHeaders[key] = value;
+    });
+
+    const req = transport.request(
+      url,
+      {
+        method: init.method,
+        headers: requestHeaders,
+      },
+      (incoming) => {
+        const chunks: Buffer[] = [];
+        incoming.on("data", (chunk: Buffer | string) => {
+          chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        });
+        incoming.on("error", reject);
+        incoming.on("end", () => {
+          const headers = new Headers();
+          for (const [key, value] of Object.entries(incoming.headers)) {
+            if (value === undefined) continue;
+            if (Array.isArray(value)) {
+              for (const item of value) headers.append(key, item);
+            } else {
+              headers.set(key, value);
+            }
+          }
+          resolve(
+            new Response(Buffer.concat(chunks), {
+              status: incoming.statusCode ?? 0,
+              statusText: incoming.statusMessage,
+              headers,
+            }),
+          );
+        });
+      },
+    );
+
+    const onAbort = () => {
+      req.destroy();
+      reject(init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+    };
+    init.signal?.addEventListener("abort", onAbort, { once: true });
+    req.on("error", (error) => {
+      init.signal?.removeEventListener("abort", onAbort);
+      reject(error);
+    });
+    req.end();
+  });
 }
 
 function assertOfficialUrl(sourceId: SourceId, rawUrl: string): URL {
@@ -227,25 +314,35 @@ export async function fetchOfficialSource(
 
   let lastError: unknown;
 
+  const requestHeadersValue = requestHeaders(sourceId, headers);
+  const bypassNextFetch = shouldBypassNextFetch(cacheMode);
+
   for (let attempt = 0; attempt <= retries; attempt += 1) {
     if (callerSignal?.aborted) throw callerSignal.reason;
 
     try {
-      const response = await fetch(url, {
-        ...requestOptions,
-        method,
-        headers: requestHeaders(sourceId, headers),
-        redirect: requestOptions.redirect ?? "error",
-        signal: composedSignal(callerSignal, timeoutMs),
-        ...(cacheMode === "no-store"
-          ? { cache: "no-store" as const }
-          : {
-              next: {
-                revalidate,
-                tags: cacheTags,
-              },
-            }),
-      });
+      const requestSignal = composedSignal(callerSignal, timeoutMs);
+      const response = bypassNextFetch
+        ? await fetchViaNodeHttp(url, {
+            method,
+            headers: requestHeadersValue,
+            signal: requestSignal,
+          })
+        : await fetch(url, {
+            ...requestOptions,
+            method,
+            headers: requestHeadersValue,
+            redirect: requestOptions.redirect ?? "error",
+            signal: requestSignal,
+            ...(cacheMode === "no-store"
+              ? { cache: "no-store" as const }
+              : {
+                  next: {
+                    revalidate,
+                    tags: cacheTags,
+                  },
+                }),
+          });
 
       if (!RETRYABLE_STATUS.has(response.status) || attempt === retries) {
         if (rejectHttpError && !response.ok) {

--- a/src/lib/global-search.ts
+++ b/src/lib/global-search.ts
@@ -685,10 +685,10 @@ export async function searchGlobal(input: {
       });
     } catch (error) {
       if (input.signal?.aborted) throw input.signal.reason ?? error;
-      // 429/503: do not issue a second IPA call; fail closed to local municipalities.
+      // Overload/5xx: never open a second IPA adapter — it amplifies 429 pages.
       if (isUpstreamOverloadedError(error)) throw error;
-      // Keep the existing full-text adapter as a fail-safe when the optional
-      // SQL search endpoint is unavailable upstream for other reasons.
+      // Keep the existing full-text adapter only when the SQL endpoint itself
+      // rejects the query shape (non-HTTP contract failures stay local above).
       entitySearch = await searchIpaEntities({
         query: normalizedQuery,
         limit: entityLimit,

--- a/tests/global-search-route.test.mjs
+++ b/tests/global-search-route.test.mjs
@@ -1,3 +1,5 @@
+process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = "1";
+
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";

--- a/tests/global-search.test.mjs
+++ b/tests/global-search.test.mjs
@@ -267,6 +267,7 @@ test("site search has no duplicate destinations and exposes useful Italian alias
 });
 
 test("municipal snapshot search finds major cities by keyword", async () => {
+  process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = "1";
   const { searchGlobal } = await import("../src/lib/global-search.ts");
   const fetchCalls = [];
   const originalFetch = globalThis.fetch;
@@ -292,7 +293,9 @@ test("municipal snapshot search finds major cities by keyword", async () => {
       ),
       "Bologna should be discoverable from the committed municipal snapshot",
     );
-    assert.ok(fetchCalls.length >= 4, "IPA SQL plus full-text fallback per query");
+    // One IPA SQL attempt per query; 5xx must not open the full-text adapter.
+    assert.equal(fetchCalls.length, 2);
+    assert.ok(fetchCalls.every((url) => url.includes("datastore_search_sql")));
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/header-search.test.mjs
+++ b/tests/header-search.test.mjs
@@ -19,7 +19,8 @@ test("la ricerca usa la query rifilata e riparte anche per variazioni di spaziat
     headerSearch,
     /const showDropdown = open && trimmedQuery\.length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH;/,
   );
-  assert.match(headerSearch, /const DEBOUNCE_MS = 400;/);
+  assert.match(headerSearch, /const DEBOUNCE_MS = 600;/);
+  assert.match(headerSearch, /clientSearchCache/);
 
   for (const rawQuery of ["  Roma", "Roma  ", "  Roma  "]) {
     assert.equal(rawQuery.trim(), "Roma");

--- a/tests/source-fetch-ipa-interactive.test.mjs
+++ b/tests/source-fetch-ipa-interactive.test.mjs
@@ -1,3 +1,5 @@
+process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = "1";
+
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
@@ -55,5 +57,55 @@ test("no-store interactive fetches do not attach a Next revalidate cache policy"
     assert.equal(seenInit?.next, undefined);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("isUpstreamOverloadedError includes gateway 5xx that amplify IPA retries", () => {
+  assert.equal(
+    isUpstreamOverloadedError(new SourceFetchError("Fonte ipa HTTP 500", "ipa", undefined, 500)),
+    true,
+  );
+  assert.equal(
+    isUpstreamOverloadedError(new SourceFetchError("Fonte ipa HTTP 502", "ipa", undefined, 502)),
+    true,
+  );
+  assert.equal(
+    isUpstreamOverloadedError(new Error("IPA SQL upstream HTTP 500")),
+    true,
+  );
+  assert.equal(
+    isUpstreamOverloadedError(new SourceFetchError("Fonte ipa HTTP 404", "ipa", undefined, 404)),
+    false,
+  );
+});
+
+test("no-store production path bypasses global fetch (Next patch)", async () => {
+  const previous = process.env.DVNS_SOURCE_FETCH_USE_GLOBAL;
+  delete process.env.DVNS_SOURCE_FETCH_USE_GLOBAL;
+
+  let globalFetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    globalFetchCalls += 1;
+    return new Response("should-not-run", { status: 599 });
+  };
+
+  try {
+    // Host not allowed for IPA — assertOfficialUrl fails before network.
+    await assert.rejects(
+      () =>
+        fetchOfficialSource("ipa", "https://example.com/x", {
+          cacheMode: "no-store",
+          rejectHttpError: true,
+          maxRetries: 0,
+          timeoutMs: 1000,
+        }),
+      /Host non consentito/,
+    );
+    assert.equal(globalFetchCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previous === undefined) delete process.env.DVNS_SOURCE_FETCH_USE_GLOBAL;
+    else process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = previous;
   }
 });


### PR DESCRIPTION
## Summary
- I path IPA interattivi (`cacheMode: no-store`) non usano più il `fetch` patchato da Next: uno status 429/5xx di Indice PA poteva ancora diventare la pagina Vercel «Too Many Requests» (es. cercando `asl` e aprendo una scheda ASL).
- In ricerca globale, anche HTTP 500/502/504 chiudono senza secondo adapter IPA (prima il 500 raddoppiava il carico).
- Autocomplete header: debounce 600ms + cache client delle risposte riuscite.

## Test plan
- [x] `node --test tests/source-fetch-ipa-interactive.test.mjs tests/global-search-route.test.mjs tests/global-search.test.mjs tests/header-search.test.mjs`
- [ ] Dopo il deploy: cercare `asl` nell’header e in `/cerca?q=asl` — deve restare 200 anche se Indice PA limita
- [ ] Aprire una scheda ASL (`/enti/asl_fg`): se IPA è in 429, fallback ANAC/avviso, non pagina «Too Many Requests»

Made with [Cursor](https://cursor.com)