### PR TITLE
feat(data): automate Legge di Bilancio snapshot refresh

### DIFF
--- a/.github/workflows/budget-law-refresh.yml
+++ b/.github/workflows/budget-law-refresh.yml
@@ -1,0 +1,46 @@
+name: Legge di Bilancio snapshot
+
+on:
+  schedule:
+    - cron: "43 6 5 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: budget-law-snapshot
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: source-operations
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22.23.2"
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Refresh the official snapshot and source lock
+        run: node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_refresh.mjs
+      - name: Update the generated inventory
+        run: python3 scripts/ci/source-snapshot-inventory.py --write
+      - name: Validate the complete candidate offline
+        run: |
+          node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --check
+          node --experimental-strip-types --test tests/bdap-legge-bilancio.test.mjs tests/bdap-budget-law-refresh.test.mjs
+          git diff --check
+      - name: Publish generated data
+        uses: ./.github/actions/publish-data-refresh
+        with:
+          artifact-id: openbdap-budget-law
+          app-client-id: ${{ vars.DATA_BOT_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.DATA_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/budget-law-refresh.yml
+++ b/.github/workflows/budget-law-refresh.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   refresh:
+    name: Refresh Legge di Bilancio snapshot
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: source-operations

--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -288,3 +288,52 @@ responsabilità. La [procedura della Pagella](PAGELLA_POLITICO_ECONOMICA.md#aggi
 descrive osservazione senza write, approvazione degli hash, cambio di vintage,
 aggiornamento del registro e rollback. Le date della fonte, dell'acquisizione,
 del polling e della revisione editoriale restano distinte.
+
+## Legge di Bilancio: refresh dello snapshot
+
+La #189 aggiunge `budget-law-refresh.yml`: controllo mensile il giorno 5 alle
+06:43 UTC, più avvio manuale. È la frequenza del controllo DVNS, non una
+promessa di rilascio mensile RGS. Il workflow legge soltanto il prodotto
+OpenBDAP `LBF_SPE_CRU_AMPMA_001`, passando da `source-fetch.ts` con allowlist,
+timeout e limiti di byte. Non usa il fallback del sito per dichiarare riuscito
+un aggiornamento.
+
+Il candidato conserva gli anni dal 2017 e tutte le missioni dello snapshot
+pubblicato. Può accettare un nuovo anno consecutivo e revisioni degli importi;
+cambiamenti di identità, licenza, schema, tassonomia o copertura richiedono
+revisione manuale. Le righe precedenti al 2017 non entrano nella vista
+comparabile. Il dato resta lo stanziamento di competenza CP A1, in euro:
+non si somma a cassa, A2/A3 o ad altre misure.
+
+La trasformazione pura è condivisa con il runtime; il contratto verifica
+snapshot e source lock, hash dei byte ufficiali, matrice anno/missione e
+totali. A fonte invariata non cambiano i file né la data di acquisizione.
+L’inventario generato espone periodo e osservazione anche quando sono annidati
+nella serie o nei metadati della fonte.
+
+Il publisher esistente può proporre, per questa sola fonte, tre percorsi:
+`src/data/generated/openbdap-budget-law-missions.json`,
+`scripts/etl/specs/openbdap-budget-law-missions.source.json` e
+`docs/SOURCE_SNAPSHOT_INVENTORY.md`. Il lock e l’inventario sono eccezioni
+esatte all’allowlist degli artifact generati: non consentono modifiche a
+codice, altri lock o altri documenti. Restano il digest dei file, i trailer
+del bot, la validazione offline e la gestione della branch dedicata
+`automation/data/budget-law`. La PR è revisionabile; nessun merge automatico.
+
+Setup: environment `source-operations`, `DATA_BOT_APP_CLIENT_ID` e
+`DATA_BOT_APP_PRIVATE_KEY`, già usati dagli altri refresh. Un errore upstream,
+un contratto non rispettato o credenziali assenti fanno fallire il job;
+lo snapshot pubblicato resta quello precedente. Per il rollback, chiudere
+la proposta o revertire il relativo merge.
+
+Comandi locali dalla root con Node 22 e dipendenze installate:
+
+```bash
+node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_refresh.mjs
+python3 scripts/ci/source-snapshot-inventory.py --write
+node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --check
+node --experimental-strip-types --test tests/bdap-legge-bilancio.test.mjs tests/bdap-budget-law-refresh.test.mjs
+```
+
+Il primo comando contatta la fonte ufficiale e scrive soltanto un candidato
+locale se cambia. Nessun comando locale qui pubblica una PR o avvia un merge.

--- a/docs/SOURCE_SNAPSHOT_INVENTORY.md
+++ b/docs/SOURCE_SNAPSHOT_INVENTORY.md
@@ -23,10 +23,10 @@ workflow scrive su `main`.
 ## Riepilogo
 
 - Artefatti nel registro: 41
-- PR automatica: 8 (data bot, branch `automation/data/*`, PR)
+- PR automatica: 9 (data bot, branch `automation/data/*`, PR)
 - solo rilevamento: 3 (controlla l'upstream, non pubblica)
 - invalidazione cache: 3 (invalida tag, non tocca gli snapshot)
-- manuale: 27 (PR umana dopo revisione)
+- manuale: 26 (PR umana dopo revisione)
 
 ## Rollback per modo
 
@@ -54,23 +54,23 @@ La revisione e il merge restano umani.
 | `integrated-catalog` | non dichiarato nello snapshot | 2026-08-23T00:00:00Z | non dichiarato nel registro | solo workflow_dispatch | `.github/workflows/source-refresh.yml` | invalidazione cache | suite ETL |
 | `integrated-rows` | non dichiarato nello snapshot | non dichiarato | non dichiarato nel registro | solo workflow_dispatch | `.github/workflows/source-refresh.yml` | invalidazione cache | suite ETL |
 | `istat-municipality-geography` | 31/12/2022 | 2026-08-25T00:00:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/istat_municipality_geography.py --validate-committed` |
-| `istat-regions-2024` | 2024 | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/istat_regions_account.py --validate-committed` |
+| `istat-regions-2024` | 2024 | 2026-08-22T00:00:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/istat_regions_account.py --validate-committed` |
 | `mef-irpef-2024` | 2024 | non dichiarato | https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?tree=2025 | `17 6 * * 1` | `.github/workflows/mef-irpef-refresh.yml` | solo rilevamento | `python scripts/etl/mef_irpef_municipal_snapshot.py --check` |
 | `mef-participations` | 2023-12-31 | 2026-08-20T10:12:54.480623Z | https://www.de.mef.gov.it/it/attivita_istituzionali/partecipazioni_pubbliche/open_data_partecipazioni/index.html | `23 5 * * *` | `.github/workflows/mef-participations-refresh.yml` | PR automatica | `python scripts/etl/mef_participations_snapshot.py --check` |
-| `openbdap-budget-law` | non dichiarato nello snapshot | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --check` |
+| `openbdap-budget-law` | 2017-2026 | 2026-08-28T23:26:32.000Z | https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_search?q=LBF_SPE_CRU_AMPMA_001&rows=20 | `43 6 5 * *` | `.github/workflows/budget-law-refresh.yml` | PR automatica | `node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --check` |
 | `opencivitas-2022` | 2022 | 2026-08-20T12:35:16Z | https://www.opencivitas.it/it/open-data | `23 4 * * *` | `.github/workflows/opencivitas-refresh.yml` | PR automatica | `python scripts/etl/opencivitas_snapshot.py --check` |
 | `opencoesione` | 2026-04-30 | 2026-08-20T08:51:13+00:00 | https://opencoesione.gov.it/it/api/aggregati/ | `17 */6 * * *` | `.github/workflows/opencoesione-refresh.yml` | PR automatica | `python scripts/etl/opencoesione_snapshot.py --check` |
 | `parliament` | non dichiarato nello snapshot | 2026-08-20T14:00:00.000Z | non dichiarato nel registro | `37 */6 * * *` | `.github/workflows/parliament-sources.yml` | solo rilevamento | `python scripts/etl/parliament_sources.py --check` |
-| `pcm-financial-2024` | 2024 | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/pcm_financial_account.py --check` |
+| `pcm-financial-2024` | 2024 | 2026-08-22T16:54:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/pcm_financial_account.py --check` |
 | `pnrr-childcare` | 2026-06-13 | 2026-08-21T12:15:00Z | https://www.italiadomani.gov.it/content/sogei-ng/it/it/catalogo-open-data.html | `37 5 * * 1` | `.github/workflows/pnrr-childcare-refresh.yml` | solo rilevamento | `python scripts/etl/pnrr_childcare_snapshot.py --check` |
 | `government-scorecard` | 2024 | 2026-08-29T23:11:43Z | https://economy-finance.ec.europa.eu/economic-research-and-databases/economic-databases/ameco-database/download-annual-data-set-macro-economic-database-ameco_en | `37 7 * * 2` | `.github/workflows/government-scorecard-refresh.yml` | PR automatica | `python3 scripts/ci/check-government-scorecard-artifacts.py` |
 | `public-debt` | 2026-06-30 | 2026-08-24T09:41:59Z | https://www.bancaditalia.it/pubblicazioni/finanza-pubblica/index.html | `17 6 * * *` | `.github/workflows/public-debt-refresh.yml` | PR automatica | `python scripts/etl/public_debt_snapshot.py --check` |
 | `rgs-consulting-payments` | non dichiarato nello snapshot | 2026-08-22T00:00:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | suite ETL |
-| `rgs-ministries-2025` | 2025 | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/rgs_ministries_account.py --validate-committed` |
+| `rgs-ministries-2025` | 2025 | 2026-08-22T00:00:00Z | non dichiarato nel registro | nessuno | nessuno | manuale | `python scripts/etl/rgs_ministries_account.py --validate-committed` |
 | `rgs-state-budget-territorial-2023` | 2023 | 2026-08-22T00:00:00Z | https://bdap-opendata.rgs.mef.gov.it/content/2023-distribuzione-territoriale-della-spesa-del-bilancio-dello-stato-spesa-statale?metadati=showall | nessuno | nessuno | manuale | suite ETL |
 | `siope-municipal` | 2026 | 2026-08-25T03:31:23+00:00 | https://www.siope.it/documenti/siope2/open/last | `29 4 * * *` | `.github/workflows/siope-refresh.yml` | PR automatica | `python scripts/etl/siope_municipal_snapshot.py --check` |
 | `ssn-cce-2024` | 2024 | 2026-08-22T00:00:00Z | https://bdap-opendata.rgs.mef.gov.it/content/2024-modello-di-rilevazione-del-conto-economico-degli-enti-del-ssn | nessuno | nessuno | manuale | `python scripts/etl/ssn_cce_snapshot.py --check` |
-| `ssn-cce-national-history` | non dichiarato nello snapshot | non dichiarato | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
+| `ssn-cce-national-history` | non dichiarato nello snapshot | 2026-08-28T12:31:43.000Z | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
 | `vive-roma-restoration` | non dichiarato nello snapshot | 2026-08-22 | non dichiarato nel registro | nessuno | nessuno | manuale | test Node |
 | `company-atlas` | 2026-08-11 | 2026-08-26T00:00:00+02:00 | https://opendata.marche.camcom.it/data/Stock-Imprese-Attive-Italia.json | `41 5 * * *` | `.github/workflows/company-atlas-refresh.yml` | PR automatica | `node scripts/etl/company_atlas_snapshot.mjs --check` |
 | `istat-pensions-2012-2022` | 2012-2022 | non dichiarato | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_pensions_snapshot.py --check` |
@@ -78,7 +78,7 @@ La revisione e il merge restano umani.
 | `eurostat-cofog-2014-2024` | 2014-2024 | 2026-09-03 | https://ec.europa.eu/eurostat/databrowser/view/gov_10a_exp/default/table?lang=en | nessuno | nessuno | manuale | `python3 scripts/etl/eurostat_cofog_snapshot.py --check` |
 | `istat-cofog-1995-2023` | 1995-2023 | 2026-09-04 | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_cofog_snapshot.py --check` |
 | `istat-poverta-assoluta-2014-2024` | 2014-2024 | 2026-09-05 | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_poverta_snapshot.py --check` |
-| `istat-epea-2016-2022` | 2016-2022 | non dichiarato | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_epea_snapshot.py --check` |
+| `istat-epea-2016-2022` | 2016-2022 | 2026-09-04 | https://esploradati.istat.it/databrowser/ | nessuno | nessuno | manuale | `python3 scripts/etl/istat_epea_snapshot.py --check` |
 | `inps-naspi-2018-2022` | 2018-2022 | 2026-09-04 | https://opendata.inps.it/opendata | nessuno | nessuno | manuale | `python3 scripts/etl/inps_naspi_snapshot.py --check` |
 | `istat-enterprise-turnover` | 2024 | 2026-08-26T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/istat_enterprise_turnover.py --check` |
 | `education-atlas` | 2026-02-23 | 2026-08-27T00:00:00+02:00 | non dichiarato nel registro | nessuno | nessuno | manuale | `python3 scripts/etl/education_atlas_snapshot.py --check` |

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -368,24 +368,33 @@
       "id": "openbdap-budget-law",
       "owner": "OpenBDAP budget-law mission series",
       "files": [
-        "src/data/generated/openbdap-budget-law-missions.json"
+        "src/data/generated/openbdap-budget-law-missions.json",
+        "scripts/etl/specs/openbdap-budget-law-missions.source.json",
+        "docs/SOURCE_SNAPSHOT_INVENTORY.md"
       ],
-      "verificationMode": "source-lock",
+      "verificationMode": "online-refresh",
       "offlineCheck": {
         "command": "node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --check",
         "coveredBy": "standalone"
       },
       "reconciliationTests": [],
       "nodeTests": [
-        "tests/bdap-legge-bilancio.test.mjs"
+        "tests/bdap-legge-bilancio.test.mjs",
+        "tests/bdap-budget-law-refresh.test.mjs"
       ],
       "generator": {
-        "command": "node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_snapshot.mjs --package-json ... --csv ... --observed-at ...",
+        "command": "node --experimental-strip-types --import ./tests/helpers/register-ts-alias.mjs scripts/etl/bdap_budget_law_refresh.mjs",
         "requiresNetworkInput": true
       },
       "sourceSpec": "scripts/etl/specs/openbdap-budget-law-missions.source.json",
-      "refreshWorkflow": null,
-      "trustModel": "Committed aggregate generated from the official catalog response and CSV, both identified by SHA-256. Runtime prefers live OpenBDAP data and uses this validated snapshot only when the source is unavailable."
+      "refreshWorkflow": ".github/workflows/budget-law-refresh.yml",
+      "trustModel": "Scheduled workflow creates a bot-authored managed PR candidate containing the snapshot and its exact reviewed source lock. Official bytes, identity, licence, complete year/mission coverage and reconciliation are validated before publication. No direct main updates; schema or taxonomy drift requires manual review.",
+      "publication": {
+        "branch": "automation/data/budget-law",
+        "commitTitle": "chore(data): refresh Legge di Bilancio snapshot",
+        "prTitle": "data: refresh Legge di Bilancio snapshot",
+        "upstreamUrl": "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_search?q=LBF_SPE_CRU_AMPMA_001&rows=20"
+      }
     },
     {
       "id": "opencivitas-2022",

--- a/scripts/ci/publish-data-refresh.py
+++ b/scripts/ci/publish-data-refresh.py
@@ -276,7 +276,12 @@ def allowlisted_paths(artifact: Artifact) -> set[str]:
     root = (ROOT / "src/data/generated").resolve()
     for path in normalized:
         resolved = (ROOT / path).resolve()
-        if resolved != root and root not in resolved.parents:
+        reviewed_budget_metadata = (
+            artifact.artifact_id == "openbdap-budget-law"
+            and path in {"scripts/etl/specs/openbdap-budget-law-missions.source.json", "docs/SOURCE_SNAPSHOT_INVENTORY.md"}
+            and resolved == ROOT / path
+        )
+        if resolved != root and root not in resolved.parents and not reviewed_budget_metadata:
             raise PublishError(f"generated file escapes the generated-data root: {path}")
         if (ROOT / path).is_symlink():
             raise PublishError(f"generated file must not be a symlink: {path}")

--- a/scripts/ci/source-snapshot-inventory.py
+++ b/scripts/ci/source-snapshot-inventory.py
@@ -100,6 +100,9 @@ def format_value(value: Any) -> str | None:
 def pick_period(payload: Any) -> str | None:
     if not isinstance(payload, dict):
         return None
+    years = payload.get("series", {}).get("years") if isinstance(payload.get("series"), dict) else None
+    if isinstance(years, list) and years and all(isinstance(year, int) for year in years):
+        return f"{min(years)}-{max(years)}"
     for key in (
         "referenceDate",
         "referencePeriod",
@@ -158,6 +161,11 @@ def pick_observed(payload: Any) -> str | None:
         formatted = format_value(payload.get(key))
         if formatted:
             return formatted
+    source = payload.get("source")
+    if isinstance(source, dict):
+        observed = pick_observed(source)
+        if observed:
+            return observed
     sources = payload.get("sources")
     if isinstance(sources, dict):
         for source in sources.values():

--- a/scripts/ci/validate-generated-artifacts.py
+++ b/scripts/ci/validate-generated-artifacts.py
@@ -46,6 +46,7 @@ PUBLICATION_IDS = frozenset(
         "consulenti-pubblici",
         "government-scorecard",
         "mef-participations",
+        "openbdap-budget-law",
         "opencivitas-2022",
         "opencoesione",
         "public-debt",

--- a/scripts/etl/bdap_budget_law_refresh.mjs
+++ b/scripts/etl/bdap_budget_law_refresh.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, renameSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  aggregateBudgetLawRecords,
+  budgetLawSeriesFromAggregate,
+  normalizeBudgetLawPackage,
+  validateBudgetLawMissionSeries,
+  validateBudgetLawSnapshotArtifact,
+} from "../../src/lib/bdap-legge-bilancio.ts";
+import { parseDelimitedRows } from "../../src/lib/data/delimited.ts";
+import { fetchOfficialSource } from "../../src/lib/data/source-fetch.ts";
+
+export const SNAPSHOT_PATH = "src/data/generated/openbdap-budget-law-missions.json";
+export const LOCK_PATH = "scripts/etl/specs/openbdap-budget-law-missions.source.json";
+export const CATALOG_URL = "https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_search?q=LBF_SPE_CRU_AMPMA_001&rows=20";
+const HEADERS = ["Esercizio Finanziario", "Stato di Previsione", "Amministrazione", "Missione", "Programma", "Unità di voto 1° Livello", "Unità di voto 2° Livello", "Unità di voto 3° Livello", "Macroaggregato", "Legge di Bilancio CP A1", "Legge di Bilancio CP A2", "Legge di Bilancio CP A3", "Legge di Bilancio CS A1", "Legge di Bilancio CS A2", "Legge di Bilancio CS A3"];
+const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+const jsonBytes = (value) => `${JSON.stringify(value, null, 2)}\n`;
+
+export function datasetFromCatalog(bytes) {
+  const payload = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  if (payload.success !== true || !Array.isArray(payload.result?.results)) throw new Error("Catalogo OpenBDAP non valido");
+  const datasets = payload.result.results.map(normalizeBudgetLawPackage).filter(Boolean);
+  if (datasets.length !== 1) throw new Error("Il catalogo deve identificare un solo prodotto Legge di Bilancio");
+  return datasets[0];
+}
+
+/** Pure candidate construction; no network, cache fallback or filesystem mutation. */
+export function buildBudgetLawRefresh({ catalogBytes, csvBytes, observedAt, previous, previousLock }) {
+  validateBudgetLawSnapshotArtifact(previous, previousLock);
+  if (new Date(observedAt).toISOString() !== observedAt || observedAt < previous.source.observedAt) {
+    throw new Error("Data di osservazione non canonica o precedente allo snapshot");
+  }
+  const dataset = datasetFromCatalog(catalogBytes);
+  // Identity and licence must match the runtime contract before any proposal.
+  validateBudgetLawMissionSeries({ ...previous.series, dataset });
+  const text = new TextDecoder("windows-1252").decode(csvBytes);
+  if (!text.includes("\r\n") || /(?<!\r)\n/.test(text)) throw new Error("Formato CSV diverso dal CRLF verificato");
+  const rows = parseDelimitedRows(text);
+  if (rows.length < 2 || JSON.stringify(rows[0]) !== JSON.stringify(HEADERS)
+    || rows.some((row) => row.length !== HEADERS.length)) {
+    throw new Error("Schema CSV Legge di Bilancio inatteso");
+  }
+  const records = rows.slice(1).map((row) => Object.fromEntries(HEADERS.map((field, index) => [field, row[index]])));
+  if (records.some((row) => !/^\d{4}$/.test(row[HEADERS[0]]?.trim() ?? "") || (Number(row[HEADERS[0]]) >= 2017 && !row.Missione?.trim()))) {
+    throw new Error("Riga CSV priva di anno o missione: aggiornamento incompleto");
+  }
+  const keys = new Set();
+  for (const row of records) {
+    if (Number(row[HEADERS[0]]) < 2017) continue;
+    const key = JSON.stringify(HEADERS.slice(0, 9).map((field) => row[field]));
+    if (keys.has(key)) throw new Error("Riga contabile duplicata nella fonte");
+    keys.add(key);
+  }
+  const aggregate = aggregateBudgetLawRecords(dataset, records, observedAt);
+  const years = aggregate.availableYears;
+  if (!years.length || years.length > 20 || years[0] !== previous.series.years[0]
+    || years.at(-1) < previous.series.years.at(-1)
+    || years.some((year, i) => i > 0 && year !== years[i - 1] + 1)) {
+    throw new Error("Copertura temporale ridotta, discontinua o oltre il contratto");
+  }
+  const expectedMissions = [...previous.series.missions].sort();
+  for (const year of years) {
+    if (JSON.stringify([...(aggregate.missionsByYear.get(year) ?? [])].sort()) !== JSON.stringify(expectedMissions)) {
+      throw new Error(`Tassonomia o copertura delle missioni cambiata nel ${year}`);
+    }
+  }
+  const series = validateBudgetLawMissionSeries({
+    ...budgetLawSeriesFromAggregate(aggregate, years.length), dataMode: "snapshot",
+  }, { expectedDataMode: "snapshot" });
+  const lock = structuredClone(previousLock);
+  lock.source.observedAt = observedAt;
+  lock.source.catalog = { bytes: catalogBytes.byteLength, sha256: digest(catalogBytes) };
+  lock.source.csv = { ...lock.source.csv, bytes: csvBytes.byteLength, sha256: digest(csvBytes), rowsIncludingHeader: records.length + 1 };
+  lock.transformation = { ...lock.transformation, years, allocations: series.allocations.length, yearOverYearDeltas: series.yearOverYearDeltas.length };
+  lock.expectedAnnualTotalsEur = Object.fromEntries(years.map((year) => [year,
+    series.allocations.filter((row) => row.year === year).reduce((sum, row) => sum + row.amountEur, 0),
+  ]));
+  const artifact = {
+    schemaVersion: 1,
+    source: { ...previous.source, observedAt,
+      catalogSha256: `sha256:${lock.source.catalog.sha256}`, catalogBytes: catalogBytes.byteLength,
+      csvSha256: `sha256:${lock.source.csv.sha256}`, csvBytes: csvBytes.byteLength,
+    },
+    series,
+  };
+  validateBudgetLawSnapshotArtifact(artifact, lock);
+  const unchanged = artifact.source.csvSha256 === previous.source.csvSha256
+    && JSON.stringify(dataset) === JSON.stringify(previous.series.dataset);
+  return { changed: !unchanged, artifact: unchanged ? previous : artifact, lock: unchanged ? previousLock : lock };
+}
+
+async function download(url, kind, maxBytes, fetchSource, signal) {
+  const response = await fetchSource("openbdap", url, {
+    kind, signal, cacheMode: "no-store", rejectHttpError: true,
+    headers: { Accept: kind === "discovery" ? "application/json" : "text/csv" },
+  });
+  if (!response.ok) { await response.body?.cancel(); throw new Error(`OpenBDAP HTTP ${response.status}`); }
+  const type = response.headers.get("content-type") ?? "";
+  if (!type.includes(kind === "discovery" ? "json" : "csv")) {
+    await response.body?.cancel(); throw new Error(`OpenBDAP formato inatteso: ${type}`);
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("OpenBDAP risposta priva di corpo");
+  const chunks = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) throw new Error(`OpenBDAP supera il limite di ${maxBytes} byte`);
+      chunks.push(value);
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function fetchBudgetLawRefresh({ previous, previousLock, observedAt = new Date().toISOString(), fetchSource = fetchOfficialSource }) {
+  validateBudgetLawSnapshotArtifact(previous, previousLock);
+  const signal = AbortSignal.timeout(70_000);
+  const catalogBytes = await download(CATALOG_URL, "discovery", 2 * 1024 * 1024, fetchSource, signal);
+  const dataset = datasetFromCatalog(catalogBytes);
+  validateBudgetLawMissionSeries({ ...previous.series, dataset });
+  const csvBytes = await download(dataset.csvUrl, "data", 32 * 1024 * 1024, fetchSource, signal);
+  return buildBudgetLawRefresh({ catalogBytes, csvBytes, observedAt, previous, previousLock });
+}
+
+export function writeBudgetLawRefresh(candidate, { snapshotPath = SNAPSHOT_PATH, lockPath = LOCK_PATH } = {}) {
+  if (!candidate.changed) return;
+  validateBudgetLawSnapshotArtifact(candidate.artifact, candidate.lock);
+  const files = [[snapshotPath, jsonBytes(candidate.artifact)], [lockPath, jsonBytes(candidate.lock)]];
+  const originals = files.map(([path]) => readFileSync(path));
+  const staged = files.map(([path]) => `${path}.${process.pid}.tmp`);
+  try {
+    files.forEach(([, payload], index) => writeFileSync(staged[index], payload, { flag: "wx" }));
+    files.forEach(([path], index) => renameSync(staged[index], path));
+  } catch (error) {
+    files.forEach(([path], index) => writeFileSync(path, originals[index]));
+    throw error;
+  } finally {
+    staged.forEach((path) => rmSync(path, { force: true }));
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  if (process.argv.length > 2) throw new Error("Il refresh non accetta URL o percorsi arbitrari");
+  const candidate = await fetchBudgetLawRefresh({ previous: readJson(SNAPSHOT_PATH), previousLock: readJson(LOCK_PATH) });
+  writeBudgetLawRefresh(candidate);
+  console.log(candidate.changed ? "Snapshot e source lock aggiornati: candidato da validare e proporre in PR" : "Fonte invariata: nessuna modifica agli artifact o alla data di acquisizione");
+}

--- a/src/lib/bdap-legge-bilancio.ts
+++ b/src/lib/bdap-legge-bilancio.ts
@@ -6,6 +6,7 @@ import {
 import { fetchOfficialSource, SourceFetchError } from "@/lib/data/source-fetch";
 import { getSourcePolicy } from "@/lib/data/source-policy";
 import { parseOpenBdapAmount } from "@/lib/data/bdap-payment-contract";
+import budgetLawSourceLock from "../../scripts/etl/specs/openbdap-budget-law-missions.source.json";
 import budgetLawSnapshotArtifact from "@/data/generated/openbdap-budget-law-missions.json";
 
 const BDAP_BASE = "https://bdap-opendata.rgs.mef.gov.it";
@@ -22,26 +23,8 @@ const EXPECTED_TITLE =
   "Legge di Bilancio Pubblicata - Serie storica - Spese per Amministrazione Missione Programma Macroaggregato";
 const SNAPSHOT_PACKAGE_ID = "e0be9f03-134b-446d-8e6c-cb5c14ddc11c";
 const SNAPSHOT_RESOURCE_ID = "32750";
-const SNAPSHOT_CATALOG_SHA256 =
-  "sha256:c29936b96b538c669f47f62319c051724cd10ce8105b38906eed85f06c696e0c";
-const SNAPSHOT_CSV_SHA256 =
-  "sha256:5988ac55ed61d517d7500402547dccd94c4cae11611f10c77459dcfe64239338";
-const SNAPSHOT_CATALOG_BYTES = 6_283;
-const SNAPSHOT_CSV_BYTES = 3_422_462;
 const SNAPSHOT_CATALOG_URL =
   `${BDAP_ACTION}/package_search?q=LBF_SPE_CRU_AMPMA_001&rows=20`;
-const SNAPSHOT_ANNUAL_TOTALS_EUR = new Map<number, number>([
-  [2017, 861_047_385_808],
-  [2018, 852_369_824_700],
-  [2019, 869_498_990_905],
-  [2020, 897_423_599_901],
-  [2021, 1_060_697_407_565],
-  [2022, 1_093_956_278_557],
-  [2023, 1_183_723_964_094],
-  [2024, 1_215_086_092_281],
-  [2025, 1_199_544_721_805],
-  [2026, 1_253_161_463_689],
-]);
 
 /**
  * The RGS mission taxonomy was reworded in 2017 (e.g. "Diritti sociali
@@ -524,7 +507,15 @@ let fullAggregateCache: { promise: Promise<FullMissionAggregate>; expiresAt: num
 async function computeFullMissionAggregate(signal: AbortSignal): Promise<FullMissionAggregate> {
   const dataset = await discoverBudgetLawMissionDataset(signal);
   const records = await fetchDatasetRows(dataset, signal);
+  return aggregateBudgetLawRecords(dataset, records, new Date().toISOString());
+}
 
+/** Shared pure transformation for runtime and offline refresh candidates. */
+export function aggregateBudgetLawRecords(
+  dataset: BudgetLawMissionDataset,
+  records: DelimitedRecord[],
+  acquiredAt: string,
+): FullMissionAggregate {
   const totalsByYearMission = new Map<string, number>();
   const missionsByYear = new Map<number, Set<string>>();
 
@@ -543,7 +534,7 @@ async function computeFullMissionAggregate(signal: AbortSignal): Promise<FullMis
   const availableYears = [...missionsByYear.keys()].sort((left, right) => left - right);
   return {
     dataset,
-    acquiredAt: new Date().toISOString(),
+    acquiredAt,
     availableYears,
     missionsByYear,
     totalsByYearMission,
@@ -868,7 +859,28 @@ type BudgetLawSnapshotArtifact = {
   series: BudgetLawMissionSeries;
 };
 
-export function validateBudgetLawSnapshotArtifact(value: unknown): BudgetLawSnapshotArtifact {
+export function validateBudgetLawSnapshotArtifact(
+  value: unknown,
+  lock: typeof budgetLawSourceLock = budgetLawSourceLock,
+): BudgetLawSnapshotArtifact {
+  if (lock.schemaVersion !== 1 || lock.datasetId !== "openbdap_legge_bilancio_storico"
+    || lock.source.packageId !== SNAPSHOT_PACKAGE_ID || lock.source.resourceId !== SNAPSHOT_RESOURCE_ID
+    || lock.source.productCode !== PRODUCT_CODE || lock.source.title !== EXPECTED_TITLE
+    || lock.source.catalogUrl !== SNAPSHOT_CATALOG_URL
+    || lock.source.csvUrl !== `${BDAP_DUMP}/${SNAPSHOT_PACKAGE_ID}.csv`
+    || lock.source.license !== "Creative Commons Attribution" || lock.source.licenseId !== "cc-by"
+    || lock.source.licenseUrl !== "http://www.opendefinition.org/licenses/cc-by"
+    || lock.transformation.measure !== ENACTED_AMOUNT_FIELD || lock.transformation.unit !== "euro"
+    || lock.transformation.minimumStableMissionYear !== MIN_STABLE_MISSION_YEAR
+    || ![lock.source.catalog, lock.source.csv].every((asset) =>
+      /^[a-f0-9]{64}$/.test(asset.sha256) && Number.isSafeInteger(asset.bytes) && asset.bytes > 0)) {
+    throw new Error("Snapshot Legge di Bilancio: source lock non valido");
+  }
+  const annualTotals = new Map(Object.entries(lock.expectedAnnualTotalsEur).map(([year, total]) => [Number(year), total]));
+  if ([...annualTotals].some(([year, total]) => !Number.isInteger(year) || year < MIN_STABLE_MISSION_YEAR
+    || !Number.isSafeInteger(total) || total <= 0)) {
+    throw new Error("Snapshot Legge di Bilancio: totali del lock non validi");
+  }
   const candidate = objectRecord(value);
   if (candidate.schemaVersion !== 1) {
     throw new Error("Snapshot Legge di Bilancio: versione artefatto non valida");
@@ -880,11 +892,11 @@ export function validateBudgetLawSnapshotArtifact(value: unknown): BudgetLawSnap
     source.title !== EXPECTED_TITLE ||
     source.license !== "Creative Commons Attribution" ||
     source.licenseUrl !== "http://www.opendefinition.org/licenses/cc-by" ||
-    source.catalogSha256 !== SNAPSHOT_CATALOG_SHA256 ||
-    source.catalogBytes !== SNAPSHOT_CATALOG_BYTES ||
+    source.catalogSha256 !== `sha256:${lock.source.catalog.sha256}` ||
+    source.catalogBytes !== lock.source.catalog.bytes ||
     source.csvUrl !== `${BDAP_DUMP}/${SNAPSHOT_PACKAGE_ID}.csv` ||
-    source.csvSha256 !== SNAPSHOT_CSV_SHA256 ||
-    source.csvBytes !== SNAPSHOT_CSV_BYTES ||
+    source.csvSha256 !== `sha256:${lock.source.csv.sha256}` ||
+    source.csvBytes !== lock.source.csv.bytes ||
     source.encoding !== "cp1252" ||
     source.delimiter !== ";" ||
     source.quoteChar !== '"' ||
@@ -898,12 +910,22 @@ export function validateBudgetLawSnapshotArtifact(value: unknown): BudgetLawSnap
   const series = validateBudgetLawMissionSeries(candidate.series, {
     expectedDataMode: "snapshot",
   });
-  if (series.observedAt !== source.observedAt) {
+  if (JSON.stringify(series.years) !== JSON.stringify(lock.transformation.years)
+    || series.missions.length !== lock.transformation.missionsPerYear
+    || series.allocations.length !== lock.transformation.allocations
+    || series.yearOverYearDeltas.length !== lock.transformation.yearOverYearDeltas
+    || lock.source.csv.columns !== 15 || !Number.isSafeInteger(lock.source.csv.rowsIncludingHeader)
+    || lock.source.csv.rowsIncludingHeader <= 1
+    || lock.source.csv.encoding !== "cp1252" || lock.source.csv.delimiter !== ";"
+    || lock.source.csv.quoteChar !== '"' || lock.source.csv.lineEnding !== "CRLF") {
+    throw new Error("Snapshot Legge di Bilancio: trasformazione non coerente con il lock");
+  }
+  if (series.observedAt !== source.observedAt || series.observedAt !== lock.source.observedAt) {
     throw new Error("Snapshot Legge di Bilancio: date di acquisizione non coerenti");
   }
   if (
-    series.years.length !== SNAPSHOT_ANNUAL_TOTALS_EUR.size ||
-    series.years.some((year) => !SNAPSHOT_ANNUAL_TOTALS_EUR.has(year))
+    series.years.length !== annualTotals.size ||
+    series.years.some((year) => !annualTotals.has(year))
   ) {
     throw new Error("Snapshot Legge di Bilancio: copertura sorgente inattesa");
   }
@@ -911,7 +933,7 @@ export function validateBudgetLawSnapshotArtifact(value: unknown): BudgetLawSnap
     const total = series.allocations
       .filter((row) => row.year === year)
       .reduce((sum, row) => sum + row.amountEur, 0);
-    if (!Number.isSafeInteger(total) || total !== SNAPSHOT_ANNUAL_TOTALS_EUR.get(year)) {
+    if (!Number.isSafeInteger(total) || total !== annualTotals.get(year)) {
       throw new Error(`Snapshot Legge di Bilancio: totale ${year} non riconciliato`);
     }
   }
@@ -1006,6 +1028,13 @@ export async function getBudgetLawMissionSeries(
     if (!options.signal?.aborted && !isTemporarySourceFailure(error)) throw error;
     return committedBudgetLawSnapshot(requestedWindow);
   }
+  return budgetLawSeriesFromAggregate(aggregate, requestedWindow);
+}
+
+export function budgetLawSeriesFromAggregate(
+  aggregate: FullMissionAggregate,
+  requestedWindow: number,
+): BudgetLawMissionSeries {
   const { dataset, acquiredAt, availableYears, missionsByYear, totalsByYearMission } = aggregate;
 
   const consecutiveYears = latestConsecutiveYears(availableYears);

--- a/tests/bdap-budget-law-refresh.test.mjs
+++ b/tests/bdap-budget-law-refresh.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import "./helpers/register-ts-alias.mjs";
+const { buildBudgetLawRefresh, fetchBudgetLawRefresh, writeBudgetLawRefresh } = await import("../scripts/etl/bdap_budget_law_refresh.mjs");
+const { validateBudgetLawSnapshotArtifact } = await import("../src/lib/bdap-legge-bilancio.ts");
+
+const previous = JSON.parse(readFileSync("src/data/generated/openbdap-budget-law-missions.json"));
+const previousLock = JSON.parse(readFileSync("scripts/etl/specs/openbdap-budget-law-missions.source.json"));
+const observedAt = new Date(Date.parse(previous.source.observedAt) + 86_400_000).toISOString();
+const fields = ["Esercizio Finanziario", "Stato di Previsione", "Amministrazione", "Missione", "Programma", "Unità di voto 1° Livello", "Unità di voto 2° Livello", "Unità di voto 3° Livello", "Macroaggregato", "Legge di Bilancio CP A1", "Legge di Bilancio CP A2", "Legge di Bilancio CP A3", "Legge di Bilancio CS A1", "Legge di Bilancio CS A2", "Legge di Bilancio CS A3"];
+const pkg = {
+  id: previous.source.packageId, name: previous.series.dataset.name, title: previous.source.title,
+  notes: previous.series.dataset.notes, metadata_modified: previous.series.dataset.metadataModified,
+  license_id: "cc-by", license_title: previous.source.license, license_url: previous.source.licenseUrl,
+  resources: [{ id: previous.source.resourceId, url: previous.source.csvUrl, format: "CSV", mimetype: "text/csv" }],
+};
+const catalog = (packages = [pkg]) => Buffer.from(JSON.stringify({ success: true, result: { results: packages } }));
+const csv = (rows = previous.series.allocations) => Buffer.from([
+  fields.join(";"), ...rows.map((row) => [row.year, "01", "AMMINISTRAZIONE", row.mission, "PROGRAMMA", "1", "2", "3", "MACRO", row.amountEur, 0, 0, 0, 0, 0]
+    .map((value) => `"${String(value).replaceAll('"', '""')}"`).join(";")), "",
+].join("\r\n"), "latin1");
+const candidate = (overrides = {}) => buildBudgetLawRefresh({ previous, previousLock, observedAt, catalogBytes: catalog(), csvBytes: csv(), ...overrides });
+
+test("refresh reconciles exact totals and binds source bytes without altering published input", () => {
+  const before = JSON.stringify(previous);
+  const next = candidate();
+  assert.equal(next.changed, true);
+  assert.deepEqual(next.artifact.series.allocations, previous.series.allocations);
+  assert.deepEqual(next.lock.expectedAnnualTotalsEur, previousLock.expectedAnnualTotalsEur);
+  assert.equal(next.lock.source.csv.rowsIncludingHeader, previous.series.allocations.length + 1);
+  assert.doesNotThrow(() => validateBudgetLawSnapshotArtifact(next.artifact, next.lock));
+  assert.throws(() => validateBudgetLawSnapshotArtifact(next.artifact));
+  assert.equal(JSON.stringify(previous), before);
+});
+
+test("unchanged sources do not churn observation timestamps or files", () => {
+  const first = candidate();
+  const next = candidate({ previous: first.artifact, previousLock: first.lock, observedAt: new Date(Date.parse(observedAt) + 86_400_000).toISOString() });
+  assert.equal(next.changed, false);
+  assert.deepEqual(next.artifact, first.artifact);
+  assert.deepEqual(next.lock, first.lock);
+});
+
+test("new consecutive years are accepted with the complete existing mission taxonomy", () => {
+  const year = previous.series.years.at(-1) + 1;
+  const rows = [...previous.series.allocations, ...previous.series.missions.map((mission) => ({ year, mission, amountEur: 1_000 }))];
+  const next = candidate({ csvBytes: csv(rows) });
+  assert.equal(next.artifact.series.years.at(-1), year);
+  assert.equal(next.lock.expectedAnnualTotalsEur[year], 34_000);
+});
+
+test("ambiguous identity, licence and reduced coverage fail closed", () => {
+  assert.throws(() => candidate({ catalogBytes: catalog([pkg, pkg]) }), /un solo/);
+  assert.throws(() => candidate({ catalogBytes: catalog([{ ...pkg, license_title: "different licence" }]) }));
+  assert.throws(() => candidate({ csvBytes: csv(previous.series.allocations.slice(1)) }), /missioni/);
+  assert.throws(() => candidate({ csvBytes: csv(previous.series.allocations.filter((row) => row.year !== previous.series.years[0])) }), /temporale/);
+  assert.throws(() => candidate({ csvBytes: Buffer.from(csv().toString("latin1").replace("Missione;", "Altro;"), "latin1") }), /Schema/);
+  assert.throws(() => candidate({ csvBytes: csv([...previous.series.allocations, previous.series.allocations[0]]) }), /duplicata/);
+  assert.throws(() => candidate({ csvBytes: Buffer.from(csv().toString("latin1").replaceAll('"0"\r\n', '"0";"extra"\r\n'), "latin1") }), /Schema/);
+  assert.throws(() => candidate({ csvBytes: Buffer.from(csv().toString("latin1"), "utf8") }), /Schema/);
+  assert.throws(() => candidate({ observedAt: "2000-01-01T00:00:00.000Z" }), /osservazione/);
+  const next = candidate();
+  next.lock.expectedAnnualTotalsEur[2017] += 1;
+  assert.throws(() => validateBudgetLawSnapshotArtifact(next.artifact, next.lock), /non riconciliato/);
+});
+
+test("online refresh uses only the official product URLs and never falls back", async () => {
+  const calls = [];
+  const next = await fetchBudgetLawRefresh({ previous, previousLock, observedAt, fetchSource: async (id, url, options) => {
+    calls.push({ id, url, options });
+    return new Response(calls.length === 1 ? catalog() : csv(), { headers: { "content-type": calls.length === 1 ? "application/json" : "text/csv" } });
+  } });
+  assert.equal(next.changed, true);
+  assert.deepEqual(calls.map((call) => call.url), [previous.source.catalogUrl, previous.source.csvUrl]);
+  assert.ok(calls.every((call) => call.id === "openbdap" && call.options.cacheMode === "no-store" && call.options.signal instanceof AbortSignal));
+  for (const status of [403, 429, 503]) {
+    await assert.rejects(fetchBudgetLawRefresh({ previous, previousLock, fetchSource: async () => new Response("error", { status }) }), new RegExp(String(status)));
+  }
+  await assert.rejects(fetchBudgetLawRefresh({ previous, previousLock, fetchSource: async () => new Response("<html/>", { headers: { "content-type": "text/html" } }) }), /formato/);
+});
+
+test("candidate is validated before both files are replaced; no-op leaves bytes untouched", () => {
+  const dir = mkdtempSync(join(tmpdir(), "budget-refresh-"));
+  const paths = { snapshotPath: join(dir, "snapshot.json"), lockPath: join(dir, "lock.json") };
+  try {
+    writeFileSync(paths.snapshotPath, JSON.stringify(previous));
+    writeFileSync(paths.lockPath, JSON.stringify(previousLock));
+    const next = candidate();
+    writeBudgetLawRefresh(next, paths);
+    assert.deepEqual(JSON.parse(readFileSync(paths.snapshotPath)), next.artifact);
+    assert.deepEqual(JSON.parse(readFileSync(paths.lockPath)), next.lock);
+    const bytes = readFileSync(paths.snapshotPath);
+    writeBudgetLawRefresh({ ...next, changed: false }, paths);
+    assert.deepEqual(readFileSync(paths.snapshotPath), bytes);
+    next.artifact.series.allocations[0].amountEur += 1;
+    assert.throws(() => writeBudgetLawRefresh(next, paths));
+    assert.deepEqual(readFileSync(paths.snapshotPath), bytes);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+
+test("historical rows outside the stable taxonomy may omit mission; published years may not", () => {
+  const rows = [...previous.series.allocations, { year: 2016, mission: "", amountEur: 10 }];
+  assert.deepEqual(candidate({ csvBytes: csv(rows) }).artifact.series.allocations, previous.series.allocations);
+  rows.at(-1).year = 2017;
+  assert.throws(() => candidate({ csvBytes: csv(rows) }), /priva di anno o missione/);
+});
+
+test("oversized discovery responses are cancelled before a CSV request", async () => {
+  let cancelled = false;
+  let calls = 0;
+  await assert.rejects(fetchBudgetLawRefresh({ previous, previousLock, fetchSource: async () => {
+    calls += 1;
+    return new Response(new ReadableStream({
+      start(controller) { controller.enqueue(new Uint8Array(2 * 1024 * 1024 + 1)); },
+      cancel() { cancelled = true; },
+    }), { headers: { "content-type": "application/json" } });
+  } }), /supera il limite/);
+  assert.equal(calls, 1);
+  assert.equal(cancelled, true);
+});

--- a/tests/bdap-legge-bilancio.test.mjs
+++ b/tests/bdap-legge-bilancio.test.mjs
@@ -450,10 +450,11 @@ test("getBudgetLawMissionSeries never labels a gap as a year-over-year change", 
 test("the committed fallback snapshot is complete, consecutive and reconciled", () => {
   const artifact = validateBudgetLawSnapshotArtifact(COMMITTED_SNAPSHOT);
   const series = artifact.series;
-  assert.deepEqual(series.years, [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]);
+  assert.deepEqual(series.years, SOURCE_SPEC.transformation.years);
+  assert.equal(series.years[0], 2017);
   assert.equal(series.missions.length, 34);
-  assert.equal(series.allocations.length, 340);
-  assert.equal(series.yearOverYearDeltas.length, 306);
+  assert.equal(series.allocations.length, SOURCE_SPEC.transformation.allocations);
+  assert.equal(series.yearOverYearDeltas.length, SOURCE_SPEC.transformation.yearOverYearDeltas);
   assert.match(COMMITTED_SNAPSHOT.source.catalogSha256, /^sha256:[0-9a-f]{64}$/);
   assert.match(COMMITTED_SNAPSHOT.source.csvSha256, /^sha256:[0-9a-f]{64}$/);
   assert.equal(

--- a/tests/etl/test_publish_data_refresh.py
+++ b/tests/etl/test_publish_data_refresh.py
@@ -21,6 +21,22 @@ SPEC.loader.exec_module(publisher)
 
 
 class PublishDataRefreshTests(TestCase):
+    def test_budget_publication_is_limited_to_snapshot_lock_and_generated_inventory(self) -> None:
+        from dataclasses import replace
+        artifact = publisher.load_artifact("openbdap-budget-law")
+        expected = {
+            "src/data/generated/openbdap-budget-law-missions.json",
+            "scripts/etl/specs/openbdap-budget-law-missions.source.json",
+            "docs/SOURCE_SNAPSHOT_INVENTORY.md",
+        }
+        self.assertEqual(publisher.allowlisted_paths(artifact), expected)
+        for path in ("src/lib/bdap-legge-bilancio.ts", "scripts/etl/specs/other.json", "docs/ROADMAP.md"):
+            with self.assertRaises(publisher.PublishError):
+                publisher.allowlisted_paths(replace(artifact, files=(path,)))
+        other = publisher.load_artifact("company-atlas")
+        with self.assertRaises(publisher.PublishError):
+            publisher.allowlisted_paths(replace(other, files=("scripts/etl/specs/openbdap-budget-law-missions.source.json",)))
+
     def test_registry_has_only_managed_source_publications(self) -> None:
         registry = json.loads((ROOT / "scripts/ci/generated-artifacts.json").read_text())
         publications = {
@@ -35,6 +51,7 @@ class PublishDataRefreshTests(TestCase):
                 "consulenti-pubblici",
                 "government-scorecard",
                 "mef-participations",
+                "openbdap-budget-law",
                 "opencivitas-2022",
                 "opencoesione",
                 "public-debt",
@@ -48,6 +65,7 @@ class PublishDataRefreshTests(TestCase):
                 "automation/data/consulenti",
                 "automation/data/government-scorecard",
                 "automation/data/mef-participations",
+                "automation/data/budget-law",
                 "automation/data/opencivitas",
                 "automation/data/opencoesione",
                 "automation/data/public-debt",

--- a/tests/etl/test_source_snapshot_inventory.py
+++ b/tests/etl/test_source_snapshot_inventory.py
@@ -1,3 +1,4 @@
+import runpy
 import subprocess
 import sys
 import unittest
@@ -26,3 +27,10 @@ class SourceSnapshotInventoryTests(unittest.TestCase):
         self.assertIn("`siope-municipal`", text)
         self.assertIn("workflow scrive su `main`", text)
         self.assertNotRegex(text, r"[—–]")
+
+    def test_reference_period_is_distinct_from_nested_observation_date(self):
+        module = runpy.run_path(str(SCRIPT))
+        payload = {"series": {"years": [2017, 2026]}, "source": {"observedAt": "2026-09-05"}}
+        self.assertEqual(module["pick_period"](payload), "2017-2026")
+        self.assertEqual(module["pick_observed"](payload), "2026-09-05")
+        self.assertIsNone(module["pick_period"]({"source": payload["source"]}))


### PR DESCRIPTION
Refs #189.

The Legge di Bilancio fallback snapshot currently needs a manual regeneration. This adds a monthly check of the existing official OpenBDAP product and a validated data-bot PR when its CSV or dataset metadata changes. Unchanged input preserves both files and acquisition dates; upstream errors remain failures.

The refresh shares the runtime aggregation and rejects changes to identity, licence, encoding, columns, accounting-row uniqueness, mission coverage or consecutive years. Snapshot hashes and annual totals are read from the reviewed source lock, with the current published data unchanged. A complete new year can be proposed without editing application code.

The publisher can change exactly the snapshot, its source lock and the generated inventory. The two metadata paths are restricted to this artifact; existing ownership, digest, provenance and PR checks remain in place. No direct main update or automatic merge is added. The playbook documents cadence, credentials, failures and rollback. Issue #189 remains open for the other sources.

Validation:
- PASS: lint/typecheck/design/brand checks, action pins, Actionlint, production build.
- PASS: full Node suite (1,008 passed, one existing live-source test skipped); final targeted refresh/runtime suite (31 passed).
- PASS: real refresh CLI against the official catalog and CSV, with no artifact or observation-date changes.
- PASS: ETL suite (471 tests, seven existing skips), 31 standalone snapshot checks, clean validation tree and `git diff --check`.
- PASS: all local production gates: 154 core browser scenarios, 21 editorial routes, report flow, CSP, and Lighthouse budgets. The budget simulator modification/share flow passed at 390, 768 and 1280px.
- PASS: Zizmor on the final workflow revision. The only change after the local application tests is the explicit workflow job name; application/build inputs are identical.
- PASS: all GitHub checks on `4a448ef3183d3a3ff50fe42c685d67055a61b6b6`, including CI / required, Zizmor, CodeQL, dependency review and Vercel preview.
- PASS: production `/api/health` reported merge `40a0909476f156f660f2934342b9324d9e9710c6` before and after verification; the public API returned 2017-2026, 34 missions and 340 allocations. The live simulator passed at 390/768/1280px with no browser errors or telemetry exceptions.
- PASS: post-merge [CI / required](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/33970776991) and [CodeQL](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/33970776988) on `40a0909476f156f660f2934342b9324d9e9710c6`.
- BLOCKED: the [manual workflow run](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/33970797542) is waiting at the existing `source-operations` environment. It requires reviewer `metaforismo` with `prevent_self_review=true`; the run was initiated by that same account and GitHub reports `current_user_can_approve=false`. No environment protection was changed or bypassed. The online CLI passed locally, but GitHub publisher execution has not been demonstrated. A different authorized collaborator can initiate a new run for `metaforismo` to review.
