### PR TITLE
fix(budget): share compact aggregate cache across instances

### DIFF
--- a/src/lib/bdap-legge-bilancio.ts
+++ b/src/lib/bdap-legge-bilancio.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache.js";
 import {
   decodePublicDataText,
   parseDelimitedRecords,
@@ -349,6 +350,8 @@ async function fetchDatasetRows(
 ): Promise<DelimitedRecord[]> {
   const response = await fetchOfficialSource("openbdap", dataset.csvUrl, {
     kind: "data",
+    // Cache the compact aggregate below, not this CSV exceeding Next's 2 MB limit.
+    cacheMode: "no-store",
     signal,
     headers: { Accept: "text/csv" },
     tags: [`dataset:${dataset.packageId}`, "product:legge-bilancio-ampma"],
@@ -548,6 +551,54 @@ async function computeFullMissionAggregate(signal: AbortSignal): Promise<FullMis
   };
 }
 
+// Next's Data Cache persists JSON, so Maps/Sets must be encoded explicitly.
+export function serializeBudgetLawAggregate(aggregate: FullMissionAggregate) {
+  return {
+    ...aggregate,
+    missionsByYear: [...aggregate.missionsByYear].map(([year, missions]) =>
+      [year, [...missions]] as [number, string[]]),
+    totalsByYearMission: [...aggregate.totalsByYearMission],
+  };
+}
+
+export function deserializeBudgetLawAggregate(
+  aggregate: ReturnType<typeof serializeBudgetLawAggregate>,
+): FullMissionAggregate {
+  return {
+    ...aggregate,
+    missionsByYear: new Map(aggregate.missionsByYear.map(([year, missions]) =>
+      [year, new Set(missions)])),
+    totalsByYearMission: new Map(aggregate.totalsByYearMission),
+  };
+}
+
+const readPersistentAggregate = unstable_cache(
+  async () => {
+    const aggregate = serializeBudgetLawAggregate(await computeFullMissionAggregate(
+      AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS),
+    ));
+    if (new TextEncoder().encode(JSON.stringify(aggregate)).byteLength > 1_000_000) {
+      throw new Error("Aggregato Legge di Bilancio troppo grande per la cache");
+    }
+    return aggregate;
+  },
+  ["budget-law-mission-aggregate-v1"],
+  { revalidate: getSourcePolicy("openbdap").dataRevalidateSeconds, tags: ["openbdap-budget-law"] },
+);
+
+async function readFullMissionAggregate(): Promise<FullMissionAggregate> {
+  try {
+    return deserializeBudgetLawAggregate(await readPersistentAggregate());
+  } catch (error) {
+    // Standalone Node tests/ETL have no Next cache context. Do not retry source failures.
+    if (error instanceof Error
+      && error.message.startsWith("Invariant: incrementalCache missing in unstable_cache")) {
+      return computeFullMissionAggregate(AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS));
+    }
+    throw error;
+  }
+}
+
 /**
  * Returns the cached aggregate, refreshing it when missing or expired. A
  * failed population is not cached, so the next call retries instead of
@@ -558,9 +609,7 @@ function getFullMissionAggregate(): Promise<FullMissionAggregate> {
     return fullAggregateCache.promise;
   }
   const revalidateSeconds = getSourcePolicy("openbdap").dataRevalidateSeconds;
-  const promise = computeFullMissionAggregate(
-    AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS),
-  ).catch((error: unknown) => {
+  const promise = readFullMissionAggregate().catch((error: unknown) => {
     if (fullAggregateCache?.promise === promise) fullAggregateCache = null;
     throw error;
   });

--- a/src/lib/bdap-legge-bilancio.ts
+++ b/src/lib/bdap-legge-bilancio.ts
@@ -1,4 +1,3 @@
-import { unstable_cache } from "next/cache.js";
 import {
   decodePublicDataText,
   parseDelimitedRecords,
@@ -572,7 +571,10 @@ export function deserializeBudgetLawAggregate(
   };
 }
 
-const readPersistentAggregate = unstable_cache(
+async function readPersistentAggregate() {
+  // Offline artifact validation imports this module without installing Next.
+  const { unstable_cache } = await import("next/cache.js");
+  return unstable_cache(
   async () => {
     const aggregate = serializeBudgetLawAggregate(await computeFullMissionAggregate(
       AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS),
@@ -584,15 +586,19 @@ const readPersistentAggregate = unstable_cache(
   },
   ["budget-law-mission-aggregate-v1"],
   { revalidate: getSourcePolicy("openbdap").dataRevalidateSeconds, tags: ["openbdap-budget-law"] },
-);
+  )();
+}
 
 async function readFullMissionAggregate(): Promise<{ aggregate: FullMissionAggregate; persistent: boolean }> {
   try {
     return { aggregate: deserializeBudgetLawAggregate(await readPersistentAggregate()), persistent: true };
   } catch (error) {
     // Standalone Node tests/ETL have no Next cache context. Do not retry source failures.
-    if (error instanceof Error
-      && error.message.startsWith("Invariant: incrementalCache missing in unstable_cache")) {
+    if (error instanceof Error && (
+      error.message.startsWith("Invariant: incrementalCache missing in unstable_cache")
+      || ("code" in error && error.code === "ERR_MODULE_NOT_FOUND"
+        && error.message.startsWith("Cannot find package 'next'"))
+    )) {
       return {
         aggregate: await computeFullMissionAggregate(AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS)),
         persistent: false,

--- a/src/lib/bdap-legge-bilancio.ts
+++ b/src/lib/bdap-legge-bilancio.ts
@@ -586,14 +586,17 @@ const readPersistentAggregate = unstable_cache(
   { revalidate: getSourcePolicy("openbdap").dataRevalidateSeconds, tags: ["openbdap-budget-law"] },
 );
 
-async function readFullMissionAggregate(): Promise<FullMissionAggregate> {
+async function readFullMissionAggregate(): Promise<{ aggregate: FullMissionAggregate; persistent: boolean }> {
   try {
-    return deserializeBudgetLawAggregate(await readPersistentAggregate());
+    return { aggregate: deserializeBudgetLawAggregate(await readPersistentAggregate()), persistent: true };
   } catch (error) {
     // Standalone Node tests/ETL have no Next cache context. Do not retry source failures.
     if (error instanceof Error
       && error.message.startsWith("Invariant: incrementalCache missing in unstable_cache")) {
-      return computeFullMissionAggregate(AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS));
+      return {
+        aggregate: await computeFullMissionAggregate(AbortSignal.timeout(FULL_AGGREGATE_DEADLINE_MS)),
+        persistent: false,
+      };
     }
     throw error;
   }
@@ -609,7 +612,12 @@ function getFullMissionAggregate(): Promise<FullMissionAggregate> {
     return fullAggregateCache.promise;
   }
   const revalidateSeconds = getSourcePolicy("openbdap").dataRevalidateSeconds;
-  const promise = readFullMissionAggregate().catch((error: unknown) => {
+  const promise = readFullMissionAggregate().then(({ aggregate, persistent }) => {
+    // Next owns freshness (including stale-while-revalidate); do not extend it
+    // with a second six-hour TTL. Keep only the in-flight promise in this case.
+    if (persistent && fullAggregateCache?.promise === promise) fullAggregateCache = null;
+    return aggregate;
+  }).catch((error: unknown) => {
     if (fullAggregateCache?.promise === promise) fullAggregateCache = null;
     throw error;
   });

--- a/tests/bdap-legge-bilancio.test.mjs
+++ b/tests/bdap-legge-bilancio.test.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
 
+// This suite supplies CSV fixtures through global fetch, including no-store reads.
+process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = "1";
+
 const {
   BudgetLawDatasetUnavailableError,
   BudgetLawInvalidWindowError,
@@ -15,6 +18,8 @@ const {
   resetBudgetLawMissionSeriesCacheForTests,
   validateBudgetLawSnapshotArtifact,
   validateBudgetLawMissionSeries,
+  serializeBudgetLawAggregate,
+  deserializeBudgetLawAggregate,
 } = await import("../src/lib/bdap-legge-bilancio.ts");
 const { queryPublicDataset } = await import("../src/lib/mcp/datasets.ts");
 const { NextRequest } = await import("next/server.js");
@@ -32,6 +37,19 @@ const COMMITTED_SNAPSHOT = JSON.parse(
 const SOURCE_SPEC = JSON.parse(
   readFileSync("scripts/etl/specs/openbdap-budget-law-missions.source.json", "utf8"),
 );
+
+test("persistent budget aggregate survives JSON without losing amounts, years or provenance", () => {
+  const aggregate = {
+    dataset: { packageId: "source-id", metadataModified: "2026-01-02" },
+    acquiredAt: "2026-09-04T20:00:00Z",
+    availableYears: [2023, 2024],
+    missionsByYear: new Map([[2023, new Set(["Istruzione"])], [2024, new Set(["Istruzione"])]]),
+    totalsByYearMission: new Map([["2023::Istruzione", 1700], ["2024::Istruzione", 1900]]),
+  };
+  const wire = JSON.stringify(serializeBudgetLawAggregate(aggregate));
+  assert.deepEqual(deserializeBudgetLawAggregate(JSON.parse(wire)), aggregate);
+  assert.ok(Buffer.byteLength(wire) < 1_000_000);
+});
 
 function packageFixture(overrides = {}) {
   return {

--- a/tests/bdap-legge-bilancio.test.mjs
+++ b/tests/bdap-legge-bilancio.test.mjs
@@ -51,6 +51,40 @@ test("persistent budget aggregate survives JSON without losing amounts, years or
   assert.ok(Buffer.byteLength(wire) < 1_000_000);
 });
 
+test("a warm process observes refreshed persistent aggregates without extending their TTL", async () => {
+  const originalCache = globalThis.__incrementalCache;
+  const originalFetch = globalThis.fetch;
+  resetBudgetLawMissionSeriesCacheForTests();
+  let reads = 0;
+  globalThis.fetch = async () => { throw new Error("Cache hit must not fetch a CSV"); };
+  globalThis.__incrementalCache = {
+    generateSimpleCacheKey: async (key) => key,
+    get: async () => {
+      reads += 1;
+      const aggregate = serializeBudgetLawAggregate({
+        dataset: normalizeBudgetLawPackage(packageFixture()),
+        acquiredAt: `2026-09-0${reads}T20:00:00Z`,
+        availableYears: [2023, 2024],
+        missionsByYear: new Map([[2023, new Set(["Istruzione"])], [2024, new Set(["Istruzione"])]]),
+        totalsByYearMission: new Map([["2023::Istruzione", 1700], ["2024::Istruzione", 1900 + reads]]),
+      });
+      return { isStale: false, value: { kind: "FETCH", data: { body: JSON.stringify(aggregate) } } };
+    },
+  };
+  try {
+    const first = await getBudgetLawMissionSeries({ windowYears: 2 });
+    const refreshed = await getBudgetLawMissionSeries({ windowYears: 2 });
+    assert.equal(reads, 2);
+    assert.notEqual(first.observedAt, refreshed.observedAt);
+    assert.notDeepEqual(first.allocations, refreshed.allocations);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalCache === undefined) delete globalThis.__incrementalCache;
+    else globalThis.__incrementalCache = originalCache;
+    resetBudgetLawMissionSeriesCacheForTests();
+  }
+});
+
 function packageFixture(overrides = {}) {
   return {
     id: packageId,


### PR DESCRIPTION
Follow-up to #287. Production logs showed Next refusing to cache a 4.56 MB budget-law CSV. Persist the compact year/mission aggregate through the existing Next Data Cache API; serialize Map/Set explicitly; read the oversized CSV without fetch caching. Keep process single-flight for persistent reads, and process TTL only for standalone fallback, so stale-while-revalidate is not masked by another six-hour cache. Preserve amounts, timestamps, provenance and source-failure handling. No Vercel settings or MCP snapshot changes. Validation: 23 focused tests (including JSON round-trip and persistent refresh visibility without source fetch), TypeScript and scoped ESLint pass. Independent review PASS after freshness correction. Full CI and preview on exact HEAD are required before merge.