### PR TITLE
build: avoid unnecessary Vercel downloads and deployments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,35 @@ o suite concorrenti. Confronta anche i digest e ripeti le misure rumorose.
 I digest non sostituiscono i test di correttezza. Questi numeri non misurano
 latenza delle fonti live, rete, rendering o cold start.
 
+### Build Vercel senza lavoro duplicato
+
+`vercel.json` evita il download Chromium solo durante l'installazione Vercel:
+quel deployment esegue `next build`, mentre i test browser girano nel job
+`production` di GitHub Actions. `npm ci` locale e in CI conserva il download
+normale; TypeScript, audit delle dipendenze e tutti i gate restano attivi.
+
+L'Ignored Build Step (`scripts/ci/vercel-ignore-build.mjs`) confronta la SHA
+attuale con `VERCEL_GIT_PREVIOUS_SHA`, l'ultimo deployment riuscito della branch.
+Salta soltanto modifiche a documentazione Markdown, test e template di issue/PR.
+Non salta i dati sotto `docs/research/data`, le specifiche ETL, i workflow o
+percorsi nuovi: sono input del deployment o richiedono una nuova verifica.
+Primo deployment, redeploy della stessa SHA, metadati mancanti e cronologia
+Git incompleta eseguono sempre il build. Le preview del codice restano attive.
+La CI GitHub continua a eseguire tutti i controlli anche se Vercel salta il build.
+
+Test mirato: `node --test tests/vercel-ignore-build.test.mjs`.
+Per verificare una decisione su due commit disponibili localmente:
+`VERCEL_GIT_PREVIOUS_SHA=SHA_PRECEDENTE VERCEL_GIT_COMMIT_SHA=SHA_ATTUALE node scripts/ci/vercel-ignore-build.mjs`.
+Il codice di uscita segue Vercel: **0 = skip, 1 = build**. Per un redeploy dovuto
+a sole impostazioni/variabili d'ambiente puoi disattivare “Use project's Ignore
+Build Step” nel dialogo Redeploy. Dopo un commit saltato, `/api/health` continua
+correttamente a indicare la revisione effettivamente distribuita.
+
+Per confrontare i costi usa durata × core della macchina Vercel e confronti
+sulla stessa revisione/cache; il tempo di un test in GitHub Actions non è una
+misura dei Build CPU Minutes di Vercel. Non disattivare controlli o observability
+per far scendere un benchmark.
+
 ### ETL e artifact verification
 
 ```bash

--- a/scripts/ci/vercel-ignore-build.mjs
+++ b/scripts/ci/vercel-ignore-build.mjs
@@ -1,0 +1,40 @@
+import { execFileSync } from "node:child_process";
+
+// Vercel runs this before installation: 0 skips the deployment, 1 builds it.
+// Compare with the last successful deployment, not HEAD^: earlier code changes
+// may still be undeployed after a failed build or a push containing many commits.
+const previous = process.env.VERCEL_GIT_PREVIOUS_SHA;
+const current = process.env.VERCEL_GIT_COMMIT_SHA;
+const sha = /^[0-9a-f]{40}$/i;
+
+function decide() {
+  if (!sha.test(previous ?? "") || !sha.test(current ?? "") || previous === current) {
+    return { skip: false, reason: "First deployment, redeploy, or missing commit metadata." };
+  }
+
+  let files;
+  try {
+    files = execFileSync("git", [
+      "diff", "--name-only", "--no-renames", "-z", previous, current, "--",
+    ], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 10_000 })
+      .split("\0").filter(Boolean);
+  } catch {
+    return { skip: false, reason: "Cannot compare deployed commits (for example, shallow history)." };
+  }
+
+  const runtimeFile = files.find((file) => !(
+    /^(README|CONTRIBUTING|AGENTS|CLAUDE|CODE_OF_CONDUCT|SECURITY)\.md$/.test(file) ||
+    (/^docs\/.*\.md$/.test(file) && !file.startsWith("docs/research/data/")) ||
+    file.startsWith("tests/") ||
+    file.startsWith(".github/ISSUE_TEMPLATE/") ||
+    file === ".github/PULL_REQUEST_TEMPLATE.md"
+  ));
+  if (runtimeFile) return { skip: false, reason: `Deployment input changed: ${runtimeFile}` };
+  // In particular, docs/research/data and scripts/etl/specs are runtime inputs.
+  // Unknown paths build by default; don't turn this into a list of source paths.
+  return { skip: true, reason: `${files.length} changed files; only documentation/tests, or identical trees.` };
+}
+
+const result = decide();
+console.log(`${result.skip ? "SKIP" : "BUILD"}: ${result.reason}`);
+process.exitCode = result.skip ? 0 : 1;

--- a/tests/vercel-ignore-build.test.mjs
+++ b/tests/vercel-ignore-build.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const script = fileURLToPath(new URL("../scripts/ci/vercel-ignore-build.mjs", import.meta.url));
+
+test("Vercel skips only non-deployment changes since the last successful build", (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), "dvns-vercel-ignore-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  const git = (...args) => execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  git("init", "--quiet");
+  git("config", "user.name", "Test");
+  git("config", "user.email", "test@example.invalid");
+  const commit = (file, content) => {
+    mkdirSync(dirname(join(cwd, file)), { recursive: true });
+    writeFileSync(join(cwd, file), content);
+    git("add", "--all");
+    git("-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture");
+    return git("rev-parse", "HEAD");
+  };
+  const run = (previous, current) => spawnSync(process.execPath, [script], {
+    cwd, encoding: "utf8",
+    env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previous, VERCEL_GIT_COMMIT_SHA: current },
+  });
+  const expect = (previous, current, status) => {
+    const result = run(previous, current);
+    assert.equal(result.status, status, result.stderr || result.stdout);
+    assert.match(result.stdout, status === 0 ? /^SKIP:/ : /^BUILD:/);
+  };
+
+  const initial = commit("src/app/page.tsx", "export default 1;");
+  const docs = commit("docs/guide with spaces.md", "Instructions");
+  const tests = commit("tests/route.test.mjs", "Assertions");
+  expect(initial, docs, 0);
+  expect(initial, tests, 0);
+  expect("", tests, 1); // First deployment: a preview must exist.
+  expect(tests, tests, 1); // Manual redeploy may contain new environment settings.
+  expect("--help", tests, 1);
+  expect("f".repeat(40), tests, 1); // Missing/shallow Git history.
+  expect(initial, "", 1);
+
+  const code = commit("src/app/page.tsx", "export default 2;");
+  const laterDocs = commit("README.md", "Documentation after a failed code build");
+  expect(tests, laterDocs, 1); // HEAD^ alone would incorrectly skip the code.
+  expect(code, laterDocs, 0);
+
+  let previous = laterDocs;
+  for (const file of [
+    "docs/research/data/anac.json", "docs/research/data/raw.md", "scripts/etl/specs/source.json",
+    "src/data/generated/data.json", "data/source-ledger/receipt.json",
+    "public/logo.svg", "package-lock.json", "next.config.ts", "vercel.json",
+    ".github/workflows/ci.yml", "unknown-new-input.txt",
+  ]) {
+    const current = commit(file, "changed");
+    expect(previous, current, 1);
+    previous = current;
+  }
+
+  // A rename out of a runtime directory must include the deletion in the diff.
+  renameSync(join(cwd, "src/app/page.tsx"), join(cwd, "docs/old-code.md"));
+  const renamed = commit("docs/rename.md", "Moved source");
+  expect(previous, renamed, 1);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "npm run build",
-  "installCommand": "npm ci",
+  "installCommand": "PUPPETEER_SKIP_DOWNLOAD=true npm ci",
+  "ignoreCommand": "node scripts/ci/vercel-ignore-build.mjs",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Vercel installs Puppeteer's browsers even though it only runs `next build`, and rebuilds the application for changes that affect only contributor documentation or tests. Keep the full dependency installation and all verification gates, while avoiding this unused work.

- Set `PUPPETEER_SKIP_DOWNLOAD=true` only in Vercel's install command. Local and GitHub Actions browser tests keep their normal installation; TypeScript and npm dependency auditing remain enabled.
- Add a dependency-free Ignored Build Step comparing the current SHA with the last successful deployment for the branch. Build by default for unknown paths, missing/shallow history, first deployments and same-SHA redeploys.
- Skip only Markdown documentation, tests and issue/PR templates. Runtime ANAC files under `docs/research/data`, source specifications, generated data, code, configuration and workflows still trigger deployments. Disable rename detection so moving a source file into docs cannot conceal its deletion.
- Document the decision command, redeploy override and expected health revision after a skipped commit.

### Evidence and validation

The actual gate replay marks 14 of 206 first-parent main commits since 2026-08-22 as non-deployment changes. This assumes each preceding commit deployed successfully and is not a measured billing reduction. A cold-cache Puppeteer postinstall installed approximately 569 MiB of browser files on disk locally; the Vercel-only flag creates no browser cache. Local network timings are not treated as Vercel build savings.

Real Git fixture tests cover docs/tests, runtime data inside docs, source locks, generated artifacts, unknown files, first deployment, same-SHA redeploy, missing history, source renames and a failed/undeployed code change followed by documentation. PASS: static checks, action pins, actionlint, the targeted Git fixture test, all 961 local Node tests (958 pass, 3 existing live-source skips), local build and the full production suite including browser, accessibility and Lighthouse gates. All GitHub checks pass, including ETL/snapshot verification, CodeQL, dependency review and Zizmor. The first Node CI attempt received HTTP 503 from OpenBDAP; rerunning only that job passed without changing or weakening any test. The additional local ETL run also passed: 423 tests, 7 expected raw-input skips; all 30 standalone snapshot checks passed.

The existing Vercel preview is Ready at this exact head. Its install took 21 seconds versus 30 seconds for the preceding production deployment; total duration was 1m06s versus 1m27s. These are separate observed runs, not a controlled benchmark, and both round to two billable minutes on Turbo. No billing reduction is claimed from that timing alone.

No application behavior, rate limits, validation, observability, dependencies or CI gates are removed. Build machine settings are separate from this patch.

### Operational follow-up

With the project owner's approval, the Vercel machine was changed from Elastic to Standard (4 vCPU / 8 GB). The automatic production deployment of this merge succeeded in 1m53s; logs confirm four cores, normal TypeScript verification and `npm ci` auditing. Public health reports the exact merge revision. No manual benchmark redeploy was triggered.

After reviewing the tradeoff, on-demand concurrent builds were disabled while retaining Standard and production build priority. Builds now queue one at a time; runtime request concurrency is unaffected. Current Vercel pricing includes Standard builds without on-demand concurrency or Elastic selection: https://vercel.com/docs/pricing#builds . Other infrastructure usage remains separate. Settings were saved and verified after a page reload.

A pre-existing transient OpenBDAP catalog error found in CI is addressed separately in #294, with explicit outage skips and regression tests ensuring contract/client/assertion errors remain blocking.
