### PR TITLE
feat(controlli): sintesi pubblica + agenda AI visuale (#243)

### DIFF
--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -2463,7 +2463,7 @@ try {
       width,
       validate: async (page) => {
         const treemapSelector = '[role="group"][aria-label^="Scegli una missione"]';
-        await page.waitForSelector(`${treemapSelector} g[role="button"]`, { timeout: 5_000 });
+        await page.waitForSelector(`${treemapSelector} g[role="button"]`, { timeout: 15_000 });
         const treemapState = await page.$eval(treemapSelector, (root) => {
           const bounds = root.getBoundingClientRect();
           const tiles = [...root.querySelectorAll('g[role="button"]')];

--- a/src/app/controlli/page.tsx
+++ b/src/app/controlli/page.tsx
@@ -164,6 +164,10 @@ export default async function ControlsPage({ searchParams }: PageProps) {
           Numeri presi da relazioni ufficiali, rivisti il {longDate(`${auditReviewedAt}T00:00:00Z`)}.
           Ogni numero dice una cosa precisa e mostra anche i suoi limiti.
         </p>
+        <p>
+          Per un quadro in tre passi (cosa emerge, dove approfondire, cosa si può migliorare) apri la{" "}
+          <Link href="/controlli/sintesi">Sintesi</Link>.
+        </p>
       </div>
 
       <nav className={styles.yearFilter} aria-label="Filtra i controlli per anno">

--- a/src/app/controlli/sintesi/page.tsx
+++ b/src/app/controlli/sintesi/page.tsx
@@ -43,7 +43,7 @@ export default function ControlliSintesiPage() {
         </p>
         <p className={styles.leadLinks}>
           <Link href="/controlli">Elenco segnali →</Link>
-          <Link href="#agenda-ai">Agenda AI →</Link>
+          <Link href="#agenda-ai">Agenda agenti AI →</Link>
           <Link href="/metodologia">Come leggiamo i dati →</Link>
         </p>
       </div>
@@ -136,109 +136,125 @@ export default function ControlliSintesiPage() {
         </div>
       </section>
 
-      <section className={`panel ${styles.aiSection}`} aria-labelledby="agenda-ai-title" id="agenda-ai">
-        <header className={styles.aiHeader}>
+      <div className={styles.aiBreak} aria-hidden="true">
+        <span>Fine percorsi umani</span>
+        <span>Inizia agenda agenti AI</span>
+      </div>
+
+      <section className={styles.aiZone} aria-labelledby="agenda-ai-title" id="agenda-ai">
+        <header className={styles.aiHero}>
+          <p className={styles.aiKicker}>{aiStewardshipDisclosure.kicker}</p>
           <span className={styles.aiBadge}>{aiStewardshipDisclosure.badge}</span>
-          <h2 id="agenda-ai-title" className="panel-title">{aiStewardshipDisclosure.title}</h2>
-          <p>{aiStewardshipDisclosure.lead}</p>
+          <h2 id="agenda-ai-title" className={styles.aiTitle}>{aiStewardshipDisclosure.title}</h2>
+          <p className={styles.aiSubtitle}>{aiStewardshipDisclosure.subtitle}</p>
+          <p className={styles.aiLead}>{aiStewardshipDisclosure.lead}</p>
         </header>
 
-        <nav className={styles.aiRail} aria-label="Priorità agenda AI">
-          {aiAgenda.map((move) => (
-            <a key={move.id} href={`#${move.id}`} className={styles.aiRailItem}>
-              <span className={styles.aiRailNum}>{move.priority}</span>
-              <span className={styles.aiRailMetric}>{move.metric.display}</span>
-              <span className={styles.aiRailTitle}>{move.title}</span>
-            </a>
-          ))}
-        </nav>
+        <div className={styles.aiBody}>
+          <nav className={styles.aiRail} aria-label="Priorità agenda AI">
+            {aiAgenda.map((move) => (
+              <a key={move.id} href={`#${move.id}`} className={styles.aiRailItem}>
+                <span className={styles.aiRailNum}>{move.priority}</span>
+                <span className={styles.aiRailMetric}>{move.metric.display}</span>
+                <span className={styles.aiRailTitle}>{move.title}</span>
+              </a>
+            ))}
+          </nav>
 
-        <details className={styles.aiRulesDetails}>
-          <summary>Regole AI: cosa può e non può fare</summary>
-          <div className={styles.aiRules}>
-            <div>
-              <h3>Cosa può fare l&apos;AI qui</h3>
-              <ul>
-                {aiStewardshipDisclosure.allowed.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
+          <details className={styles.aiRulesDetails}>
+            <summary>Regole AI: cosa può e non può fare</summary>
+            <div className={styles.aiRules}>
+              <div>
+                <h3>Cosa può fare l&apos;AI qui</h3>
+                <ul>
+                  {aiStewardshipDisclosure.allowed.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3>Cosa non può fare</h3>
+                <ul>
+                  {aiStewardshipDisclosure.prohibited.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
             </div>
-            <div>
-              <h3>Cosa non può fare</h3>
-              <ul>
-                {aiStewardshipDisclosure.prohibited.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </details>
+          </details>
 
-        <ol className={styles.aiBoard}>
-          {aiAgenda.map((move) => {
-            const maxBar = Math.max(...move.bars.map((bar) => bar.value), Number.EPSILON);
-            return (
-              <li key={move.id} id={move.id} className={styles.aiCard}>
-                <div className={styles.aiCardTop}>
-                  <span className={styles.aiPriority}>Priorità {move.priority}</span>
-                  <h3>{move.title}</h3>
-                  <p className={styles.aiShortWhy}>{move.shortWhy}</p>
-                </div>
+          <ol className={styles.aiBoard}>
+            {aiAgenda.map((move) => {
+              const maxBar = Math.max(...move.bars.map((bar) => bar.value), Number.EPSILON);
+              return (
+                <li key={move.id} id={move.id} className={styles.aiCard}>
+                  <div className={styles.aiCardTop}>
+                    <span className={styles.aiPriority}>Priorità {move.priority}</span>
+                    <h3>{move.title}</h3>
+                  </div>
 
-                <div className={styles.aiMetric}>
-                  <span className={styles.aiMetricLabel}>{move.metric.label}</span>
-                  <strong className={styles.aiMetricValue}>{move.metric.display}</strong>
-                  {move.metric.hint ? (
-                    <span className={styles.aiMetricHint}>{move.metric.hint}</span>
-                  ) : null}
-                </div>
+                  <dl className={styles.aiBrief}>
+                    <div>
+                      <dt>Cosa riguarda</dt>
+                      <dd>{move.concerns}</dd>
+                    </div>
+                    <div>
+                      <dt>Operazione</dt>
+                      <dd>{move.operation}</dd>
+                    </div>
+                    <div>
+                      <dt>Effetto</dt>
+                      <dd>{move.effect}</dd>
+                    </div>
+                  </dl>
 
-                <figure className={styles.aiChart}>
-                  <figcaption>{move.chartCaption}</figcaption>
-                  <ul
-                    className={styles.aiBars}
-                    role="img"
-                    aria-label={move.chartCaption}
-                  >
-                    {move.bars.map((bar) => (
-                      <li key={`${move.id}-${bar.label}`}>
-                        <div className={styles.aiBarMeta}>
-                          <span>{bar.label}</span>
-                          <span>{bar.display}</span>
-                        </div>
-                        <div
-                          className={styles.aiBarTrack}
-                          aria-hidden="true"
-                        >
-                          <span
-                            className={styles.aiBarFill}
-                            style={{ width: `${barWidthPercent(move.bars, bar.value)}%` }}
-                            data-share={Math.round((bar.value / maxBar) * 100)}
-                          />
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </figure>
+                  <div className={styles.aiMetric}>
+                    <span className={styles.aiMetricLabel}>{move.metric.label}</span>
+                    <strong className={styles.aiMetricValue}>{move.metric.display}</strong>
+                    {move.metric.hint ? (
+                      <span className={styles.aiMetricHint}>{move.metric.hint}</span>
+                    ) : null}
+                  </div>
 
-                <div className={styles.aiCardBody}>
-                  <p className={styles.aiWould}>
-                    <span className={styles.aiWouldLabel}>L&apos;agente farebbe</span>
-                    {move.agentWould}
-                  </p>
-                  <details className={styles.aiWhyDetails}>
-                    <summary>Perché (dato completo)</summary>
-                    <p>{move.why}</p>
-                  </details>
-                  <p className={styles.aiLinks}>
-                    <Link href={move.deepenHref}>{move.deepenLabel} →</Link>
-                  </p>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
+                  <figure className={styles.aiChart}>
+                    <figcaption>{move.chartCaption}</figcaption>
+                    <ul
+                      className={styles.aiBars}
+                      role="img"
+                      aria-label={move.chartCaption}
+                    >
+                      {move.bars.map((bar) => (
+                        <li key={`${move.id}-${bar.label}`}>
+                          <div className={styles.aiBarMeta}>
+                            <span>{bar.label}</span>
+                            <span>{bar.display}</span>
+                          </div>
+                          <div className={styles.aiBarTrack} aria-hidden="true">
+                            <span
+                              className={styles.aiBarFill}
+                              style={{ width: `${barWidthPercent(move.bars, bar.value)}%` }}
+                              data-share={Math.round((bar.value / maxBar) * 100)}
+                            />
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </figure>
+
+                  <div className={styles.aiCardBody}>
+                    <details className={styles.aiWhyDetails}>
+                      <summary>Dato di origine (osservazione)</summary>
+                      <p>{move.why}</p>
+                    </details>
+                    <p className={styles.aiLinks}>
+                      <Link href={move.deepenHref}>{move.deepenLabel} →</Link>
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
       </section>
 
       <section className={`panel ${styles.next}`} aria-labelledby="next-title">

--- a/src/app/controlli/sintesi/page.tsx
+++ b/src/app/controlli/sintesi/page.tsx
@@ -1,0 +1,259 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  aiStewardshipDisclosure,
+  buildAiStewardshipAgenda,
+  buildControlliSintesiPathways,
+  sintesiReadingOrder,
+  type AiStewardshipMove,
+  type SintesiKind,
+} from "@/lib/controlli-sintesi";
+import styles from "./sintesi.module.css";
+
+export const metadata: Metadata = {
+  title: "Sintesi: cosa monitorare",
+  description:
+    "Quadro leggibile di osservazioni, screening, ipotesi di miglioramento e agenda AI esplicitamente etichettata sulla spesa pubblica. Non attribuisce sprechi o illeciti.",
+};
+
+const kindLabels: Record<SintesiKind, string> = {
+  osservazione: "Osservazione",
+  screening: "Screening",
+  ipotesi: "Ipotesi di miglioramento",
+};
+
+function barWidthPercent(bars: AiStewardshipMove["bars"], value: number): number {
+  const max = Math.max(...bars.map((bar) => bar.value), Number.EPSILON);
+  return Math.max(4, Math.round((value / max) * 100));
+}
+
+export default function ControlliSintesiPage() {
+  const pathways = buildControlliSintesiPathways();
+  const aiAgenda = buildAiStewardshipAgenda(pathways);
+
+  return (
+    <main className={`shell page ${styles.page}`}>
+      <div className="page-intro">
+        <p className="eyebrow">Cosa controllare · Sintesi</p>
+        <h1>Cosa monitorare, dove approfondire, cosa si può migliorare</h1>
+        <p>
+          Questa pagina non è una classifica di sprechi. Raccoglie ciò che i dati in piattaforma
+          già mostrano, in tre passi: cosa emerge, dove andare a leggere, cosa si può fare per
+          verificare o migliorare. Ogni cifra resta legata a fonte, periodo e limiti.
+        </p>
+        <p className={styles.leadLinks}>
+          <Link href="/controlli">Elenco segnali →</Link>
+          <Link href="#agenda-ai">Agenda AI →</Link>
+          <Link href="/metodologia">Come leggiamo i dati →</Link>
+        </p>
+      </div>
+
+      <section className={`panel ${styles.howTo}`} aria-labelledby="how-to-title">
+        <h2 id="how-to-title" className="panel-title">Come si legge</h2>
+        <ol className={styles.steps}>
+          {sintesiReadingOrder.map((step) => (
+            <li key={step.step}>
+              <span className={styles.stepIndex}>{step.step}</span>
+              <div>
+                <strong>{step.title}</strong>
+                <p>{step.text}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className={styles.guardrail}>
+          Non attribuiamo sprechi, illeciti o responsabilità. Un segnale orienta un controllo;
+          le ipotesi di miglioramento non sono risparmi già in cassa.
+        </p>
+      </section>
+
+      <section className={styles.pathways} aria-labelledby="pathways-title">
+        <div className={styles.pathwaysIntro}>
+          <h2 id="pathways-title" className="panel-title">
+            {pathways.length} percorsi verificabili
+          </h2>
+          <p>
+            Numeri presi da OpenCivitas, ANAC, MEF, Corte dei conti, RGS, Banca d&apos;Italia,
+            Eurostat, Guardia di finanza e dagli scenari già pubblicati su Cosa controllare.
+            Nulla di nuovo inventato qui.
+          </p>
+        </div>
+
+        <div className={styles.pathwayList}>
+          {pathways.map((pathway, index) => (
+            <article
+              key={pathway.id}
+              className={`panel ${styles.pathway}`}
+              data-kind={pathway.kind}
+              aria-labelledby={`pathway-${pathway.id}`}
+            >
+              <header className={styles.pathwayHeader}>
+                <span className={styles.pathwayIndex}>{String(index + 1).padStart(2, "0")}</span>
+                <div>
+                  <span className={styles.kind}>{kindLabels[pathway.kind]}</span>
+                  <span className={styles.area}>{pathway.area}</span>
+                  <h3 id={`pathway-${pathway.id}`}>{pathway.headline}</h3>
+                </div>
+              </header>
+
+              <dl className={styles.blocks}>
+                <div>
+                  <dt>Cosa emerge</dt>
+                  <dd>{pathway.observation}</dd>
+                </div>
+                <div>
+                  <dt>Dove approfondire</dt>
+                  <dd>
+                    <Link href={pathway.deepenHref}>{pathway.deepenLabel}</Link>
+                  </dd>
+                </div>
+                <div>
+                  <dt>Cosa si può fare</dt>
+                  <dd>{pathway.action}</dd>
+                </div>
+              </dl>
+
+              <footer className={styles.meta}>
+                <p>
+                  <span>Fonte</span>{" "}
+                  {pathway.sourceUrl.startsWith("/") ? (
+                    <Link href={pathway.sourceUrl}>{pathway.sourceLabel}</Link>
+                  ) : (
+                    <a href={pathway.sourceUrl} target="_blank" rel="noreferrer">
+                      {pathway.sourceLabel} ↗
+                    </a>
+                  )}
+                </p>
+                <p>
+                  <span>Periodo</span> {pathway.period}
+                </p>
+                <p>
+                  <span>Limiti</span> {pathway.limits}
+                </p>
+              </footer>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={`panel ${styles.aiSection}`} aria-labelledby="agenda-ai-title" id="agenda-ai">
+        <header className={styles.aiHeader}>
+          <span className={styles.aiBadge}>{aiStewardshipDisclosure.badge}</span>
+          <h2 id="agenda-ai-title" className="panel-title">{aiStewardshipDisclosure.title}</h2>
+          <p>{aiStewardshipDisclosure.lead}</p>
+        </header>
+
+        <nav className={styles.aiRail} aria-label="Priorità agenda AI">
+          {aiAgenda.map((move) => (
+            <a key={move.id} href={`#${move.id}`} className={styles.aiRailItem}>
+              <span className={styles.aiRailNum}>{move.priority}</span>
+              <span className={styles.aiRailMetric}>{move.metric.display}</span>
+              <span className={styles.aiRailTitle}>{move.title}</span>
+            </a>
+          ))}
+        </nav>
+
+        <details className={styles.aiRulesDetails}>
+          <summary>Regole AI: cosa può e non può fare</summary>
+          <div className={styles.aiRules}>
+            <div>
+              <h3>Cosa può fare l&apos;AI qui</h3>
+              <ul>
+                {aiStewardshipDisclosure.allowed.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3>Cosa non può fare</h3>
+              <ul>
+                {aiStewardshipDisclosure.prohibited.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </details>
+
+        <ol className={styles.aiBoard}>
+          {aiAgenda.map((move) => {
+            const maxBar = Math.max(...move.bars.map((bar) => bar.value), Number.EPSILON);
+            return (
+              <li key={move.id} id={move.id} className={styles.aiCard}>
+                <div className={styles.aiCardTop}>
+                  <span className={styles.aiPriority}>Priorità {move.priority}</span>
+                  <h3>{move.title}</h3>
+                  <p className={styles.aiShortWhy}>{move.shortWhy}</p>
+                </div>
+
+                <div className={styles.aiMetric}>
+                  <span className={styles.aiMetricLabel}>{move.metric.label}</span>
+                  <strong className={styles.aiMetricValue}>{move.metric.display}</strong>
+                  {move.metric.hint ? (
+                    <span className={styles.aiMetricHint}>{move.metric.hint}</span>
+                  ) : null}
+                </div>
+
+                <figure className={styles.aiChart}>
+                  <figcaption>{move.chartCaption}</figcaption>
+                  <ul
+                    className={styles.aiBars}
+                    role="img"
+                    aria-label={move.chartCaption}
+                  >
+                    {move.bars.map((bar) => (
+                      <li key={`${move.id}-${bar.label}`}>
+                        <div className={styles.aiBarMeta}>
+                          <span>{bar.label}</span>
+                          <span>{bar.display}</span>
+                        </div>
+                        <div
+                          className={styles.aiBarTrack}
+                          aria-hidden="true"
+                        >
+                          <span
+                            className={styles.aiBarFill}
+                            style={{ width: `${barWidthPercent(move.bars, bar.value)}%` }}
+                            data-share={Math.round((bar.value / maxBar) * 100)}
+                          />
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </figure>
+
+                <div className={styles.aiCardBody}>
+                  <p className={styles.aiWould}>
+                    <span className={styles.aiWouldLabel}>L&apos;agente farebbe</span>
+                    {move.agentWould}
+                  </p>
+                  <details className={styles.aiWhyDetails}>
+                    <summary>Perché (dato completo)</summary>
+                    <p>{move.why}</p>
+                  </details>
+                  <p className={styles.aiLinks}>
+                    <Link href={move.deepenHref}>{move.deepenLabel} →</Link>
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      <section className={`panel ${styles.next}`} aria-labelledby="next-title">
+        <h2 id="next-title" className="panel-title">Cosa non fa ancora questa pagina</h2>
+        <ul>
+          <li>Non confronta automaticamente lo stesso servizio venduto a prezzi diversi tra enti (serve un join CPV/prezzo ancora da costruire).</li>
+          <li>Non pubblica piste investigative senza revisione umana.</li>
+          <li>Non propone tagli nominativi a persone, ditte o amministrazioni.</li>
+          <li>L&apos;agenda AI non è un modello live: è una proposta deterministica etichettata, rivedibile da un umano.</li>
+        </ul>
+        <p>
+          Per i segnali grezzi e le tabelle complete resta{" "}
+          <Link href="/controlli">Cosa controllare</Link>.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/controlli/sintesi/page.tsx
+++ b/src/app/controlli/sintesi/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import {
   aiStewardshipDisclosure,
+  buildAiInterventionMap,
+  buildAiNextMoves,
   buildAiStewardshipAgenda,
   buildControlliSintesiPathways,
   sintesiReadingOrder,
@@ -30,6 +32,8 @@ function barWidthPercent(bars: AiStewardshipMove["bars"], value: number): number
 export default function ControlliSintesiPage() {
   const pathways = buildControlliSintesiPathways();
   const aiAgenda = buildAiStewardshipAgenda(pathways);
+  const interventionMap = buildAiInterventionMap(aiAgenda);
+  const nextMoves = buildAiNextMoves();
 
   return (
     <main className={`shell page ${styles.page}`}>
@@ -148,6 +152,7 @@ export default function ControlliSintesiPage() {
           <h2 id="agenda-ai-title" className={styles.aiTitle}>{aiStewardshipDisclosure.title}</h2>
           <p className={styles.aiSubtitle}>{aiStewardshipDisclosure.subtitle}</p>
           <p className={styles.aiLead}>{aiStewardshipDisclosure.lead}</p>
+          <p className={styles.aiHowTo}>{aiStewardshipDisclosure.howToRead}</p>
         </header>
 
         <div className={styles.aiBody}>
@@ -193,17 +198,22 @@ export default function ControlliSintesiPage() {
                     <h3>{move.title}</h3>
                   </div>
 
+                  <p className={styles.aiProposal}>
+                    <span className={styles.aiProposalLabel}>In pratica propone</span>
+                    {move.proposal}
+                  </p>
+
                   <dl className={styles.aiBrief}>
                     <div>
                       <dt>Cosa riguarda</dt>
                       <dd>{move.concerns}</dd>
                     </div>
                     <div>
-                      <dt>Operazione</dt>
+                      <dt>Come lavora</dt>
                       <dd>{move.operation}</dd>
                     </div>
                     <div>
-                      <dt>Effetto</dt>
+                      <dt>Che effetto avrebbe</dt>
                       <dd>{move.effect}</dd>
                     </div>
                   </dl>
@@ -254,6 +264,73 @@ export default function ControlliSintesiPage() {
               );
             })}
           </ol>
+
+          <section className={styles.aiMap} aria-labelledby="ai-map-title" id="mappa-interventi">
+            <h3 id="ai-map-title" className={styles.aiBlockTitle}>Mappa degli interventi</h3>
+            <p className={styles.aiBlockLead}>
+              L&apos;ordine che seguirebbe l&apos;agente: dal vincolo del debito fino alle ipotesi
+              pubbliche. Tocca un passo per saltare alla priorità.
+            </p>
+            <ol className={styles.aiMapList}>
+              {interventionMap.map((step, index) => (
+                <li key={step.moveId}>
+                  <a href={`#${step.moveId}`} className={styles.aiMapStep}>
+                    <span className={styles.aiMapOrder}>{step.order}</span>
+                    <span className={styles.aiMapCopy}>
+                      <strong>{step.label}</strong>
+                      <span>{step.plain}</span>
+                    </span>
+                  </a>
+                  {index < interventionMap.length - 1 ? (
+                    <span className={styles.aiMapArrow} aria-hidden="true">↓</span>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className={styles.aiNext} aria-labelledby="ai-next-title" id="ancora-da-fare">
+            <h3 id="ai-next-title" className={styles.aiBlockTitle}>
+              Dopo la priorità 7: cosa potremmo ancora fare?
+            </h3>
+            <p className={styles.aiBlockLead}>
+              Check sui conti e sui dati già in piattaforma (debito, manovra, territori, fondi,
+              partecipate, incarichi, invalidità, confronti acquisti). Queste non sono nella lista
+              delle 7 priorità: sono le prossime mosse più utili, sempre con fonte e senza accuse.
+            </p>
+            <ol className={styles.aiNextList}>
+              {nextMoves.map((move, index) => (
+                <li key={move.id} className={styles.aiNextCard}>
+                  <span className={styles.aiNextIndex}>{String(index + 1).padStart(2, "0")}</span>
+                  <div className={styles.aiNextBody}>
+                    <h4>{move.title}</h4>
+                    <p className={styles.aiProposal}>
+                      <span className={styles.aiProposalLabel}>In pratica propone</span>
+                      {move.proposal}
+                    </p>
+                    <dl className={styles.aiNextMeta}>
+                      <div>
+                        <dt>Perché ora</dt>
+                        <dd>{move.whyNow}</dd>
+                      </div>
+                      <div>
+                        <dt>Che effetto avrebbe</dt>
+                        <dd>{move.effect}</dd>
+                      </div>
+                    </dl>
+                    <div className={styles.aiNextMetric}>
+                      <span>{move.metricLabel}</span>
+                      <strong>{move.metricDisplay}</strong>
+                    </div>
+                    <p className={styles.aiLinks}>
+                      <Link href={move.deepenHref}>{move.deepenLabel} →</Link>
+                      <span>{move.sourceNote}</span>
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
         </div>
       </section>
 

--- a/src/app/controlli/sintesi/sintesi.module.css
+++ b/src/app/controlli/sintesi/sintesi.module.css
@@ -231,45 +231,111 @@
   color: var(--color-accent-800);
 }
 
-.aiSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  border-top: 3px solid var(--color-neutral-800);
-  min-width: 0;
+.aiBreak {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-2);
+  margin: var(--space-2) 0 0;
+  padding: var(--space-3) 0;
+  border-top: 1px dashed var(--color-neutral-400);
+  border-bottom: 1px dashed var(--color-neutral-400);
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
 }
 
-.aiHeader {
+.aiBreak span:last-child {
+  text-align: right;
+  color: var(--color-neutral-900);
+}
+
+.aiZone {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 0;
+  margin: 0 calc(var(--space-3) * -1);
+  border: 1px solid var(--color-neutral-800);
+  background: var(--color-neutral-100);
+  overflow: clip;
+}
+
+.aiHero {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  max-width: 78ch;
+  padding: var(--space-4) var(--space-3);
+  background:
+    linear-gradient(
+      145deg,
+      var(--color-neutral-900) 0%,
+      color-mix(in srgb, var(--color-neutral-900) 82%, var(--color-accent-700)) 100%
+    );
+  color: #f7f4f2;
+}
+
+.aiKicker {
+  margin: 0;
+  color: color-mix(in srgb, #f7f4f2 72%, transparent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
 }
 
 .aiBadge {
   align-self: flex-start;
-  padding: 4px 8px;
-  border: 1px solid var(--color-neutral-800);
-  background: var(--color-neutral-100);
+  margin-top: 2px;
+  padding: 5px 9px;
+  border: 1px solid color-mix(in srgb, #f7f4f2 55%, transparent);
+  background: color-mix(in srgb, #f7f4f2 10%, transparent);
+  color: #f7f4f2;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: .05em;
   text-transform: uppercase;
 }
 
-.aiHeader .panel-title { margin: 0; }
+.aiTitle {
+  margin: var(--space-2) 0 0;
+  font-family: var(--font-heading);
+  font-size: clamp(28px, 7vw, 42px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: #fff;
+}
 
-.aiHeader p {
+.aiSubtitle {
   margin: 0;
-  color: var(--color-neutral-700);
+  max-width: 40ch;
+  color: color-mix(in srgb, #f7f4f2 88%, transparent);
+  font-size: clamp(15px, 3.6vw, 18px);
+  line-height: 1.4;
+}
+
+.aiLead {
+  margin: var(--space-2) 0 0;
+  max-width: 68ch;
+  color: color-mix(in srgb, #f7f4f2 76%, transparent);
   font-size: 14px;
   line-height: 1.55;
+}
+
+.aiBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-3);
+  min-width: 0;
 }
 
 .aiRail {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(148px, 1fr);
+  grid-auto-columns: minmax(152px, 72vw);
   gap: var(--space-2);
   margin: 0 calc(var(--space-3) * -1);
   padding: 2px var(--space-3) var(--space-2);
@@ -284,8 +350,8 @@
   gap: 4px;
   min-width: 0;
   padding: var(--space-3);
-  border: 1px solid var(--color-neutral-300);
-  background: var(--color-neutral-50, #fafafa);
+  border: 1px solid var(--color-neutral-400);
+  background: #fff;
   color: inherit;
   text-decoration: none;
   scroll-snap-align: start;
@@ -324,8 +390,8 @@
 }
 
 .aiRulesDetails {
-  border: 1px solid var(--color-neutral-300);
-  background: var(--color-neutral-50, #fafafa);
+  border: 1px solid var(--color-neutral-400);
+  background: #fff;
 }
 
 .aiRulesDetails > summary {
@@ -378,14 +444,14 @@
   gap: var(--space-3);
   min-width: 0;
   padding: var(--space-3);
-  border: 1px solid var(--color-neutral-300);
-  border-top: 3px solid var(--color-accent-700);
-  background: var(--color-raised, #fff);
+  border: 1px solid var(--color-neutral-400);
+  border-left: 4px solid var(--color-neutral-900);
+  background: #fff;
   scroll-margin-top: 5.5rem;
 }
 
 .aiCardTop h3 {
-  margin: 6px 0 var(--space-2);
+  margin: 6px 0 0;
   font-family: var(--font-heading);
   font-size: clamp(18px, 4.2vw, 24px);
   font-weight: var(--font-heading-weight);
@@ -401,11 +467,41 @@
   text-transform: uppercase;
 }
 
-.aiShortWhy {
+.aiBrief {
   margin: 0;
-  color: var(--color-neutral-700);
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.aiBrief > div {
+  display: grid;
+  gap: 4px;
+  padding: var(--space-3);
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-50, #fafafa);
+  min-width: 0;
+}
+
+.aiBrief > div:nth-child(3) {
+  border-color: color-mix(in srgb, var(--color-accent-700) 35%, var(--color-neutral-300));
+  background: color-mix(in srgb, var(--color-accent-700) 7%, white);
+}
+
+.aiBrief dt {
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.aiBrief dd {
+  margin: 0;
+  color: var(--color-neutral-900);
   font-size: 14px;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .aiMetric {
@@ -506,27 +602,6 @@
   border-top: 1px solid var(--color-neutral-200);
 }
 
-.aiWould {
-  margin: 0;
-  color: var(--color-neutral-900);
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-.aiWouldLabel {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--color-neutral-600);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-}
-
-.aiWhyDetails {
-  border-top: 1px solid var(--color-neutral-200);
-}
-
 .aiWhyDetails > summary {
   min-height: 44px;
   padding: 10px 0;
@@ -558,14 +633,29 @@
 }
 
 @media (min-width: 720px) {
+  .aiZone {
+    margin: 0;
+  }
+
+  .aiHero,
+  .aiBody {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+
   .aiRules {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .aiBrief {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .aiCard {
     grid-template-columns: minmax(160px, 0.38fr) minmax(0, 1fr);
     grid-template-areas:
       "top top"
+      "brief brief"
       "metric chart"
       "body body";
     gap: var(--space-3) var(--space-4);
@@ -573,6 +663,7 @@
   }
 
   .aiCardTop { grid-area: top; }
+  .aiBrief { grid-area: brief; }
   .aiMetric { grid-area: metric; align-content: start; }
   .aiChart { grid-area: chart; }
   .aiCardBody { grid-area: body; }
@@ -593,5 +684,13 @@
 @media (max-width: 800px) {
   .steps {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .aiBreak {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .aiBreak span:last-child {
+    text-align: left;
   }
 }

--- a/src/app/controlli/sintesi/sintesi.module.css
+++ b/src/app/controlli/sintesi/sintesi.module.css
@@ -324,6 +324,17 @@
   line-height: 1.55;
 }
 
+.aiHowTo {
+  margin: var(--space-2) 0 0;
+  max-width: 68ch;
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, #f7f4f2 28%, transparent);
+  background: color-mix(in srgb, #f7f4f2 8%, transparent);
+  color: #f7f4f2;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
 .aiBody {
   display: flex;
   flex-direction: column;
@@ -464,6 +475,27 @@
   font-size: 11px;
   font-weight: 700;
   letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.aiProposal {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--color-accent-700) 40%, var(--color-neutral-300));
+  background: color-mix(in srgb, var(--color-accent-700) 10%, white);
+  color: var(--color-neutral-900);
+  font-size: 16px;
+  line-height: 1.45;
+  font-weight: 550;
+}
+
+.aiProposalLabel {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--color-accent-800);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
   text-transform: uppercase;
 }
 
@@ -632,6 +664,197 @@
   color: var(--color-accent-800);
 }
 
+.aiBlockTitle {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-heading);
+  font-size: clamp(22px, 4vw, 30px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.15;
+}
+
+.aiBlockLead {
+  margin: 0 0 var(--space-3);
+  max-width: 72ch;
+  color: var(--color-neutral-700);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.aiMap,
+.aiNext {
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-4) var(--space-3);
+  border: 1px solid var(--color-neutral-400);
+  background: #fff;
+}
+
+.aiMapList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.aiMapList > li {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.aiMapStep {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-50, #fafafa);
+  color: inherit;
+  text-decoration: none;
+}
+
+.aiMapStep:hover,
+.aiMapStep:focus-visible {
+  border-color: var(--color-accent-700);
+  outline: none;
+}
+
+.aiMapOrder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: var(--color-neutral-900);
+  color: #fff;
+  font-family: var(--font-heading);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.aiMapCopy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.aiMapCopy strong {
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+.aiMapCopy span {
+  color: var(--color-neutral-700);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.aiMapArrow {
+  display: block;
+  padding-left: 0.85rem;
+  color: var(--color-neutral-500);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.aiNextList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.aiNextCard {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-neutral-300);
+  border-left: 4px solid var(--color-accent-700);
+  background: var(--color-neutral-50, #fafafa);
+}
+
+.aiNextIndex {
+  font-family: var(--font-heading);
+  font-size: 20px;
+  font-weight: var(--font-heading-weight);
+  line-height: 1;
+  color: var(--color-neutral-500);
+}
+
+.aiNextBody {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.aiNextBody h4 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: clamp(17px, 3.8vw, 22px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.2;
+}
+
+.aiNextMeta {
+  margin: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.aiNextMeta > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.aiNextMeta dt {
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.aiNextMeta dd {
+  margin: 0;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.aiNextMetric {
+  display: grid;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-neutral-300);
+  background: #fff;
+}
+
+.aiNextMetric span {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.aiNextMetric strong {
+  font-family: var(--font-heading);
+  font-size: clamp(18px, 4vw, 24px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
 @media (min-width: 720px) {
   .aiZone {
     margin: 0;
@@ -651,10 +874,20 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
+  .aiNextMeta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .aiMap,
+  .aiNext {
+    padding: var(--space-4);
+  }
+
   .aiCard {
     grid-template-columns: minmax(160px, 0.38fr) minmax(0, 1fr);
     grid-template-areas:
       "top top"
+      "proposal proposal"
       "brief brief"
       "metric chart"
       "body body";
@@ -663,6 +896,7 @@
   }
 
   .aiCardTop { grid-area: top; }
+  .aiProposal { grid-area: proposal; }
   .aiBrief { grid-area: brief; }
   .aiMetric { grid-area: metric; align-content: start; }
   .aiChart { grid-area: chart; }

--- a/src/app/controlli/sintesi/sintesi.module.css
+++ b/src/app/controlli/sintesi/sintesi.module.css
@@ -456,7 +456,7 @@
   min-width: 0;
   padding: var(--space-3);
   border: 1px solid var(--color-neutral-400);
-  border-left: 4px solid var(--color-neutral-900);
+  border-top: 3px solid var(--color-neutral-900);
   background: #fff;
   scroll-margin-top: 5.5rem;
 }
@@ -776,7 +776,7 @@
   min-width: 0;
   padding: var(--space-3);
   border: 1px solid var(--color-neutral-300);
-  border-left: 4px solid var(--color-accent-700);
+  border-top: 3px solid var(--color-accent-700);
   background: var(--color-neutral-50, #fafafa);
 }
 

--- a/src/app/controlli/sintesi/sintesi.module.css
+++ b/src/app/controlli/sintesi/sintesi.module.css
@@ -1,0 +1,597 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.leadLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-4);
+  margin: var(--space-3) 0 0;
+}
+
+.leadLinks a {
+  font-weight: 650;
+  color: var(--color-accent-800);
+}
+
+.howTo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.steps li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.stepIndex {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-neutral-400);
+  font-family: var(--font-heading);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.steps strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 15px;
+}
+
+.steps p {
+  margin: 0;
+  color: var(--color-neutral-700);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.guardrail {
+  margin: 0;
+  max-width: 72ch;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-300);
+  color: var(--color-neutral-700);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.pathways {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.pathwaysIntro {
+  max-width: 72ch;
+}
+
+.pathwaysIntro .panel-title {
+  margin: 0 0 var(--space-2);
+}
+
+.pathwaysIntro p {
+  margin: 0;
+  color: var(--color-neutral-700);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.pathwayList {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.pathway {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.pathway[data-kind="screening"] {
+  border-top: 3px solid var(--color-accent-700);
+}
+
+.pathway[data-kind="ipotesi"] {
+  border-top: 3px solid var(--color-neutral-800);
+}
+
+.pathway[data-kind="osservazione"] {
+  border-top: 3px solid var(--color-neutral-500);
+}
+
+.pathwayHeader {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.pathwayIndex {
+  font-family: var(--font-heading);
+  font-size: 22px;
+  font-weight: var(--font-heading-weight);
+  line-height: 1;
+  color: var(--color-neutral-500);
+}
+
+.kind,
+.area {
+  display: inline-block;
+  margin-right: var(--space-2);
+  margin-bottom: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.kind { color: var(--color-accent-800); }
+.area { color: var(--color-neutral-600); }
+
+.pathwayHeader h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: clamp(20px, 2.4vw, 26px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.2;
+}
+
+.blocks {
+  margin: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.blocks > div {
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-200);
+}
+
+.blocks dt {
+  margin: 0 0 4px;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.blocks dd {
+  margin: 0;
+  max-width: 78ch;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--color-neutral-900);
+}
+
+.blocks a {
+  font-weight: 650;
+  color: var(--color-accent-800);
+}
+
+.meta {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-neutral-300);
+}
+
+.meta p {
+  margin: 0;
+  max-width: 78ch;
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.meta span {
+  font-weight: 700;
+  color: var(--color-neutral-800);
+}
+
+.meta a {
+  color: var(--color-accent-800);
+}
+
+.next ul {
+  margin: var(--space-3) 0;
+  padding-left: 1.2rem;
+  color: var(--color-neutral-800);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.next p {
+  margin: 0;
+  color: var(--color-neutral-700);
+  font-size: 14px;
+}
+
+.next a {
+  font-weight: 650;
+  color: var(--color-accent-800);
+}
+
+.aiSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border-top: 3px solid var(--color-neutral-800);
+  min-width: 0;
+}
+
+.aiHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: 78ch;
+}
+
+.aiBadge {
+  align-self: flex-start;
+  padding: 4px 8px;
+  border: 1px solid var(--color-neutral-800);
+  background: var(--color-neutral-100);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.aiHeader .panel-title { margin: 0; }
+
+.aiHeader p {
+  margin: 0;
+  color: var(--color-neutral-700);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.aiRail {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(148px, 1fr);
+  gap: var(--space-2);
+  margin: 0 calc(var(--space-3) * -1);
+  padding: 2px var(--space-3) var(--space-2);
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.aiRailItem {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-50, #fafafa);
+  color: inherit;
+  text-decoration: none;
+  scroll-snap-align: start;
+}
+
+.aiRailItem:hover,
+.aiRailItem:focus-visible {
+  border-color: var(--color-accent-700);
+  outline: none;
+}
+
+.aiRailNum {
+  color: var(--color-accent-800);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.aiRailMetric {
+  font-family: var(--font-heading);
+  font-size: clamp(18px, 4vw, 22px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+
+.aiRailTitle {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.aiRulesDetails {
+  border: 1px solid var(--color-neutral-300);
+  background: var(--color-neutral-50, #fafafa);
+}
+
+.aiRulesDetails > summary {
+  min-height: 44px;
+  padding: 12px var(--space-3);
+  font-size: 14px;
+  font-weight: 650;
+  cursor: pointer;
+  list-style: none;
+}
+
+.aiRulesDetails > summary::-webkit-details-marker {
+  display: none;
+}
+
+.aiRulesDetails[open] > summary {
+  border-bottom: 1px solid var(--color-neutral-300);
+}
+
+.aiRules {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-4);
+  padding: var(--space-3);
+}
+
+.aiRules h3 {
+  margin: 0 0 var(--space-2);
+  font-size: 14px;
+}
+
+.aiRules ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-neutral-800);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.aiBoard {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--space-4);
+}
+
+.aiCard {
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-neutral-300);
+  border-top: 3px solid var(--color-accent-700);
+  background: var(--color-raised, #fff);
+  scroll-margin-top: 5.5rem;
+}
+
+.aiCardTop h3 {
+  margin: 6px 0 var(--space-2);
+  font-family: var(--font-heading);
+  font-size: clamp(18px, 4.2vw, 24px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1.2;
+}
+
+.aiPriority {
+  display: inline-block;
+  color: var(--color-accent-800);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.aiShortWhy {
+  margin: 0;
+  color: var(--color-neutral-700);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.aiMetric {
+  display: grid;
+  gap: 4px;
+  padding: var(--space-3);
+  background: linear-gradient(
+    160deg,
+    var(--color-neutral-100) 0%,
+    color-mix(in srgb, var(--color-accent-700) 8%, white) 100%
+  );
+  border: 1px solid var(--color-neutral-300);
+  min-width: 0;
+}
+
+.aiMetricLabel {
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.aiMetricValue {
+  font-family: var(--font-heading);
+  font-size: clamp(28px, 8vw, 40px);
+  font-weight: var(--font-heading-weight);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.aiMetricHint {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.aiChart {
+  margin: 0;
+  min-width: 0;
+}
+
+.aiChart figcaption {
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-600);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.aiBars {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.aiBarMeta {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: 4px;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.aiBarMeta span:first-child {
+  min-width: 0;
+  color: var(--color-neutral-800);
+}
+
+.aiBarMeta span:last-child {
+  flex: 0 0 auto;
+  color: var(--color-neutral-700);
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+}
+
+.aiBarTrack {
+  height: 10px;
+  overflow: hidden;
+  background: var(--color-neutral-200);
+}
+
+.aiBarFill {
+  display: block;
+  height: 100%;
+  max-width: 100%;
+  background: var(--color-accent-700);
+}
+
+.aiCardBody {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-neutral-200);
+}
+
+.aiWould {
+  margin: 0;
+  color: var(--color-neutral-900);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.aiWouldLabel {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--color-neutral-600);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.aiWhyDetails {
+  border-top: 1px solid var(--color-neutral-200);
+}
+
+.aiWhyDetails > summary {
+  min-height: 44px;
+  padding: 10px 0;
+  color: var(--color-accent-800);
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.aiWhyDetails p {
+  margin: 0 0 var(--space-2);
+  color: var(--color-neutral-800);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.aiLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+  color: var(--color-neutral-600);
+  font-size: 13px;
+}
+
+.aiLinks a {
+  font-weight: 650;
+  color: var(--color-accent-800);
+}
+
+@media (min-width: 720px) {
+  .aiRules {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .aiCard {
+    grid-template-columns: minmax(160px, 0.38fr) minmax(0, 1fr);
+    grid-template-areas:
+      "top top"
+      "metric chart"
+      "body body";
+    gap: var(--space-3) var(--space-4);
+    padding: var(--space-4);
+  }
+
+  .aiCardTop { grid-area: top; }
+  .aiMetric { grid-area: metric; align-content: start; }
+  .aiChart { grid-area: chart; }
+  .aiCardBody { grid-area: body; }
+}
+
+@media (min-width: 1100px) {
+  .aiRail {
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    grid-auto-flow: dense;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    grid-auto-columns: unset;
+    scroll-snap-type: none;
+  }
+}
+
+@media (max-width: 800px) {
+  .steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/lib/controlli-sintesi.ts
+++ b/src/lib/controlli-sintesi.ts
@@ -13,8 +13,11 @@ import { openCivitasSnapshot } from "@/lib/opencivitas-snapshot";
 import { queryOpenCivitasSpendingOutliers } from "@/lib/opencivitas-outliers";
 import { summarizeOpenCivitasQuadrants } from "@/lib/opencivitas-quadrants";
 import { getPublicDebtView } from "@/lib/public-debt";
+import { mefParticipationsSnapshot } from "@/lib/mef-participations-snapshot";
 import { rgsConsultingSnapshot } from "@/lib/rgs-consulting-snapshot";
 import { querySsnCce } from "@/lib/ssn-cce-snapshot";
+import { getEditorialTopic } from "@/lib/integrated-editorial";
+import opencoesioneOverview from "@/data/generated/opencoesione-overview.json";
 
 export type SintesiKind = "osservazione" | "screening" | "ipotesi";
 
@@ -44,11 +47,13 @@ export type AiStewardshipMove = Readonly<{
   id: string;
   priority: number;
   title: string;
-  /** What domain / object the move covers. */
+  /** Plain-language: what this is about. */
   concerns: string;
-  /** How the agent would operate. */
+  /** One sentence a non-expert can quote: what the agent proposes to do. */
+  proposal: string;
+  /** How the agent would operate, still plain language. */
   operation: string;
-  /** Expected orientation effect if humans follow up (not a guaranteed saving). */
+  /** What would change for citizens / public accounts (orientation, not a guarantee). */
   effect: string;
   why: string;
   basedOnPathwayIds: readonly string[];
@@ -61,6 +66,26 @@ export type AiStewardshipMove = Readonly<{
   }>;
   bars: readonly AiChartBar[];
   chartCaption: string;
+}>;
+
+export type AiInterventionMapStep = Readonly<{
+  order: number;
+  moveId: string;
+  label: string;
+  plain: string;
+}>;
+
+export type AiNextMove = Readonly<{
+  id: string;
+  title: string;
+  whyNow: string;
+  proposal: string;
+  effect: string;
+  metricLabel: string;
+  metricDisplay: string;
+  deepenHref: string;
+  deepenLabel: string;
+  sourceNote: string;
 }>;
 
 function signalById(id: string): AuditSignal {
@@ -473,55 +498,61 @@ export function buildAiStewardshipAgenda(
     {
       id: "ai-map-constraints",
       priority: 1,
-      title: "Mappare prima i vincoli di bilancio",
-      concerns: "Stock di debito pubblico, interessi annui e scadenze residue.",
+      title: "Prima di tutto: quanto costa il debito",
+      concerns:
+        "Il debito pubblico e quanto paghiamo ogni anno di interessi. È il punto di partenza: senza questo numero, ogni 'risparmio' rischia di essere una promessa vuota.",
+      proposal:
+        "Propone di mostrare sempre, in apertura di qualsiasi piano di revisione, tre cifre: quanto debito c'è, quanto paghiamo di interessi, quanto scade entro un anno.",
       operation:
-        "L'agente legge stock, interessi e quota in scadenza entro un anno e li dispone come vincoli prima di qualsiasi proposta su spese o entrate.",
+        "L'agente prende questi tre numeri dalle fonti ufficiali e li mette in cima. Solo dopo guarda le spese da rivedere.",
       effect:
-        "Definisce un perimetro sostenibile: le revisioni successive restano confrontabili con il costo del debito, senza presentarle come cassa libera.",
+        "Chi legge capisce subito il vincolo: non si presenta un taglio come soldi già in tasca se prima non si vede il costo del debito.",
       why: debt.observation,
       basedOnPathwayIds: ["public-debt-interest"],
       deepenHref: debt.deepenHref,
-      deepenLabel: "Apri il debito pubblico",
+      deepenLabel: "Vedi il debito pubblico",
       metric: {
-        label: "Interessi annui (Eurostat)",
+        label: "Interessi pagati in un anno",
         display: formatBillion(interestBillion, 1),
-        hint: `Scadenza ≤1 anno: ${(maturity.upToOneYearBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        hint: `Scade entro 1 anno: ${(maturity.upToOneYearBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}% del debito`,
       },
       bars: [
         {
-          label: "Fino a 1 anno",
+          label: "Scade entro 1 anno",
           value: maturity.upToOneYearBasisPoints,
           display: `${(maturity.upToOneYearBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
         },
         {
-          label: "Da 1 a 5 anni",
+          label: "Scade tra 1 e 5 anni",
           value: maturity.oneToFiveYearsBasisPoints,
           display: `${(maturity.oneToFiveYearsBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
         },
         {
-          label: "Oltre 5 anni",
+          label: "Scade oltre 5 anni",
           value: maturity.overFiveYearsBasisPoints,
           display: `${(maturity.overFiveYearsBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
         },
       ],
-      chartCaption: "Scadenze residue del debito (quote sul totale)",
+      chartCaption: "Quando torna a scadenza il debito (quote sul totale)",
     },
     {
       id: "ai-review-tax-expenditures",
       priority: 2,
-      title: "Ordinare le agevolazioni fiscali per revisione",
-      concerns: "Agevolazioni fiscali MEF con stima puntuale e onere Superbonus già censito.",
+      title: "Mettere in fila le agevolazioni fiscali che hanno una cifra",
+      concerns:
+        "Sconti e agevolazioni sulle tasse. Molte esistono sulla carta: l'agente guarda solo quelle a cui il MEF ha già messo un valore in euro.",
+      proposal:
+        "Propone una lista pubblica delle agevolazioni con stima in euro, da far valutare a persone (non all'AI) prima di cambiare le leggi.",
       operation:
-        "L'agente produce una coda delle sole misure con stima numerica, esclude quelle senza copertura e richiede una valutazione redistributiva umana prima di ipotesi normative.",
+        "Toglie dalla lista le misure senza numero. Tiene Superbonus e altre voci grandi come contesto, senza sommarle a casaccio.",
       effect:
-        "Il dibattito fiscale parte da una shortlist verificabile: meno rumore sulle misure senza cifra, più trasparenza su dove una revisione potrebbe incidere.",
+        "Il dibattito parte da 'queste misure costano circa X', non da slogan. Eventuali tagli restano una scelta politica umana.",
       why: tax.observation,
       basedOnPathwayIds: ["tax-expenditures", "superbonus"],
       deepenHref: tax.deepenHref,
-      deepenLabel: "Apri le agevolazioni",
+      deepenLabel: "Vedi le agevolazioni",
       metric: {
-        label: "Stima puntuale MEF",
+        label: "Agevolazioni con stima MEF",
         display: formatBillion(taxSignal.value, 1),
         hint: taxSignal.coverage,
       },
@@ -532,30 +563,33 @@ export function buildAiStewardshipAgenda(
           display: formatBillion(taxSignal.value, 1),
         },
         {
-          label: "Superbonus (onere cumulato)",
+          label: "Superbonus (costo accumulato)",
           value: superbonusSignal.value,
           display: formatBillion(superbonusSignal.value, 1),
         },
       ],
-      chartCaption: "Ordini di grandezza fiscali già in piattaforma (non sommare come un unico risparmio)",
+      chartCaption: "Due ordini di grandezza fiscali (non vanno sommati come un unico risparmio)",
     },
     {
       id: "ai-open-procurement",
       priority: 3,
-      title: "Aprire più concorrenza negli appalti",
-      concerns: "Affidamenti diretti ANAC e contratti a ridotta concorrenza sul valore.",
+      title: "Far concorrere di più chi vende allo Stato",
+      concerns:
+        "Appalti e affidamenti: quando una gara ha pochi concorrenti, o si compra 'in diretta' senza un confronto ampio.",
+      proposal:
+        "Propone di aprire più gare competitive e di spiegare per iscritto quando si sceglie invece un affidamento diretto o una procedura ristretta.",
       operation:
-        "L'agente segnala procedure vicino alla soglia e perimetri a ridotta concorrenza come code di verifica; propone di allargare la platea e di documentare le deroghe, senza attribuire illeciti.",
+        "Segnala dove gli affidamenti diretti sono molti sul numero di procedure, e dove c'è molto valore a ridotta concorrenza. Non accusa nessuno di reato.",
       effect:
-        "Più controlli mirati e più confronto competitivo dove i dati lo suggeriscono; l'esito resta amministrativo e umano, non una sentenza automatica.",
+        "Più fornitori in gara può far scendere i prezzi e alzare la qualità; il controllo resta umano.",
       why: `${anac.observation} ${competition.observation}`,
       basedOnPathwayIds: ["anac-direct-awards", "reduced-competition-value"],
       deepenHref: anac.deepenHref,
-      deepenLabel: "Apri gli appalti ANAC",
+      deepenLabel: "Vedi gli appalti",
       metric: {
-        label: "Affidamenti diretti (su n. procedure)",
+        label: "Affidamenti diretti (sul numero di procedure)",
         display: `${anac2025.byNumber.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
-        hint: `Sul valore: ${anac2025.byValue.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        hint: `Sul valore complessivo: ${anac2025.byValue.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
       },
       bars: [
         {
@@ -569,60 +603,66 @@ export function buildAiStewardshipAgenda(
           display: `${anac2025.byValue.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
         },
         {
-          label: "Ridotta concorrenza (valore)",
+          label: "Valore a ridotta concorrenza",
           value: Math.min(100, (reducedCompetition.value / anac2025.totalValueBillion) * 100),
           display: formatBillion(reducedCompetition.value, 1),
         },
       ],
-      chartCaption: "ANAC 2025: quote e perimetro a ridotta concorrenza (scale diverse, lettura descrittiva)",
+      chartCaption: "ANAC 2025: quanto pesano le procedure poco aperte (scale diverse, lettura semplice)",
     },
     {
       id: "ai-municipal-profiles",
       priority: 4,
-      title: "Priorità ai Comuni con profilo spesa alta / servizi bassi",
-      concerns: "Profili OpenCivitas dei Comuni: spesa storica alta rispetto a servizi bassi.",
+      title: "Guardare i Comuni che spendono tanto e offrono poco",
+      concerns:
+        "Bilanci comunali confrontati con un valore di riferimento e con il livello dei servizi (OpenCivitas).",
+      proposal:
+        "Propone di partire dai Comuni dove la spesa è alta e i servizi risultano bassi, chiedendo spiegazioni e confronti con Comuni simili prima di qualsiasi taglio.",
       operation:
-        "L'agente costruisce una coda di lettura sui Comuni del profilo spesa alta / servizi bassi e chiede il confronto con pari e con i livelli di servizio prima di ipotesi locali.",
+        "Prepara una coda di lettura: prima i dati, poi il confronto con pari, poi eventuali scelte locali. Non fa una classifica di 'cattivi amministratori'.",
       effect:
-        "Gli interventi locali partono dai casi dove spesa e servizi divergono di più, senza trasformare lo screening in una classifica di colpe.",
+        "Si interviene dove c'è più da capire; i cittadini vedono spesa e servizi insieme, non solo un totale.",
       why: oc.observation,
       basedOnPathwayIds: ["opencivitas-high-low", "opencivitas-outliers"],
       deepenHref: oc.deepenHref,
-      deepenLabel: "Apri il confronto OpenCivitas",
+      deepenLabel: "Confronta i Comuni",
       metric: {
-        label: "Comuni nel profilo",
+        label: "Comuni nel profilo spesa alta / servizi bassi",
         display: highLow.municipalities.toLocaleString("it-IT"),
-        hint: `su ${quadrants.completeMunicipalities.toLocaleString("it-IT")} con livelli completi`,
+        hint: `su ${quadrants.completeMunicipalities.toLocaleString("it-IT")} con dati completi`,
       },
       bars: [
         {
-          label: "Spesa alta / servizi bassi",
+          label: "Profilo da approfondire",
           value: highLow.municipalities,
           display: highLow.municipalities.toLocaleString("it-IT"),
         },
         {
-          label: "Altri profili completi",
+          label: "Altri Comuni con dati completi",
           value: otherMunicipalities,
           display: otherMunicipalities.toLocaleString("it-IT"),
         },
       ],
-      chartCaption: `OpenCivitas ${openCivitasSnapshot.referenceYear}: conteggio Comuni (profilo descrittivo)`,
+      chartCaption: `OpenCivitas ${openCivitasSnapshot.referenceYear}: quanti Comuni rientrano nel profilo`,
     },
     {
       id: "ai-health-mix",
       priority: 5,
-      title: "Riequilibrare il mix sanitario interno / esterno",
-      concerns: "Costi di produzione SSN, servizi acquistati e personale sanitario esterno.",
+      title: "Capire quanto la sanità compra fuori e quanto fa in casa",
+      concerns:
+        "Soldi della sanità pubblica: servizi comprati all'esterno e personale 'a gettone' o esterno.",
+      proposal:
+        "Propone simulazioni (non tagli automatici) per vedere cosa cambierebbe se una parte dei servizi esterni tornasse a personale stabile, dove ha senso clinico.",
       operation:
-        "L'agente monitora il peso dei servizi acquistati e della spesa per personale esterno, li confronta con le assunzioni stabili e propone solo simulazioni di riequilibrio.",
+        "Misura il peso dei servizi acquistati sui costi di produzione e la spesa per personale esterno. Confronta, non decide al posto dei medici o delle Regioni.",
       effect:
-        "Si vede dove il mix interno/esterno pesa di più; eventuali scelte restano cliniche e di bilancio, non tagli automatici ai servizi.",
+        "Si vede dove la dipendenza dall'esterno è più forte; le scelte restano sanitarie e politiche, non un taglio cieco.",
       why: ssn.observation,
       basedOnPathwayIds: ["ssn-production-costs", "healthcare-external-staff"],
       deepenHref: ssn.deepenHref,
-      deepenLabel: "Apri la sanità",
+      deepenLabel: "Vedi la sanità",
       metric: {
-        label: "Servizi acquistati sul costo di produzione",
+        label: "Quota di servizi acquistati",
         display: `${purchasedShare.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
         hint: `Personale esterno: ${formatBillion(healthcare.value, 3)}`,
       },
@@ -633,62 +673,221 @@ export function buildAiStewardshipAgenda(
           display: formatBillionFromCents(purchasedServicesCents),
         },
         {
-          label: "Resto dei costi di produzione",
+          label: "Altri costi di produzione",
           value: Math.max(0, productionCostsCents - purchasedServicesCents),
           display: formatBillionFromCents(Math.max(0, productionCostsCents - purchasedServicesCents)),
         },
       ],
-      chartCaption: "Composizione del costo di produzione SSN (aggregato nazionale selezionato)",
+      chartCaption: "Come si spezza il costo di produzione del SSN (dato nazionale)",
     },
     {
       id: "ai-consulting-and-collection",
       priority: 6,
-      title: "Rivedere consulenze ripetute e stock di riscossione",
-      concerns: "Pagamenti di consulenza RGS per amministrazione e stock nominale della riscossione.",
+      title: "Separare consulenze ripetute e crediti difficili da riscuotere",
+      concerns:
+        "Due cose diverse: soldi pagati per consulenze ai ministeri, e lo stock enorme di cartelle ancora da riscuotere (che non è denaro già disponibile).",
+      proposal:
+        "Propone di pubblicare ogni anno chi paga di più in consulenze e perché, e di trattare lo stock della riscossione come credito incerto, non come 'tesoretto'.",
       operation:
-        "L'agente confronta le amministrazioni con i pagamenti di consulenza più alti e tiene separato lo stock della riscossione dal gettito annuale, proponendo audit contabili e piani di recupero verificabili.",
+        "Confronta le amministrazioni con i pagamenti più alti per consulenze. Tiene la riscossione su un binario separato: piano di recupero realistico, senza confonderla con le entrate dell'anno.",
       effect:
-        "Si riduce la confusione tra flussi e stock: le consulenze si leggono per andamento, la riscossione resta un credito nominale da non trattare come tesoretto.",
+        "Meno confusione: si capisce cosa si compra con le consulenze e cosa, invece, è solo un credito nominale difficile da incassare.",
       why: `${consult.observation} ${collection.observation}`,
       basedOnPathwayIds: ["rgs-consulting", "collection-stock"],
       deepenHref: consult.deepenHref,
-      deepenLabel: "Apri le consulenze",
+      deepenLabel: "Vedi le consulenze",
       metric: {
-        label: "Stock riscossione (nominale)",
+        label: "Stock nominale della riscossione",
         display: formatBillion(collectionSignal.value, 1),
-        hint: "Non è un tesoretto disponibile",
+        hint: "Gran parte non è realisticamente recuperabile subito",
       },
       bars: consultTop.map((row) => ({
         label: shortAdminLabel(row.administration),
         value: row.paidCashCents / consultMax,
         display: formatMillionFromCents(row.paidCashCents),
       })),
-      chartCaption: `Top ${consultTop.length} amministrazioni per pagamenti di consulenza (${consultYear})`,
+      chartCaption: `Chi ha pagato di più in consulenze (${consultYear})`,
     },
     {
       id: "ai-publish-hypothesis",
       priority: 7,
-      title: "Pubblicare solo ipotesi con assunzioni esplicite",
-      concerns: "Scenario centrale di miglioramento e sue componenti dichiarate.",
+      title: "Dire in chiaro quanto si potrebbe migliorare (con le ipotesi)",
+      concerns:
+        "Uno scenario di miglioramento già calcolato sul sito: non è soldi in cassa, è un 'se facessimo X con queste assunzioni'.",
+      proposal:
+        `Propone di usare lo scenario centrale (${formatBillion(centralScenario.annualBillion, 2)} all'anno) solo come ordine di grandezza pubblico, sempre con le assunzioni visibili.`,
       operation:
-        `L'agente usa lo scenario centrale (${formatBillion(centralScenario.annualBillion, 2)}/anno) solo come ordine di grandezza, con assunzioni visibili, e vieta di presentarlo come risparmio già disponibile.`,
+        "Mostra le parti dello scenario (agevolazioni, appalti, sanità, debiti fuori bilancio). Vieta di presentarlo come risparmio già fatto.",
       effect:
-        "Il pubblico vede un'ipotesi di policy con formula e limiti: utile al dibattito, non confondibile con soldi già in cassa.",
+        "Cittadini e media discutono su numeri dichiarati, non su promesse senza formule.",
       why: scenario.observation,
       basedOnPathwayIds: ["improvement-hypothesis"],
       deepenHref: scenario.deepenHref,
-      deepenLabel: "Apri gli scenari",
+      deepenLabel: "Vedi gli scenari",
       metric: {
-        label: "Scenario centrale (ipotesi/anno)",
+        label: "Ipotesi scenario centrale / anno",
         display: formatBillion(centralScenario.annualBillion, 2),
-        hint: "Ipotesi di policy, non previsione",
+        hint: "Ipotesi di policy, non previsione e non cassa",
       },
       bars: centralScenarioBreakdown.map((row) => ({
         label: shortAdminLabel(row.label, 42),
         value: row.value / scenarioMax,
         display: formatBillion(row.value, 2),
       })),
-      chartCaption: "Scomposizione dello scenario centrale (quote assunte, non risparmi certi)",
+      chartCaption: "Di cosa è fatto lo scenario centrale (assunzioni, non soldi certi)",
+    },
+  ];
+}
+
+/** Visual reading order of the 7 AI moves for the intervention map. */
+export function buildAiInterventionMap(
+  agenda: readonly AiStewardshipMove[] = buildAiStewardshipAgenda(),
+): readonly AiInterventionMapStep[] {
+  return agenda.map((move) => ({
+    order: move.priority,
+    moveId: move.id,
+    label: move.title,
+    plain: move.proposal,
+  }));
+}
+
+/**
+ * Extra interventions grounded in platform data not yet in the 7-priority agenda.
+ * Built after an end-to-end pass of audit signals, cohesion, participations and editorial gates.
+ */
+export function buildAiNextMoves(): readonly AiNextMove[] {
+  const offBudget = signalById("off-budget-debt");
+  const pnrr = signalById("pnrr-beyond-2026");
+  const pathways = buildControlliSintesiPathways();
+  const offBudgetPath = pathways.find((row) => row.id === "off-budget-debt");
+  const pnrrPath = pathways.find((row) => row.id === "pnrr-beyond-2026");
+  const consip = getEditorialTopic("appalti", "consip-da-confrontare");
+  if (!consip) throw new Error("Topic editoriale consip-da-confrontare assente");
+
+  const publicCostBillion = opencoesioneOverview.totals.publicCostCents / 100_000_000_000;
+  const paymentsBillion = opencoesioneOverview.totals.paymentsCents / 100_000_000_000;
+  const participations = mefParticipationsSnapshot;
+
+  return [
+    {
+      id: "next-off-budget",
+      title: "Fermare i nuovi debiti fuori bilancio nei Comuni",
+      whyNow:
+        offBudgetPath?.observation
+        ?? `${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(offBudget.value)} mln € di debiti fuori bilancio rilevati dalla Corte dei conti.`,
+      proposal:
+        "Propone di rafforzare i controlli sugli acquisti senza impegno preventivo e di pubblicare, per ogni Comune coinvolto, quanto nasce ancora fuori bilancio.",
+      effect:
+        "Meno passività 'sorpresa' nei bilanci locali; non è un recupero automatico dello stock già esistente.",
+      metricLabel: "Debiti fuori bilancio rilevati",
+      metricDisplay: `${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(offBudget.value)} mln €`,
+      deepenHref: offBudgetPath?.deepenHref ?? "/controlli",
+      deepenLabel: "Vedi il segnale sui debiti fuori bilancio",
+      sourceNote: `${offBudget.source.institution} · ${offBudget.source.title} · ${offBudget.referenceDate}`,
+    },
+    {
+      id: "next-pnrr-cohesion",
+      title: "Tenere sotto controllo PNRR e fondi di coesione",
+      whyNow:
+        pnrrPath?.observation
+        ?? `Circa ${formatBillion(pnrr.value, 1)} di risorse PNRR previste oltre il 2026.`,
+      proposal:
+        "Propone una dashboard pubblica di scadenze e pagamenti: cosa è in corso, cosa è concluso, cosa è ancora da avviare, senza confondere ritardo e denaro perso.",
+      effect:
+        "Si vede se i progetti avanzano davvero; i cittadini possono chiedere conto sui tempi.",
+      metricLabel: "Costo pubblico progetti vs pagamenti (OpenCoesione)",
+      metricDisplay: `${formatBillion(publicCostBillion, 0)} costo · ${formatBillion(paymentsBillion, 0)} pagati`,
+      deepenHref: "/coesione",
+      deepenLabel: "Apri Coesione e PNRR",
+      sourceNote: `OpenCoesione overview · PNRR oltre 2026: ${formatBillion(pnrr.value, 1)} (${pnrr.referenceDate})`,
+    },
+    {
+      id: "next-participations",
+      title: "Fare luce sulle società partecipate",
+      whyNow: `Il MEF censisce ${participations.totals.participationRecords.toLocaleString("it-IT")} rapporti di partecipazione; ${participations.declaredEvidence.directAwardRecords.toLocaleString("it-IT")} dichiarano affidamenti diretti.`,
+      proposal:
+        "Propone di aggiornare e pubblicare l'elenco delle partecipate con i segnali dichiarati (affidamento diretto / controllo analogo) e di chiedere spiegazioni periodiche dove i due segnali coesistono.",
+      effect:
+        "Più trasparenza su chi controlla cosa; non è una sentenza di illegalità.",
+      metricLabel: "Partecipazioni censite (MEF)",
+      metricDisplay: participations.totals.participationRecords.toLocaleString("it-IT"),
+      deepenHref: "/partecipazioni",
+      deepenLabel: "Apri le partecipazioni",
+      sourceNote: `Rilevazione MEF ${participations.referenceYear} · ${participations.declaredEvidence.legalMeaning}`,
+    },
+    {
+      id: "next-appointments",
+      title: "Monitorare gli incarichi esterni (oltre le consulenze RGS)",
+      whyNow:
+        "In piattaforma c'è anche la serie nazionale degli incarichi (diversa dai soli pagamenti RGS per consulenze).",
+      proposal:
+        "Propone di confrontare anno su anno incarichi esterni e dipendente, evidenziando gli enti dove crescono di più assegnazioni e pagamenti, senza liste di nomi da giudicare.",
+      effect:
+        "Si capisce se lo Stato compra lavoro esterno in modo ripetuto o se rafforza capacità interne.",
+      metricLabel: "Pagina di dettaglio",
+      metricDisplay: "Incarichi",
+      deepenHref: "/incarichi",
+      deepenLabel: "Apri gli incarichi",
+      sourceNote: "Dataset consulenti/incarichi già in catalogo MCP",
+    },
+    {
+      id: "next-budget-law",
+      title: "Leggere la Legge di Bilancio missione per missione",
+      whyNow:
+        "I dati di stanziamento enacted per missione permettono di vedere cosa cresce o cala rispetto all'anno prima.",
+      proposal:
+        "Propone di ordinare le missioni per variazione annuale e di aprire un approfondimento pubblico dove le voci crescono di più, senza mescolare stanziamenti e pagamenti consuntivi.",
+      effect:
+        "Il dibattito sulla manovra parte da numeri confrontabili, non solo da titoli di giornale.",
+      metricLabel: "Pagina di dettaglio",
+      metricDisplay: "Legge di Bilancio",
+      deepenHref: "/spese/legge-di-bilancio",
+      deepenLabel: "Apri la Legge di Bilancio",
+      sourceNote: "Serie storica OpenBDAP legge di bilancio",
+    },
+    {
+      id: "next-territorial",
+      title: "Confrontare la spesa dello Stato sul territorio",
+      whyNow:
+        "Esistono già la spesa statale territorializzata (RGS) e i conti CPT regionali: oggi si possono leggere meglio insieme.",
+      proposal:
+        "Propone confronti pro capite e per missione a livelli non sommabili (Italia, macroaree, regioni), segnalando scostamenti da approfondire, non un 'residuo fiscale' inventato.",
+      effect:
+        "Si vede dove lo Stato spende di più o di meno per abitante, con i limiti del dato in chiaro.",
+      metricLabel: "Pagine di dettaglio",
+      metricDisplay: "Territoriale + CPT",
+      deepenHref: "/spese/territoriale",
+      deepenLabel: "Apri la spesa territorializzata",
+      sourceNote: "RGS spesa territoriale · CPT finanza regionale su /territori/fisco",
+    },
+    {
+      id: "next-invalidity",
+      title: "Seguire la spesa per invalidità civile regione per regione",
+      whyNow:
+        "I dati INPS su invalidità civile mostrano spesa e nuove pensioni per territorio.",
+      proposal:
+        "Propone di pubblicare l'andamento regionale e di approfondire dove crescono insieme spesa e nuove prestazioni, guardando servizi e controlli amministrativi, senza accusare i beneficiari.",
+      effect:
+        "Più chiarezza sulla qualità della spesa sociale; niente 'caccia' alle persone.",
+      metricLabel: "Pagina di dettaglio",
+      metricDisplay: "Invalidità INPS",
+      deepenHref: "/spese/invalidita",
+      deepenLabel: "Apri l'invalidità civile",
+      sourceNote: "Dataset INPS invalidità civile",
+    },
+    {
+      id: "next-consip-gate",
+      title: "Rendere confrontabili gli acquisti (prima di parlare di prezzi)",
+      whyNow: consip.hubSummary,
+      proposal:
+        "Propone di obbligare modello, SKU, quantità, periodo e IVA nei contratti candidati al confronto: senza questi campi non si pubblica alcun 'sovrapprezzo'.",
+      effect:
+        "Si sblocca un confronto prezzi futuro onesto; oggi si rende trasparente il buco informativo.",
+      metricLabel: "Contratti non ancora confrontabili",
+      metricDisplay: consip.primaryMetric,
+      deepenHref: "/dati",
+      deepenLabel: "Apri il catalogo dati (appalti)",
+      sourceNote: `${consip.title} · ${consip.status}`,
     },
   ];
 }
@@ -714,10 +913,12 @@ export const sintesiReadingOrder = [
 export const aiStewardshipDisclosure = {
   badge: "Sezione agenti AI · non ufficiale",
   kicker: "Capitolo distinto dai percorsi umani sopra",
-  title: "Agenda gestita da agenti AI",
-  subtitle: "Cosa farebbe un agente se dovesse orientare spese e leggi dello Stato",
+  title: "Cosa proporrebbe un agente AI",
+  subtitle: "In linguaggio semplice: sette mosse, poi una mappa, poi cosa manca ancora",
   lead:
-    "Questa fascia è separata di proposito: non è il continuo dei 15 percorsi. È un'agenda deterministica etichettata come AI, non parere del Governo, non modello live e non sostituto delle scelte democratiche. Ogni priorità usa solo i numeri già mostrati sopra.",
+    "Qui non continuiamo l'elenco dei percorsi. Qui un agente AI (regole fisse, non un robot che decide da solo) dice cosa farebbe se dovesse aiutare a orientare spese e leggi. Non è parere del Governo. Ogni proposta usa solo numeri già in piattaforma.",
+  howToRead:
+    "Per ogni priorità leggi prima 'In pratica propone', poi cosa riguarda, come lavora e che effetto avrebbe. I grafici sono il dato di supporto.",
   allowed: auditMethodology.aiUse.allowed,
   prohibited: auditMethodology.aiUse.prohibited,
 } as const;

--- a/src/lib/controlli-sintesi.ts
+++ b/src/lib/controlli-sintesi.ts
@@ -1,0 +1,704 @@
+import {
+  auditMethodology,
+  auditScenarioAssumptions,
+  auditScenarioBasis,
+  auditScenarios,
+  auditSignals,
+  centralScenarioBreakdown,
+  procurementComparisons,
+  procurementServicesAndSupplies2025,
+  type AuditSignal,
+} from "@/lib/audit-data";
+import { openCivitasSnapshot } from "@/lib/opencivitas-snapshot";
+import { queryOpenCivitasSpendingOutliers } from "@/lib/opencivitas-outliers";
+import { summarizeOpenCivitasQuadrants } from "@/lib/opencivitas-quadrants";
+import { getPublicDebtView } from "@/lib/public-debt";
+import { rgsConsultingSnapshot } from "@/lib/rgs-consulting-snapshot";
+import { querySsnCce } from "@/lib/ssn-cce-snapshot";
+
+export type SintesiKind = "osservazione" | "screening" | "ipotesi";
+
+export type SintesiPathway = Readonly<{
+  id: string;
+  kind: SintesiKind;
+  area: string;
+  headline: string;
+  observation: string;
+  deepenHref: string;
+  deepenLabel: string;
+  action: string;
+  sourceLabel: string;
+  sourceUrl: string;
+  period: string;
+  limits: string;
+}>;
+
+export type AiChartBar = Readonly<{
+  label: string;
+  /** Relative weight for bar width (same unit within a chart). */
+  value: number;
+  display: string;
+}>;
+
+export type AiStewardshipMove = Readonly<{
+  id: string;
+  priority: number;
+  title: string;
+  /** One-line context for the card body. */
+  shortWhy: string;
+  why: string;
+  agentWould: string;
+  basedOnPathwayIds: readonly string[];
+  deepenHref: string;
+  deepenLabel: string;
+  metric: Readonly<{
+    label: string;
+    display: string;
+    hint?: string;
+  }>;
+  bars: readonly AiChartBar[];
+  chartCaption: string;
+}>;
+
+function signalById(id: string): AuditSignal {
+  const signal = auditSignals.find((candidate) => candidate.id === id);
+  if (!signal) throw new Error(`Segnale audit assente: ${id}`);
+  return signal;
+}
+
+function formatBillion(value: number, digits = 1): string {
+  return `${new Intl.NumberFormat("it-IT", {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  }).format(value)} mld €`;
+}
+
+function formatMillionFromCents(cents: number): string {
+  return `${new Intl.NumberFormat("it-IT", {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  }).format(cents / 100_000_000)} mln €`;
+}
+
+function formatBillionFromCents(cents: number, digits = 1): string {
+  return formatBillion(cents / 100_000_000_000, digits);
+}
+
+function formatEuroFromCents(cents: number): string {
+  return new Intl.NumberFormat("it-IT", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+function consultingYear(): number {
+  const years = [...new Set(rgsConsultingSnapshot.rows.map((row) => row.year))];
+  years.sort((left, right) => left - right);
+  const year = years.at(-1);
+  if (year === undefined) throw new Error("Nessun anno consulenze RGS nello snapshot");
+  return year;
+}
+
+function topConsultingAdministrations(year: number, limit: number) {
+  const totals = new Map<string, number>();
+  for (const row of rgsConsultingSnapshot.rows) {
+    if (row.year !== year) continue;
+    totals.set(row.administration, (totals.get(row.administration) ?? 0) + row.paidCashCents);
+  }
+  return [...totals.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0], "it"))
+    .slice(0, limit)
+    .map(([administration, paidCashCents]) => ({ administration, paidCashCents }));
+}
+
+/**
+ * Editorial synthesis pathways built only from adapters already on the platform.
+ * Numbers are never invented here; copy stays descriptive (verify / improve), never accusatory.
+ */
+export function buildControlliSintesiPathways(): readonly SintesiPathway[] {
+  const anac2025 = procurementComparisons[2025];
+  const tax = signalById("tax-expenditures");
+  const healthcare = signalById("healthcare-external-staff");
+  const offBudget = signalById("off-budget-debt");
+  const reducedCompetition = signalById("procurement-low-competition-value");
+  const pnrr = signalById("pnrr-beyond-2026");
+  const superbonus = signalById("superbonus-accrued-deductions");
+  const collection = signalById("collection-stock");
+  const gdf = signalById("gdf-public-spending-fraud");
+  const outliers = queryOpenCivitasSpendingOutliers({ limit: 3 });
+  const quadrants = summarizeOpenCivitasQuadrants(openCivitasSnapshot.municipalities);
+  const highLow = quadrants.quadrants.find((quadrant) => quadrant.key === "high-low");
+  if (!highLow) throw new Error("Quadrante OpenCivitas high-low assente");
+  const debt = getPublicDebtView();
+  const ssn = querySsnCce({});
+  const ssnValues = ssn.selectedAggregate.values;
+  if (!ssnValues) throw new Error("Valori nazionali SSN assenti nello snapshot");
+  const productionCostsCents = ssnValues.productionCosts;
+  const purchasedServicesCents = ssnValues.purchasedServices;
+  const purchasedShare = productionCostsCents > 0
+    ? (purchasedServicesCents / productionCostsCents) * 100
+    : 0;
+  const consultYear = consultingYear();
+  const consultTop = topConsultingAdministrations(consultYear, 3);
+  const consultPaid = rgsConsultingSnapshot.rows
+    .filter((row) => row.year === consultYear)
+    .reduce((sum, row) => sum + row.paidCashCents, 0);
+  const central = auditScenarios.find((scenario) => scenario.id === "central");
+  if (!central) throw new Error("Scenario centrale assente");
+
+  const outlierExamples = outliers.outliers
+    .map((outlier) => {
+      const signed = formatEuroFromCents(Math.abs(outlier.differencePerCapitaCents));
+      const side = outlier.direction === "sopra" ? "sopra" : "sotto";
+      return `${outlier.name} (${side} soglia, ${signed}/ab.)`;
+    })
+    .join("; ");
+
+  const pathways: SintesiPathway[] = [
+    {
+      id: "opencivitas-outliers",
+      kind: "screening",
+      area: "Comuni",
+      headline: "Spesa comunale lontana dal valore di riferimento",
+      observation:
+        outliers.pagination.total === 0
+          ? `OpenCivitas ${openCivitasSnapshot.referenceYear}: nessuno scostamento oltre la soglia regionale con i dati attuali.`
+          : `OpenCivitas ${openCivitasSnapshot.referenceYear}: ${outliers.pagination.total} Comuni (su ${outliers.evaluatedMunicipalities} valutati) risultano oltre la soglia regionale Tukey sulla differenza per abitante tra spesa storica e spesa standard. Esempi: ${outlierExamples}.`,
+      deepenHref: "/controlli",
+      deepenLabel: "Vedi lo screening completo",
+      action:
+        "Confrontare spesa storica, valore di riferimento e livello dei servizi; verificare costi locali prima di qualsiasi ipotesi di revisione.",
+      sourceLabel: "OpenCivitas · screening derivato DVNS",
+      sourceUrl: openCivitasSnapshot.source.datasetUrl,
+      period: String(openCivitasSnapshot.referenceYear),
+      limits:
+        "Screening statistico, non esito di controllo. La differenza dalla spesa standard non dimostra uno spreco.",
+    },
+    {
+      id: "opencivitas-high-low",
+      kind: "screening",
+      area: "Comuni",
+      headline: "Spesa alta e servizi bassi (profilo OpenCivitas)",
+      observation:
+        `Nel rilascio ${openCivitasSnapshot.referenceYear}, ${highLow.municipalities.toLocaleString("it-IT")} Comuni rientrano nel profilo descrittivo spesa da 6 a 10 e servizi da 0 a 5 (su ${quadrants.completeMunicipalities.toLocaleString("it-IT")} con livelli completi). Spesa storica aggregata del profilo: ${formatBillionFromCents(highLow.historicalSpendingCents)}; valore di riferimento aggregato: ${formatBillionFromCents(highLow.standardSpendingCents)}.`,
+      deepenHref: "/territori/confronto",
+      deepenLabel: "Apri il confronto OpenCivitas",
+      action:
+        "Leggere insieme spesa e servizi: il profilo segnala dove approfondire qualità e costi, non un giudizio automatico di inefficienza.",
+      sourceLabel: "OpenCivitas · quadranti descrittivi",
+      sourceUrl: openCivitasSnapshot.source.datasetUrl,
+      period: String(openCivitasSnapshot.referenceYear),
+      limits:
+        "Classificazione descrittiva sui livelli pubblicati (soglia 6). Non è una graduatoria di merito.",
+    },
+    {
+      id: "anac-direct-awards",
+      kind: "osservazione",
+      area: "Appalti",
+      headline: "Affidamenti diretti e fascia vicino alla soglia",
+      observation:
+        `Nella relazione ANAC ${anac2025.year}, gli affidamenti diretti sono il ${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(anac2025.byNumber)}% delle procedure da 40.000 € in su (per numero). Su servizi e forniture, ANAC segnala quasi il ${procurementServicesAndSupplies2025.directAwardShare}% di affidamenti diretti; le procedure tra ${procurementServicesAndSupplies2025.thresholdBandLowerEuro.toLocaleString("it-IT")} e ${procurementServicesAndSupplies2025.thresholdBandUpperEuro.toLocaleString("it-IT")} € passano da ${procurementServicesAndSupplies2025.thresholdBandCount2021.toLocaleString("it-IT")} (2021) a ${procurementServicesAndSupplies2025.thresholdBandCount2025.toLocaleString("it-IT")} (2025).`,
+      deepenHref: "/appalti",
+      deepenLabel: "Apri il verticale appalti",
+      action:
+        "Verificare motivazioni, concorrenza effettiva e ripetizione dello stesso operatore; la concentrazione vicino alla soglia indica dove approfondire, non un illecito automatico.",
+      sourceLabel: anac2025.sourceTitle,
+      sourceUrl: anac2025.sourceUrl,
+      period: String(anac2025.year),
+      limits: procurementServicesAndSupplies2025.caveat,
+    },
+    {
+      id: "tax-expenditures",
+      kind: "osservazione",
+      area: tax.area,
+      headline: "Agevolazioni fiscali da rivedere con metodo",
+      observation: `${tax.label}: ${formatBillion(tax.value)}. ${tax.plainMeaning}`,
+      deepenHref: "/controlli",
+      deepenLabel: "Vedi il segnale nelle priorità",
+      action:
+        "Selezionare misure con stima puntuale e basso target pubblico, poi stimare effetti redistributivi prima di una revisione normativa.",
+      sourceLabel: `${tax.source.institution} · ${tax.source.title}`,
+      sourceUrl: tax.source.url,
+      period: tax.referenceDate,
+      limits: tax.caveat,
+    },
+    {
+      id: "superbonus",
+      kind: "osservazione",
+      area: superbonus.area,
+      headline: "Superbonus: costo fiscale cumulato da monitorare",
+      observation: `${superbonus.label}: ${formatBillion(superbonus.value)}. ${superbonus.plainMeaning}`,
+      deepenHref: "/controlli",
+      deepenLabel: "Vedi il segnale nelle priorità",
+      action:
+        "Tenere separate detrazioni maturate e pagamenti di cassa; verificare sovrapposizioni con altre agevolazioni prima di qualsiasi ipotesi di revisione.",
+      sourceLabel: `${superbonus.source.institution} · ${superbonus.source.title}`,
+      sourceUrl: superbonus.source.url,
+      period: superbonus.referenceDate,
+      limits: superbonus.caveat,
+    },
+    {
+      id: "healthcare-external-staff",
+      kind: "osservazione",
+      area: healthcare.area,
+      headline: "Personale sanitario esterno: dipendenza da valutare",
+      observation: `${healthcare.label}: ${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(healthcare.value)} mln €. ${healthcare.plainMeaning}`,
+      deepenHref: "/spese/sanita",
+      deepenLabel: "Apri la spesa sanitaria",
+      action:
+        "Confrontare costo esterno e assunzioni stabili per branca; il ricorso a esterni può essere necessario, ma va monitorato se strutturale.",
+      sourceLabel: `${healthcare.source.institution} · ${healthcare.source.title}`,
+      sourceUrl: healthcare.source.url,
+      period: healthcare.referenceDate,
+      limits: healthcare.caveat,
+    },
+    {
+      id: "ssn-production-costs",
+      kind: "osservazione",
+      area: "Sanità",
+      headline: "Costi di produzione SSN e servizi acquistati",
+      observation:
+        `Conto economico consuntivo SSN ${ssn.referenceYear}: costi della produzione ${formatBillionFromCents(productionCostsCents)}; servizi acquistati ${formatBillionFromCents(purchasedServicesCents)} (${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(purchasedShare)}% del totale produzione).`,
+      deepenHref: "/spese/sanita",
+      deepenLabel: "Apri il Conto economico SSN",
+      action:
+        "Monitorare il peso dei servizi acquistati rispetto al personale interno; è competenza economica, non cassa SIOPE.",
+      sourceLabel: "OpenBDAP · Conto economico enti SSN",
+      sourceUrl: "/spese/sanita",
+      period: String(ssn.referenceYear),
+      limits: ssn.observation.accountingBasis,
+    },
+    {
+      id: "off-budget-debt",
+      kind: "osservazione",
+      area: offBudget.area,
+      headline: "Debiti fuori bilancio nei Comuni",
+      observation: `${offBudget.label}: ${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(offBudget.value)} mln €. ${offBudget.plainMeaning}`,
+      deepenHref: "/territori",
+      deepenLabel: "Apri i territori e i pagamenti comunali",
+      action:
+        "Priorità agli enti con acquisti senza impegno preventivo: rafforzare controlli contabili e trasparenza degli impegni, non sanzioni automatiche da questo dato.",
+      sourceLabel: `${offBudget.source.institution} · ${offBudget.source.title}`,
+      sourceUrl: offBudget.source.url,
+      period: offBudget.referenceDate,
+      limits: offBudget.caveat,
+    },
+    {
+      id: "public-debt-interest",
+      kind: "osservazione",
+      area: "Debito pubblico",
+      headline: "Stock di debito e peso degli interessi",
+      observation:
+        `Stock BdI al ${debt.stock.referenceDate}: ${formatBillionFromCents(debt.stock.totalCents, 1)}. Interessi sul bilancio pubblico (Eurostat ${debt.citizenImpact.annualInterest.referenceYear}): ${formatBillionFromCents(debt.citizenImpact.annualInterest.interestExpenseCents, 1)}, pari a ${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 2 }).format(debt.citizenImpact.annualInterest.euroPerHundredEuro)} € ogni 100 € di spesa pubblica totale. Quota in scadenza entro un anno: ${new Intl.NumberFormat("it-IT", { maximumFractionDigits: 1 }).format(debt.citizenImpact.refinancingExposure.upToOneYearShareBasisPoints / 100)}%.`,
+      deepenHref: "/debito",
+      deepenLabel: "Apri il debito pubblico",
+      action:
+        "Usare stock, fabbisogno e interessi come vincolo di contesto per qualsiasi ipotesi di revisione di spesa o entrate; non sono un taglio automatico.",
+      sourceLabel: "Banca d'Italia · Eurostat gov_10a_main",
+      sourceUrl: debt.sources.bancaditalia.landingUrl,
+      period: debt.stock.referenceDate,
+      limits:
+        "Stock e interessi hanno fonti e periodi distinti. Non attribuiscono responsabilità a un singolo governo senza contesto.",
+    },
+    {
+      id: "rgs-consulting",
+      kind: "osservazione",
+      area: "Consulenze ministeriali",
+      headline: "Pagamenti per consulenze (categorie economiche RGS)",
+      observation:
+        consultTop.length === 0
+          ? `Snapshot RGS ${consultYear}: nessun pagamento di consulenza nello snapshot.`
+          : `Nel ${consultYear} lo snapshot RGS registra ${formatMillionFromCents(consultPaid)} di pagamenti di cassa per consulenze (aggregati PG). Principali amministrazioni per importo pagato: ${consultTop
+              .map((row) => `${row.administration} (${formatMillionFromCents(row.paidCashCents)})`)
+              .join("; ")}.`,
+      deepenHref: "/spese/consulenze",
+      deepenLabel: "Apri consulenze ministeriali",
+      action:
+        "Drill-down per amministrazione e piano di gestione: confrontare anni e verificare se i servizi sono ripetuti o sostituibili con capacità interne.",
+      sourceLabel: "Ragioneria Generale dello Stato · OpenBDAP consulenze",
+      sourceUrl: "https://bdap-opendata.rgs.mef.gov.it/",
+      period: String(consultYear),
+      limits:
+        "Aggregati contabili PG, senza nominativi di consulenti. Non è una classifica di merito o di spreco.",
+    },
+    {
+      id: "reduced-competition-value",
+      kind: "osservazione",
+      area: reducedCompetition.area,
+      headline: "Valore delle procedure a ridotta concorrenza",
+      observation: `${reducedCompetition.label}: ${formatBillion(reducedCompetition.value)}. ${reducedCompetition.plainMeaning}`,
+      deepenHref: "/appalti",
+      deepenLabel: "Apri gli appalti",
+      action:
+        "Allargare la platea di operatori e documentare meglio le deroghe: il dato misura esposizione a ridotta concorrenza, non un illecito.",
+      sourceLabel: `${reducedCompetition.source.institution} · ${reducedCompetition.source.title}`,
+      sourceUrl: reducedCompetition.source.url,
+      period: reducedCompetition.referenceDate,
+      limits: reducedCompetition.caveat,
+    },
+    {
+      id: "pnrr-beyond-2026",
+      kind: "osservazione",
+      area: pnrr.area,
+      headline: "Risorse PNRR previste oltre il 2026",
+      observation: `${pnrr.label}: ${formatBillion(pnrr.value)}. ${pnrr.plainMeaning}`,
+      deepenHref: "/coesione/asili",
+      deepenLabel: "Apri fondi e progetti (asili PNRR)",
+      action:
+        "Monitorare scadenze, stati di avanzamento e capacità di spesa; il dato misura programmazione, non ritardi individuali.",
+      sourceLabel: `${pnrr.source.institution} · ${pnrr.source.title}`,
+      sourceUrl: pnrr.source.url,
+      period: pnrr.referenceDate,
+      limits: pnrr.caveat,
+    },
+    {
+      id: "collection-stock",
+      kind: "osservazione",
+      area: collection.area,
+      headline: "Carichi affidati alla riscossione",
+      observation: `${collection.label}: ${formatBillion(collection.value)}. ${collection.plainMeaning}`,
+      deepenHref: "/controlli",
+      deepenLabel: "Vedi il segnale nelle priorità",
+      action:
+        "Distinguere stock storico e nuove affidamenti; valutare strategie di riscossione senza confondere credito affidato e gettito annuale.",
+      sourceLabel: `${collection.source.institution} · ${collection.source.title}`,
+      sourceUrl: collection.source.url,
+      period: collection.referenceDate,
+      limits: collection.caveat,
+    },
+    {
+      id: "gdf-controls",
+      kind: "osservazione",
+      area: gdf.area,
+      headline: "Esiti dei controlli della Guardia di finanza",
+      observation:
+        `La Guardia di finanza comunica oltre ${formatBillion(gdf.value)} di esiti di controllo a danno del bilancio nazionale e dell'Unione europea (${gdf.coverage}).`,
+      deepenHref: "/controlli",
+      deepenLabel: "Vedi il segnale nelle priorità",
+      action:
+        "Usare il comunicato ufficiale come priorità di lettura istituzionale; non equivale a condanne definitive o somme già recuperate.",
+      sourceLabel: `${gdf.source.institution} · ${gdf.source.title}`,
+      sourceUrl: gdf.source.url,
+      period: gdf.referenceDate,
+      limits: gdf.caveat,
+    },
+    {
+      id: "improvement-hypothesis",
+      kind: "ipotesi",
+      area: "Ipotesi di miglioramento",
+      headline: "Scenario centrale: dove una revisione potrebbe agire",
+      observation:
+        `Ipotesi di policy (non un risparmio già disponibile): scenario centrale a ${formatBillion(central.annualBillion, 2)}/anno, costruito su basi dichiarate (agevolazioni ${formatBillion(auditScenarioBasis.taxExpendituresBillion)}, ridotta concorrenza ${formatBillion(auditScenarioBasis.reducedCompetitionBillion)}, personale sanitario esterno ${formatBillion(auditScenarioBasis.externalHealthcareStaffBillion, 3)}, acquisti senza impegno ${formatBillion(auditScenarioBasis.purchasesWithoutPriorCommitmentBillion, 3)}). Quote assunte: appalti ${Math.round(auditScenarioAssumptions.central.procurementAuditedShare * 100)}% del perimetro × ${Math.round(auditScenarioAssumptions.central.procurementEfficiencyRate * 1000) / 10}% efficienza; agevolazioni ${Math.round(auditScenarioAssumptions.central.taxReviewRate * 100)}%; sanità ${Math.round(auditScenarioAssumptions.central.healthcareReductionRate * 100)}%; prevenzione debiti ${Math.round(auditScenarioAssumptions.central.debtPreventionRate * 100)}%. Componenti: ${centralScenarioBreakdown
+          .map((row) => `${row.label} ${formatBillion(row.value, 1)}`)
+          .join("; ")}.`,
+      deepenHref: "/controlli#policy-scenarios-title",
+      deepenLabel: "Vedi scenari e assunzioni",
+      action:
+        "Usare lo scenario solo come ordine di grandezza per un dibattito pubblico: ogni voce richiede una misura normativa o amministrativa verificabile.",
+      sourceLabel: auditScenarioBasis.sourceTitle,
+      sourceUrl: "/metodologia",
+      period: auditScenarioBasis.reviewedAt,
+      limits:
+        "Sono ipotesi di politica pubblica. Non sono risparmi già disponibili e non sono previsioni ufficiali.",
+    },
+  ];
+
+  return pathways;
+}
+
+function shortAdminLabel(name: string, max = 28): string {
+  if (name.length <= max) return name;
+  return `${name.slice(0, Math.max(1, max - 1)).trimEnd()}…`;
+}
+
+/**
+ * Deterministic "what an AI steward would do" agenda.
+ * Explicitly AI-labeled: not a live model call, not government advice, grounded in the same pathways.
+ * Each move carries a metric + bar chart built from the same sourced numbers (no invented figures).
+ */
+export function buildAiStewardshipAgenda(
+  pathways: readonly SintesiPathway[] = buildControlliSintesiPathways(),
+): readonly AiStewardshipMove[] {
+  const byId = new Map(pathways.map((pathway) => [pathway.id, pathway]));
+  const need = (id: string) => {
+    const pathway = byId.get(id);
+    if (!pathway) throw new Error(`Percorso assente per agenda AI: ${id}`);
+    return pathway;
+  };
+
+  const tax = need("tax-expenditures");
+  const anac = need("anac-direct-awards");
+  const competition = need("reduced-competition-value");
+  const debt = need("public-debt-interest");
+  const oc = need("opencivitas-high-low");
+  const ssn = need("ssn-production-costs");
+  const consult = need("rgs-consulting");
+  const collection = need("collection-stock");
+  const scenario = need("improvement-hypothesis");
+
+  const centralScenario = auditScenarios.find((row) => row.id === "central");
+  if (!centralScenario) throw new Error("Scenario centrale assente per agenda AI");
+
+  const debtView = getPublicDebtView();
+  const interestBillion = debtView.citizenImpact.annualInterest.interestExpenseCents / 100_000_000_000;
+  const maturity = debtView.residualMaturity.shares;
+  const taxSignal = signalById("tax-expenditures");
+  const superbonusSignal = signalById("superbonus-accrued-deductions");
+  const anac2025 = procurementComparisons[2025];
+  const reducedCompetition = signalById("procurement-low-competition-value");
+  const collectionSignal = signalById("collection-stock");
+  const healthcare = signalById("healthcare-external-staff");
+  const quadrants = summarizeOpenCivitasQuadrants(openCivitasSnapshot.municipalities);
+  const highLow = quadrants.quadrants.find((quadrant) => quadrant.key === "high-low");
+  if (!highLow) throw new Error("Quadrante OpenCivitas high-low assente per agenda AI");
+  const otherMunicipalities = Math.max(0, quadrants.completeMunicipalities - highLow.municipalities);
+  const ssnQuery = querySsnCce({});
+  const ssnValues = ssnQuery.selectedAggregate.values;
+  if (!ssnValues) throw new Error("Valori nazionali SSN assenti per agenda AI");
+  const productionCostsCents = ssnValues.productionCosts;
+  const purchasedServicesCents = ssnValues.purchasedServices;
+  const purchasedShare = productionCostsCents > 0
+    ? (purchasedServicesCents / productionCostsCents) * 100
+    : 0;
+  const consultYear = consultingYear();
+  const consultTop = topConsultingAdministrations(consultYear, 3);
+  const consultMax = Math.max(...consultTop.map((row) => row.paidCashCents), 1);
+  const scenarioMax = Math.max(...centralScenarioBreakdown.map((row) => row.value), 0.01);
+
+  return [
+    {
+      id: "ai-map-constraints",
+      priority: 1,
+      title: "Mappare prima i vincoli di bilancio",
+      shortWhy: "Prima i vincoli, poi le revisioni di spesa o di entrate.",
+      why: debt.observation,
+      agentWould:
+        "Partirebbe da stock di debito, interessi e scadenze entro un anno per fissare il perimetro sostenibile.",
+      basedOnPathwayIds: ["public-debt-interest"],
+      deepenHref: debt.deepenHref,
+      deepenLabel: "Apri il debito pubblico",
+      metric: {
+        label: "Interessi annui (Eurostat)",
+        display: formatBillion(interestBillion, 1),
+        hint: `Scadenza ≤1 anno: ${(maturity.upToOneYearBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+      },
+      bars: [
+        {
+          label: "Fino a 1 anno",
+          value: maturity.upToOneYearBasisPoints,
+          display: `${(maturity.upToOneYearBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        },
+        {
+          label: "Da 1 a 5 anni",
+          value: maturity.oneToFiveYearsBasisPoints,
+          display: `${(maturity.oneToFiveYearsBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        },
+        {
+          label: "Oltre 5 anni",
+          value: maturity.overFiveYearsBasisPoints,
+          display: `${(maturity.overFiveYearsBasisPoints / 100).toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        },
+      ],
+      chartCaption: "Scadenze residue del debito (quote sul totale)",
+    },
+    {
+      id: "ai-review-tax-expenditures",
+      priority: 2,
+      title: "Ordinare le agevolazioni fiscali per revisione",
+      shortWhy: "Shortlist solo sulle misure con stima puntuale MEF.",
+      why: tax.observation,
+      agentWould:
+        "Produrrebbe una coda di misure con stima numerica e chiederebbe una valutazione redistributiva umana prima di ipotesi normative.",
+      basedOnPathwayIds: ["tax-expenditures", "superbonus"],
+      deepenHref: tax.deepenHref,
+      deepenLabel: "Apri le agevolazioni",
+      metric: {
+        label: "Stima puntuale MEF",
+        display: formatBillion(taxSignal.value, 1),
+        hint: taxSignal.coverage,
+      },
+      bars: [
+        {
+          label: "Agevolazioni con stima",
+          value: taxSignal.value,
+          display: formatBillion(taxSignal.value, 1),
+        },
+        {
+          label: "Superbonus (onere cumulato)",
+          value: superbonusSignal.value,
+          display: formatBillion(superbonusSignal.value, 1),
+        },
+      ],
+      chartCaption: "Ordini di grandezza fiscali già in piattaforma (non sommare come un unico risparmio)",
+    },
+    {
+      id: "ai-open-procurement",
+      priority: 3,
+      title: "Aprire più concorrenza negli appalti",
+      shortWhy: "Code di verifica su affidamenti diretti e ridotta concorrenza.",
+      why: `${anac.observation} ${competition.observation}`,
+      agentWould:
+        "Segnalerebbe procedure vicino alla soglia e perimetri a ridotta concorrenza; proporrebbe più platea e deroghe documentate, senza attribuire illeciti.",
+      basedOnPathwayIds: ["anac-direct-awards", "reduced-competition-value"],
+      deepenHref: anac.deepenHref,
+      deepenLabel: "Apri gli appalti ANAC",
+      metric: {
+        label: "Affidamenti diretti (su n. procedure)",
+        display: `${anac2025.byNumber.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        hint: `Sul valore: ${anac2025.byValue.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+      },
+      bars: [
+        {
+          label: "Diretti sul numero",
+          value: anac2025.byNumber,
+          display: `${anac2025.byNumber.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        },
+        {
+          label: "Diretti sul valore",
+          value: anac2025.byValue,
+          display: `${anac2025.byValue.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        },
+        {
+          label: "Ridotta concorrenza (valore)",
+          value: Math.min(100, (reducedCompetition.value / anac2025.totalValueBillion) * 100),
+          display: formatBillion(reducedCompetition.value, 1),
+        },
+      ],
+      chartCaption: "ANAC 2025: quote e perimetro a ridotta concorrenza (scale diverse, lettura descrittiva)",
+    },
+    {
+      id: "ai-municipal-profiles",
+      priority: 4,
+      title: "Priorità ai Comuni con profilo spesa alta / servizi bassi",
+      shortWhy: "Coda di lettura sui profili OpenCivitas, non una classifica di colpe.",
+      why: oc.observation,
+      agentWould:
+        "Costruirebbe una coda sui Comuni spesa alta / servizi bassi e chiederebbe il confronto con pari prima di ipotesi locali.",
+      basedOnPathwayIds: ["opencivitas-high-low", "opencivitas-outliers"],
+      deepenHref: oc.deepenHref,
+      deepenLabel: "Apri il confronto OpenCivitas",
+      metric: {
+        label: "Comuni nel profilo",
+        display: highLow.municipalities.toLocaleString("it-IT"),
+        hint: `su ${quadrants.completeMunicipalities.toLocaleString("it-IT")} con livelli completi`,
+      },
+      bars: [
+        {
+          label: "Spesa alta / servizi bassi",
+          value: highLow.municipalities,
+          display: highLow.municipalities.toLocaleString("it-IT"),
+        },
+        {
+          label: "Altri profili completi",
+          value: otherMunicipalities,
+          display: otherMunicipalities.toLocaleString("it-IT"),
+        },
+      ],
+      chartCaption: `OpenCivitas ${openCivitasSnapshot.referenceYear}: conteggio Comuni (profilo descrittivo)`,
+    },
+    {
+      id: "ai-health-mix",
+      priority: 5,
+      title: "Riequilibrare il mix sanitario interno / esterno",
+      shortWhy: "Monitorare servizi acquistati e personale esterno con simulazioni, non tagli automatici.",
+      why: ssn.observation,
+      agentWould:
+        "Terrebbe sotto osservazione il peso dei servizi acquistati e della spesa per personale esterno; proporrebbe solo simulazioni.",
+      basedOnPathwayIds: ["ssn-production-costs", "healthcare-external-staff"],
+      deepenHref: ssn.deepenHref,
+      deepenLabel: "Apri la sanità",
+      metric: {
+        label: "Servizi acquistati sul costo di produzione",
+        display: `${purchasedShare.toLocaleString("it-IT", { maximumFractionDigits: 1 })}%`,
+        hint: `Personale esterno: ${formatBillion(healthcare.value, 3)}`,
+      },
+      bars: [
+        {
+          label: "Servizi acquistati",
+          value: purchasedServicesCents,
+          display: formatBillionFromCents(purchasedServicesCents),
+        },
+        {
+          label: "Resto dei costi di produzione",
+          value: Math.max(0, productionCostsCents - purchasedServicesCents),
+          display: formatBillionFromCents(Math.max(0, productionCostsCents - purchasedServicesCents)),
+        },
+      ],
+      chartCaption: "Composizione del costo di produzione SSN (aggregato nazionale selezionato)",
+    },
+    {
+      id: "ai-consulting-and-collection",
+      priority: 6,
+      title: "Rivedere consulenze ripetute e stock di riscossione",
+      shortWhy: "Confrontare amministrazioni in alto e tenere lo stock separato dal gettito.",
+      why: `${consult.observation} ${collection.observation}`,
+      agentWould:
+        "Confronterebbe le amministrazioni con i pagamenti di consulenza più alti e terrebbe separato lo stock della riscossione dal gettito annuale.",
+      basedOnPathwayIds: ["rgs-consulting", "collection-stock"],
+      deepenHref: consult.deepenHref,
+      deepenLabel: "Apri le consulenze",
+      metric: {
+        label: "Stock riscossione (nominale)",
+        display: formatBillion(collectionSignal.value, 1),
+        hint: "Non è un tesoretto disponibile",
+      },
+      bars: consultTop.map((row) => ({
+        label: shortAdminLabel(row.administration),
+        value: row.paidCashCents / consultMax,
+        display: formatMillionFromCents(row.paidCashCents),
+      })),
+      chartCaption: `Top ${consultTop.length} amministrazioni per pagamenti di consulenza (${consultYear})`,
+    },
+    {
+      id: "ai-publish-hypothesis",
+      priority: 7,
+      title: "Pubblicare solo ipotesi con assunzioni esplicite",
+      shortWhy: "Lo scenario centrale è un ordine di grandezza, non cassa già disponibile.",
+      why: scenario.observation,
+      agentWould:
+        `Userebbe lo scenario centrale (${formatBillion(centralScenario.annualBillion, 2)}/anno) solo con assunzioni visibili. ${auditMethodology.scenarioMeaning}`,
+      basedOnPathwayIds: ["improvement-hypothesis"],
+      deepenHref: scenario.deepenHref,
+      deepenLabel: "Apri gli scenari",
+      metric: {
+        label: "Scenario centrale (ipotesi/anno)",
+        display: formatBillion(centralScenario.annualBillion, 2),
+        hint: "Ipotesi di policy, non previsione",
+      },
+      bars: centralScenarioBreakdown.map((row) => ({
+        label: shortAdminLabel(row.label, 42),
+        value: row.value / scenarioMax,
+        display: formatBillion(row.value, 2),
+      })),
+      chartCaption: "Scomposizione dello scenario centrale (quote assunte, non risparmi certi)",
+    },
+  ];
+}
+
+export const sintesiReadingOrder = [
+  {
+    step: "1",
+    title: "Cosa emerge",
+    text: "Osservazioni e screening già calcolati dai dati in piattaforma.",
+  },
+  {
+    step: "2",
+    title: "Dove approfondire",
+    text: "Link alla pagina di dettaglio o alla fonte ufficiale.",
+  },
+  {
+    step: "3",
+    title: "Cosa si può fare",
+    text: "Piste di verifica o di miglioramento. Mai accuse automatiche.",
+  },
+] as const;
+
+export const aiStewardshipDisclosure = {
+  badge: "Proposta AI · non ufficiale",
+  title: "Se un agente AI dovesse gestire spese e leggi: cosa farebbe",
+  lead:
+    "Agenda deterministica etichettata come AI: non è parere del Governo, non è un modello live e non sostituisce scelte democratiche. Ogni priorità usa solo i numeri dei percorsi sopra (fonte, periodo, limiti; niente accuse automatiche).",
+  allowed: auditMethodology.aiUse.allowed,
+  prohibited: auditMethodology.aiUse.prohibited,
+} as const;

--- a/src/lib/controlli-sintesi.ts
+++ b/src/lib/controlli-sintesi.ts
@@ -44,10 +44,13 @@ export type AiStewardshipMove = Readonly<{
   id: string;
   priority: number;
   title: string;
-  /** One-line context for the card body. */
-  shortWhy: string;
+  /** What domain / object the move covers. */
+  concerns: string;
+  /** How the agent would operate. */
+  operation: string;
+  /** Expected orientation effect if humans follow up (not a guaranteed saving). */
+  effect: string;
   why: string;
-  agentWould: string;
   basedOnPathwayIds: readonly string[];
   deepenHref: string;
   deepenLabel: string;
@@ -471,10 +474,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-map-constraints",
       priority: 1,
       title: "Mappare prima i vincoli di bilancio",
-      shortWhy: "Prima i vincoli, poi le revisioni di spesa o di entrate.",
+      concerns: "Stock di debito pubblico, interessi annui e scadenze residue.",
+      operation:
+        "L'agente legge stock, interessi e quota in scadenza entro un anno e li dispone come vincoli prima di qualsiasi proposta su spese o entrate.",
+      effect:
+        "Definisce un perimetro sostenibile: le revisioni successive restano confrontabili con il costo del debito, senza presentarle come cassa libera.",
       why: debt.observation,
-      agentWould:
-        "Partirebbe da stock di debito, interessi e scadenze entro un anno per fissare il perimetro sostenibile.",
       basedOnPathwayIds: ["public-debt-interest"],
       deepenHref: debt.deepenHref,
       deepenLabel: "Apri il debito pubblico",
@@ -506,10 +511,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-review-tax-expenditures",
       priority: 2,
       title: "Ordinare le agevolazioni fiscali per revisione",
-      shortWhy: "Shortlist solo sulle misure con stima puntuale MEF.",
+      concerns: "Agevolazioni fiscali MEF con stima puntuale e onere Superbonus già censito.",
+      operation:
+        "L'agente produce una coda delle sole misure con stima numerica, esclude quelle senza copertura e richiede una valutazione redistributiva umana prima di ipotesi normative.",
+      effect:
+        "Il dibattito fiscale parte da una shortlist verificabile: meno rumore sulle misure senza cifra, più trasparenza su dove una revisione potrebbe incidere.",
       why: tax.observation,
-      agentWould:
-        "Produrrebbe una coda di misure con stima numerica e chiederebbe una valutazione redistributiva umana prima di ipotesi normative.",
       basedOnPathwayIds: ["tax-expenditures", "superbonus"],
       deepenHref: tax.deepenHref,
       deepenLabel: "Apri le agevolazioni",
@@ -536,10 +543,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-open-procurement",
       priority: 3,
       title: "Aprire più concorrenza negli appalti",
-      shortWhy: "Code di verifica su affidamenti diretti e ridotta concorrenza.",
+      concerns: "Affidamenti diretti ANAC e contratti a ridotta concorrenza sul valore.",
+      operation:
+        "L'agente segnala procedure vicino alla soglia e perimetri a ridotta concorrenza come code di verifica; propone di allargare la platea e di documentare le deroghe, senza attribuire illeciti.",
+      effect:
+        "Più controlli mirati e più confronto competitivo dove i dati lo suggeriscono; l'esito resta amministrativo e umano, non una sentenza automatica.",
       why: `${anac.observation} ${competition.observation}`,
-      agentWould:
-        "Segnalerebbe procedure vicino alla soglia e perimetri a ridotta concorrenza; proporrebbe più platea e deroghe documentate, senza attribuire illeciti.",
       basedOnPathwayIds: ["anac-direct-awards", "reduced-competition-value"],
       deepenHref: anac.deepenHref,
       deepenLabel: "Apri gli appalti ANAC",
@@ -571,10 +580,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-municipal-profiles",
       priority: 4,
       title: "Priorità ai Comuni con profilo spesa alta / servizi bassi",
-      shortWhy: "Coda di lettura sui profili OpenCivitas, non una classifica di colpe.",
+      concerns: "Profili OpenCivitas dei Comuni: spesa storica alta rispetto a servizi bassi.",
+      operation:
+        "L'agente costruisce una coda di lettura sui Comuni del profilo spesa alta / servizi bassi e chiede il confronto con pari e con i livelli di servizio prima di ipotesi locali.",
+      effect:
+        "Gli interventi locali partono dai casi dove spesa e servizi divergono di più, senza trasformare lo screening in una classifica di colpe.",
       why: oc.observation,
-      agentWould:
-        "Costruirebbe una coda sui Comuni spesa alta / servizi bassi e chiederebbe il confronto con pari prima di ipotesi locali.",
       basedOnPathwayIds: ["opencivitas-high-low", "opencivitas-outliers"],
       deepenHref: oc.deepenHref,
       deepenLabel: "Apri il confronto OpenCivitas",
@@ -601,10 +612,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-health-mix",
       priority: 5,
       title: "Riequilibrare il mix sanitario interno / esterno",
-      shortWhy: "Monitorare servizi acquistati e personale esterno con simulazioni, non tagli automatici.",
+      concerns: "Costi di produzione SSN, servizi acquistati e personale sanitario esterno.",
+      operation:
+        "L'agente monitora il peso dei servizi acquistati e della spesa per personale esterno, li confronta con le assunzioni stabili e propone solo simulazioni di riequilibrio.",
+      effect:
+        "Si vede dove il mix interno/esterno pesa di più; eventuali scelte restano cliniche e di bilancio, non tagli automatici ai servizi.",
       why: ssn.observation,
-      agentWould:
-        "Terrebbe sotto osservazione il peso dei servizi acquistati e della spesa per personale esterno; proporrebbe solo simulazioni.",
       basedOnPathwayIds: ["ssn-production-costs", "healthcare-external-staff"],
       deepenHref: ssn.deepenHref,
       deepenLabel: "Apri la sanità",
@@ -631,10 +644,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-consulting-and-collection",
       priority: 6,
       title: "Rivedere consulenze ripetute e stock di riscossione",
-      shortWhy: "Confrontare amministrazioni in alto e tenere lo stock separato dal gettito.",
+      concerns: "Pagamenti di consulenza RGS per amministrazione e stock nominale della riscossione.",
+      operation:
+        "L'agente confronta le amministrazioni con i pagamenti di consulenza più alti e tiene separato lo stock della riscossione dal gettito annuale, proponendo audit contabili e piani di recupero verificabili.",
+      effect:
+        "Si riduce la confusione tra flussi e stock: le consulenze si leggono per andamento, la riscossione resta un credito nominale da non trattare come tesoretto.",
       why: `${consult.observation} ${collection.observation}`,
-      agentWould:
-        "Confronterebbe le amministrazioni con i pagamenti di consulenza più alti e terrebbe separato lo stock della riscossione dal gettito annuale.",
       basedOnPathwayIds: ["rgs-consulting", "collection-stock"],
       deepenHref: consult.deepenHref,
       deepenLabel: "Apri le consulenze",
@@ -654,10 +669,12 @@ export function buildAiStewardshipAgenda(
       id: "ai-publish-hypothesis",
       priority: 7,
       title: "Pubblicare solo ipotesi con assunzioni esplicite",
-      shortWhy: "Lo scenario centrale è un ordine di grandezza, non cassa già disponibile.",
+      concerns: "Scenario centrale di miglioramento e sue componenti dichiarate.",
+      operation:
+        `L'agente usa lo scenario centrale (${formatBillion(centralScenario.annualBillion, 2)}/anno) solo come ordine di grandezza, con assunzioni visibili, e vieta di presentarlo come risparmio già disponibile.`,
+      effect:
+        "Il pubblico vede un'ipotesi di policy con formula e limiti: utile al dibattito, non confondibile con soldi già in cassa.",
       why: scenario.observation,
-      agentWould:
-        `Userebbe lo scenario centrale (${formatBillion(centralScenario.annualBillion, 2)}/anno) solo con assunzioni visibili. ${auditMethodology.scenarioMeaning}`,
       basedOnPathwayIds: ["improvement-hypothesis"],
       deepenHref: scenario.deepenHref,
       deepenLabel: "Apri gli scenari",
@@ -695,10 +712,12 @@ export const sintesiReadingOrder = [
 ] as const;
 
 export const aiStewardshipDisclosure = {
-  badge: "Proposta AI · non ufficiale",
-  title: "Se un agente AI dovesse gestire spese e leggi: cosa farebbe",
+  badge: "Sezione agenti AI · non ufficiale",
+  kicker: "Capitolo distinto dai percorsi umani sopra",
+  title: "Agenda gestita da agenti AI",
+  subtitle: "Cosa farebbe un agente se dovesse orientare spese e leggi dello Stato",
   lead:
-    "Agenda deterministica etichettata come AI: non è parere del Governo, non è un modello live e non sostituisce scelte democratiche. Ogni priorità usa solo i numeri dei percorsi sopra (fonte, periodo, limiti; niente accuse automatiche).",
+    "Questa fascia è separata di proposito: non è il continuo dei 15 percorsi. È un'agenda deterministica etichettata come AI, non parere del Governo, non modello live e non sostituto delle scelte democratiche. Ogni priorità usa solo i numeri già mostrati sopra.",
   allowed: auditMethodology.aiUse.allowed,
   prohibited: auditMethodology.aiUse.prohibited,
 } as const;

--- a/src/lib/public-discovery.ts
+++ b/src/lib/public-discovery.ts
@@ -21,6 +21,7 @@ export const PUBLIC_INDEXABLE_PATHS = [
   "/coesione/asili",
   "/confronti",
   "/controlli",
+  "/controlli/sintesi",
   "/dati",
   "/debito",
   "/enti",

--- a/src/lib/site-navigation.ts
+++ b/src/lib/site-navigation.ts
@@ -95,12 +95,13 @@ export const PRIMARY_NAV: readonly NavSection[] = [
   {
     href: "/controlli",
     label: "Cosa controllare",
-    aliases: ["/appalti", "/incarichi", "/dati", "/trasparenza"],
+    aliases: ["/appalti", "/incarichi", "/dati", "/trasparenza", "/controlli/sintesi"],
     children: [
       { href: "/appalti", label: "Appalti" },
       { href: "/incarichi", label: "Incarichi" },
       { href: "/dati", label: "Catalogo dati" },
       { href: "/controlli", label: "Segnali" },
+      { href: "/controlli/sintesi", label: "Sintesi" },
       { href: "/esplora", label: "Esplora relazioni" },
     ],
   },
@@ -195,6 +196,7 @@ export const SITE_MAP_GROUPS: readonly { title: string; links: readonly NavLink[
       { href: "/incarichi/dettaglio", label: "Incarichi di dettaglio" },
       { href: "/dati", label: "Catalogo dati" },
       { href: "/controlli", label: "Segnali" },
+      { href: "/controlli/sintesi", label: "Sintesi" },
       { href: "/trasparenza", label: "Trasparenza e verifiche" },
     ],
   },

--- a/tests/controlli-sintesi.test.mjs
+++ b/tests/controlli-sintesi.test.mjs
@@ -18,7 +18,10 @@ test("controlli sintesi page keeps verification copy and no automatic guilt labe
   assert.match(page, /buildControlliSintesiPathways/);
   assert.match(page, /buildAiStewardshipAgenda/);
   assert.match(page, /agenda-ai/);
-  assert.match(page, /aiBoard|aiMetric|aiBars|aiRail/);
+  assert.match(page, /aiZone|aiHero|aiBrief/);
+  assert.match(page, /Cosa riguarda/);
+  assert.match(page, /Operazione/);
+  assert.match(page, /Effetto/);
   assert.match(page, /Regole AI/);
   assert.match(page, /aiStewardshipDisclosure/);
   assert.match(page, /Non attribuiamo sprechi, illeciti o responsabilità/);
@@ -30,9 +33,12 @@ test("controlli sintesi page keeps verification copy and no automatic guilt labe
   assert.match(lib, /centralScenarioBreakdown/);
   assert.match(lib, /buildAiStewardshipAgenda/);
   assert.match(lib, /aiStewardshipDisclosure/);
+  assert.match(lib, /Agenda gestita da agenti AI/);
+  assert.match(lib, /concerns:/);
+  assert.match(lib, /operation:/);
+  assert.match(lib, /effect:/);
   assert.match(lib, /metric:/);
   assert.match(lib, /bars:/);
-  assert.match(lib, /Proposta AI/);
   assert.match(lib, /non dimostra uno spreco/i);
   assert.match(nav, /\/controlli\/sintesi/);
   assert.match(nav, /label: "Sintesi"/);
@@ -67,21 +73,24 @@ test("buildControlliSintesiPathways and AI agenda stay sourced and non-accusator
 
   const agenda = buildAiStewardshipAgenda(pathways);
   assert.ok(agenda.length >= 5);
-  assert.match(aiStewardshipDisclosure.badge, /Proposta AI/);
-  assert.match(aiStewardshipDisclosure.lead, /Agenda deterministica|esplicitamente basata su AI|etichettata come AI/i);
+  assert.match(aiStewardshipDisclosure.badge, /agenti AI/i);
+  assert.match(aiStewardshipDisclosure.title, /Agenda gestita da agenti AI/);
+  assert.match(aiStewardshipDisclosure.lead, /separata di proposito|etichettata come AI/i);
   for (const move of agenda) {
     assert.ok(move.metric.display.trim().length > 0, move.id);
     assert.ok(move.bars.length >= 2, move.id);
-    assert.ok(move.shortWhy.trim().length > 10, move.id);
+    assert.ok(move.concerns.trim().length > 15, move.id);
+    assert.ok(move.operation.trim().length > 30, move.id);
+    assert.ok(move.effect.trim().length > 20, move.id);
     assert.ok(move.chartCaption.trim().length > 10, move.id);
-    assert.ok(
-      /agente|Produrrebbe|Segnalerebbe|Costruirebbe|Monitorerebbe|Confronterebbe|Userebbe|Partirebbe|Terrebbe|L'agente/i.test(move.agentWould),
-      move.id,
-    );
+    assert.match(move.operation, /L'agente|agente/i);
     assert.doesNotMatch(
-      `${move.title}\n${move.agentWould}\n${move.shortWhy}`,
+      `${move.title}\n${move.concerns}\n${move.operation}\n${move.effect}`,
       /\b(corrotto|frode|colpevole|spreco accertato)\b/i,
     );
-    assert.doesNotMatch(`${move.shortWhy}\n${move.agentWould}\n${move.chartCaption}`, /—|–/);
+    assert.doesNotMatch(
+      `${move.concerns}\n${move.operation}\n${move.effect}\n${move.chartCaption}`,
+      /—|–/,
+    );
   }
 });

--- a/tests/controlli-sintesi.test.mjs
+++ b/tests/controlli-sintesi.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+async function source(relativePath) {
+  return readFile(new URL(relativePath, import.meta.url), "utf8");
+}
+
+test("controlli sintesi page keeps verification copy and no automatic guilt labels", async () => {
+  const [page, lib, nav] = await Promise.all([
+    source("../src/app/controlli/sintesi/page.tsx"),
+    source("../src/lib/controlli-sintesi.ts"),
+    source("../src/lib/site-navigation.ts"),
+  ]);
+
+  assert.match(page, /Cosa monitorare, dove approfondire/);
+  assert.match(page, /buildControlliSintesiPathways/);
+  assert.match(page, /buildAiStewardshipAgenda/);
+  assert.match(page, /agenda-ai/);
+  assert.match(page, /aiBoard|aiMetric|aiBars|aiRail/);
+  assert.match(page, /Regole AI/);
+  assert.match(page, /aiStewardshipDisclosure/);
+  assert.match(page, /Non attribuiamo sprechi, illeciti o responsabilità/);
+  assert.doesNotMatch(page, /\b(frode|corrotto|colpevole|spreco accertato)\b/i);
+  assert.doesNotMatch(lib, /—|–/);
+  assert.match(lib, /OpenCivitas/);
+  assert.match(lib, /procurementComparisons/);
+  assert.match(lib, /rgsConsultingSnapshot/);
+  assert.match(lib, /centralScenarioBreakdown/);
+  assert.match(lib, /buildAiStewardshipAgenda/);
+  assert.match(lib, /aiStewardshipDisclosure/);
+  assert.match(lib, /metric:/);
+  assert.match(lib, /bars:/);
+  assert.match(lib, /Proposta AI/);
+  assert.match(lib, /non dimostra uno spreco/i);
+  assert.match(nav, /\/controlli\/sintesi/);
+  assert.match(nav, /label: "Sintesi"/);
+});
+
+test("buildControlliSintesiPathways and AI agenda stay sourced and non-accusatory", async () => {
+  const {
+    buildControlliSintesiPathways,
+    buildAiStewardshipAgenda,
+    aiStewardshipDisclosure,
+  } = await import("../src/lib/controlli-sintesi.ts");
+  const pathways = buildControlliSintesiPathways();
+  assert.ok(pathways.length >= 10);
+  for (const pathway of pathways) {
+    assert.ok(pathway.observation.trim().length > 40, pathway.id);
+    assert.ok(pathway.action.trim().length > 20, pathway.id);
+    assert.ok(pathway.sourceLabel.trim().length > 3, pathway.id);
+    assert.ok(pathway.period.trim().length > 0, pathway.id);
+    assert.ok(pathway.limits.trim().length > 10, pathway.id);
+    assert.match(pathway.deepenHref, /^\//);
+    assert.doesNotMatch(
+      `${pathway.headline}\n${pathway.observation}\n${pathway.action}`,
+      /\b(corrotto|frode|colpevole|spreco accertato)\b/i,
+    );
+  }
+  assert.ok(pathways.some((pathway) => pathway.id === "opencivitas-outliers"));
+  assert.ok(pathways.some((pathway) => pathway.id === "anac-direct-awards"));
+  assert.ok(pathways.some((pathway) => pathway.id === "improvement-hypothesis"));
+  assert.ok(pathways.some((pathway) => pathway.id === "public-debt-interest"));
+  assert.ok(pathways.some((pathway) => pathway.id === "opencivitas-high-low"));
+  assert.ok(pathways.some((pathway) => pathway.id === "ssn-production-costs"));
+
+  const agenda = buildAiStewardshipAgenda(pathways);
+  assert.ok(agenda.length >= 5);
+  assert.match(aiStewardshipDisclosure.badge, /Proposta AI/);
+  assert.match(aiStewardshipDisclosure.lead, /Agenda deterministica|esplicitamente basata su AI|etichettata come AI/i);
+  for (const move of agenda) {
+    assert.ok(move.metric.display.trim().length > 0, move.id);
+    assert.ok(move.bars.length >= 2, move.id);
+    assert.ok(move.shortWhy.trim().length > 10, move.id);
+    assert.ok(move.chartCaption.trim().length > 10, move.id);
+    assert.ok(
+      /agente|Produrrebbe|Segnalerebbe|Costruirebbe|Monitorerebbe|Confronterebbe|Userebbe|Partirebbe|Terrebbe|L'agente/i.test(move.agentWould),
+      move.id,
+    );
+    assert.doesNotMatch(
+      `${move.title}\n${move.agentWould}\n${move.shortWhy}`,
+      /\b(corrotto|frode|colpevole|spreco accertato)\b/i,
+    );
+    assert.doesNotMatch(`${move.shortWhy}\n${move.agentWould}\n${move.chartCaption}`, /—|–/);
+  }
+});

--- a/tests/controlli-sintesi.test.mjs
+++ b/tests/controlli-sintesi.test.mjs
@@ -17,29 +17,25 @@ test("controlli sintesi page keeps verification copy and no automatic guilt labe
   assert.match(page, /Cosa monitorare, dove approfondire/);
   assert.match(page, /buildControlliSintesiPathways/);
   assert.match(page, /buildAiStewardshipAgenda/);
+  assert.match(page, /buildAiInterventionMap/);
+  assert.match(page, /buildAiNextMoves/);
   assert.match(page, /agenda-ai/);
-  assert.match(page, /aiZone|aiHero|aiBrief/);
-  assert.match(page, /Cosa riguarda/);
-  assert.match(page, /Operazione/);
-  assert.match(page, /Effetto/);
+  assert.match(page, /mappa-interventi/);
+  assert.match(page, /ancora-da-fare/);
+  assert.match(page, /In pratica propone/);
+  assert.match(page, /aiZone|aiHero|aiBrief|aiProposal/);
   assert.match(page, /Regole AI/);
   assert.match(page, /aiStewardshipDisclosure/);
   assert.match(page, /Non attribuiamo sprechi, illeciti o responsabilità/);
   assert.doesNotMatch(page, /\b(frode|corrotto|colpevole|spreco accertato)\b/i);
   assert.doesNotMatch(lib, /—|–/);
   assert.match(lib, /OpenCivitas/);
-  assert.match(lib, /procurementComparisons/);
-  assert.match(lib, /rgsConsultingSnapshot/);
-  assert.match(lib, /centralScenarioBreakdown/);
-  assert.match(lib, /buildAiStewardshipAgenda/);
-  assert.match(lib, /aiStewardshipDisclosure/);
-  assert.match(lib, /Agenda gestita da agenti AI/);
-  assert.match(lib, /concerns:/);
-  assert.match(lib, /operation:/);
-  assert.match(lib, /effect:/);
-  assert.match(lib, /metric:/);
-  assert.match(lib, /bars:/);
-  assert.match(lib, /non dimostra uno spreco/i);
+  assert.match(lib, /proposal:/);
+  assert.match(lib, /buildAiNextMoves/);
+  assert.match(lib, /buildAiInterventionMap/);
+  assert.match(lib, /Cosa proporrebbe un agente AI/);
+  assert.match(lib, /mefParticipationsSnapshot/);
+  assert.match(lib, /opencoesioneOverview/);
   assert.match(nav, /\/controlli\/sintesi/);
   assert.match(nav, /label: "Sintesi"/);
 });
@@ -48,6 +44,8 @@ test("buildControlliSintesiPathways and AI agenda stay sourced and non-accusator
   const {
     buildControlliSintesiPathways,
     buildAiStewardshipAgenda,
+    buildAiInterventionMap,
+    buildAiNextMoves,
     aiStewardshipDisclosure,
   } = await import("../src/lib/controlli-sintesi.ts");
   const pathways = buildControlliSintesiPathways();
@@ -64,33 +62,43 @@ test("buildControlliSintesiPathways and AI agenda stay sourced and non-accusator
       /\b(corrotto|frode|colpevole|spreco accertato)\b/i,
     );
   }
-  assert.ok(pathways.some((pathway) => pathway.id === "opencivitas-outliers"));
-  assert.ok(pathways.some((pathway) => pathway.id === "anac-direct-awards"));
-  assert.ok(pathways.some((pathway) => pathway.id === "improvement-hypothesis"));
-  assert.ok(pathways.some((pathway) => pathway.id === "public-debt-interest"));
-  assert.ok(pathways.some((pathway) => pathway.id === "opencivitas-high-low"));
-  assert.ok(pathways.some((pathway) => pathway.id === "ssn-production-costs"));
 
   const agenda = buildAiStewardshipAgenda(pathways);
   assert.ok(agenda.length >= 5);
   assert.match(aiStewardshipDisclosure.badge, /agenti AI/i);
-  assert.match(aiStewardshipDisclosure.title, /Agenda gestita da agenti AI/);
-  assert.match(aiStewardshipDisclosure.lead, /separata di proposito|etichettata come AI/i);
+  assert.match(aiStewardshipDisclosure.title, /Cosa proporrebbe un agente AI/);
+  assert.match(aiStewardshipDisclosure.howToRead, /In pratica propone/i);
   for (const move of agenda) {
     assert.ok(move.metric.display.trim().length > 0, move.id);
     assert.ok(move.bars.length >= 2, move.id);
-    assert.ok(move.concerns.trim().length > 15, move.id);
+    assert.ok(move.concerns.trim().length > 20, move.id);
+    assert.match(move.proposal, /Propone/i, move.id);
     assert.ok(move.operation.trim().length > 30, move.id);
     assert.ok(move.effect.trim().length > 20, move.id);
-    assert.ok(move.chartCaption.trim().length > 10, move.id);
-    assert.match(move.operation, /L'agente|agente/i);
     assert.doesNotMatch(
-      `${move.title}\n${move.concerns}\n${move.operation}\n${move.effect}`,
+      `${move.title}\n${move.proposal}\n${move.concerns}\n${move.operation}\n${move.effect}`,
       /\b(corrotto|frode|colpevole|spreco accertato)\b/i,
     );
     assert.doesNotMatch(
-      `${move.concerns}\n${move.operation}\n${move.effect}\n${move.chartCaption}`,
+      `${move.proposal}\n${move.concerns}\n${move.operation}\n${move.effect}`,
       /—|–/,
     );
   }
+
+  const map = buildAiInterventionMap(agenda);
+  assert.equal(map.length, agenda.length);
+  assert.ok(map.every((step) => step.plain.includes("Propone") || /Propone/i.test(step.plain)));
+
+  const next = buildAiNextMoves();
+  assert.ok(next.length >= 6);
+  for (const move of next) {
+    assert.match(move.proposal, /Propone/i, move.id);
+    assert.match(move.deepenHref, /^\//);
+    assert.ok(move.sourceNote.trim().length > 5, move.id);
+    assert.doesNotMatch(`${move.title}\n${move.proposal}\n${move.effect}`, /—|–|\b(frode|corrotto)\b/i);
+  }
+  assert.ok(next.some((move) => move.id === "next-off-budget"));
+  assert.ok(next.some((move) => move.id === "next-pnrr-cohesion"));
+  assert.ok(next.some((move) => move.id === "next-participations"));
+  assert.ok(next.some((move) => move.id === "next-consip-gate"));
 });

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -299,8 +299,12 @@ test("activeNavSection resolves nested routes to the parent menu", () => {
   assert.equal(isNavChildActive("/appalti", "/appalti", appalti.children), true);
   assert.deepEqual(
     appalti?.children?.map((child) => child.label),
-    ["Appalti", "Incarichi", "Catalogo dati", "Segnali", "Esplora relazioni"],
+    ["Appalti", "Incarichi", "Catalogo dati", "Segnali", "Sintesi", "Esplora relazioni"],
   );
+
+  const sintesi = activeNavSection("/controlli/sintesi");
+  assert.equal(sintesi?.href, "/controlli");
+  assert.equal(isNavChildActive("/controlli/sintesi", "/controlli/sintesi", sintesi.children), true);
 
   const catalog = activeNavSection("/dati/vincitori");
   assert.equal(catalog?.href, "/controlli");


### PR DESCRIPTION
## Summary
- Nuova pagina `/controlli/sintesi`: 15 percorsi verificabili (osservazione / screening / ipotesi) collegati a fonti già in piattaforma, senza accuse automatiche.
- Sezione **Proposta AI · non ufficiale** sulla stessa pagina: 7 priorità con metrica grande, barre CSS, rail scorrevole mobile-first e testo lungo ripiegato in `details`.
- Nav + link da Cosa controllare; test di copy fail-closed.

## Test plan
- [ ] Aprire `/controlli/sintesi` su desktop: rail 7 priorità, card con metriche e barre
- [ ] Stessa pagina su mobile (~390px): rail scroll orizzontale, card a colonna unica, tap targets ≥44px su summary
- [ ] Verificare che ogni cifra AI abbia controparte nei percorsi sopra (nessun numero inventato)
- [ ] `node --experimental-strip-types --test tests/controlli-sintesi.test.mjs`
- [ ] Controllare assenza di `—`/`–` e di linguaggio accusatorio

Closes #243

Made with [Cursor](https://cursor.com)