### PR TITLE
fix(data): chiudi il prefisso di provenienza Consip sulla barra

### DIFF
--- a/scripts/etl/consip_ordini_snapshot.py
+++ b/scripts/etl/consip_ordini_snapshot.py
@@ -84,7 +84,7 @@ def load_source_spec(path: Path) -> dict[str, Any]:
     if spec["datasetId"] != "consip-ordini":
         raise SnapshotError("source lock: datasetId inatteso")
     landing = spec["source"].get("landingUrl", "")
-    if not landing.startswith("https://dati.consip.it"):
+    if not landing.startswith("https://dati.consip.it/"):
         raise SnapshotError("source lock: landing URL non ufficiale Consip")
     for name, asset in spec["source"]["assets"].items():
         if not str(asset.get("url", "")).startswith("https://dati.consip.it/download/dataset/"):

--- a/src/lib/data/consip-ordini-contract.ts
+++ b/src/lib/data/consip-ordini-contract.ts
@@ -9,6 +9,12 @@ import { z } from "zod";
  * dalla fonte). Il contratto blocca: identità inattesa, caveats assenti,
  * provenienza non ufficiale, licenza diversa da quella verificata sul catalogo,
  * riconciliazioni rotte fra aggregati e totali, e conteggi che non tornano.
+ *
+ * I prefissi di provenienza si chiudono con la barra: senza,
+ * "https://dati.consip.it" e' prefisso letterale anche di
+ * "https://dati.consip.it.example.org", e un host ostile passerebbe per
+ * ufficiale. L'hash del lock resta la difesa vera sui byte, ma il controllo
+ * di provenienza deve dire il vero da solo.
  */
 
 const nonNegativeInt = z.number().int().min(0);
@@ -75,7 +81,7 @@ export const consipOrdiniMetadataSchema = z
     source: z
       .object({
         owner: z.string().min(1),
-        landingUrl: z.string().refine((url) => url.startsWith("https://dati.consip.it"), "Landing URL Consip non ufficiale"),
+        landingUrl: z.string().refine((url) => url.startsWith("https://dati.consip.it/"), "Landing URL Consip non ufficiale"),
         licenseId: z.literal("CC-BY-4.0"),
         licenseNote: z.string().min(1),
         packages: z.record(z.string(), z.string().min(1)),
@@ -103,7 +109,7 @@ export const consipOrdiniMetadataSchema = z
         provenance: z
           .object({
             holder: z.string().min(1),
-            canonicalUrls: z.array(z.string().refine((url) => url.startsWith("https://dati.consip.it"), "URL non ufficiale")).min(1),
+            canonicalUrls: z.array(z.string().refine((url) => url.startsWith("https://dati.consip.it/"), "URL non ufficiale")).min(1),
             publicationDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
             acquisitionDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
             checkedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),

--- a/tests/consip-ordini.test.mjs
+++ b/tests/consip-ordini.test.mjs
@@ -16,8 +16,23 @@ test("il bundle Consip mantiene periodo, canali e provenienza ufficiale", () => 
   assert.deepEqual(validated.data.channels, ["convenzioni", "mepa"]);
   assert.equal(validated.data.totals.length, 6);
   assert.equal(validated.metadata.source.licenseId, "CC-BY-4.0");
-  assert.equal(validated.metadata.source.landingUrl.startsWith("https://dati.consip.it"), true);
+  assert.equal(validated.metadata.source.landingUrl.startsWith("https://dati.consip.it/"), true);
   assert.equal(Object.keys(validated.metadata.source.assets).length, 6);
+});
+
+test("un host che imita il dominio Consip viene rifiutato", () => {
+  // "https://dati.consip.it" senza barra finale e' prefisso letterale anche di
+  // "https://dati.consip.it.example.org": un controllo di provenienza che si
+  // fermasse li' direbbe ufficiale un host di terzi.
+  const spoofedLanding = structuredClone(consipOrdiniMetadata);
+  spoofedLanding.source.landingUrl = "https://dati.consip.it.example.org/";
+  assert.throws(() => validateConsipOrdiniBundle(consipOrdiniData, spoofedLanding));
+
+  const spoofedCanonical = structuredClone(consipOrdiniMetadata);
+  spoofedCanonical.semantics.provenance.canonicalUrls = [
+    "https://dati.consip.it.example.org/download/dataset/ordini-mepa-2025.csv",
+  ];
+  assert.throws(() => validateConsipOrdiniBundle(consipOrdiniData, spoofedCanonical));
 });
 
 test("i caveats dichiarano i limiti del dato invece di lasciarli dedurre", () => {


### PR DESCRIPTION
## Cosa cambia

Chiude i rilievi CodeQL *incomplete URL substring sanitization* sul codice Consip entrato con #267, rendendo veri i controlli di provenienza.

`"https://dati.consip.it"` senza barra finale è prefisso letterale anche di `"https://dati.consip.it.example.org"`: un host di terzi che scelga quel nome passava per ufficiale in tre controlli.

- `src/lib/data/consip-ordini-contract.ts` — `landingUrl` e `canonicalUrls`
- `scripts/etl/consip_ordini_snapshot.py` — il landing URL nel source lock

I due controlli che puntano già a `…/download/dataset/` erano invece corretti e restano invariati.

Tutti gli URL committati hanno già la barra dopo l'host (verificato: `landingUrl` e tutti e sette i `canonicalUrls`), quindi la stretta non tocca dati validi.

Sulla valutazione data nell'issue: è vero che la difesa sostanziale sono l'hash del lock e lo zod strict, e infatti questi rilievi non erano bloccanti. Ma un controllo di provenienza che si chiama così deve dire il vero da solo, senza dipendere dal fatto che un altro strato lo copra — se un domani venisse riusato altrove, si porterebbe dietro il buco.

## Evidenza

- [x] Il diff è limitato al problema dichiarato: quattro righe di controllo più un test.
- [x] Ho aggiunto un test che fallisce senza la modifica. `un host che imita il dominio Consip viene rifiutato` prova entrambe le vie (landing e canonicalUrls) con `https://dati.consip.it.example.org`: **fallisce sul contratto attuale di `main`** e passa dopo la correzione.
- [x] `npm test`, test ETL Python, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

Nessun artefatto rigenerato: cambia solo il codice di validazione, non i byte vincolati né il lock.

Le sezioni **Dati pubblici**, **UI e accessibilità** e **API e MCP** non si applicano: nessun dato, nessuna superficie utente e nessuna interfaccia cambiano.

## Limiti e prove non eseguite

- **Zizmor**: non eseguita, il job `security` non ha equivalente locale fra i comandi npm.
- Ho controllato le altre fonti: dopo questa correzione **ogni** controllo di prefisso URL in `src/` e `scripts/` termina con la barra (OpenBDAP, ANAC, ISTAT, MEF, Finanze). I due Consip erano le uniche eccezioni, quindi non resta nulla di analogo da sistemare altrove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSMvghvbi2dFjVf1d4QSB6
