### PR TITLE
docs(readme): fondatori, contributors con avatar e schema import obbligatorio

### DIFF
--- a/.cursor/rules/new-data-import-standard.mdc
+++ b/.cursor/rules/new-data-import-standard.mdc
@@ -1,0 +1,14 @@
+---
+description: Enforce the standard import schema for every new dataset
+alwaysApply: true
+---
+
+# New Data Import Standard
+
+When work adds or changes a dataset, treat the common import schema as mandatory.
+
+- Require an official source with canonical public URLs before publishing data.
+- Prefer the integrated corpus as the entry point for official tables; otherwise keep an equivalent adapter that preserves `headers`, string cells, `evidence`, `sourceUrls`, and content hashes.
+- Require the three semantic fields `soldi`, `periodo`, and `provenance` in the published reading model, keeping the relevant dates distinct.
+- Keep every dataset import fail-closed: unexpected schema, unofficial provenance, incoherent license or period, hash drift, duplicates, invalid money values, or broken reconciliations must stop the import.
+- Do not merge PRs, including external contributions, that add data without this schema. If the source cannot satisfy it yet, limit the contribution to cataloging, proof artifacts, or documentation of the gap instead of inventing values.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,11 @@ import, tre assi obbligatori (soldi, periodo, provenance) e decisione
 corpus vs snapshot tipizzato. Gli agenti usano la skill
 `.agents/skills/import-dvns-dataset/`.
 
+Una PR che aggiunge dati senza questo schema non è pronta al merge, anche se i
+test tecnici passano. Se manca uno dei campi obbligatori o la fonte non espone
+un perimetro verificabile, il contributo deve fermarsi a catalogazione, proof o
+documentazione del limite invece di inventare valori.
+
 ## Verifica locale
 
 La CI è organizzata in cinque job paralleli (`static`, `security`, `node`,
@@ -128,4 +133,7 @@ Il merge su `main` è consentito quando il check `required` è verde e i thread
 di review sono risolti. GitHub non chiede l'approve di un altro maintainer.
 La review umana resta utile su UI ampia, fonti nuove, workflow e sicurezza:
 valuta correttezza, semantica dei dati, accessibilità e manutenibilità oltre
-ciò che i test coprono. Non usare force-push sulle branch dei contributor.
+ciò che i test coprono. Per le PR dati, la review deve controllare anche
+aderenza allo schema comune di import, presenza di `soldi`/`periodo`/`provenance`
+e comportamento fail-closed del contratto. Non usare force-push sulle branch dei
+contributor.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,30 @@ Per una nuova fonte, in issue indica: ente, URL ufficiale, licenza, formato, fre
 Richieste della community: [docs/COMMUNITY_FEEDBACK.md](docs/COMMUNITY_FEEDBACK.md).
 Coda di sviluppo con priorità e issue: [docs/ROADMAP.md](docs/ROADMAP.md).
 
-## Contributori
+## Fondatori
 
 - [@fragiannicola](https://x.com/fragiannicola)
 - [@dom_gag_96](https://x.com/dom_gag_96)
+
+## Contributors
+
+<!-- Grazie a tutti i contributori del progetto! -->
+
+<a href="https://github.com/metaforismo"><img src="https://avatars.githubusercontent.com/u/39646696?v=4" width="50" height="50" alt="metaforismo" style="border-radius:50%" /></a>
+<a href="https://github.com/dg996"><img src="https://avatars.githubusercontent.com/u/111145375?v=4" width="50" height="50" alt="dg996" style="border-radius:50%" /></a>
+<a href="https://github.com/sephmartin"><img src="https://avatars.githubusercontent.com/u/275498367?v=4" width="50" height="50" alt="sephmartin" style="border-radius:50%" /></a>
+<a href="https://github.com/lucaosti"><img src="https://avatars.githubusercontent.com/u/27920903?v=4" width="50" height="50" alt="lucaosti" style="border-radius:50%" /></a>
+<a href="https://github.com/rinocitarella"><img src="https://avatars.githubusercontent.com/u/42648964?v=4" width="50" height="50" alt="rinocitarella" style="border-radius:50%" /></a>
+<a href="https://github.com/Elgabor"><img src="https://avatars.githubusercontent.com/u/71511127?v=4" width="50" height="50" alt="Elgabor" style="border-radius:50%" /></a>
+<a href="https://github.com/marianimatteo-lexroom"><img src="https://avatars.githubusercontent.com/u/253467472?v=4" width="50" height="50" alt="marianimatteo-lexroom" style="border-radius:50%" /></a>
+<a href="https://github.com/nellicus"><img src="https://avatars.githubusercontent.com/u/8770097?v=4" width="50" height="50" alt="nellicus" style="border-radius:50%" /></a>
+<a href="https://github.com/Zer0codestuff"><img src="https://avatars.githubusercontent.com/u/105509672?v=4" width="50" height="50" alt="Zer0codestuff" style="border-radius:50%" /></a>
+<a href="https://github.com/calca"><img src="https://avatars.githubusercontent.com/u/78342?v=4" width="50" height="50" alt="calca" style="border-radius:50%" /></a>
+<a href="https://github.com/saliougaye"><img src="https://avatars.githubusercontent.com/u/72109418?v=4" width="50" height="50" alt="saliougaye" style="border-radius:50%" /></a>
+<a href="https://github.com/VoxamVox"><img src="https://avatars.githubusercontent.com/u/178662220?v=4" width="50" height="50" alt="VoxamVox" style="border-radius:50%" /></a>
+<a href="https://github.com/danielemeanti23"><img src="https://avatars.githubusercontent.com/u/76477634?v=4" width="50" height="50" alt="danielemeanti23" style="border-radius:50%" /></a>
+<a href="https://github.com/not-knope"><img src="https://avatars.githubusercontent.com/u/102312680?v=4" width="50" height="50" alt="not-knope" style="border-radius:50%" /></a>
+<a href="https://github.com/superpios"><img src="https://avatars.githubusercontent.com/u/122306526?v=4" width="50" height="50" alt="superpios" style="border-radius:50%" /></a>
 
 ## Licenza
 


### PR DESCRIPTION
- Rinomina **Contributori** in **Fondatori** (Dom e Francesco).
- Aggiunge sezione **Contributors** con foto profilo GitHub di tutti i 15 contributori umani del repo.
- Aggiunge regola Cursor `alwaysApply` per lo schema di import obbligatorio (`.cursor/rules/new-data-import-standard.mdc`).
- Rafforza il CONTRIBUTING con il requisito esplicito: una PR dati senza schema comune non è pronta al merge; la review deve controllare `soldi`/`periodo`/`provenance` e comportamento fail-closed.

Made with [Cursor](https://cursor.com)