### PR TITLE
fix(ci): rimetti in esecuzione il monitor delle fonti (#254)

### DIFF
--- a/.github/workflows/source-health.yml
+++ b/.github/workflows/source-health.yml
@@ -9,15 +9,21 @@ on:
 permissions:
   contents: read
 
+# cancel-in-progress: false — a probe that is already running, or already
+# waiting, is the observation we want. A newer schedule must never discard it.
 concurrency:
   group: source-health
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   probe:
     name: probe
     runs-on: ubuntu-24.04
-    environment: source-operations
+    # No environment gate on purpose: this job reads one public URL and uses no
+    # secret. The source-operations environment guards the data-bot credential
+    # that refresh workflows need to open pull requests; behind its required
+    # reviewers a scheduled run waits for a human, so an unattended monitor
+    # would never observe anything.
     timeout-minutes: 5
     env:
       CANONICAL_BASE_URL: https://www.dovevannoinostrisoldi.com

--- a/tests/source-operations-gate.test.mjs
+++ b/tests/source-operations-gate.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { parse } from "yaml";
+
+const workflowDir = path.join(process.cwd(), ".github", "workflows");
+const workflows = fs
+  .readdirSync(workflowDir)
+  .filter((name) => name.endsWith(".yml"))
+  .map((name) => {
+    const source = fs.readFileSync(path.join(workflowDir, name), "utf8");
+    return { name, source, document: parse(source) };
+  });
+
+// `on` is a YAML 1.1 boolean; the 1.2 core schema keeps it a string. Read both.
+function triggers(document) {
+  return document?.on ?? document?.true ?? {};
+}
+
+function environmentName(job) {
+  const environment = job?.environment;
+  return typeof environment === "string" ? environment : environment?.name;
+}
+
+test("every job behind source-operations actually needs its credential", () => {
+  const gated = [];
+  for (const { name, document } of workflows) {
+    for (const [jobId, job] of Object.entries(document?.jobs ?? {})) {
+      if (environmentName(job) === "source-operations") gated.push({ name, jobId, job });
+    }
+  }
+
+  assert.ok(gated.length > 0, "expected the refresh workflows to keep the gate");
+
+  for (const { name, jobId, job } of gated) {
+    // The environment carries required reviewers, so a scheduled run waits for a
+    // human. That trade is only worth making for a job that uses the data-bot
+    // credential the environment protects: a credential-free job parked behind
+    // it can never run unattended, and a cancelled run raises no alert.
+    assert.match(
+      JSON.stringify(job),
+      /secrets\./,
+      `${name}: job "${jobId}" is gated on source-operations but uses no secret`,
+    );
+  }
+});
+
+test("the source health monitor can run unattended", () => {
+  const workflow = workflows.find(({ name }) => name === "source-health.yml");
+  assert.ok(workflow, "source-health.yml is missing");
+
+  assert.ok(triggers(workflow.document).schedule, "the monitor must stay scheduled");
+
+  for (const [jobId, job] of Object.entries(workflow.document.jobs ?? {})) {
+    assert.equal(
+      environmentName(job),
+      undefined,
+      `job "${jobId}" must not sit behind an approval gate it cannot obtain on a schedule`,
+    );
+  }
+
+  // A newer schedule must never cancel a probe that is already running or
+  // waiting: a cancelled run reports no conclusion, so the outage it was meant
+  // to observe passes unnoticed.
+  assert.equal(workflow.document.concurrency?.["cancel-in-progress"], false);
+});


### PR DESCRIPTION
## Cosa cambia

Il workflow `Source health` torna a eseguire il probe. **Non lo esegue dal 2026-08-26**: il monitor che questa issue voleva costruire esisteva già, ma era fermo in silenzio. Chiude il follow-up 1 di #254.

L'environment `source-operations` (creato il 2026-08-25, `required_reviewers` + `prevent_self_review`) gate-a dieci workflow, tutti con `concurrency` a group fisso e `cancel-in-progress: true`. Ogni run schedulato entra in `waiting` per l'approvazione e il run successivo **cancella quello in attesa**: la coda di approvazione non ha mai un elemento stabile. E poiché `cancelled` non è `failure`, GitHub non manda notifiche — il guasto è invisibile.

Misura sul monitor: ultimo probe eseguito `2026-08-26T07:29:30Z`; i 26 run successivi non hanno mai eseguito il job (25 `cancelled`; 1 chiuso `failure` con `job=probe conclusion=cancelled`, senza eseguire un solo step); il 27° è in `waiting`.

**Perimetro stretto di proposito.** I nove workflow di refresh restano invariati: usano `secrets.DATA_BOT_APP_PRIVATE_KEY` per aprire le PR e il gate protegge esattamente quella credenziale. Come riequilibrare la loro coda di approvazione è una decisione operativa vostra e non la prendo io da esterno — la riporto in #254 con le evidenze.

`source-health.yml` è l'eccezione: non contiene **nessuna** espressione `${{ }}` — né `secrets.`, né `vars.` — ha `permissions: contents: read`, non committa nulla e fa una sola `curl` verso un URL pubblico. Dall'environment non consuma niente, mentre dietro un'approvazione umana un monitor schedulato non può osservare fuori orario.

- rimosso `environment: source-operations` dal job `probe`, col motivo scritto accanto;
- `cancel-in-progress: false`: un probe già avviato, o già in attesa, **è** l'osservazione che ci interessa;
- `tests/source-operations-gate.test.mjs` fissa l'invariante — *un job dietro `source-operations` deve usare almeno un secret* — così la stessa svista non può rientrare in silenzio.

## Evidenza

- [x] Il diff è limitato al problema dichiarato (un workflow, un file di test).
- [x] Ho aggiunto test che falliscono senza la modifica: ripristinando il workflow com'era su `main`, i due test falliscono con «job "probe" is gated on source-operations but uses no secret» e «job "probe" must not sit behind an approval gate it cannot obtain on a schedule»; passano dopo la modifica.
- [x] `npm test`, test ETL Python, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

Le sezioni **Dati pubblici**, **UI e accessibilità** e **API e MCP** non si applicano: la PR non tocca dati, superfici utente, API o MCP.

```
npm run ci:static        ✅
npm run test:node        ✅  814 pass / 0 fail
npm run test:etl         ✅  386 test, OK (skipped=4)
npm run test:snapshots   ✅  26 standalone check, worktree pulito
npm run build            ✅
git diff --check         ✅
```

## Limiti e prove non eseguite

- **Zizmor**: non eseguita, il job `security` non ha equivalente locale fra i comandi npm — ed è proprio il job che ha più titolo a giudicare una modifica ai workflow.
- **La regola `required_reviewers` sull'environment** è una impostazione del repository: non posso né verificarla né cambiarla da qui (`GET .../environments/source-operations/variables` → 403), e resta vostra.
- **L'effetto reale si vede solo dopo il merge**: che il probe torni a eseguirsi sul cron è verificabile soltanto sul vostro Actions, non in locale.
- **I nove workflow di refresh** restano fermi: questa PR non li sblocca, per scelta.
- L'outage OpenBDAP in sé è di terzi e il fail-closed esistente è già corretto. In #254 segnalo che il sintomo è peggiorato — l'host ora accetta il TCP e non risponde più, invece di restituire il JSON `Cannot convert data to csv` — quindi chi verificherà il ripristino troverà un timeout, non quell'errore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSMvghvbi2dFjVf1d4QSB6
