### PR TITLE
docs(openbdap): chiudi #254 — verifica ripristino con anno/mese

### DIFF
--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -139,6 +139,26 @@ La ricerca delle opere pubbliche non dipende da alias OData scritti a mano. Il c
 
 Il refresh orario invalida il tag OpenBDAP e la route `/api/opere`. Al primo accesso successivo vengono ricontrollati metadati e schema; i dati di una singola ricerca CUP hanno cache di 6 ore e possono essere serviti per altre 24 ore mentre avviene la riconvalida. La risposta espone separatamente data della fonte e momento del controllo della piattaforma.
 
+### OpenBDAP pagamenti Stato — verifica del ripristino
+
+Dopo un disservizio del dump CSV («Cannot convert data to csv») o un timeout dell'host,
+controllare prima la fonte e poi la produzione:
+
+```bash
+# Dump CSV atteso: intestazioni testuali, non JSON Dataset Error
+curl -sS 'https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/datastore/dump/<package-uuid>.csv?download=1' | head
+
+# Produzione: ultimo rilascio disponibile (nessun filtro)
+curl -sS 'https://www.dovevannoinostrisoldi.com/api/spese/stato'
+
+# Produzione: periodo specifico — usare i nomi italiani anno/mese, non year/month
+curl -sS 'https://www.dovevannoinostrisoldi.com/api/spese/stato?anno=2025&mese=8'
+```
+
+`year` e `month` non sono parametri riconosciuti: se presenti soli, la route restituisce
+l'ultimo rilascio pubblicato (comportamento atteso, non un bug del filtro). Per scegliere
+un mese contabile usare sempre `anno` e, se serve, `mese` (1–12).
+
 ### MEF IRPEF comunale
 
 Il dataset è annuale e snapshot-managed. La pubblicazione della fonte, l'anno

--- a/tests/spese-stato-route.test.mjs
+++ b/tests/spese-stato-route.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { parseReferencePeriod } = await import("../src/lib/data/reference-period.ts");
+
+test("year e month non sono parametri riconosciuti: restituiscono periodo vuoto", () => {
+  const result = parseReferencePeriod(new URLSearchParams("year=2025&month=8"));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value, {});
+});
+
+test("anno e mese italiani vengono accettati", () => {
+  const result = parseReferencePeriod(new URLSearchParams("anno=2025&mese=8"));
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value, { year: 2025, month: 8 });
+});
+
+test("mese senza anno viene rifiutato", () => {
+  const result = parseReferencePeriod(new URLSearchParams("mese=8"));
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.error, /anno/i);
+});
+
+test("anno o mese non validi vengono rifiutati", () => {
+  for (const query of ["anno=2025x", "anno=1999", "anno=2025&mese=0", "anno=2025&mese=13"]) {
+    const result = parseReferencePeriod(new URLSearchParams(query));
+    assert.equal(result.ok, false, query);
+  }
+});
+
+test("produzione: year/month ignorati, anno/mese filtrano", async (context) => {
+  const base = "https://www.dovevannoinostrisoldi.com/api/spese/stato";
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const [latest, english, italian] = await Promise.all([
+      fetch(base, { signal: controller.signal }),
+      fetch(`${base}?year=2025&month=8`, { signal: controller.signal }),
+      fetch(`${base}?anno=2025&mese=8`, { signal: controller.signal }),
+    ]);
+    if (!latest.ok || !english.ok || !italian.ok) {
+      context.skip("endpoint produzione non raggiungibile");
+      return;
+    }
+    const latestPayload = await latest.json();
+    const englishPayload = await english.json();
+    const italianPayload = await italian.json();
+    assert.equal(latestPayload.ok, true);
+    assert.deepEqual(latestPayload.period, englishPayload.period);
+    assert.equal(italianPayload.period.year, 2025);
+    assert.equal(italianPayload.period.month, 8);
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      context.skip("endpoint produzione non raggiungibile");
+      return;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Confermiamo il riscontro di @GYBeccaria: outage OpenBDAP risolto, probe `source-health` operativo (#272), produzione di nuovo `up`.

**Chiusura #254:** il sintomo originale (dump CSV «Cannot convert…» + `/stato` fail-closed) non c'è più. I follow-up 2 (snapshot committato) e 3 (adapter OData) restano decisioni di prodotto.

**Nota sul §3 (parametri `year`/`month`):** non è un bug del filtro — `/api/spese/stato` accetta **`anno`** e **`mese`**. Con parametri assenti o non riconosciuti restituisce l'ultimo rilascio (comportamento atteso):

```bash
# Comando nell'issue → sempre ultimo rilascio
curl -sS 'https://www.dovevannoinostrisoldi.com/api/spese/stato?year=2025&month=8'

# Parametri corretti → filtrano
curl -sS 'https://www.dovevannoinostrisoldi.com/api/spese/stato?anno=2025&mese=8'
```

## Cambiamenti in questo PR

- Sezione «OpenBDAP pagamenti Stato — verifica del ripristino» in `docs/FRESHNESS_AND_REFRESH.md`
- Test `tests/spese-stato-route.test.mjs` che documenta il comportamento `anno`/`mese` vs `year`/`month`

Closes #254
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a032b3-ca84-744e-81fd-1f967340754c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a032b3-ca84-744e-81fd-1f967340754c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

