### PR TITLE
feat(enti): scheda comunale più leggibile per i cittadini

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -1323,6 +1323,10 @@ try {
         assertTextMatches(text, /Da gennaio ad agosto 2026/i, label);
         assertTextMatches(text, /Dati parziali/i, label);
         assertTextMatches(text, /Per cosa ha pagato il Comune/i, label);
+        assertTextMatches(text, /Costi di funzionamento quotidiano/i, label);
+        assertTextMatches(text, /Valore tipico \(mediana\)/i, label);
+        assertTextMatches(text, /Scala OpenCivitas da 0 a 10/i, label);
+        assertTextMatches(text, /non dimostra spreco/i, label);
         assertTextMatches(text, /Pagamenti registrati per anno/i, label);
         assertTextMatches(text, /Confronti e dettaglio territoriale/i, label);
         assertTextMatches(text, /Altre categorie/i, label);

--- a/src/app/enti/[codice]/municipality-economics.tsx
+++ b/src/app/enti/[codice]/municipality-economics.tsx
@@ -2,7 +2,11 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import { compactEuro, exactEuro, integer, longDate, percent } from "@/lib/format";
 import type { MunicipalityProfile } from "@/lib/municipality-profile";
-import { buildMunicipalitySpendingRows } from "@/lib/municipality-spending-view";
+import {
+  buildMunicipalitySpendingRows,
+  explainMunicipalitySpendingTitle,
+  municipalitySpendingTitleLabel,
+} from "@/lib/municipality-spending-view";
 import type { ReportedMeasure } from "@/lib/mef-irpef-snapshot";
 import styles from "./scheda.module.css";
 
@@ -46,15 +50,18 @@ function servicesComparison(basisPoints: number): string {
   return `${percent(Math.abs(basisPoints) / 100)} ${basisPoints > 0 ? "in più" : "in meno"}`;
 }
 
-const titleExplanations: Readonly<Record<string, string>> = {
-  "0": "Pagamenti ancora da classificare nella voce contabile definitiva.",
-  "1": "Servizi, personale, acquisti e altre spese di funzionamento.",
-  "2": "Opere pubbliche, investimenti e acquisto di beni durevoli.",
-  "3": "Acquisizioni di partecipazioni, crediti e altre attività finanziarie.",
-  "4": "Restituzione della quota capitale di prestiti e mutui.",
-  "5": "Restituzione di anticipazioni ricevute dal tesoriere.",
-  "7": "Somme incassate o pagate per conto di terzi e partite di giro.",
-};
+function openCivitasLevelGuide(level: number | null, kind: "spending" | "services"): string {
+  if (level === null) {
+    return kind === "spending"
+      ? "Livello di spesa non pubblicato dalla fonte per questo Comune."
+      : "Livello dei servizi non pubblicato dalla fonte per questo Comune.";
+  }
+  const band = level <= 5 ? "nella metà bassa" : "nella metà alta";
+  if (kind === "spending") {
+    return `Scala OpenCivitas da 0 a 10: ${level} è ${band}. Non è un voto e non dimostra da solo spreco o virtù.`;
+  }
+  return `Scala OpenCivitas da 0 a 10: ${level} è ${band}. Misura un indicatore pubblicato, non la qualità percepita dei servizi.`;
+}
 
 function coverageText(year: MunicipalityProfile["siope"]["data"]["years"][number]): string {
   return year.completeness === "partial"
@@ -98,6 +105,11 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
             <h2 className={styles.sectionTitle} id="siope-title">Quanto ha pagato il Comune</h2>
           </div>
         </div>
+        <p className={styles.readingGuide} data-siope-reading-guide>
+          Qui trovi i pagamenti di cassa registrati da SIOPE: quanto è uscito dai conti del Comune nel periodo.
+          Non coincidono sempre con il servizio ricevuto sul territorio, perché un pagamento può riguardare
+          terzi, mutui o partite di giro.
+        </p>
 
         <dl className={styles.paymentSummary} aria-label={`Sintesi dei pagamenti ${latestSiope.year}`}>
           <div className={styles.paymentTotal}>
@@ -121,6 +133,7 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
                   ? "Non disponibile"
                   : roundedEuro(latestSiope.perCapitaCents)}
               </dd>
+              <small>Totale diviso per la popolazione ISTAT usata nella scheda</small>
             </div>
             <div>
               <dt>Per km²</dt>
@@ -129,7 +142,9 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
                   ? "Non disponibile"
                   : exactEuro(latestSiope.perSquareKmCents / 100)}
               </dd>
-              {geography ? <small>Superficie ISTAT {decimal.format(geography.surfaceSquareKilometres)} km²</small> : null}
+              {geography
+                ? <small>Superficie ISTAT {decimal.format(geography.surfaceSquareKilometres)} km²</small>
+                : <small>Normalizzazione sulla superficie del territorio</small>}
             </div>
             <div>
               <dt>Copertura</dt>
@@ -157,6 +172,10 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
               </div>
               <span className="tag tag-neutral">{peer.year}</span>
             </div>
+            <p className={styles.readingGuide} data-peer-reading-guide>
+              Il confronto mette questo Comune accanto ad altri con caratteristiche territoriali simili.
+              Serve a capire se i pagamenti sono insoliti nel gruppo, non a giudicare efficienza o qualità dei servizi.
+            </p>
             <div
               className={styles.peerTrack}
               style={{
@@ -169,20 +188,53 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
               <span aria-hidden="true"><i /><b /></span>
             </div>
             <dl className={styles.peerValues}>
-              <div><dt>Comune</dt><dd>{exactEuro(latestSiope.perSquareKmCents / 100)} / km²</dd></div>
-              <div><dt>Mediana dei pari</dt><dd>{exactEuro(peer.perSquareKmCents.median / 100)} / km²</dd></div>
-              <div><dt>Fascia centrale</dt><dd>Da {exactEuro(peer.perSquareKmCents.p25 / 100)} a {exactEuro(peer.perSquareKmCents.p75 / 100)}</dd></div>
+              <div>
+                <dt>Questo Comune</dt>
+                <dd>{exactEuro(latestSiope.perSquareKmCents / 100)} / km²</dd>
+              </div>
+              <div>
+                <dt>Valore tipico dei simili</dt>
+                <dd>{exactEuro(peer.perSquareKmCents.median / 100)} / km²</dd>
+                <small>Mediana dei pari</small>
+              </div>
+              <div>
+                <dt>Fascia centrale</dt>
+                <dd>Da {exactEuro(peer.perSquareKmCents.p25 / 100)} a {exactEuro(peer.perSquareKmCents.p75 / 100)}</dd>
+                <small>Metà centrale dei Comuni simili</small>
+              </div>
             </dl>
             {peer.perCapitaCents && latestSiope.perCapitaCents !== null ? (
               <dl className={styles.peerValues} aria-label="Confronto per abitante con Comuni simili">
-                <div><dt>Comune per abitante</dt><dd>{roundedEuro(latestSiope.perCapitaCents)}</dd></div>
-                <div><dt>Mediana pari / ab.</dt><dd>{roundedEuro(peer.perCapitaCents.median)}</dd></div>
                 <div>
-                  <dt>Fascia centrale / ab.</dt>
+                  <dt>Questo Comune / abitante</dt>
+                  <dd>{roundedEuro(latestSiope.perCapitaCents)}</dd>
+                </div>
+                <div>
+                  <dt>Valore tipico / abitante</dt>
+                  <dd>{roundedEuro(peer.perCapitaCents.median)}</dd>
+                  <small>Mediana dei pari</small>
+                </div>
+                <div>
+                  <dt>Fascia centrale / abitante</dt>
                   <dd>Da {roundedEuro(peer.perCapitaCents.p25)} a {roundedEuro(peer.perCapitaCents.p75)}</dd>
+                  <small>Dal 25° al 75° percentile</small>
                 </div>
               </dl>
             ) : null}
+            <ul className={styles.termGlossary} data-peer-glossary>
+              <li>
+                <strong>Valore tipico (mediana)</strong>
+                <span>È il Comune di mezzo nel gruppo: metà spende di meno, metà di più.</span>
+              </li>
+              <li>
+                <strong>Fascia centrale</strong>
+                <span>Intervallo in cui si colloca la metà centrale dei Comuni simili, escludendo i valori estremi.</span>
+              </li>
+              <li>
+                <strong>Per km² e per abitante</strong>
+                <span>Due letture diverse dello stesso totale. Usale insieme: una sola può fuorviare.</span>
+              </li>
+            </ul>
             <p className={styles.sourceNote}>Il confronto è descrittivo: non misura efficienza, qualità dei servizi o spesa necessaria.</p>
           </section>
         ) : null}
@@ -190,7 +242,10 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
         {latestSiope.hasMovements ? (
           <div className={styles.spendingBreakdown}>
             <h3>Per cosa ha pagato il Comune</h3>
-            <p>Le categorie contabili mostrate compongono il totale registrato nel periodo.</p>
+            <p>
+              Le voci sotto sono categorie contabili SIOPE, riscritte in linguaggio comune.
+              Insieme compongono il totale registrato nel periodo.
+            </p>
             <div aria-label={`Principali pagamenti ${latestSiope.year} per categoria SIOPE`}>
               {spendingRows.map((title) => {
                 const share = latestSiope.totalCents
@@ -198,9 +253,12 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
                   : 0;
                 return (
                   <div className={styles.spendingRow} key={title.key}>
-                    <div>
-                      <strong>{title.label}</strong>
-                      <span>{percent(share)}</span>
+                    <div className={styles.spendingCopy}>
+                      <div className={styles.spendingHeading}>
+                        <strong>{title.label}</strong>
+                        <span>{percent(share)}</span>
+                      </div>
+                      <p>{title.explanation}</p>
                     </div>
                     <div className={styles.spendingTrack} aria-hidden="true">
                       <span style={{ "--share": `${share}%` } as CSSProperties} />
@@ -212,15 +270,20 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
             </div>
             <details className={styles.methodDetails} data-siope-titles>
               <summary>Cosa significano i Titoli SIOPE?</summary>
-              <p>I numeri sono codici contabili, non una graduatoria. Il Titolo 6 non appartiene alle uscite.</p>
+              <p>
+                I numeri sono codici contabili ufficiali, non una graduatoria di merito.
+                Il Titolo 6 non appartiene alle uscite.
+              </p>
               <dl>
                 {latestSiope.titles
                   .slice()
                   .sort((left, right) => Number(left.code) - Number(right.code))
                   .map((title) => (
                     <div key={title.code}>
-                      <dt>Titolo {title.code} · {title.label}</dt>
-                      <dd>{titleExplanations[title.code]}</dd>
+                      <dt>
+                        Titolo {title.code} · {municipalitySpendingTitleLabel(title.code, title.label)}
+                      </dt>
+                      <dd>{explainMunicipalitySpendingTitle(title.code)}</dd>
                     </div>
                   ))}
               </dl>
@@ -340,11 +403,17 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
         </div>
         {openCivitas ? (
           <>
+            <p className={styles.readingGuide} data-opencivitas-reading-guide>
+              OpenCivitas confronta la spesa storica del Comune con un valore di riferimento (spesa standard)
+              calcolato sulle caratteristiche del territorio e sui servizi analizzati dalla fonte.
+              Una differenza in più o in meno non dimostra spreco: va letta insieme ai servizi e al contesto locale.
+            </p>
             <div className={styles.benchmarkBlock}>
               <h3>Spesa registrata e valore di riferimento</h3>
               <p>
-                La spesa standard è un valore di riferimento calcolato considerando le caratteristiche del Comune
-                e i servizi analizzati dalla fonte.
+                <strong>Spesa registrata</strong> è quanto risulta speso storicamente.
+                {" "}
+                <strong>Valore di riferimento</strong> è la stima OpenCivitas del fabbisogno standard per un Comune con caratteristiche simili.
               </p>
               <ul
                 className={styles.benchmarkChart}
@@ -378,6 +447,7 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
             </div>
             <div className={styles.benchmarkBlock}>
               <h3>Spesa per abitante</h3>
+              <p>Stessi due concetti, divisi per abitante: utile per confrontare Comuni di dimensioni diverse.</p>
               <ul
                 className={styles.benchmarkChart}
                 aria-label={`Spesa per abitante storica e standard ${openCivitas.referenceYear}`}
@@ -386,12 +456,12 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
                   {
                     amountCents: openCivitas.record.historicalPerCapitaCents,
                     key: "historical-pc",
-                    label: "Registrata / ab.",
+                    label: "Spesa registrata per abitante",
                   },
                   {
                     amountCents: openCivitas.record.standardPerCapitaCents,
                     key: "standard-pc",
-                    label: "Riferimento / ab.",
+                    label: "Valore di riferimento per abitante",
                   },
                 ].map((row) => (
                   <li key={row.key}>
@@ -412,28 +482,45 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
                 <dt>Differenza rispetto al valore di riferimento</dt>
                 <dd>{signedEuro(openCivitas.record.differenceCents)}</dd>
                 <small>{signedPerCapita(openCivitas.record.differencePerCapitaCents)}</small>
+                <p className={styles.metricExplain}>{openCivitas.methodology.differenceMeaning}</p>
               </div>
               <div>
                 <dt>Differenza per km²</dt>
                 <dd>{openCivitas.differencePerSquareKmCents === null ? "Non disponibile" : signedEuro(openCivitas.differencePerSquareKmCents)}</dd>
                 <small>Normalizzazione sulla superficie ISTAT {openCivitas.referenceYear}</small>
+                <p className={styles.metricExplain}>
+                  Stessa differenza di spesa, riportata sulla superficie del Comune. Utile insieme al dato per abitante.
+                </p>
               </div>
               <div>
                 <dt>Servizi rispetto a Comuni simili</dt>
                 <dd>{openCivitas.record.serviceDifferenceBasisPoints === null ? "Non valutabile" : servicesComparison(openCivitas.record.serviceDifferenceBasisPoints)}</dd>
                 <small>{openCivitas.record.serviceLevel === null ? "Indicatore non disponibile" : `Indicatore OpenCivitas: livello ${openCivitas.record.serviceLevel} su 10`}</small>
+                <p className={styles.metricExplain}>{openCivitas.methodology.serviceMeaning}</p>
               </div>
             </dl>
             <dl className={styles.metricGrid} aria-label="Livelli OpenCivitas">
               <div>
                 <dt>Livello spesa</dt>
                 <dd>{openCivitas.record.spendingLevel === null ? "n.d." : `${openCivitas.record.spendingLevel} / 10`}</dd>
+                <p className={styles.metricExplain}>{openCivitasLevelGuide(openCivitas.record.spendingLevel, "spending")}</p>
               </div>
               <div>
                 <dt>Livello servizi</dt>
                 <dd>{openCivitas.record.serviceLevel === null ? "n.d." : `${openCivitas.record.serviceLevel} / 10`}</dd>
+                <p className={styles.metricExplain}>{openCivitasLevelGuide(openCivitas.record.serviceLevel, "services")}</p>
               </div>
             </dl>
+            <ul className={styles.termGlossary} data-opencivitas-glossary>
+              <li>
+                <strong>Come leggerlo</strong>
+                <span>{openCivitas.methodology.rankingWarning}</span>
+              </li>
+              <li>
+                <strong>Copertura</strong>
+                <span>{openCivitas.methodology.coverageWarning}</span>
+              </li>
+            </ul>
             <p className={styles.sourceNote}>
               Fonte: <a href={openCivitas.source.datasetUrl} target="_blank" rel="noreferrer">OpenCivitas ↗</a>.
               La differenza dalla spesa standard non dimostra uno spreco: va letta con servizi, costi e caratteristiche locali.
@@ -452,6 +539,10 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
           </div>
           <span className="tag tag-neutral">Dati al {longDate(pnrr.referenceDate)}</span>
         </div>
+        <p className={styles.readingGuide}>
+          Elenco limitato agli interventi PNRR su asili e prima infanzia collegati a questo Comune.
+          L’importo finanziato non è necessariamente denaro già pagato.
+        </p>
         <dl className={styles.metricGrid}>
           <div><dt>Progetti collegati al Comune</dt><dd>{integer(pnrr.totalProjects)}</dd></div>
           <div>
@@ -508,6 +599,10 @@ export function MunicipalityEconomics({ profile }: { profile: MunicipalityProfil
           {irpef ? <span className="tag tag-neutral">Anno d’imposta {irpef.period.taxYear}</span> : null}
         </summary>
         <div className={styles.secondaryContent}>
+          <p className={styles.readingGuide}>
+            Questi numeri descrivono le dichiarazioni dei residenti, non il bilancio del Comune.
+            L’addizionale comunale è un’imposta dichiarata: non è una stima dell’evasione.
+          </p>
           {irpef ? (
             <>
               <dl className={styles.metricGrid}>

--- a/src/app/enti/[codice]/scheda.module.css
+++ b/src/app/enti/[codice]/scheda.module.css
@@ -291,10 +291,63 @@
   gap: var(--space-3);
   margin: 0;
 }
+.peerValues + .peerValues { margin-top: var(--space-3); }
 .peerValues dt,
 .territoryDetails dt { color: var(--color-neutral-600); font-size: 11px; text-transform: uppercase; letter-spacing: .05em; }
 .peerValues dd,
 .territoryDetails dd { margin: 4px 0 0; font-weight: 700; }
+.peerValues small {
+  display: block;
+  margin-top: 4px;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.readingGuide {
+  max-width: 72ch;
+  margin: 0 0 var(--space-4);
+  color: var(--color-neutral-700);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.termGlossary {
+  display: grid;
+  gap: var(--space-3);
+  margin: var(--space-4) 0 0;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-100);
+  list-style: none;
+}
+
+.termGlossary li {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.termGlossary strong {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.termGlossary span {
+  color: var(--color-neutral-700);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.metricExplain {
+  max-width: 42ch;
+  margin: 6px 0 0;
+  color: var(--color-neutral-600);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.45;
+}
 
 .territoryDetails {
   margin-top: var(--space-4);
@@ -344,30 +397,44 @@
 
 .spendingRow {
   display: grid;
-  grid-template-columns: minmax(150px, 1.2fr) minmax(120px, 1fr) minmax(90px, auto);
-  align-items: center;
+  grid-template-columns: minmax(180px, 1.45fr) minmax(100px, .9fr) minmax(90px, auto);
+  align-items: start;
   gap: var(--space-3);
-  padding: 10px 0;
+  padding: 12px 0;
   border-top: 1px solid var(--color-neutral-200);
 }
 
-.spendingRow > div:first-child {
+.spendingCopy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.spendingHeading {
   display: flex;
   justify-content: space-between;
   gap: var(--space-2);
   min-width: 0;
 }
+
 .spendingRow strong { font-size: 13px; }
-.spendingRow span { color: var(--color-neutral-600); font-size: 12px; }
+.spendingHeading span { color: var(--color-neutral-600); font-size: 12px; flex: none; }
+.spendingCopy > p {
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  line-height: 1.45;
+}
 .spendingRow b {
   text-align: right;
   font-family: var(--font-heading);
   font-size: 15px;
   font-variant-numeric: tabular-nums;
+  padding-top: 1px;
 }
-
 .spendingTrack {
   height: 10px;
+  margin-top: 6px;
   overflow: hidden;
   background: var(--color-neutral-200);
 }
@@ -780,8 +847,18 @@
   .peerValues,
   .territoryDetails dl { grid-template-columns: minmax(0, 1fr); }
   .metricGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .spendingRow { grid-template-columns: minmax(0, 1fr) auto; }
-  .spendingTrack { grid-column: 1 / -1; grid-row: 2; }
+  .spendingRow {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "copy amount"
+      "track track";
+  }
+  .spendingCopy { grid-area: copy; }
+  .spendingRow > b { grid-area: amount; }
+  .spendingTrack {
+    grid-area: track;
+    margin-top: 0;
+  }
   .trendChart { gap: var(--space-2); }
   .trendChart li { grid-template-rows: auto 110px auto minmax(30px, auto); }
   .trendPlot > span { width: min(58px, 62%); }

--- a/src/lib/municipality-spending-view.ts
+++ b/src/lib/municipality-spending-view.ts
@@ -8,11 +8,34 @@ const FRIENDLY_LABELS: Readonly<Record<string, string>> = {
   "7": "Partite di giro e conto terzi",
 };
 
+const TITLE_EXPLANATIONS: Readonly<Record<string, string>> = {
+  "0": "Somme già pagate ma non ancora assegnate alla voce contabile definitiva. Non indicano una destinazione di servizio.",
+  "1": "Costi di funzionamento quotidiano: personale, utenze, manutenzioni, acquisti e servizi per i cittadini.",
+  "2": "Soldi usati per opere pubbliche, lavori e beni destinati a durare nel tempo, come edifici o attrezzature.",
+  "3": "Operazioni finanziarie del Comune: partecipazioni, crediti o altre attività patrimoniali. Non sono servizi quotidiani.",
+  "4": "Rate di mutui e prestiti già contratti: restituiscono il capitale, non finanziano nuovi servizi.",
+  "5": "Restituzione di anticipazioni temporanee ricevute dal tesoriere. Movimenti di cassa, non nuova spesa per servizi.",
+  "7": "Soldi che passano dal Comune per conto di terzi o come partite di giro. Di solito non sono spesa propria del Comune.",
+};
+
+const OTHER_EXPLANATION =
+  "Somma delle voci minori non mostrate tra le principali. Completa il totale pagato nel periodo.";
+
 export type MunicipalitySpendingRow = Readonly<{
   key: string;
+  code: string | null;
   label: string;
+  explanation: string;
   amountCents: number;
 }>;
+
+export function explainMunicipalitySpendingTitle(code: string): string {
+  return TITLE_EXPLANATIONS[code] ?? "Categoria contabile SIOPE pubblicata dalla fonte ufficiale.";
+}
+
+export function municipalitySpendingTitleLabel(code: string, fallback: string): string {
+  return FRIENDLY_LABELS[code] ?? fallback;
+}
 
 export function buildMunicipalitySpendingRows(
   titles: readonly Readonly<{ code: string; label: string; amountCents: number }>[],
@@ -25,13 +48,21 @@ export function buildMunicipalitySpendingRows(
     .slice(0, 4)
     .map((title) => ({
       key: title.code,
-      label: FRIENDLY_LABELS[title.code] ?? title.label,
+      code: title.code,
+      label: municipalitySpendingTitleLabel(title.code, title.label),
+      explanation: explainMunicipalitySpendingTitle(title.code),
       amountCents: title.amountCents,
     }));
   const mainCents = main.reduce((sum, row) => sum + row.amountCents, 0);
   if (mainCents > totalCents) throw new Error("Categorie principali oltre il totale comunale");
   const otherCents = totalCents - mainCents;
   return otherCents > 0
-    ? [...main, { key: "other", label: "Altre categorie", amountCents: otherCents }]
+    ? [...main, {
+      key: "other",
+      code: null,
+      label: "Altre categorie",
+      explanation: OTHER_EXPLANATION,
+      amountCents: otherCents,
+    }]
     : main;
 }

--- a/tests/municipality-economics-copy.test.mjs
+++ b/tests/municipality-economics-copy.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+async function source(relativePath) {
+  return readFile(new URL(relativePath, import.meta.url), "utf8");
+}
+
+test("municipality economics keeps citizen explanations visible on every scheda", async () => {
+  const [economics, spendingView] = await Promise.all([
+    source("../src/app/enti/[codice]/municipality-economics.tsx"),
+    source("../src/lib/municipality-spending-view.ts"),
+  ]);
+
+  assert.match(economics, /data-siope-reading-guide/);
+  assert.match(economics, /data-peer-reading-guide/);
+  assert.match(economics, /data-peer-glossary/);
+  assert.match(economics, /data-opencivitas-reading-guide/);
+  assert.match(economics, /data-opencivitas-glossary/);
+  assert.match(economics, /title\.explanation/);
+  assert.match(economics, /openCivitas\.methodology\.differenceMeaning/);
+  assert.match(economics, /openCivitas\.methodology\.serviceMeaning/);
+  assert.match(economics, /Scala OpenCivitas da 0 a 10/);
+  assert.match(economics, /Valore tipico \(mediana\)/);
+  assert.match(economics, /Spesa registrata per abitante/);
+  assert.match(economics, /Valore di riferimento per abitante/);
+  assert.doesNotMatch(economics, /—|–/);
+
+  assert.match(spendingView, /Costi di funzionamento quotidiano/);
+  assert.match(spendingView, /partite di giro/);
+  assert.match(spendingView, /OTHER_EXPLANATION/);
+  assert.match(spendingView, /explainMunicipalitySpendingTitle/);
+});

--- a/tests/municipality-profile.test.mjs
+++ b/tests/municipality-profile.test.mjs
@@ -82,6 +82,10 @@ test("citizen-facing main categories plus other categories reconcile with SIOPE 
   assert.equal(rows.length, 5);
   assert.equal(rows.at(-1).label, "Altre categorie");
   assert.equal(rows.reduce((sum, row) => sum + row.amountCents, 0), latest.totalCents);
+  for (const row of rows) {
+    assert.ok(row.explanation.trim().length > 20, `${row.label} deve spiegare la voce`);
+  }
+  assert.match(rows[0].explanation, /funzionamento|opere|prestiti|conto terzi|classificare|finanziarie|anticipazioni/i);
 });
 
 test("ordinary-statute municipality joins every available source by exact identifiers", async () => {


### PR DESCRIPTION
## Summary
- Aggiunge spiegazioni inline alle principali voci di spesa SIOPE (spese correnti, investimenti, partite di giro, ecc.) su ogni scheda comunale
- Chiarisce mediana, fascia centrale, spesa registrata vs valore di riferimento e livelli OpenCivitas 0-10, senza trasformarli in giudizi di spreco
- Stessa impostazione per tutti i Comuni; OpenCivitas resta fail-closed dove la fonte non copre (es. Regioni a statuto speciale)

## Test plan
- [x] `node --test tests/municipality-economics-copy.test.mjs tests/municipality-profile.test.mjs tests/ui-craft-regressions.test.mjs tests/copy-quality.test.mjs`
- [x] Build + smoke e2e locale su Benevento, Milano, Roma (390px/1280px) e Cagliari (fail-closed OpenCivitas)
- [ ] CI browser `Scheda economica Benevento` (390/768/1280)
- [ ] Controllo manuale su una scheda con peer benchmark e una senza


Made with [Cursor](https://cursor.com)