### PR TITLE
feat(governi): automate scorecard refresh lifecycle

### DIFF
--- a/.github/workflows/government-scorecard-refresh.yml
+++ b/.github/workflows/government-scorecard-refresh.yml
@@ -35,14 +35,12 @@ jobs:
       - name: Refresh official inputs atomically
         run: |
           snapshot_retrieved_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          python3 scripts/etl/government_scorecard_snapshot.py --retrieved-at "$snapshot_retrieved_at"
-          python3 scripts/etl/government_scorecard_chronology.py
-          python3 scripts/etl/government_scorecard_page.py --refresh --retrieved-at "$snapshot_retrieved_at"
+          python3 scripts/etl/government_scorecard_refresh.py --retrieved-at "$snapshot_retrieved_at"
       - name: Validate generated contract and score
         run: |
-          python3 -m unittest tests/etl/test_government_scorecard_snapshot.py tests/etl/test_government_scorecard_chronology.py tests/etl/test_government_scorecard_page.py
-          python3 scripts/ci/check-government-scorecard-artifacts.py
-          node --experimental-strip-types --test tests/government-scorecard-data.test.mjs tests/government-scorecard-calculation.test.mjs tests/government-scorecard-page.test.mjs
+          python3 -m unittest tests/etl/test_government_scorecard_snapshot.py tests/etl/test_government_scorecard_chronology.py tests/etl/test_government_scorecard_page.py tests/etl/test_government_scorecard_refresh.py
+          npm run government-scorecard:verify
+          python3 scripts/ci/source-snapshot-inventory.py --check
           git diff --check
       - name: Publish generated data
         uses: ./.github/actions/publish-data-refresh

--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -271,3 +271,20 @@ Stato attuale:
 - Debito pubblico: quattro ZIP BDS e una risposta JSON-stat Eurostat sono scaricati soltanto dal workflow dedicato; schema, serie, hash e riconciliazioni devono passare prima della sostituzione atomica dello snapshot.
 
 Non riscriviamo tutti gli adapter contemporaneamente soltanto per uniformità estetica: ogni migrazione deve mantenere gli stessi risultati e passare lint, typecheck, design gate e build.
+
+## Pagella dei governi: ciclo di aggiornamento
+
+Il workflow settimanale `government-scorecard-refresh.yml` usa
+`government_scorecard_refresh.py` e il publisher dati comune. Controlla tutte
+le serie più spesso del minimo semestrale, conserva le ricevute immutate e
+non produce un candidato per il solo passaggio del tempo. La revisione del
+contesto scade dopo tre mesi di calendario e diventa obbligatoria al cambio di
+governo: una ricevuta lega data, catalogo e cronologia. La scadenza o un drift
+inatteso blocca la pubblicazione mantenendo l'ultimo rilascio valido.
+
+Il manutentore fonti segue errori di acquisizione e contratti; il manutentore
+editoriale revisiona contesto e giuramenti. Il workflow non sostituisce queste
+responsabilità. La [procedura della Pagella](PAGELLA_POLITICO_ECONOMICA.md#aggiornamento-manuale-e-errori)
+descrive osservazione senza write, approvazione degli hash, cambio di vintage,
+aggiornamento del registro e rollback. Le date della fonte, dell'acquisizione,
+del polling e della revisione editoriale restano distinte.

--- a/docs/PAGELLA_POLITICO_ECONOMICA.md
+++ b/docs/PAGELLA_POLITICO_ECONOMICA.md
@@ -205,24 +205,99 @@ Il workflow:
 
 Nessun aggiornamento pubblica direttamente su `main`.
 
-### Cadenza editoriale
+### Frequenze e responsabilità
 
-- **Dati del voto:** verifica a ogni nuovo vintage AMECO e comunque almeno ogni sei mesi.
-- **Grafici Eurostat:** rilevazione automatica settimanale; revisione dei cambiamenti tramite PR.
-- **Contesto:** revisione almeno trimestrale, dopo eventi economici internazionali rilevanti e al cambio di governo.
-- **Cronologia:** aggiornamento al giuramento di un nuovo governo, usando una fonte della Presidenza della Repubblica.
+L'unico workflow `government-scorecard-refresh.yml` interroga AMECO e le nove
+query Eurostat ogni martedì, quindi più spesso del minimo semestrale. Si può
+avviare anche manualmente. Il log registra l'ora del controllo, l'esito e la
+scadenza del contesto; `retrieved_at` resta la data di acquisizione del payload,
+non quella dell'ultimo polling riuscito. Un controllo fallito non prova che i
+dati siano aggiornati: il manutentore responsabile delle fonti deve esaminare
+le run fallite e ripetere l'acquisizione entro il semestre.
 
-Il contesto non viene generato da notizie senza revisione. Un elemento nuovo richiede periodo, breve spiegazione del possibile canale economico, fonte autorevole e verifica umana.
+Il manutentore editoriale rivede contesto economico, europeo e internazionale
+entro tre mesi di calendario dalla revisione precedente e al cambio di governo.
+La ricevuta `refreshPolicy.contextReview` nel contratto di provenienza della
+pagina lega la data ai contenuti completi e al registro dei giuramenti tramite
+SHA-256. La ricevuta iniziale identifica il catalogo congelato del 3 settembre
+2026; questa modifica tecnica non aggiunge una nuova revisione editoriale.
+Alla scadenza, il workflow continua a osservare le serie ma blocca la
+pubblicazione e segnala la revisione necessaria. Non inventa contesto né aggiorna
+la data della revisione da solo. Anche una revisione senza cambiamenti richiede
+la registrazione esplicita della nuova data da parte del manutentore.
+
+### Aggiornamento manuale e errori
+
+Usare un checkout pulito e l'orchestratore del workflow, non una sequenza di
+write indipendenti dei singoli ETL:
+
+```bash
+python3 scripts/etl/government_scorecard_refresh.py --observe --retrieved-at <timestamp-UTC>
+```
+
+`--observe` controlla schema, identità, unità, flag e completezza e stampa le
+ricevute acquisite senza scrivere snapshot o candidati. Un nuovo payload non
+approvato resta bloccato: confrontare periodo, fonte, termini di riuso, hash e
+valori con il rilascio precedente prima di riportare le ricevute nel
+`refreshPolicy` di `government-scorecard-page.source.json`. Non approvare un
+hash soltanto perché è quello restituito dal download.
+
+Per un nuovo vintage AMECO aggiornare insieme source spec e manifest metodologico
+(vintage, anni osservati e anni di previsione). `scoreAcquiredAt` e
+`coreArtifactSha256` fissano esattamente l'acquisizione approvata. Una revisione
+storica richiede un confronto esplicito dei voti e l'aggiornamento motivato dei
+test di riferimento; non viene accettata silenziosamente dal polling.
+
+```bash
+python3 scripts/etl/government_scorecard_refresh.py --retrieved-at <timestamp-UTC>
+python3 scripts/ci/source-snapshot-inventory.py --write
+npm run government-scorecard:verify
+npm run test:etl
+npm run test:snapshots
+```
+
+Preparare nello stesso contributo le modifiche editoriali/metodologiche e gli
+snapshot che le applicano: non pubblicare un contratto nuovo con dati vecchi.
+Se cambia il periodo del voto, aggiornare l'inventario prima del refresh
+(l'inventario deriva dal source spec); il refresh ne controlla l'allineamento.
+I file immutati non vengono riscritti. Il manifest pubblico, i download e le
+ricevute sono derivati dai medesimi file validati, senza un secondo generatore.
+
+Timeout, payload parziale, cambiamento inatteso di schema, fonte, licenza,
+identità, periodo o hash interrompono il refresh. I dati sono preparati in
+memoria; un errore nella sostituzione locale o nella verifica finale ripristina
+i byte precedenti. La pubblicazione usa l'unico commit/candidato del publisher
+esistente: una run interrotta non raggiunge quel passo. L'atomicità pubblica è
+quella dell'albero Git, non una transazione fra file di un server in esecuzione.
+Non eseguire l'ETL nella directory di un'applicazione in servizio.
+
+Il publisher rimane limitato ai due artifact generati: cronologia, metodologia
+e approvazioni editoriali richiedono un contributo umano. Nessun commit o
+candidato viene prodotto se non cambia alcun dato. I log delle run conservano
+la prova dei controlli che non hanno prodotto modifiche.
 
 ### Cambio di governo
 
-Quando giura un nuovo governo occorre:
-
-1. aggiungere il nuovo giuramento al registro cronologico e verificare la fonte;
-2. chiudere automaticamente il mandato precedente con quella stessa data esclusiva;
-3. aggiungere il contesto iniziale del nuovo governo;
-4. rigenerare i due artefatti;
-5. eseguire test e controllo visivo prima della PR.
+1. Verificare il giuramento sulla notizia specifica della Presidenza della
+   Repubblica. Aggiungere al registro ID univoco, nome, data, URL e locator;
+   aggiornare `asOfDate` e `verifiedAt`. I 17 giuramenti già verificati sono
+   protetti; nuove voci sono ammesse solo in coda e in ordine temporale.
+2. Il modello chiude il mandato precedente alla data esclusiva del successore.
+   Nel catalogo `contexts` dello snapshot della pagina aggiornare la scheda
+   cronologica precedente e aggiungere le sei categorie del nuovo governo,
+   con fonti, periodo e canale economico. Una categoria vuota richiede comunque
+   la revisione del catalogo; non copiare automaticamente il contesto precedente.
+3. Ricalcolare gli hash degli elementi modificati con
+   `government_scorecard_page._canonical_hash` sull'evidenza (tutti i campi
+   eccetto `retrieved_at` e `evidence_sha256`), poi gli hash del catalogo e del
+   registro nella ricevuta `contextReview`. Registrare la data della revisione.
+   Date, nomi, fonti e confini del mandato devono riconciliare.
+4. Eseguire l'orchestratore e le verifiche sopra; aggiornare i test di riferimento
+   del governo diventato storico e aggiungere il nuovo caso. Verificare in browser
+   governo corrente, archivio, confronto e download.
+5. Il nuovo governo compare dal registro, ma resta senza voto finché non supera
+   durata minima e finestra annuale comune completa. Solo osservazioni AMECO
+   entrano nel calcolo; previsioni e serie di contesto non possono sostituirle.
 
 ## I due artefatti mantenuti
 

--- a/scripts/ci/check-government-scorecard-artifacts.py
+++ b/scripts/ci/check-government-scorecard-artifacts.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(ROOT / "scripts" / "etl"))
 import government_scorecard_chronology  # noqa: E402
 import government_scorecard_page  # noqa: E402
 import government_scorecard_snapshot  # noqa: E402
+import government_scorecard_refresh  # noqa: E402
 
 
 def main() -> None:
@@ -31,7 +32,8 @@ def main() -> None:
     )
     government_scorecard_snapshot.validate_snapshot(scorecard)
     government_scorecard_chronology.validate_registry(chronology)
-    government_scorecard_page.validate(page)
+    policy = government_scorecard_refresh.load_policy(government_scorecard_refresh.POLICY_PATH)
+    government_scorecard_refresh.validate_release(scorecard, page, chronology, policy)
     print("ok: government scorecard core and page snapshots")
 
 

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -537,16 +537,18 @@
       "reconciliationTests": [
         "tests/etl/test_government_scorecard_snapshot.py",
         "tests/etl/test_government_scorecard_chronology.py",
-        "tests/etl/test_government_scorecard_page.py"
+        "tests/etl/test_government_scorecard_page.py",
+        "tests/etl/test_government_scorecard_refresh.py"
       ],
       "nodeTests": [
         "tests/government-scorecard-data.test.mjs",
         "tests/government-scorecard-calculation.test.mjs",
         "tests/government-scorecard-page.test.mjs",
-        "tests/government-scorecard-downloads.test.mjs"
+        "tests/government-scorecard-downloads.test.mjs",
+        "tests/government-scorecard-refresh.test.mjs"
       ],
       "generator": {
-        "command": "python3 scripts/etl/government_scorecard_snapshot.py --retrieved-at <UTC timestamp> && python3 scripts/etl/government_scorecard_chronology.py && python3 scripts/etl/government_scorecard_page.py --refresh --retrieved-at <same UTC timestamp>",
+        "command": "python3 scripts/etl/government_scorecard_refresh.py --retrieved-at <UTC timestamp>",
         "requiresNetworkInput": true
       },
       "refreshWorkflow": ".github/workflows/government-scorecard-refresh.yml",

--- a/scripts/etl/government_scorecard_chronology.py
+++ b/scripts/etl/government_scorecard_chronology.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import urllib.parse
 import tempfile
 from datetime import date
 from pathlib import Path
@@ -77,32 +79,39 @@ def validate_registry(candidate: object) -> dict[str, Any]:
         raise RegistryValidationError("campi del registro v6 inattesi")
     if candidate.get("schemaVersion") != 1 or candidate.get("registryVersion") != "quirinale-government-oaths-v1":
         raise RegistryValidationError("versione del registro v6 inattesa")
-    if candidate.get("verifiedAt") != "2026-09-01" or candidate.get("asOfDate") != "2026-08-29":
-        raise RegistryValidationError("date congelate del registro v6 inattese")
     _iso_date(candidate["verifiedAt"], "verifiedAt")
     _iso_date(candidate["asOfDate"], "asOfDate")
+    if candidate["verifiedAt"] < candidate["asOfDate"]:
+        raise RegistryValidationError("registro verificato prima della data di riferimento")
     if candidate.get("eventDefinition") != "Giuramento del Presidente del Consiglio e dei ministri nelle mani del Presidente della Repubblica":
         raise RegistryValidationError("evento istituzionale inatteso")
     if candidate.get("constitutionalSourceUrl") != "https://www.senato.it/istituzione/la-costituzione/parte-ii/titolo-iii/sezione-i/articolo-93":
         raise RegistryValidationError("fonte costituzionale inattesa")
 
     governments = candidate.get("governments")
-    if not isinstance(governments, list) or len(governments) != len(EXPECTED_GOVERNMENTS):
-        raise RegistryValidationError("il registro deve contenere esattamente 17 governi")
+    if not isinstance(governments, list) or len(governments) < len(EXPECTED_GOVERNMENTS):
+        raise RegistryValidationError("il registro deve contenere almeno i 17 governi verificati")
     previous_start: str | None = None
-    for index, (government, expected) in enumerate(zip(governments, EXPECTED_GOVERNMENTS, strict=True)):
+    ids = set()
+    for index, government in enumerate(governments):
         if not isinstance(government, dict) or set(government) != GOVERNMENT_FIELDS:
             raise RegistryValidationError(f"governo {index}: campi mancanti o editoriali inattesi")
-        expected_id, expected_name, expected_start, source_key = expected
         start = _iso_date(government.get("startDate"), f"governo {index}.startDate")
-        if (
-            government.get("id") != expected_id
-            or government.get("name") != expected_name
-            or start != expected_start
-            or government.get("sourceOwner") != "Presidenza della Repubblica"
-            or government.get("sourceUrl") != SOURCE_URLS[source_key]
-        ):
-            raise RegistryValidationError(f"governo {index}: ID, nome, data o fonte divergente")
+        if index < len(EXPECTED_GOVERNMENTS):
+            expected_id, expected_name, expected_start, source_key = EXPECTED_GOVERNMENTS[index]
+            if (government.get("id"), government.get("name"), start, government.get("sourceUrl")) != (expected_id, expected_name, expected_start, SOURCE_URLS[source_key]):
+                raise RegistryValidationError(f"governo {index}: ID, nome, data o fonte divergente")
+        else:
+            url = urllib.parse.urlparse(government.get("sourceUrl", ""))
+            if (url.scheme != "https" or url.netloc != "www.quirinale.it"
+                    or not url.path.startswith("/it/notizie/") or len(url.path) <= len("/it/notizie/")
+                    or url.query or url.fragment or start > candidate["asOfDate"]):
+                raise RegistryValidationError("nuovo giuramento: fonte o data non verificabile")
+        if (government.get("sourceOwner") != "Presidenza della Repubblica"
+                or not isinstance(government.get("id"), str) or not re.fullmatch(r"[a-z0-9-]+", government["id"])
+                or government["id"] in ids or not isinstance(government.get("name"), str) or not government["name"].strip()):
+            raise RegistryValidationError("identita governo inattesa o duplicata")
+        ids.add(government["id"])
         locator = government.get("sourceLocator")
         if not isinstance(locator, str) or len(locator.strip()) < 30 or start[:4] not in locator:
             raise RegistryValidationError(f"governo {index}: locator Quirinale mancante")

--- a/scripts/etl/government_scorecard_page.py
+++ b/scripts/etl/government_scorecard_page.py
@@ -8,6 +8,7 @@ import datetime as dt
 import hashlib
 import json
 import math
+import re
 import os
 import tempfile
 import urllib.parse
@@ -94,7 +95,12 @@ def _fetch_eurostat(dataset: str, filters: tuple[tuple[str, str], ...], since_pe
     request = urllib.request.Request(url, headers={"User-Agent": "DoveVannoINostriSoldi/0.2 data-refresh"})
     try:
         with urllib.request.urlopen(request, timeout=45) as response:
-            payload = response.read()
+            final = urllib.parse.urlparse(response.geturl())
+            if final.scheme != "https" or final.netloc != "ec.europa.eu":
+                raise SupplementalSnapshotError("Eurostat redirect outside official origin")
+            payload = response.read(10 * 1024 * 1024 + 1)
+            if len(payload) > 10 * 1024 * 1024:
+                raise SupplementalSnapshotError("Eurostat response too large")
     except OSError as exc:
         raise SupplementalSnapshotError(f"Eurostat download failed: {dataset}") from exc
     try:
@@ -103,7 +109,50 @@ def _fetch_eurostat(dataset: str, filters: tuple[tuple[str, str], ...], since_pe
         raise SupplementalSnapshotError(f"Eurostat returned invalid JSON: {dataset}") from exc
     if not isinstance(data, dict) or "error" in data:
         raise SupplementalSnapshotError(f"Eurostat returned an error: {dataset}")
+    validate_jsonstat(data, filters)
     return data, payload, url
+
+
+def validate_jsonstat(data: dict[str, Any], filters: tuple[tuple[str, str], ...]) -> None:
+    """Validate the raw cube before selectors can silently discard schema drift."""
+    if data.get("version") != "2.0" or data.get("class") != "dataset" or data.get("source") != "ESTAT":
+        raise SupplementalSnapshotError("Eurostat schema/source identity mismatch")
+    expected = {"geo": [code for code, _ in COUNTRIES]}
+    for key, value in filters:
+        expected.setdefault(key, []).append(value)
+    dimensions, sizes = data.get("id"), data.get("size")
+    if (not isinstance(dimensions, list) or len(dimensions) != len(set(dimensions))
+            or set(dimensions) != set(expected) | {"time"}
+            or not isinstance(sizes, list) or len(sizes) != len(dimensions)):
+        raise SupplementalSnapshotError("Eurostat dimension drift")
+    for dimension, size in zip(dimensions, sizes, strict=True):
+        positions = _category_positions(data, dimension)
+        if type(size) is not int or not 0 < size <= 1_000_000 or any(type(index) is not int for index in positions.values()) or sorted(positions.values()) != list(range(size)):
+            raise SupplementalSnapshotError("Eurostat dimension size mismatch")
+        if dimension != "time" and set(positions) != set(expected[dimension]):
+            raise SupplementalSnapshotError(f"Eurostat filter/identity drift: {dimension}")
+        if dimension == "time":
+            pattern = {"A": r"\d{4}", "Q": r"\d{4}-Q[1-4]", "M": r"\d{4}-(?:0[1-9]|1[0-2])"}[expected["freq"][0]]
+            if any(re.fullmatch(pattern, period) is None for period in positions):
+                raise SupplementalSnapshotError("Eurostat period drift")
+    count = math.prod(sizes)
+    if count > 1_000_000:
+        raise SupplementalSnapshotError("Eurostat cube too large")
+    for field in ("value", "status"):
+        values = data.get(field, {} if field == "status" else None)
+        if isinstance(values, list):
+            if len(values) != count:
+                raise SupplementalSnapshotError("Eurostat incomplete cube")
+            values = dict(enumerate(values))
+        if not isinstance(values, dict) or any(not str(key).isdigit() or not 0 <= int(key) < count for key in values):
+            raise SupplementalSnapshotError("Eurostat malformed cube")
+        for value in values.values():
+            if field == "status":
+                if value is not None and not isinstance(value, str):
+                    raise SupplementalSnapshotError("Eurostat malformed status")
+                _publication_status(value)
+            elif value is not None and (type(value) not in (int, float) or not math.isfinite(value)):
+                raise SupplementalSnapshotError("Eurostat malformed value")
 
 
 def _category_positions(data: dict[str, Any], dimension: str) -> dict[str, int]:
@@ -176,6 +225,8 @@ def _period_start(period: str) -> str:
 
 def _publication_status(upstream_status: str | None) -> str:
     flags = set(upstream_status or "")
+    if flags - set("bdepnsuz;"):
+        raise SupplementalSnapshotError("unsupported or forecast Eurostat publication flag")
     if "e" in flags:
         return "estimated"
     if "p" in flags:
@@ -286,7 +337,7 @@ def _primary_balance_series(data: dict[str, Any], source: dict[str, Any]) -> dic
 def _ameco_source(core: dict[str, Any]) -> dict[str, Any]:
     raw = core["sources"]["ameco"]
     return {
-        "id": "ameco:2026-spring",
+        "id": f"ameco:{raw['release'].split()[1]}-{raw['release'].split()[0].lower()}",
         "owner": raw["owner"],
         "title": raw["title"],
         "dataset_code": "AMECO",
@@ -787,9 +838,9 @@ def _contexts_for_snapshot(core: dict[str, Any], chronology: dict[str, Any], ser
     return existing
 
 
-def build_snapshot(retrieved_at: str) -> dict[str, Any]:
-    core = _load(CORE_PATH)
-    chronology = _load(CHRONOLOGY_PATH)
+def build_snapshot(retrieved_at: str, *, core=None, chronology=None, existing=None, core_hash=None) -> dict[str, Any]:
+    core = core if core is not None else _load(CORE_PATH)
+    chronology = chronology if chronology is not None else _load(CHRONOLOGY_PATH)
     ameco = _ameco_source(core)
     inflation_data, inflation_payload, inflation_url = _fetch_eurostat("prc_hicp_minr", (("freq", "M"), ("unit", "RCH_A"), ("coicop18", "TOTAL")), "1996-01")
     unemployment_data, unemployment_payload, unemployment_url = _fetch_eurostat("une_rt_m", (("freq", "M"), ("s_adj", "SA"), ("age", "TOTAL"), ("sex", "T"), ("unit", "PC_ACT")), "1997-01")
@@ -827,7 +878,7 @@ def build_snapshot(retrieved_at: str) -> dict[str, Any]:
     snapshot = {
         "schema_version": SCHEMA_VERSION,
         "snapshot_version": SNAPSHOT_VERSION,
-        "as_of_date": SNAPSHOT_DATE,
+        "as_of_date": retrieved_at[:10],
         "coverage": {
             "first_period": "1995",
             "latest_published_periods": [{"indicator_id": item["indicator_id"], "period": item["latest_published_period"]} for item in ordered_series],
@@ -846,22 +897,27 @@ def build_snapshot(retrieved_at: str) -> dict[str, Any]:
             population_source,
         ],
         "series": ordered_series,
-        "contexts": _contexts_for_snapshot(core, chronology, ordered_series, retrieved_at),
-        "score_contract": {"supplemental_score_impact": "none", "core_artifact_sha256": _sha256(CORE_PATH.read_bytes())},
+        "contexts": existing["contexts"] if existing is not None else _contexts_for_snapshot(core, chronology, ordered_series, retrieved_at),
+        "score_contract": {"supplemental_score_impact": "none", "core_artifact_sha256": core_hash or _sha256(CORE_PATH.read_bytes())},
     }
-    validate(snapshot)
+    validate(snapshot, core_hash=core_hash, chronology=chronology)
     return snapshot
 
 
-def validate(snapshot: dict[str, Any]) -> None:
+def validate(snapshot: dict[str, Any], *, core_hash=None, chronology=None) -> None:
     expected_keys = {"schema_version", "snapshot_version", "as_of_date", "coverage", "sources", "series", "contexts", "score_contract"}
     if set(snapshot) != expected_keys:
         raise SupplementalSnapshotError("unexpected snapshot fields")
+    try:
+        if dt.date.fromisoformat(snapshot["as_of_date"]).isoformat() != snapshot["as_of_date"]:
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise SupplementalSnapshotError("invalid snapshot reference date") from exc
     if snapshot.get("schema_version") != SCHEMA_VERSION or snapshot.get("snapshot_version") != SNAPSHOT_VERSION:
         raise SupplementalSnapshotError("snapshot identity mismatch")
     if snapshot.get("score_contract") != {
         "supplemental_score_impact": "none",
-        "core_artifact_sha256": _sha256(CORE_PATH.read_bytes()),
+        "core_artifact_sha256": core_hash or _sha256(CORE_PATH.read_bytes()),
     }:
         raise SupplementalSnapshotError("page data must not affect the score and must reference the current core artifact")
     series = snapshot.get("series")
@@ -887,7 +943,8 @@ def validate(snapshot: dict[str, Any]) -> None:
         if item.get("latest_published_period") != max(all_periods):
             raise SupplementalSnapshotError("latest published period mismatch")
     contexts = snapshot.get("contexts")
-    if not isinstance(contexts, list) or len(contexts) != 17:
+    chronology = chronology if chronology is not None else _load(CHRONOLOGY_PATH)
+    if not isinstance(contexts, list) or [(item.get("government_id"), item.get("government_name")) for item in contexts] != [(item["id"], item["name"]) for item in chronology["governments"]]:
         raise SupplementalSnapshotError("context government coverage mismatch")
     for context in contexts:
         slides = context.get("slides", [])

--- a/scripts/etl/government_scorecard_refresh.py
+++ b/scripts/etl/government_scorecard_refresh.py
@@ -72,6 +72,8 @@ def validate_release(core, supplemental, registry, policy):
     if set(review) != {"reviewedAt", "contextsSha256", "chronologySha256"}:
         score.fail("context review: unexpected schema")
     review_deadline(review["reviewedAt"])
+    if review["reviewedAt"] > supplemental["as_of_date"]:
+        score.fail("context review date exceeds snapshot as_of_date")
     if (review["contextsSha256"] != page._canonical_hash(supplemental["contexts"])
             or review["chronologySha256"] != page._canonical_hash(registry)
             or review["reviewedAt"] < registry["verifiedAt"]):

--- a/scripts/etl/government_scorecard_refresh.py
+++ b/scripts/etl/government_scorecard_refresh.py
@@ -59,7 +59,7 @@ def review_deadline(reviewed_at):
     return dt.date(year, month, min(reviewed.day, calendar.monthrange(year, month)[1]))
 
 
-def validate_release(core, supplemental, registry, policy):
+def validate_release(core, supplemental, registry, policy, checked_at=None):
     """The same offline contract gates both refresh and the existing publisher."""
     score.validate_snapshot(core)
     chronology.validate_registry(registry)
@@ -72,6 +72,9 @@ def validate_release(core, supplemental, registry, policy):
     if set(review) != {"reviewedAt", "contextsSha256", "chronologySha256"}:
         score.fail("context review: unexpected schema")
     review_deadline(review["reviewedAt"])
+    checked_at = checked_at or dt.datetime.now(dt.UTC).date()
+    if supplemental["as_of_date"] > checked_at.isoformat():
+        score.fail("snapshot as_of_date exceeds validation date")
     if review["reviewedAt"] > supplemental["as_of_date"]:
         score.fail("context review date exceeds snapshot as_of_date")
     if (review["contextsSha256"] != page._canonical_hash(supplemental["contexts"])
@@ -236,8 +239,8 @@ def refresh(retrieved_at, *, root=ROOT, fetch_score=score.download, build_page=p
                           "scoreAcquiredAt": candidate_core["sources"]["ameco"]["retrievedAt"],
                           "coreArtifactSha256": score.sha256(encoded(candidate_core))}, ensure_ascii=False, indent=2))
         return False
-    validate_release(candidate_core, candidate_page, registry, policy)
     today = dt.date.fromisoformat(retrieved_at[:10])
+    validate_release(candidate_core, candidate_page, registry, policy, checked_at=today)
     if today < dt.date.fromisoformat(policy["contextReview"]["reviewedAt"]):
         score.fail("context review date is in the future")
     if today >= review_deadline(policy["contextReview"]["reviewedAt"]):

--- a/scripts/etl/government_scorecard_refresh.py
+++ b/scripts/etl/government_scorecard_refresh.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Refresh the registered scorecard pair, retaining the last valid release on failure."""
+from __future__ import annotations
+
+import argparse
+import calendar
+import copy
+import datetime as dt
+import json
+import os
+import tempfile
+import subprocess
+from pathlib import Path
+
+try:
+    from . import government_scorecard_snapshot as score
+    from . import government_scorecard_page as page
+    from . import government_scorecard_chronology as chronology
+except ImportError:
+    import government_scorecard_snapshot as score
+    import government_scorecard_page as page
+    import government_scorecard_chronology as chronology
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "scripts/etl/specs/government-scorecard-page.source.json"
+
+
+def load_policy(path):
+    spec = score.load_json(path)
+    if (spec.get("schemaVersion") != page.SCHEMA_VERSION
+            or spec.get("snapshotVersion") != page.SNAPSHOT_VERSION
+            or spec.get("geographies") != [code for code, _ in page.COUNTRIES]
+            or spec.get("scoreImpact") != "none"
+            or spec.get("sourceContract", {}).get("license") != {
+                "ameco": "CC BY 4.0 unless otherwise indicated",
+                "eurostat": "Free reuse with source acknowledgement, subject to the exceptions in the Eurostat copyright notice",
+            }
+            or spec.get("sourceContract", {}).get("termsUrls") != [
+                "https://commission.europa.eu/legal-notice_en", page.EUROSTAT_TERMS,
+            ]):
+        score.fail("page provenance schema, identity or license drift")
+    return spec["refreshPolicy"]
+
+
+def encoded(value):
+    return (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode()
+
+
+def receipt(source):
+    return {key: value for key, value in source.items() if key != "retrieved_at"}
+
+
+def review_deadline(reviewed_at):
+    chronology._iso_date(reviewed_at, "contextReview.reviewedAt")
+    reviewed = dt.date.fromisoformat(reviewed_at)
+    month = reviewed.month + 3
+    year = reviewed.year + (month > 12)
+    month = (month - 1) % 12 + 1
+    return dt.date(year, month, min(reviewed.day, calendar.monthrange(year, month)[1]))
+
+
+def validate_release(core, supplemental, registry, policy):
+    """The same offline contract gates both refresh and the existing publisher."""
+    score.validate_snapshot(core)
+    chronology.validate_registry(registry)
+    page.validate(supplemental, core_hash=score.sha256(encoded(core)), chronology=registry)
+    if set(policy) != {"contextReview", "approvedSources", "approvedPeriods", "coreArtifactSha256", "scoreAcquiredAt"}:
+        score.fail("refresh policy: unexpected schema")
+    if score.sha256(encoded(core)) != policy["coreArtifactSha256"] or core["sources"]["ameco"]["retrievedAt"] != policy["scoreAcquiredAt"]:
+        score.fail("unreviewed score revision or core artifact hash")
+    review = policy["contextReview"]
+    if set(review) != {"reviewedAt", "contextsSha256", "chronologySha256"}:
+        score.fail("context review: unexpected schema")
+    review_deadline(review["reviewedAt"])
+    if (review["contextsSha256"] != page._canonical_hash(supplemental["contexts"])
+            or review["chronologySha256"] != page._canonical_hash(registry)
+            or review["reviewedAt"] < registry["verifiedAt"]):
+        score.fail("context/government change requires a matching editorial review")
+    for index, government in enumerate(registry["governments"]):
+        context = supplemental["contexts"][index]
+        oath = next(slide for slide in context["slides"] if slide["category"] == "chronology")["items"]
+        end = registry["governments"][index + 1]["startDate"] if index + 1 < len(registry["governments"]) else None
+        if (len(oath) != 1 or oath[0]["start_date"] != government["startDate"]
+                or oath[0]["end_date_or_null"] != end
+                or oath[0]["sources"] != [{"owner": government["sourceOwner"], "type": "official", "url": government["sourceUrl"]}]):
+            score.fail("government transition: context chronology does not reconcile")
+    expected = policy["approvedSources"]
+    actual = [receipt(item) for item in supplemental["sources"]]
+    if actual != expected:
+        score.fail("source/schema/license/period/hash drift: review the acquired receipts before publication")
+    if supplemental["sources"][0] != page._ameco_source(core):
+        score.fail("AMECO receipt does not reconcile with score data")
+    if supplemental["coverage"]["latest_published_periods"] != policy["approvedPeriods"]:
+        score.fail("unexpected published period: review required")
+    sources = {item["id"]: item for item in supplemental["sources"]}
+    by_dataset = {item["dataset_code"]: item for item in supplemental["sources"]}
+    for series in supplemental["series"]:
+        for geography in series["geographies"]:
+            for point in geography["points"]:
+                if point["period_start"] != page._period_start(point["period"]):
+                    score.fail("point period does not reconcile")
+                if page._publication_status(point["upstream_status_or_null"]) != point["status"]:
+                    score.fail("observed/forecast publication status mismatch")
+                components = point.get("component_sources")
+                if components:
+                    for component in components:
+                        source = by_dataset.get(component["dataset_code"], {})
+                        if (component["raw_sha256"] != source.get("raw_sha256")
+                                or component["source_url"] != source.get("query_url")):
+                            score.fail("component receipt/hash mismatch")
+                    hashes = [item["raw_sha256"] for item in components]
+                    if series["indicator_id"] == "primary_balance":
+                        hashes.append("B9+D41PAY")
+                        derivation = point["derivation"]
+                        if point["value"] != round(derivation["net_lending_percent_gdp"] + derivation["interest_payable_percent_gdp"], 4):
+                            score.fail("primary balance does not reconcile")
+                    if point["raw_sha256"] != page._canonical_hash(hashes):
+                        score.fail("derived hash mismatch")
+                else:
+                    source = sources.get(point["source_id"], {})
+                    for point_key, source_key in (("source_owner", "owner"), ("source_url", "query_url"),
+                                                  ("retrieved_at", "retrieved_at"), ("raw_sha256", "raw_sha256")):
+                        if point[point_key] != source.get(source_key):
+                            score.fail("point receipt/hash mismatch")
+                if series["usage"] == "score_and_context":
+                    raw = next(item for item in core["indicators"] if item["id"] == series["indicator_id"])
+                    country = dict(page.COUNTRIES)[geography["geography"]]
+                    values = {item["year"]: item["value"] for item in raw["countries"][country]}
+                    if point["year"] > core["sources"]["ameco"]["observedThrough"] or point["value"] != values.get(point["year"]):
+                        score.fail("score display must use common observed AMECO values")
+
+
+def preserve_unchanged_receipts(candidate, previous):
+    """A successful poll is recorded in the run log, never by rewriting acquisition dates."""
+    previous_sources = {item["id"]: item for item in previous["sources"]}
+    retained = {}
+    for source in candidate["sources"]:
+        old = previous_sources.get(source["id"])
+        if old is not None and receipt(source) == receipt(old):
+            source["retrieved_at"] = old["retrieved_at"]
+            retained[source["id"]] = old["retrieved_at"]
+    for series in candidate["series"]:
+        for geography in series["geographies"]:
+            for point in geography["points"]:
+                if point["source_id"] in retained:
+                    point["retrieved_at"] = retained[point["source_id"]]
+                elif point.get("component_sources"):
+                    components = point["component_sources"]
+                    old_sources = {item["dataset_code"]: item for item in previous["sources"]}
+                    if all(item["raw_sha256"] == old_sources.get(item["dataset_code"], {}).get("raw_sha256") for item in components):
+                        old_series = next(item for item in previous["series"] if item["indicator_id"] == series["indicator_id"])
+                        old_geo = next(item for item in old_series["geographies"] if item["geography"] == geography["geography"])
+                        old_point = next((item for item in old_geo["points"] if item["period"] == point["period"]), None)
+                        if old_point:
+                            point["retrieved_at"] = old_point["retrieved_at"]
+    without_date = lambda value: {key: item for key, item in value.items() if key != "as_of_date"}
+    if without_date(candidate) == without_date(previous):
+        candidate["as_of_date"] = previous["as_of_date"]
+
+
+def require_complete_update(candidate, previous):
+    for series, old_series in zip(candidate["series"], previous["series"], strict=True):
+        for geo, old_geo in zip(series["geographies"], old_series["geographies"], strict=True):
+            if not {point["period"] for point in old_geo["points"]} <= {point["period"] for point in geo["points"]}:
+                score.fail("partial update removed previously published observations")
+
+
+def replace_release(outputs, validate):
+    """Local rollback plus the publisher's single Git tree provide release atomicity.
+
+    No running application reads this ETL workspace. A killed runner cannot reach
+    the publish step; ordinary errors restore the exact original bytes locally.
+    """
+    originals = {path: path.read_bytes() for path in outputs}
+    parent = next(iter(outputs)).parent
+    # Prepare every candidate and rollback copy before replacing any file.
+    # Rollback uses rename, so it needs no further allocation after a disk-full error.
+    with tempfile.TemporaryDirectory(prefix=".scorecard-refresh-", dir=parent) as directory:
+        staged = Path(directory)
+        for index, (path, value) in enumerate(outputs.items()):
+            with (staged / f"{index}.previous").open("wb") as handle:
+                handle.write(originals[path])
+                handle.flush()
+                os.fsync(handle.fileno())
+            score.atomic_write(staged / f"{index}.candidate", value)
+        if any(path.read_bytes() != payload for path, payload in originals.items()):
+            score.fail("scorecard changed concurrently; retry from a clean checkout")
+        replaced = []
+        try:
+            for index, (path, value) in enumerate(outputs.items()):
+                if encoded(value) != originals[path]:
+                    os.replace(staged / f"{index}.candidate", path)
+                    replaced.append((index, path))
+            validate()
+        except BaseException:
+            for index, path in reversed(replaced):
+                os.replace(staged / f"{index}.previous", path)
+            raise
+
+
+def refresh(retrieved_at, *, root=ROOT, fetch_score=score.download, build_page=page.build_snapshot, verify=None, observe=False):
+    retrieved_at = page._timestamp(retrieved_at)
+    score_path = root / "src/data/generated/government-scorecard.json"
+    page_path = root / "src/data/generated/government-scorecard-page.json"
+    registry = score.load_json(root / "scripts/etl/specs/government-scorecard-chronology.json")
+    policy = load_policy(root / "scripts/etl/specs/government-scorecard-page.source.json")
+    previous_core, previous_page = score.load_json(score_path), score.load_json(page_path)
+    # Check bindings before network access; an expired review does not prevent
+    # economic observation, but prevents publication after that observation.
+    chronology.validate_registry(registry)
+    spec = score.load_json(root / "scripts/etl/specs/government-scorecard.source.json")
+    payload = fetch_score(spec["ameco"]["downloadUrl"])
+    acquired_at = retrieved_at if observe else policy["scoreAcquiredAt"]
+    candidate_core = score.build_snapshot(spec, payload, acquired_at)
+    # Editorial caveats are reviewed content, not economic observations.
+    candidate_core["caveats"] = previous_core["caveats"]
+    score.validate_snapshot(candidate_core)  # requires the complete common observed panel
+    old_core = copy.deepcopy(previous_core)
+    old_core["generatedAt"] = acquired_at
+    old_core["sources"]["ameco"]["retrievedAt"] = acquired_at
+    if old_core == candidate_core:
+        candidate_core = previous_core
+    candidate_page = build_page(retrieved_at, core=candidate_core, chronology=registry,
+                                existing=previous_page, core_hash=score.sha256(encoded(candidate_core)))
+    preserve_unchanged_receipts(candidate_page, previous_page)
+    require_complete_update(candidate_page, previous_page)
+    if observe:
+        print(json.dumps({"approvedSources": [receipt(item) for item in candidate_page["sources"]],
+                          "approvedPeriods": candidate_page["coverage"]["latest_published_periods"],
+                          "scoreAcquiredAt": candidate_core["sources"]["ameco"]["retrievedAt"],
+                          "coreArtifactSha256": score.sha256(encoded(candidate_core))}, ensure_ascii=False, indent=2))
+        return False
+    validate_release(candidate_core, candidate_page, registry, policy)
+    today = dt.date.fromisoformat(retrieved_at[:10])
+    if today < dt.date.fromisoformat(policy["contextReview"]["reviewedAt"]):
+        score.fail("context review date is in the future")
+    if today >= review_deadline(policy["contextReview"]["reviewedAt"]):
+        score.fail("quarterly context review overdue; last valid snapshot retained")
+    changed = candidate_core != previous_core or candidate_page != previous_page
+    if changed:
+        replace_release({score_path: candidate_core, page_path: candidate_page}, verify or (lambda: None))
+    print(f"observed official economic inputs at {retrieved_at}; changed={str(changed).lower()}; context review due {review_deadline(policy['contextReview']['reviewedAt'])}")
+    return changed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--retrieved-at", required=True)
+    parser.add_argument("--observe", action="store_true", help="print acquired receipts for human review without writing a candidate")
+    args = parser.parse_args()
+    def verify():
+        subprocess.run(["npm", "run", "government-scorecard:verify"], cwd=ROOT, check=True)
+        subprocess.run(["python3", "scripts/ci/source-snapshot-inventory.py", "--check"], cwd=ROOT, check=True)
+    refresh(args.retrieved_at, verify=verify, observe=args.observe)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/etl/government_scorecard_refresh.py
+++ b/scripts/etl/government_scorecard_refresh.py
@@ -132,7 +132,7 @@ def validate_release(core, supplemental, registry, policy):
                         score.fail("score display must use common observed AMECO values")
 
 
-def preserve_unchanged_receipts(candidate, previous):
+def preserve_unchanged_receipts(candidate, previous, reviewed_at):
     """A successful poll is recorded in the run log, never by rewriting acquisition dates."""
     previous_sources = {item["id"]: item for item in previous["sources"]}
     retained = {}
@@ -157,7 +157,7 @@ def preserve_unchanged_receipts(candidate, previous):
                             point["retrieved_at"] = old_point["retrieved_at"]
     without_date = lambda value: {key: item for key, item in value.items() if key != "as_of_date"}
     if without_date(candidate) == without_date(previous):
-        candidate["as_of_date"] = previous["as_of_date"]
+        candidate["as_of_date"] = max(previous["as_of_date"], reviewed_at)
 
 
 def require_complete_update(candidate, previous):
@@ -224,7 +224,11 @@ def refresh(retrieved_at, *, root=ROOT, fetch_score=score.download, build_page=p
         candidate_core = previous_core
     candidate_page = build_page(retrieved_at, core=candidate_core, chronology=registry,
                                 existing=previous_page, core_hash=score.sha256(encoded(candidate_core)))
-    preserve_unchanged_receipts(candidate_page, previous_page)
+    preserve_unchanged_receipts(
+        candidate_page,
+        previous_page,
+        policy["contextReview"]["reviewedAt"],
+    )
     require_complete_update(candidate_page, previous_page)
     if observe:
         print(json.dumps({"approvedSources": [receipt(item) for item in candidate_page["sources"]],

--- a/scripts/etl/government_scorecard_snapshot.py
+++ b/scripts/etl/government_scorecard_snapshot.py
@@ -10,6 +10,7 @@ import io
 import json
 import math
 import os
+import re
 import tempfile
 import urllib.parse
 import urllib.request
@@ -141,9 +142,17 @@ def validate_spec(spec: dict[str, Any]) -> dict[str, Any]:
         or ameco.get("encoding") != "latin-1"
     ):
         fail("ameco: metadati inattesi")
+    if (any(type(ameco.get(key)) is not int for key in ("observedThrough", "forecastFrom", "forecastThrough"))
+            or not 1995 <= ameco["observedThrough"] < ameco["forecastFrom"] <= ameco["forecastThrough"] <= 2100
+            or ameco["forecastFrom"] != ameco["observedThrough"] + 1
+            or ameco["release"] != method["source"]["vintage"]
+            or re.fullmatch(r"(?:Spring|Autumn) \d{4} Economic Forecast", ameco["release"]) is None):
+        fail("AMECO: observed and forecast periods or vintage diverge")
     countries = require_dict(ameco.get("countries"), "ameco.countries")
     if tuple((key, value.get("code")) for key, value in countries.items()) != COUNTRIES:
         fail("ameco.countries: set inatteso")
+    if [value.get("currencyCode") for value in countries.values()] != ["EURO-ITL", "EURO-FRF", "EURO-DEM", "EURO-ESP"]:
+        fail("ameco.countries: currency identity mismatch")
     source_items = require_list(ameco.get("series"), "ameco.series")
     method_items = require_list(method.get("indicators"), "method.indicators")
     if len(source_items) != 6 or len(method_items) != 6:
@@ -200,13 +209,13 @@ def safe_archive(payload: bytes) -> dict[str, bytes]:
     return members
 
 
-def ameco_rows(payload: bytes, encoding: str, label: str) -> dict[str, dict[str, str]]:
+def ameco_rows(payload: bytes, encoding: str, label: str, years=EXPECTED_YEARS) -> dict[str, dict[str, str]]:
     try:
         text = payload.decode(encoding)
     except (UnicodeDecodeError, LookupError):
         fail(f"{label}: encoding non valido")
     reader = csv.DictReader(io.StringIO(text, newline=""))
-    expected = ["CODE", "COUNTRY", "SUB-CHAPTER", "TITLE", "UNIT", *map(str, EXPECTED_YEARS), "Unnamed: 73"]
+    expected = ["CODE", "COUNTRY", "SUB-CHAPTER", "TITLE", "UNIT", *map(str, years), f"Unnamed: {len(years) + 5}"]
     if reader.fieldnames != expected:
         fail(f"{label}: intestazione CSV inattesa")
     rows: dict[str, dict[str, str]] = {}
@@ -240,8 +249,18 @@ def extract_indicators(spec: dict[str, Any], method: dict[str, Any], payload: by
         for item in configs
         for source in ([item["numerator"], item["denominator"]] if "derived" in item else [item])
     }
-    files = {name: ameco_rows(archive[name], ameco["encoding"], name) for name in needed_files}
+    years = tuple(range(1960, ameco["forecastThrough"] + 1))
+    files = {name: ameco_rows(archive[name], ameco["encoding"], name, years) for name in needed_files}
     method_by_id = {item["id"]: item for item in method["indicators"]}
+    def source_row(config, country_id, country_code):
+        code = config["codeTemplate"].format(country=country_code)
+        row = files[config["file"]].get(code)
+        expected_unit = config["rawUnitTemplate"].format(currency=ameco["countries"][country_id]["currencyCode"])
+        if (row is None or row["TITLE"] != config["title"] or row["UNIT"] != expected_unit
+                or row["COUNTRY"] != country_id.title()):
+            fail(f"AMECO: serie mancante o identita divergente {code}")
+        return code, row
+
     output: list[dict[str, Any]] = []
     for item in configs:
         method_item = method_by_id[item["id"]]
@@ -251,13 +270,9 @@ def extract_indicators(spec: dict[str, Any], method: dict[str, Any], payload: by
             values: list[dict[str, Any]] = []
             if "derived" in item:
                 left_config, right_config = item["numerator"], item["denominator"]
-                left_code = left_config["codeTemplate"].format(country=country_code)
-                right_code = right_config["codeTemplate"].format(country=country_code)
-                left_row = files[left_config["file"]].get(left_code)
-                right_row = files[right_config["file"]].get(right_code)
-                if left_row is None or right_row is None or left_row["TITLE"] != left_config["title"] or right_row["TITLE"] != right_config["title"]:
-                    fail(f"AMECO: serie derivata mancante {item['id']}.{country_id}")
-                for year in EXPECTED_YEARS:
+                left_code, left_row = source_row(left_config, country_id, country_code)
+                right_code, right_row = source_row(right_config, country_id, country_code)
+                for year in years:
                     left = decimal_value(left_row[str(year)], f"{left_code}.{year}")
                     right = decimal_value(right_row[str(year)], f"{right_code}.{year}")
                     if left is None or right is None:
@@ -269,11 +284,8 @@ def extract_indicators(spec: dict[str, Any], method: dict[str, Any], payload: by
                     values.append({"year": year, "value": value})
                 source_codes[country_id] = [left_code, right_code]
             else:
-                code = item["codeTemplate"].format(country=country_code)
-                row = files[item["file"]].get(code)
-                if row is None or row["TITLE"] != item["title"]:
-                    fail(f"AMECO: serie mancante {item['id']}.{country_id}")
-                values = [{"year": year, "value": decimal_value(row[str(year)], f"{code}.{year}")} for year in EXPECTED_YEARS]
+                code, row = source_row(item, country_id, country_code)
+                values = [{"year": year, "value": decimal_value(row[str(year)], f"{code}.{year}")} for year in years]
                 source_codes[country_id] = [code]
             countries[country_id] = values
         output.append({
@@ -328,7 +340,8 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         fail("snapshot: versione non supportata")
     spec = load_json(DEFAULT_SPEC, "source spec")
     method = validate_spec(spec)
-    source = require_dict(require_dict(snapshot["sources"], "sources").get("ameco"), "sources.ameco")
+    exact_keys(require_dict(snapshot["sources"], "sources"), {"ameco"}, "sources")
+    source = require_dict(snapshot["sources"].get("ameco"), "sources.ameco")
     ameco = spec["ameco"]
     for field in (
         "owner", "title", "release", "releaseDate", "landingUrl", "downloadUrl", "termsUrl", "license",
@@ -336,8 +349,9 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
     ):
         if source.get(field) != ameco.get(field):
             fail(f"snapshot: metadato fonte divergente ({field})")
-    if not isinstance(source.get("bytes"), int) or source["bytes"] <= 0 or not isinstance(source.get("sha256"), str) or len(source["sha256"]) != 64:
+    if not isinstance(source.get("bytes"), int) or source["bytes"] <= 0 or not isinstance(source.get("sha256"), str) or re.fullmatch(r"[0-9a-f]{64}", source["sha256"]) is None:
         fail("snapshot: ricevuta AMECO non valida")
+    years = list(range(1960, source["forecastThrough"] + 1))
     indicators = require_list(snapshot["indicators"], "indicators")
     if [item.get("id") for item in indicators] != [item["id"] for item in method["indicators"]]:
         fail("snapshot: ordine indicatori divergente")
@@ -352,12 +366,15 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
             or item["sourceSeries"] != source_series_from_method(expected)
         ):
             fail(f"snapshot: contratto indicatore divergente ({item['id']})")
+        expected_codes = {country: [source["selector_template"].format(country=code) for source in expected["source_series"]] for country, code in COUNTRIES}
+        if item["sourceCodes"] != expected_codes:
+            fail("snapshot: source series identity mismatch")
         minimum, maximum = VALUE_RANGES[item["id"]]
         countries = require_dict(item["countries"], f"{item['id']}.countries")
         if tuple(countries) != tuple(country_id for country_id, _ in COUNTRIES):
             fail(f"{item['id']}: paesi inattesi")
         for country_id, points in countries.items():
-            if len(points) != len(EXPECTED_YEARS) or [point.get("year") for point in points] != list(EXPECTED_YEARS):
+            if len(points) != len(years) or [point.get("year") for point in points] != years:
                 fail(f"{item['id']}.{country_id}: anni inattesi")
             for point in points:
                 value = point.get("value")

--- a/scripts/etl/specs/government-scorecard-page.source.json
+++ b/scripts/etl/specs/government-scorecard-page.source.json
@@ -107,5 +107,175 @@
     "primaryBalance": "net_lending_percent_gdp + interest_payable_percent_gdp"
   },
   "contextRule": "A single geopolitics, shocks and crises category contains only essential source-backed events with a documented economic channel; an empty category is allowed only after the verified catalog has been checked.",
-  "scoreImpact": "none"
+  "scoreImpact": "none",
+  "refreshPolicy": {
+    "contextReview": {
+      "reviewedAt": "2026-09-03",
+      "contextsSha256": "0f26fd970ae9e586acc3485ca9135aa68c5e77912e904b46e81669309aa59105",
+      "chronologySha256": "cd7c8b6ab9e54da4fc7a8604de2b29963a47664e245380416b9a44358966c01e"
+    },
+    "approvedSources": [
+      {
+        "id": "ameco:2026-spring",
+        "owner": "European Commission, Directorate-General for Economic and Financial Affairs",
+        "title": "AMECO annual macro-economic database",
+        "dataset_code": "AMECO",
+        "source_version": "Spring 2026 Economic Forecast",
+        "query_url": "https://ec.europa.eu/economy_finance/db_indicators/ameco/documents/ameco0_csv.zip",
+        "landing_url": "https://economy-finance.ec.europa.eu/economic-research-and-databases/economic-databases/ameco-database/download-annual-data-set-macro-economic-database-ameco_en",
+        "terms_url": "https://commission.europa.eu/legal-notice_en",
+        "upstream_updated_at": "2026-06-03",
+        "raw_bytes": 6181987,
+        "raw_sha256": "b460629037dfc994d805b3f236c80feb6c49bc86b3cde3f3cfc32027a08c3005"
+      },
+      {
+        "id": "eurostat:prc_hicp_minr",
+        "owner": "Eurostat",
+        "title": "HICP monthly annual rate of change",
+        "dataset_code": "prc_hicp_minr",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&freq=M&unit=RCH_A&coicop18=TOTAL&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1996-01",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/prc_hicp_minr/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-09-01T23:00:00+0200",
+        "raw_bytes": 34093,
+        "raw_sha256": "956328f6b1faf0df194c7d875fcc99eb56d6b86336592e34c76f6233c1f0bd65"
+      },
+      {
+        "id": "eurostat:une_rt_m",
+        "owner": "Eurostat",
+        "title": "Monthly unemployment rate",
+        "dataset_code": "une_rt_m",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/une_rt_m?lang=en&freq=M&s_adj=SA&age=TOTAL&sex=T&unit=PC_ACT&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1997-01",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/une_rt_m/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-09-01T11:00:00+0200",
+        "raw_bytes": 30824,
+        "raw_sha256": "55c27931bf65ab8819cca2ae504c86a82f0d9886bc0bec094c224576998c1ff3"
+      },
+      {
+        "id": "eurostat:lfsi_emp_q",
+        "owner": "Eurostat",
+        "title": "Quarterly seasonally adjusted employment rate",
+        "dataset_code": "lfsi_emp_q",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/lfsi_emp_q?lang=en&freq=Q&indic_em=EMP_LFS&s_adj=SA&sex=T&age=Y20-64&unit=PC_POP&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=2009-Q1",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/lfsi_emp_q/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-06-11T23:00:00+0200",
+        "raw_bytes": 9530,
+        "raw_sha256": "7e770c1467f45eabcda60daade28ad6f35eddfa678f956291ab05ff1fded9bcd"
+      },
+      {
+        "id": "eurostat:namq_10_pc",
+        "owner": "Eurostat",
+        "title": "Quarterly real GDP per capita",
+        "dataset_code": "namq_10_pc",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/namq_10_pc?lang=en&freq=Q&unit=CLV_I20_HAB&s_adj=NSA&na_item=B1GQ&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1995-Q1",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/namq_10_pc/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-09-03T11:00:00+0200",
+        "raw_bytes": 14119,
+        "raw_sha256": "0487b09adc59e4b80c870f3c56feabf2efc47ca0fc15fdc1f46d0903a6da20b5"
+      },
+      {
+        "id": "eurostat:gov_10dd_edpt1",
+        "owner": "Eurostat",
+        "title": "Government deficit/surplus, debt and associated data",
+        "dataset_code": "gov_10dd_edpt1",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/gov_10dd_edpt1?lang=en&freq=A&unit=MIO_EUR&sector=S13&na_item=GD&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1995",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/gov_10dd_edpt1/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-04-22T11:00:00+0200",
+        "raw_bytes": 5348,
+        "raw_sha256": "54d543a133f589a32bcbd81e1c07e5226c5db7f9b65937d801a400a0dd45d962"
+      },
+      {
+        "id": "eurostat:gov_10q_ggdebt",
+        "owner": "Eurostat",
+        "title": "Quarterly general government gross debt",
+        "dataset_code": "gov_10q_ggdebt",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/gov_10q_ggdebt?lang=en&freq=Q&unit=PC_GDP&sector=S13&na_item=GD&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1995-Q1",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/gov_10q_ggdebt/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-07-21T11:00:00+0200",
+        "raw_bytes": 12246,
+        "raw_sha256": "6c885cdb3e49fb676364eec17a9796672f42569a7b5fa11d066e99d537394335"
+      },
+      {
+        "id": "eurostat:gov_10q_ggnfa",
+        "owner": "Eurostat",
+        "title": "Quarterly government finance statistics",
+        "dataset_code": "gov_10q_ggnfa",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/gov_10q_ggnfa?lang=en&freq=Q&unit=PC_GDP&s_adj=NSA&sector=S13&na_item=B9&na_item=D41PAY&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1995-Q1",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/gov_10q_ggnfa/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-07-21T11:00:00+0200",
+        "raw_bytes": 17310,
+        "raw_sha256": "7ccdd011fa8f9fcd2289bd35eb99602f2a01f4a32c4be5ae1bf2cfe7a5d1df4b"
+      },
+      {
+        "id": "eurostat:namq_10_gdp",
+        "owner": "Eurostat",
+        "title": "Quarterly national accounts main GDP aggregates",
+        "dataset_code": "namq_10_gdp",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/namq_10_gdp?lang=en&freq=Q&unit=PC_GDP&s_adj=SCA&na_item=P51G&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1995-Q1",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/namq_10_gdp/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-09-03T11:00:00+0200",
+        "raw_bytes": 13020,
+        "raw_sha256": "ad1fcf26cb8cfb4a2d18e3c676964e799606970b52ac196eb4215747e33eb820"
+      },
+      {
+        "id": "eurostat:nama_10_pe",
+        "owner": "Eurostat",
+        "title": "Population and employment by main activity",
+        "dataset_code": "nama_10_pe",
+        "query_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/nama_10_pe?lang=en&freq=A&unit=THS_PER&na_item=POP_NC&geo=IT&geo=FR&geo=DE&geo=ES&sinceTimePeriod=1995",
+        "landing_url": "https://ec.europa.eu/eurostat/databrowser/view/nama_10_pe/default/table?lang=en",
+        "terms_url": "https://ec.europa.eu/eurostat/web/main/help/copyright-notice",
+        "upstream_updated_at": "2026-09-03T11:00:00+0200",
+        "raw_bytes": 5491,
+        "raw_sha256": "bcc55ecbb2f5410d93ea6c6d993fc3a94f581d4b52b7bf9318cef9e656fd358d"
+      }
+    ],
+    "approvedPeriods": [
+      {
+        "indicator_id": "inflation",
+        "period": "2026-08"
+      },
+      {
+        "indicator_id": "real_compensation",
+        "period": "2024"
+      },
+      {
+        "indicator_id": "unemployment",
+        "period": "2026-07"
+      },
+      {
+        "indicator_id": "employment_rate",
+        "period": "2026-Q1"
+      },
+      {
+        "indicator_id": "real_gdp_per_capita",
+        "period": "2026-Q2"
+      },
+      {
+        "indicator_id": "debt_ratio",
+        "period": "2026-Q1"
+      },
+      {
+        "indicator_id": "debt_per_capita",
+        "period": "2025"
+      },
+      {
+        "indicator_id": "primary_balance",
+        "period": "2026-Q1"
+      },
+      {
+        "indicator_id": "investment_share",
+        "period": "2026-Q2"
+      }
+    ],
+    "coreArtifactSha256": "f814dfe6f5bf7f6c93f1c52282e0f1829835a797bc14d1d81d3d684a3a7f4894",
+    "scoreAcquiredAt": "2026-08-29T23:11:43Z"
+  }
 }

--- a/scripts/etl/specs/government-scorecard.source.json
+++ b/scripts/etl/specs/government-scorecard.source.json
@@ -22,19 +22,23 @@
     "countries": {
       "italy": {
         "code": "ITA",
-        "label": "Italia"
+        "label": "Italia",
+        "currencyCode": "EURO-ITL"
       },
       "france": {
         "code": "FRA",
-        "label": "Francia"
+        "label": "Francia",
+        "currencyCode": "EURO-FRF"
       },
       "germany": {
         "code": "DEU",
-        "label": "Germania"
+        "label": "Germania",
+        "currencyCode": "EURO-DEM"
       },
       "spain": {
         "code": "ESP",
-        "label": "Spagna"
+        "label": "Spagna",
+        "currencyCode": "EURO-ESP"
       }
     },
     "series": [
@@ -45,7 +49,8 @@
         "file": "AMECO7.CSV",
         "codeTemplate": "{country}.3.1.0.0.RWCDC",
         "title": "Real compensation per employee deflator private consumption: total economy",
-        "unit": "National currency: 2020 = 100"
+        "unit": "National currency: 2020 = 100",
+        "rawUnitTemplate": "(National currency: 2020 = 100)"
       },
       {
         "id": "unemployment",
@@ -54,7 +59,8 @@
         "file": "AMECO1.CSV",
         "codeTemplate": "{country}.1.0.0.0.ZUTN",
         "title": "Unemployment rate: total :- Member States: definition EUROSTAT",
-        "unit": "Percentage of active population"
+        "unit": "Percentage of active population",
+        "rawUnitTemplate": "(Percentage of active population)"
       },
       {
         "id": "real_gdp_per_capita",
@@ -63,7 +69,8 @@
         "file": "AMECO6.CSV",
         "codeTemplate": "{country}.1.1.0.0.RVGDP",
         "title": "Gross domestic product at 2020 reference levels per head of population",
-        "unit": "1000 national currency, 2020 reference levels"
+        "unit": "1000 national currency, 2020 reference levels",
+        "rawUnitTemplate": "1000 {currency}"
       },
       {
         "id": "debt_ratio",
@@ -72,7 +79,8 @@
         "file": "AMECO18.CSV",
         "codeTemplate": "{country}.1.0.319.0.UDGG",
         "title": "General government consolidated gross debt :- Excessive deficit procedure (based on ESA 2010)",
-        "unit": "Percentage of GDP at current prices (excessive deficit procedure)"
+        "unit": "Percentage of GDP at current prices (excessive deficit procedure)",
+        "rawUnitTemplate": "(Percentage of GDP at current prices (excessive deficit procedure))"
       },
       {
         "id": "primary_balance",
@@ -81,7 +89,8 @@
         "file": "AMECO16.CSV",
         "codeTemplate": "{country}.1.0.319.0.UBLGI",
         "title": "Net lending (+) or net borrowing (-) excluding interest: general government :- ESA 2010 (Including one-off proceeds relative to the allocation of mobile phone licences (UMTS))",
-        "unit": "Percentage of GDP at current prices (excessive deficit procedure)"
+        "unit": "Percentage of GDP at current prices (excessive deficit procedure)",
+        "rawUnitTemplate": "(Percentage of GDP at current prices (excessive deficit procedure))"
       },
       {
         "id": "investment_share",
@@ -92,13 +101,15 @@
           "file": "AMECO3.CSV",
           "codeTemplate": "{country}.1.0.0.0.UIGT",
           "title": "Gross fixed capital formation at current prices: total economy",
-          "unit": "Mrd national currency"
+          "unit": "Mrd national currency",
+          "rawUnitTemplate": "Mrd {currency}"
         },
         "denominator": {
           "file": "AMECO6.CSV",
           "codeTemplate": "{country}.1.0.0.0.UVGD",
           "title": "Gross domestic product at current prices",
-          "unit": "Mrd national currency"
+          "unit": "Mrd national currency",
+          "rawUnitTemplate": "Mrd {currency}"
         },
         "unit": "Percentage of GDP at current prices"
       }

--- a/src/lib/data/government-scorecard-contract.ts
+++ b/src/lib/data/government-scorecard-contract.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+import sourceSpec from "../../../scripts/etl/specs/government-scorecard.source.json";
+import pageSpec from "../../../scripts/etl/specs/government-scorecard-page.source.json";
+
 import canonicalManifest from "../../../scripts/etl/specs/government-scorecard-methodology.json";
 import {
   GOVERNMENT_SCORECARD_V6_CHRONOLOGY,
@@ -62,10 +65,10 @@ export const governmentScorecardV6ManifestSchema = z.object({
     source_id: z.literal("ameco"),
     source_owner: z.literal("European Commission, Directorate-General for Economic and Financial Affairs"),
     dataset_code: z.literal("AMECO"),
-    vintage: z.literal("Spring 2026 Economic Forecast"),
-    observed_through: z.literal(2024),
-    forecast_from: z.literal(2025),
-    forecast_through: z.literal(2027),
+    vintage: z.literal(sourceSpec.ameco.release),
+    observed_through: z.literal(sourceSpec.ameco.observedThrough),
+    forecast_from: z.literal(sourceSpec.ameco.forecastFrom),
+    forecast_through: z.literal(sourceSpec.ameco.forecastThrough),
   }).strict(),
   countries: z.tuple([z.literal("IT"), z.literal("FR"), z.literal("DE"), z.literal("ES")]),
   peers: z.tuple([z.literal("FR"), z.literal("DE"), z.literal("ES")]),
@@ -186,9 +189,9 @@ export const governmentScorecardV6InputSchema = z.object({
     source_owner: z.string().min(1),
     dataset_code: z.literal("AMECO"),
     vintage: z.string().min(1),
-    published_at: z.literal("2026-06-03"),
-    upstream_updated_at: z.literal("2026-06-03"),
-    retrieved_at: z.literal("2026-08-29T23:11:43Z"),
+    published_at: z.literal(sourceSpec.ameco.releaseDate),
+    upstream_updated_at: z.literal(sourceSpec.ameco.releaseDate),
+    retrieved_at: z.literal(pageSpec.refreshPolicy.scoreAcquiredAt),
     observed_through: z.number().int(),
     forecast_from: z.number().int(),
     forecast_through: z.number().int(),
@@ -196,8 +199,8 @@ export const governmentScorecardV6InputSchema = z.object({
     landing_url: z.literal("https://economy-finance.ec.europa.eu/economic-research-and-databases/economic-databases/ameco-database/download-annual-data-set-macro-economic-database-ameco_en"),
     reuse_url: z.literal("https://commission.europa.eu/legal-notice_en"),
     license: z.literal("CC BY 4.0 unless otherwise indicated"),
-    raw_sha256: sha256.pipe(z.literal("b460629037dfc994d805b3f236c80feb6c49bc86b3cde3f3cfc32027a08c3005")),
-    raw_bytes: z.literal(6_181_987),
+    raw_sha256: sha256.pipe(z.literal(pageSpec.refreshPolicy.approvedSources[0].raw_sha256)),
+    raw_bytes: z.literal(pageSpec.refreshPolicy.approvedSources[0].raw_bytes),
     limitations: z.array(z.string().min(1)).min(1),
   }).strict(),
   window: z.object({

--- a/src/lib/data/government-scorecard-page-contract.ts
+++ b/src/lib/data/government-scorecard-page-contract.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 
 import { z } from "zod";
 
+import pageSpec from "../../../scripts/etl/specs/government-scorecard-page.source.json";
+
 import supplementalSnapshot from "@/data/generated/government-scorecard-page.json";
 import { GOVERNMENT_SCORECARD_V6_CHRONOLOGY } from "@/lib/government-scorecard-chronology";
 
@@ -190,7 +192,7 @@ const contextSlideSchema = z.discriminatedUnion("status", [readyContextSlideSche
 export const governmentScorecardV6SupplementalSnapshotSchema = z.object({
   schema_version: z.literal(4),
   snapshot_version: z.literal("government-scorecard-page-2026-09-03-r3"),
-  as_of_date: z.literal("2026-09-03"),
+  as_of_date: z.iso.date(),
   coverage: z.object({
     first_period: z.literal("1995"),
     latest_published_periods: z.array(z.object({
@@ -205,24 +207,20 @@ export const governmentScorecardV6SupplementalSnapshotSchema = z.object({
     government_id: z.string().regex(/^[a-z0-9-]+$/),
     government_name: z.string().min(1),
     slides: z.array(contextSlideSchema).length(6),
-  }).strict()).length(17),
+  }).strict()).length(GOVERNMENT_SCORECARD_V6_CHRONOLOGY.length),
   score_contract: z.object({
     supplemental_score_impact: z.literal("none"),
-    core_artifact_sha256: z.literal("f814dfe6f5bf7f6c93f1c52282e0f1829835a797bc14d1d81d3d684a3a7f4894"),
+    core_artifact_sha256: z.literal(pageSpec.refreshPolicy.coreArtifactSha256),
   }).strict(),
 }).strict().superRefine((snapshot, context) => {
-  const expectedSourceIds = [
-    "ameco:2026-spring",
-    "eurostat:prc_hicp_minr",
-    "eurostat:une_rt_m",
-    "eurostat:lfsi_emp_q",
-    "eurostat:namq_10_pc",
-    "eurostat:gov_10dd_edpt1",
-    "eurostat:gov_10q_ggdebt",
-    "eurostat:gov_10q_ggnfa",
-    "eurostat:namq_10_gdp",
-    "eurostat:nama_10_pe",
-  ];
+  const expectedSourceIds = pageSpec.refreshPolicy.approvedSources.map((source) => source.id);
+  snapshot.sources.forEach((source, index) => {
+    const { retrieved_at, ...receipt } = source;
+    void retrieved_at;
+    if (canonicalHash(receipt) !== canonicalHash(pageSpec.refreshPolicy.approvedSources[index])) {
+      context.addIssue({ code: "custom", message: "ricevuta diversa dalla fonte approvata", path: ["sources", index] });
+    }
+  });
   if (snapshot.sources.some((source, index) => source.id !== expectedSourceIds[index])) {
     context.addIssue({ code: "custom", message: "registro fonti divergente", path: ["sources"] });
   }

--- a/src/lib/government-scorecard-chronology.ts
+++ b/src/lib/government-scorecard-chronology.ts
@@ -51,16 +51,26 @@ export const governmentScorecardV6ChronologyRegistrySchema = z.object({
   asOfDate: isoDate,
   eventDefinition: z.literal("Giuramento del Presidente del Consiglio e dei ministri nelle mani del Presidente della Repubblica"),
   constitutionalSourceUrl: z.literal("https://www.senato.it/istituzione/la-costituzione/parte-ii/titolo-iii/sezione-i/articolo-93"),
-  governments: z.array(governmentSchema).length(EXPECTED_GOVERNMENTS.length),
+  governments: z.array(governmentSchema).min(EXPECTED_GOVERNMENTS.length),
 }).strict().superRefine((registry, context) => {
+  if (registry.verifiedAt < registry.asOfDate || new Set(registry.governments.map((government) => government.id)).size !== registry.governments.length) {
+    context.addIssue({ code: "custom", message: "date del registro o identita duplicate", path: ["governments"] });
+  }
   registry.governments.forEach((government, index) => {
     const expected = EXPECTED_GOVERNMENTS[index];
+    if (!expected) {
+      const source = new URL(government.sourceUrl);
+      if (source.protocol !== "https:" || source.host !== "www.quirinale.it" || source.username || source.password
+        || !source.pathname.startsWith("/it/notizie/") || source.pathname.length <= "/it/notizie/".length
+        || source.search || source.hash || government.startDate > registry.asOfDate) {
+        context.addIssue({ code: "custom", message: "nuovo giuramento: fonte o data non verificabile", path: ["governments", index] });
+      }
+    }
     if (
-      !expected
-      || government.id !== expected[0]
+      expected && (government.id !== expected[0]
       || government.name !== expected[1]
       || government.startDate !== expected[2]
-      || government.sourceUrl !== SOURCE_URLS[expected[3]]
+      || government.sourceUrl !== SOURCE_URLS[expected[3]])
     ) {
       context.addIssue({
         code: "custom",

--- a/src/lib/government-scorecard-governments.ts
+++ b/src/lib/government-scorecard-governments.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+import sourceSpec from "../../scripts/etl/specs/government-scorecard.source.json";
+import pageSpec from "../../scripts/etl/specs/government-scorecard-page.source.json";
+
 import annualSnapshot from "@/data/generated/government-scorecard.json";
 import { GOVERNMENT_SCORECARD_V6_MANIFEST } from "@/lib/data/government-scorecard-contract";
 import { getGovernmentScorecardV6SupplementalSnapshot } from "@/lib/data/government-scorecard-page-contract";
@@ -21,25 +24,7 @@ import {
 import { getGovernmentScorecardV6Sensitivity } from "@/lib/government-scorecard-sensitivity";
 import { deriveAnnualStatisticalWindowV6, durationDaysV6 } from "@/lib/government-scorecard-temporal";
 
-export const GOVERNMENT_SCORECARD_V6_GOVERNMENT_IDS = [
-  "dini-i",
-  "prodi-i",
-  "dalema-i",
-  "dalema-ii",
-  "amato-ii",
-  "berlusconi-ii",
-  "berlusconi-iii",
-  "prodi-ii",
-  "berlusconi-iv",
-  "monti-i",
-  "letta-i",
-  "renzi-i",
-  "gentiloni-i",
-  "conte-i",
-  "conte-ii",
-  "draghi-i",
-  "meloni-i",
-] as const;
+export const GOVERNMENT_SCORECARD_V6_GOVERNMENT_IDS = GOVERNMENT_SCORECARD_V6_CHRONOLOGY.map((government) => government.id);
 
 export type GovernmentScorecardV6GovernmentId = (typeof GOVERNMENT_SCORECARD_V6_GOVERNMENT_IDS)[number];
 
@@ -72,18 +57,18 @@ const rawAnnualDatasetSchema = z.object({
   sources: z.object({
     ameco: z.object({
       owner: z.literal("European Commission, Directorate-General for Economic and Financial Affairs"),
-      release: z.literal("Spring 2026 Economic Forecast"),
-      releaseDate: z.literal("2026-06-03"),
+      release: z.literal(sourceSpec.ameco.release),
+      releaseDate: z.literal(sourceSpec.ameco.releaseDate),
       landingUrl: z.literal("https://economy-finance.ec.europa.eu/economic-research-and-databases/economic-databases/ameco-database/download-annual-data-set-macro-economic-database-ameco_en"),
       downloadUrl: z.literal("https://ec.europa.eu/economy_finance/db_indicators/ameco/documents/ameco0_csv.zip"),
       termsUrl: z.literal("https://commission.europa.eu/legal-notice_en"),
       license: z.literal("CC BY 4.0 unless otherwise indicated"),
-      retrievedAt: z.literal("2026-08-29T23:11:43Z"),
-      bytes: z.literal(6_181_987),
-      sha256: z.literal("b460629037dfc994d805b3f236c80feb6c49bc86b3cde3f3cfc32027a08c3005"),
-      observedThrough: z.literal(2024),
-      forecastFrom: z.literal(2025),
-      forecastThrough: z.literal(2027),
+      retrievedAt: z.literal(pageSpec.refreshPolicy.scoreAcquiredAt),
+      bytes: z.literal(pageSpec.refreshPolicy.approvedSources[0].raw_bytes),
+      sha256: z.literal(pageSpec.refreshPolicy.approvedSources[0].raw_sha256),
+      observedThrough: z.literal(sourceSpec.ameco.observedThrough),
+      forecastFrom: z.literal(sourceSpec.ameco.forecastFrom),
+      forecastThrough: z.literal(sourceSpec.ameco.forecastThrough),
     }),
   }).strict(),
   indicators: z.array(rawIndicatorSchema).length(6),
@@ -239,7 +224,7 @@ function sourceInput() {
     raw_bytes: source.bytes,
     limitations: [
       "I valori annuali iniziale e finale AMECO non descrivono ciò che accade dentro l'anno.",
-      "Il vintage Spring 2026 classifica il 2025-2027 come previsione: questi anni non entrano nel voto.",
+      `Il vintage ${source.release} classifica il ${source.forecastFrom}-${source.forecastThrough} come previsione: questi anni non entrano nel voto.`,
     ],
   };
 }

--- a/tests/etl/test_government_scorecard_refresh.py
+++ b/tests/etl/test_government_scorecard_refresh.py
@@ -161,6 +161,20 @@ class RefreshTests(unittest.TestCase):
         self.assertEqual(self.files(), self.originals)
         self.assertEqual(str(refresh.review_deadline('2026-01-31')), '2026-04-30')
 
+    def test_unchanged_context_review_advances_snapshot_date_once(self):
+        self.policy['contextReview']['reviewedAt'] = '2026-09-04'
+        self.save_policy()
+
+        self.assertTrue(self.run_refresh(timestamp='2026-09-04T08:00:00Z'))
+        first = self.files()
+        result = page._load(self.root / 'src/data/generated/government-scorecard-page.json')
+        self.assertEqual(result['as_of_date'], '2026-09-04')
+        self.assertEqual(first['government-scorecard.json'], self.originals['government-scorecard.json'])
+
+        self.page = result
+        self.assertFalse(self.run_refresh(timestamp='2026-09-05T08:00:00Z'))
+        self.assertEqual(self.files(), first)
+
     def test_failed_final_validation_restores_both_exact_original_files(self):
         self.approve_inflation_change()
         def fail():

--- a/tests/etl/test_government_scorecard_refresh.py
+++ b/tests/etl/test_government_scorecard_refresh.py
@@ -292,6 +292,13 @@ class OfflineContextReviewDateTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'context review date exceeds snapshot as_of_date'):
             refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
 
+    def test_offline_release_rejects_future_snapshot_and_review(self):
+        future = (refresh.dt.datetime.now(refresh.dt.UTC).date() + refresh.dt.timedelta(days=1)).isoformat()
+        self.supplemental['as_of_date'] = future
+        self.policy['contextReview']['reviewedAt'] = future
+        with self.assertRaisesRegex(ValueError, 'snapshot as_of_date exceeds validation date'):
+            refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
+
     def test_offline_release_accepts_review_on_snapshot_date_and_current_release(self):
         refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
         self.policy['contextReview']['reviewedAt'] = self.supplemental['as_of_date']

--- a/tests/etl/test_government_scorecard_refresh.py
+++ b/tests/etl/test_government_scorecard_refresh.py
@@ -1,0 +1,282 @@
+import copy
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.etl import government_scorecard_refresh as refresh
+from scripts.etl import government_scorecard_snapshot as score
+from scripts.etl import government_scorecard_page as page
+from tests.etl.test_government_scorecard_snapshot import ameco_zip, load_spec
+
+
+class RefreshTests(unittest.TestCase):
+    def setUp(self):
+        self.output = io.StringIO()
+        redirect = contextlib.redirect_stdout(self.output)
+        redirect.__enter__()
+        self.addCleanup(redirect.__exit__, None, None, None)
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.spec = load_spec()
+        self.payload = ameco_zip(self.spec)
+        self.core = score.build_snapshot(self.spec, self.payload, '2026-09-03T08:00:00Z')
+        self.page = page._load(page.OUTPUT)
+        self.registry = page._load(page.CHRONOLOGY_PATH)
+        self.page['sources'][0] = page._ameco_source(self.core)
+        self.page['series'][1] = page._ameco_series(self.core, self.page['sources'][0])[0]
+        self.page['score_contract']['core_artifact_sha256'] = score.sha256(refresh.encoded(self.core))
+        self.policy = page._load(refresh.POLICY_PATH)['refreshPolicy']
+        self.policy['approvedSources'] = [refresh.receipt(item) for item in self.page['sources']]
+        self.policy['coreArtifactSha256'] = score.sha256(refresh.encoded(self.core))
+        self.policy['scoreAcquiredAt'] = self.core['sources']['ameco']['retrievedAt']
+        self.write('scripts/etl/specs/government-scorecard.source.json', self.spec)
+        self.write('scripts/etl/specs/government-scorecard-chronology.json', self.registry)
+        self.write('src/data/generated/government-scorecard.json', self.core)
+        self.write('src/data/generated/government-scorecard-page.json', self.page)
+        self.save_policy()
+        self.originals = self.files()
+
+    def write(self, name, value):
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(refresh.encoded(value))
+
+    def save_policy(self):
+        spec = page._load(refresh.POLICY_PATH)
+        spec['refreshPolicy'] = self.policy
+        self.write('scripts/etl/specs/government-scorecard-page.source.json', spec)
+
+    def files(self):
+        return {path.name: path.read_bytes() for path in (self.root / 'src/data/generated').iterdir()}
+
+    def build(self, timestamp, **kwargs):
+        result = copy.deepcopy(self.page)
+        result['as_of_date'] = timestamp[:10]
+        for source in result['sources'][1:]:
+            source['retrieved_at'] = timestamp
+        for series in result['series']:
+            if series['indicator_id'] != 'real_compensation':
+                for geo in series['geographies']:
+                    for point in geo['points']:
+                        point['retrieved_at'] = timestamp
+        result['score_contract']['core_artifact_sha256'] = kwargs['core_hash']
+        return result
+
+    def run_refresh(self, builder=None, **kwargs):
+        timestamp = kwargs.pop('timestamp', '2026-09-05T08:00:00Z')
+        return refresh.refresh(timestamp, root=self.root,
+                               fetch_score=lambda _: self.payload, build_page=builder or self.build, **kwargs)
+
+    def approve_inflation_change(self):
+        source = self.page['sources'][1]
+        source['raw_sha256'] = 'a' * 64
+        source['upstream_updated_at'] = '2026-09-04T08:00:00Z'
+        for geo in self.page['series'][0]['geographies']:
+            for point in geo['points']:
+                point['raw_sha256'] = source['raw_sha256']
+                point['value'] += 0.1
+        self.policy['approvedSources'] = [refresh.receipt(item) for item in self.page['sources']]
+        self.save_policy()
+
+    def test_no_change_retains_exact_bytes_and_does_not_verify_or_publish(self):
+        self.assertFalse(self.run_refresh(verify=lambda: self.fail('no candidate expected')))
+        self.assertEqual(self.files(), self.originals)
+
+    def test_approved_update_then_repeated_poll_is_idempotent(self):
+        self.approve_inflation_change()
+        self.assertTrue(self.run_refresh())
+        first = self.files()
+        self.page = page._load(self.root / 'src/data/generated/government-scorecard-page.json')
+        self.assertFalse(self.run_refresh())
+        self.assertEqual(self.files(), first)
+        self.assertEqual(first['government-scorecard.json'], self.originals['government-scorecard.json'])
+
+    def test_incomplete_or_malformed_raw_score_never_writes(self):
+        for payload in (b'not zip', ameco_zip(self.spec, omit_member='AMECO18.CSV')):
+            self.payload = payload
+            with self.assertRaises(score.SnapshotError):
+                self.run_refresh()
+            self.assertEqual(self.files(), self.originals)
+
+    def test_schema_source_license_identity_period_and_hash_drift(self):
+        mutations = [
+            lambda value: value.__setitem__('schema_version', 99),
+            lambda value: value['sources'][1].__setitem__('owner', 'other'),
+            lambda value: value['sources'][1].__setitem__('terms_url', 'https://example.test/license'),
+            lambda value: value['sources'][1].__setitem__('dataset_code', 'other'),
+            lambda value: value['sources'][1].__setitem__('raw_sha256', '0' * 64),
+            lambda value: value['series'][0]['geographies'][0]['points'][0].__setitem__('period', '2050-01'),
+            lambda value: value['contexts'][0].__setitem__('government_id', 'other'),
+        ]
+        for mutation in mutations:
+            def builder(timestamp, **kwargs):
+                result = self.build(timestamp, **kwargs)
+                mutation(result)
+                return result
+            with self.subTest(mutation=mutation), self.assertRaises(ValueError):
+                self.run_refresh(builder)
+            self.assertEqual(self.files(), self.originals)
+
+    def test_no_common_observed_panel_keeps_last_valid_snapshot(self):
+        def missing(indicator, country, filename, row):
+            if indicator == 'unemployment' and country == 'spain':
+                row[5 + 2024 - 1960] = ':'
+        self.payload = ameco_zip(self.spec, mutate_row=missing)
+        with self.assertRaisesRegex(ValueError, 'osservazione obbligatoria'):
+            self.run_refresh()
+        self.assertEqual(self.files(), self.originals)
+
+    def test_license_declaration_drift_fails_before_acquisition(self):
+        path = self.root / 'scripts/etl/specs/government-scorecard-page.source.json'
+        spec = page._load(path)
+        spec['sourceContract']['license']['eurostat'] = 'other license'
+        path.write_bytes(refresh.encoded(spec))
+        with self.assertRaisesRegex(ValueError, 'license drift'):
+            self.run_refresh()
+        self.assertEqual(self.files(), self.originals)
+
+    def test_partial_page_update_is_rejected(self):
+        def builder(timestamp, **kwargs):
+            result = self.build(timestamp, **kwargs)
+            result['series'][0]['geographies'][0]['points'].pop(0)
+            return result
+        with self.assertRaisesRegex(ValueError, 'partial update'):
+            self.run_refresh(builder)
+        self.assertEqual(self.files(), self.originals)
+
+    def test_forecast_flag_cannot_become_observed(self):
+        for flag in ('f', 'epf', 'unknown'):
+            with self.subTest(flag=flag), self.assertRaises(ValueError):
+                page._publication_status(flag)
+
+    def test_context_review_expiry_does_not_modify_the_snapshot(self):
+        with self.assertRaisesRegex(ValueError, 'quarterly context review overdue'):
+            self.run_refresh(timestamp='2026-12-03T08:00:00Z')
+        self.assertEqual(self.files(), self.originals)
+        self.assertEqual(str(refresh.review_deadline('2026-01-31')), '2026-04-30')
+
+    def test_failed_final_validation_restores_both_exact_original_files(self):
+        self.approve_inflation_change()
+        def fail():
+            raise RuntimeError('runtime contract failure')
+        with self.assertRaisesRegex(RuntimeError, 'runtime contract'):
+            self.run_refresh(verify=fail)
+        self.assertEqual(self.files(), self.originals)
+
+    def test_staging_failure_keeps_both_original_files(self):
+        outputs = {self.root / 'src/data/generated/government-scorecard.json': {'changed': 1},
+                   self.root / 'src/data/generated/government-scorecard-page.json': {'changed': 2}}
+        original_write = score.atomic_write
+        calls = 0
+        def write(path, value):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError('disk failure')
+            original_write(path, value)
+        with patch.object(score, 'atomic_write', side_effect=write), self.assertRaises(OSError):
+            refresh.replace_release(outputs, lambda: None)
+        self.assertEqual(self.files(), self.originals)
+
+    def test_second_install_failure_restores_first_by_rename(self):
+        outputs = {self.root / 'src/data/generated/government-scorecard.json': {'changed': 1},
+                   self.root / 'src/data/generated/government-scorecard-page.json': {'changed': 2}}
+        real_replace = refresh.os.replace
+        def replace(source, target):
+            if str(source).endswith('1.candidate'):
+                raise OSError('disk failure')
+            real_replace(source, target)
+        with patch.object(refresh.os, 'replace', side_effect=replace), self.assertRaises(OSError):
+            refresh.replace_release(outputs, lambda: None)
+        self.assertEqual(self.files(), self.originals)
+
+    def test_economic_poll_preserves_existing_editorial_caveats(self):
+        self.core['caveats'][2] = 'Reviewed editorial caveat retained verbatim.'
+        self.write('src/data/generated/government-scorecard.json', self.core)
+        digest = score.sha256(refresh.encoded(self.core))
+        self.page['score_contract']['core_artifact_sha256'] = digest
+        self.write('src/data/generated/government-scorecard-page.json', self.page)
+        self.policy['coreArtifactSha256'] = digest
+        self.save_policy()
+        before = self.files()
+        self.assertFalse(self.run_refresh())
+        self.assertEqual(self.files(), before)
+
+    def test_government_change_requires_complete_reviewed_context(self):
+        self.registry['verifiedAt'] = self.registry['asOfDate'] = '2026-09-04'
+        self.registry['governments'].append({
+            'id': 'fixture-i', 'name': 'Fixture I', 'startDate': '2026-09-04',
+            'sourceOwner': 'Presidenza della Repubblica',
+            'sourceUrl': 'https://www.quirinale.it/it/notizie/fixture-giuramento',
+            'sourceLocator': 'Fixture del giuramento verificato del 4 settembre 2026.',
+        })
+        refresh.chronology.validate_registry(self.registry)
+        self.write('scripts/etl/specs/government-scorecard-chronology.json', self.registry)
+        with self.assertRaisesRegex(ValueError, 'context government'):
+            self.run_refresh()
+        self.assertEqual(self.files(), self.originals)
+
+    def test_reviewed_government_transition_preserves_score_and_closes_previous_mandate(self):
+        self.registry['verifiedAt'] = self.registry['asOfDate'] = '2026-09-04'
+        government = {
+            'id': 'fixture-i', 'name': 'Fixture I', 'startDate': '2026-09-04',
+            'sourceOwner': 'Presidenza della Repubblica',
+            'sourceUrl': 'https://www.quirinale.it/it/notizie/fixture-giuramento',
+            'sourceLocator': 'Fixture del giuramento verificato del 4 settembre 2026.',
+        }
+        self.registry['governments'].append(government)
+        old_oath = self.page['contexts'][-1]['slides'][-1]['items'][0]
+        old_oath['end_date_or_null'] = government['startDate']
+        old_oath['period'] = old_oath['start_date'] + '–' + government['startDate']
+        old_oath['evidence_sha256'] = page._canonical_hash({key: value for key, value in old_oath.items() if key not in ('retrieved_at', 'evidence_sha256')})
+        context = {'government_id': government['id'], 'government_name': government['name'], 'slides': []}
+        for category in page.CONTEXT_CATEGORIES:
+            item = page._context_item('fixture-i:' + category.replace('_', '-'), 'Fixture',
+                government['sourceLocator'], government['startDate'], None, 'institutional_timeline',
+                government['sourceUrl'], '2026-09-04T08:00:00Z')
+            context['slides'].append(page._ready_slide(category, 'Fixture', 'Fixture', 'Fixture', [item]))
+        self.page['contexts'].append(context)
+        self.policy['contextReview'] = {'reviewedAt': '2026-09-04',
+            'contextsSha256': page._canonical_hash(self.page['contexts']),
+            'chronologySha256': page._canonical_hash(self.registry)}
+        self.write('scripts/etl/specs/government-scorecard-chronology.json', self.registry)
+        self.save_policy()
+        self.assertTrue(self.run_refresh())
+        result = page._load(self.root / 'src/data/generated/government-scorecard-page.json')
+        self.assertEqual(len(result['contexts']), 18)
+        self.assertEqual(result['contexts'][-2]['slides'][-1]['items'][0]['end_date_or_null'], '2026-09-04')
+        self.assertEqual(self.files()['government-scorecard.json'], self.originals['government-scorecard.json'])
+
+    def test_observation_mode_emits_receipts_without_writing_unapproved_changes(self):
+        self.page['sources'][1]['raw_sha256'] = 'a' * 64
+        self.assertFalse(self.run_refresh(observe=True))
+        self.assertEqual(self.files(), self.originals)
+
+
+class RawEurostatTests(unittest.TestCase):
+    def cube(self):
+        return {'version': '2.0', 'class': 'dataset', 'source': 'ESTAT',
+                'id': ['freq', 'geo', 'time'], 'size': [1, 4, 1],
+                'dimension': {key: {'category': {'index': values}} for key, values in
+                              {'freq': ['A'], 'geo': ['IT', 'FR', 'DE', 'ES'], 'time': ['2025']}.items()},
+                'value': {'0': 1, '1': 2, '2': 3, '3': 4}}
+
+    def test_valid_cube_and_malformed_payloads(self):
+        page.validate_jsonstat(self.cube(), (('freq', 'A'),))
+        for mutate in (
+            lambda v: v.__setitem__('source', 'other'),
+            lambda v: v.__setitem__('version', '3'),
+            lambda v: v.__setitem__('value', [1]),
+            lambda v: v.__setitem__('size', [1, 5, 1]),
+            lambda v: v['dimension']['time']['category'].__setitem__('index', ['2025-13']),
+            lambda v: v.__setitem__('status', {'0': 'f'}),
+        ):
+            candidate = self.cube()
+            mutate(candidate)
+            with self.subTest(mutate=mutate), self.assertRaises(ValueError):
+                page.validate_jsonstat(candidate, (('freq', 'A'),))

--- a/tests/etl/test_government_scorecard_refresh.py
+++ b/tests/etl/test_government_scorecard_refresh.py
@@ -1,7 +1,6 @@
 import copy
 import contextlib
 import io
-import json
 import runpy
 import tempfile
 import unittest

--- a/tests/etl/test_government_scorecard_refresh.py
+++ b/tests/etl/test_government_scorecard_refresh.py
@@ -2,6 +2,7 @@ import copy
 import contextlib
 import io
 import json
+import runpy
 import tempfile
 import unittest
 from pathlib import Path
@@ -256,6 +257,53 @@ class RefreshTests(unittest.TestCase):
         self.page['sources'][1]['raw_sha256'] = 'a' * 64
         self.assertFalse(self.run_refresh(observe=True))
         self.assertEqual(self.files(), self.originals)
+
+
+class OfflineContextReviewDateTests(unittest.TestCase):
+    def setUp(self):
+        self.core = score.load_json(score.DEFAULT_OUTPUT)
+        self.supplemental = page._load(page.OUTPUT)
+        self.registry = page._load(page.CHRONOLOGY_PATH)
+        self.policy = refresh.load_policy(refresh.POLICY_PATH)
+
+    def test_offline_release_rejects_future_review_with_valid_hashes(self):
+        self.policy['contextReview']['reviewedAt'] = (
+            refresh.dt.date.fromisoformat(self.supplemental['as_of_date'])
+            + refresh.dt.timedelta(days=1)
+        ).isoformat()
+        self.assertEqual(self.policy['contextReview']['contextsSha256'],
+                         page._canonical_hash(self.supplemental['contexts']))
+        self.assertEqual(self.policy['contextReview']['chronologySha256'],
+                         page._canonical_hash(self.registry))
+        with self.assertRaisesRegex(ValueError, 'context review date exceeds snapshot as_of_date'):
+            refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
+
+    def test_offline_release_accepts_review_on_snapshot_date_and_current_release(self):
+        refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
+        self.policy['contextReview']['reviewedAt'] = self.supplemental['as_of_date']
+        refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
+
+    def test_offline_release_still_rejects_review_before_registry_verification(self):
+        self.policy['contextReview']['reviewedAt'] = (
+            refresh.dt.date.fromisoformat(self.registry['verifiedAt'])
+            - refresh.dt.timedelta(days=1)
+        ).isoformat()
+        with self.assertRaisesRegex(ValueError, 'requires a matching editorial review'):
+            refresh.validate_release(self.core, self.supplemental, self.registry, self.policy)
+
+    def test_ci_checker_inherits_future_review_rejection(self):
+        checker = runpy.run_path(str(refresh.ROOT / 'scripts/ci/check-government-scorecard-artifacts.py'))
+        with contextlib.redirect_stdout(io.StringIO()):
+            checker['main']()
+        policy = copy.deepcopy(self.policy)
+        policy['contextReview']['reviewedAt'] = (
+            refresh.dt.date.fromisoformat(self.supplemental['as_of_date'])
+            + refresh.dt.timedelta(days=1)
+        ).isoformat()
+        # Replace only the receipt input; exercise the real checker and validator.
+        with patch.object(checker['government_scorecard_refresh'], 'load_policy', return_value=policy):
+            with self.assertRaisesRegex(ValueError, 'context review date exceeds snapshot as_of_date'):
+                checker['main']()
 
 
 class RawEurostatTests(unittest.TestCase):

--- a/tests/etl/test_government_scorecard_snapshot.py
+++ b/tests/etl/test_government_scorecard_snapshot.py
@@ -56,7 +56,7 @@ def ameco_zip(
                     country_id.title(),
                     "fixture",
                     part["title"],
-                    part["unit"],
+                    part["rawUnitTemplate"].format(currency=country["currencyCode"]),
                     *values(base=base),
                     "",
                 ]
@@ -94,6 +94,7 @@ class GovernmentScorecardSnapshotTests(unittest.TestCase):
 
     def test_source_spec_rejects_origin_country_and_method_drift(self) -> None:
         mutations = [
+            lambda value: value["ameco"].__setitem__("license", "other license"),
             lambda value: value["ameco"].__setitem__("downloadUrl", "https://example.test/ameco.zip"),
             lambda value: value["ameco"]["countries"]["italy"].__setitem__("code", "XXX"),
             lambda value: value["ameco"]["series"][0].__setitem__("direction", "lower"),

--- a/tests/government-scorecard-data.test.mjs
+++ b/tests/government-scorecard-data.test.mjs
@@ -1,3 +1,4 @@
+import pageSpec from "../scripts/etl/specs/government-scorecard-page.source.json" with { type: "json" };
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFileSync, readdirSync } from "node:fs";
@@ -119,17 +120,7 @@ test("the score artifact contains only the AMECO panel required by the current m
 test("page data preserve publication status, sources and the score-artifact link", () => {
   const snapshot = getGovernmentScorecardV6SupplementalSnapshot();
   const coreHash = createHash("sha256").update(readFileSync(corePath)).digest("hex");
-  const expectedLatestPeriods = new Map([
-    ["inflation", "2026-08"],
-    ["real_compensation", "2024"],
-    ["unemployment", "2026-07"],
-    ["employment_rate", "2026-Q1"],
-    ["real_gdp_per_capita", "2026-Q2"],
-    ["debt_ratio", "2026-Q1"],
-    ["debt_per_capita", "2025"],
-    ["primary_balance", "2026-Q1"],
-    ["investment_share", "2026-Q2"],
-  ]);
+  const expectedLatestPeriods = new Map(pageSpec.refreshPolicy.approvedPeriods.map((item) => [item.indicator_id, item.period]));
   assert.deepEqual(GOVERNMENT_SCORECARD_V6_SUPPLEMENTAL_INDICATOR_IDS, EXPECTED_INDICATORS);
   assert.equal(snapshot.score_contract.supplemental_score_impact, "none");
   assert.equal(snapshot.score_contract.core_artifact_sha256, coreHash);

--- a/tests/government-scorecard-page.test.mjs
+++ b/tests/government-scorecard-page.test.mjs
@@ -1,3 +1,4 @@
+import pageSpec from "../scripts/etl/specs/government-scorecard-page.source.json" with { type: "json" };
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -106,16 +107,7 @@ test("the current-government charts expose the latest reliable display data with
     ["primary_balance", "2022-Q4"],
     ["investment_share", "2022-Q4"],
   ]);
-  const latestByIndicator = new Map([
-    ["inflation", "2026-08"],
-    ["unemployment", "2026-07"],
-    ["employment_rate", "2026-Q1"],
-    ["real_gdp_per_capita", "2026-Q2"],
-    ["debt_ratio", "2026-Q1"],
-    ["debt_per_capita", "2025"],
-    ["primary_balance", "2026-Q1"],
-    ["investment_share", "2026-Q2"],
-  ]);
+  const latestByIndicator = new Map(pageSpec.refreshPolicy.approvedPeriods.map((item) => [item.indicator_id, item.period]));
   for (const slide of current.charts.slides) {
     const window = slide.mandate_window;
     const visibleCounts = slide.series.map((series) => series.points.filter((point) => isGovernmentChartPointInWindow(

--- a/tests/government-scorecard-refresh.test.mjs
+++ b/tests/government-scorecard-refresh.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+// Isolate module caches while exercising the real runtime against a future
+// oath fixture. No tracked files or production registry are changed.
+test("a new oath becomes current, closes its predecessor and receives no forecast-based score", () => {
+  const script = `
+    import './tests/helpers/register-ts-alias.mjs';
+    import { readFileSync } from 'node:fs';
+    import { registerHooks } from 'node:module';
+    const registry = JSON.parse(readFileSync('scripts/etl/specs/government-scorecard-chronology.json', 'utf8'));
+    registry.asOfDate = registry.verifiedAt = '2026-09-04';
+    registry.governments.push({
+      id: 'fixture-i', name: 'Fixture I', startDate: '2026-09-04',
+      sourceOwner: 'Presidenza della Repubblica',
+      sourceUrl: 'https://www.quirinale.it/it/notizie/fixture-giuramento',
+      sourceLocator: 'Fixture del giuramento verificato del 4 settembre 2026.'
+    });
+    registerHooks({load(url, context, nextLoad) {
+      if (url.endsWith('/government-scorecard-chronology.json')) {
+        return { format: 'json', source: JSON.stringify(registry), shortCircuit: true };
+      }
+      return nextLoad(url, context);
+    }});
+    const { GOVERNMENT_SCORECARD_V6_CHRONOLOGY: chronology } = await import('./src/lib/government-scorecard-chronology.ts');
+    const { getGovernmentScorecardV6Assessment: assess, GOVERNMENT_SCORECARD_V6_GOVERNMENT_IDS: ids } = await import('./src/lib/government-scorecard-governments.ts');
+    console.log(JSON.stringify({ ids, current: chronology.at(-1), previous: chronology.at(-2), assessment: assess('fixture-i') }));
+  `;
+  const result = spawnSync(process.execPath, ["--experimental-strip-types", "--input-type=module", "-e", script], {
+    cwd: new URL("../", import.meta.url), encoding: "utf8", timeout: 30_000,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.ids.at(-1), "fixture-i");
+  assert.equal(output.current.status, "current");
+  assert.equal(output.previous.status, "ended");
+  assert.equal(output.previous.end_exclusive, "2026-09-04");
+  assert.equal(output.assessment.score_state, "not_scored_short");
+  assert.equal(output.assessment.window.end_year, null);
+  assert.equal(output.assessment.gate.forecast_free, true);
+});


### PR DESCRIPTION
## Cosa cambia

Integra la Pagella dei governi v6 nel flusso dati gestito esistente, senza creare un sistema parallelo.

- aggiunge un refresh riproducibile e idempotente per dati economici, contesto e cambio di governo;
- applica revisione almeno semestrale ai dati e trimestrale al contesto;
- blocca la pubblicazione quando schema, fonte, licenza, periodo, hash o date non rispettano il contratto;
- mantiene separati dati osservati e previsioni: le previsioni non entrano nel voto;
- impedisce il ricalcolo senza una finestra osservata comune e completa;
- documenta responsabilità, frequenze, fallimenti e procedura manuale.

Maintainer responsabile della review e dell'integrazione, solo per cambiamenti sostanziali: `da assegnare`.

Closes Elgabor/DoveVannoINostriSoldi#3

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [x] Ho aggiunto o aggiornato test che falliscono senza la modifica.
- [x] `npm test`, test ETL Python, typecheck, lint, design check e build passano.
- [x] Ho verificato `git diff --check`.

### Dati pubblici

- [x] URL ufficiale, titolare, licenza, periodo e data di osservazione sono espliciti.
- [x] Schema, hash, provenienza e riconciliazioni falliscono in modo chiuso.
- [x] Importi, frequenze, saldi, pagamenti e finanziamenti non vengono confusi.
- [x] Il testo evita inferenze su spreco, frode, merito, qualità o responsabilità non dimostrate.

Gli snapshot e i voti approvati non cambiano in questa PR.

### UI e accessibilità

La PR non modifica la superficie utente. Come controllo di regressione sono state verificate le pagine della Pagella a 390, 768 e 1280 px, inclusi confronto, mandato breve e dati mancanti.

- [x] Tastiera, focus, stati e console browser verificati dalla suite di produzione.
- [x] 390, 768 e 1280 px verificati senza overflow o contenuti irraggiungibili.
- [x] Tabelle e grafici esistenti conservano l'equivalente accessibile.

### API e MCP

La PR non aggiunge né modifica API o strumenti MCP. I relativi smoke test HTTP e il carico locale sono passati come controllo di regressione.

- [x] Input e contratti esistenti continuano a essere validati.
- [x] La superficie MCP resta pubblica, stateless, limitata e read-only.
- [x] Verificato il route HTTP reale nella suite di produzione.

## Verifiche eseguite

- `npm run ci:static`
- `npm run ci:action-pins`
- `npm test`: 975 pass, 1 skip live OpenBDAP
- `npm run test:etl`: 446 test, 7 skip per fixture opzionali
- `npm run test:snapshots`
- `npm run build`
- `NEXT_PORT=43317 npm run test:production`
- Lighthouse finale: Performance 92%, Accessibility 100%, Best Practices 100%, SEO 100%
- `git diff --check`

## Limiti e prove non eseguite

- Il refresh live ha rilevato tre ricevute Eurostat nuove da sottoporre a revisione umana e ha correttamente impedito la pubblicazione; snapshot e voti restano invariati.
- Python locale: 3.14.2. Python 3.12 non è disponibile localmente e sarà verificato dalla CI GitHub.
- Un test Node live è saltato perché OpenBDAP non era raggiungibile.
- Sette test ETL opzionali sono saltati per fixture non presenti.
- Resta il warning Turbopack preesistente relativo al tracing dinamico ANAC.
