### PR TITLE
test: handle transient OpenBDAP catalog outages after a successful probe

### DIFF
--- a/tests/helpers/live-openbdap.mjs
+++ b/tests/helpers/live-openbdap.mjs
@@ -37,10 +37,12 @@ export async function isOpenBdapReachable({ timeoutMs = 8_000 } = {}) {
 }
 
 export function isTransientSourceError(error) {
-  // The CSV endpoint can fail after the lightweight CKAN probe succeeds.
-  // Match only its explicit transient HTTP failures, never schema/assertion errors.
-  if (error instanceof Error && error.name === "Error"
-    && /^OpenBDAP CSV HTTP (?:429|5\d{2})(?: per l'anno \d{4})?$/.test(error.message)) return true;
+  // Discovery and CSV requests can fail after the lightweight probe succeeds.
+  // Match explicit transient HTTP failures, never schema/assertion errors.
+  if (error instanceof Error && error.name === "Error") {
+    if (/^OpenBDAP package_search HTTP (?:429|5\d{2})$/.test(error.message)) return true;
+    if (/^OpenBDAP CSV HTTP (?:429|5\d{2})(?: per l'anno \d{4})?$/.test(error.message)) return true;
+  }
   if (error?.name === "OpenBdapUnavailableError") return true;
   if (error?.name === "AbortError" || error?.name === "TimeoutError") return true;
   if (error?.name === "SourceFetchError") {

--- a/tests/openbdap-response.test.mjs
+++ b/tests/openbdap-response.test.mjs
@@ -1,7 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import "./helpers/register-ts-alias.mjs";
-import { isTransientSourceError } from "./helpers/live-openbdap.mjs";
+import { isTransientSourceError, runLiveOpenBdap } from "./helpers/live-openbdap.mjs";
+
+test("live OpenBDAP handles discovery outages after a successful probe and propagates contract failures", async (t) => {
+  t.mock.method(globalThis, "fetch", async () => new Response("{}"));
+  const skipped = [];
+  const context = { skip: (reason) => skipped.push(reason) };
+  for (const status of [429, 500, 502, 503, 504]) {
+    await runLiveOpenBdap(context, async () => {
+      throw new Error(`OpenBDAP package_search HTTP ${status}`);
+    });
+  }
+  assert.equal(skipped.length, 5);
+  assert.ok(skipped.every((reason) => reason.includes("non raggiungibile")));
+  for (const error of [
+    ...[400, 401, 403, 404].map((status) => new Error(`OpenBDAP package_search HTTP ${status}`)),
+    new Error("OpenBDAP package_search HTTP 503: unexpected schema"),
+    new Error("Header CSV divergente"),
+    new assert.AssertionError({ message: "OpenBDAP package_search HTTP 503" }),
+  ]) {
+    await assert.rejects(runLiveOpenBdap(context, async () => { throw error; }), (actual) => actual === error);
+  }
+  assert.equal(skipped.length, 5);
+});
 
 test("live OpenBDAP classifies CSV outages without hiding contract or client errors", () => {
   for (const status of [429, 500, 502, 503, 504]) {


### PR DESCRIPTION
Live OpenBDAP tests can pass the initial reachability probe and then receive HTTP 503 from `package_search`. The existing outage handler recognizes CSV download failures but misses catalog discovery failures, making the full Node job fail for an upstream outage. This occurred on both the #292 PR and its post-merge CI.

Recognize only the exact discovery error for HTTP 429/5xx, using the same explicit skip policy already applied to CSV outages. Keep client/configuration errors, unknown messages and assertion failures blocking. Application code, data contracts and CI gates are unchanged.

A regression test exercises `runLiveOpenBdap` with a successful probe followed by discovery failure. It fails before the fix and passes after it, and verifies the original errors propagate for 400/401/403/404, schema-related messages and AssertionError (including an identical 503 message). All six focused tests, ESLint and diff checks pass; the full local Node suite passes with loopback available: 962 tests, 959 pass, 3 explicit live-source skips. Node CI reports the same result. Complete ETL/snapshot and production CI gates remain required before merge. An initial sandboxed local run could not listen on loopback; its environment failure is not counted as a pass.
