### PR TITLE
fix(ui): keep white labels on red button hover

### DIFF
--- a/src/app/dati/dati.module.css
+++ b/src/app/dati/dati.module.css
@@ -143,6 +143,7 @@
 }
 
 .viewSwitch a[aria-current="page"]:hover {
+  color: var(--color-on-strong);
   background: var(--color-accent-800);
 }
 

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -159,13 +159,13 @@
 .btn svg { display: block; }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
 .btn:active:not(:disabled) { transform: scale(.98); }
-.btn-primary { background: var(--color-accent-700); color: var(--color-on-strong); }
+.btn-primary { background: var(--color-accent-700); color: var(--color-raised); }
 .btn-primary:hover,
 .btn-primary:focus-visible {
   background: var(--color-accent-800);
-  color: var(--color-on-strong);
+  color: var(--color-raised);
 }
-.btn-primary:active { background: var(--color-accent-900); color: var(--color-on-strong); }
+.btn-primary:active { background: var(--color-accent-900); color: var(--color-raised); }
 .btn-secondary { border-color: var(--color-neutral-400); }
 .btn-secondary:hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
 .btn-secondary:active { background: color-mix(in srgb, var(--color-text) 14%, transparent); }

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -159,14 +159,21 @@
 .btn svg { display: block; }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
 .btn:active:not(:disabled) { transform: scale(.98); }
-.btn-primary { background: var(--color-accent-700); color: var(--color-raised); }
-.btn-primary:hover { background: var(--color-accent-800); }
-.btn-primary:active { background: var(--color-accent-900); }
+.btn-primary { background: var(--color-accent-700); color: var(--color-on-strong); }
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  background: var(--color-accent-800);
+  color: var(--color-on-strong);
+}
+.btn-primary:active { background: var(--color-accent-900); color: var(--color-on-strong); }
 .btn-secondary { border-color: var(--color-neutral-400); }
 .btn-secondary:hover { background: color-mix(in srgb, var(--color-text) 7%, transparent); }
 .btn-secondary:active { background: color-mix(in srgb, var(--color-text) 14%, transparent); }
 .btn-ghost { color: var(--color-accent-700); padding-inline: var(--space-1); }
-.btn-ghost:hover { background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
+.btn-ghost:hover {
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-accent-800);
+}
 .btn-block {
   width: 100%;
   padding: 11px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,7 +35,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 a { color: var(--color-accent-700); text-decoration: none; }
-a:hover { color: var(--color-accent-800); }
+/* `.btn` keeps its own hover colors: a global accent-800 here would erase
+   white label text on filled primary buttons (same hue as the hover fill). */
+a:not(.btn):hover { color: var(--color-accent-800); }
 button, input, select, textarea { font: inherit; }
 code { font: 500 .92em var(--font-mono); color: var(--color-neutral-700); }
 img, svg { display: block; max-width: 100%; }

--- a/src/components/period-selector.module.css
+++ b/src/components/period-selector.module.css
@@ -36,7 +36,10 @@
   color: var(--color-raised);
   background: var(--color-accent-700);
 }
-.wrapper a[aria-current="page"]:hover { background: var(--color-accent-800); }
+.wrapper a[aria-current="page"]:hover {
+  color: var(--color-on-strong);
+  background: var(--color-accent-800);
+}
 
 @media (max-width: 560px) {
   .wrapper {

--- a/src/components/report-problem/report-problem.module.css
+++ b/src/components/report-problem/report-problem.module.css
@@ -214,7 +214,10 @@
   background: var(--color-accent-700);
   border: 1px solid var(--color-accent-700);
 }
-.primary:hover:not(:disabled) { background: var(--color-accent-800); }
+.primary:hover:not(:disabled) {
+  background: var(--color-accent-800);
+  color: var(--color-on-strong);
+}
 .primary:disabled { opacity: .7; cursor: progress; }
 .secondary {
   color: var(--color-text);

--- a/tests/accessibility-tokens.test.mjs
+++ b/tests/accessibility-tokens.test.mjs
@@ -30,7 +30,12 @@ test("secondary text token meets WCAG AA on every shared light surface", () => {
 
 test("primary button pair meets WCAG AA", () => {
   assert.ok(contrast(token("color-accent-700"), token("color-raised")) >= 4.5);
+  assert.ok(contrast(token("color-accent-800"), token("color-raised")) >= 4.5);
   assert.match(css, /\.btn-primary\s*\{[^}]*background:\s*var\(--color-accent-700\)[^}]*color:\s*var\(--color-raised\)/s);
+  assert.match(
+    css,
+    /\.btn-primary:hover,\s*\.btn-primary:focus-visible\s*\{[^}]*background:\s*var\(--color-accent-800\)[^}]*color:\s*var\(--color-raised\)/s,
+  );
 });
 
 test("municipality summary and partial status palette pairs meet WCAG AA", () => {


### PR DESCRIPTION
## Summary
- Global `a:hover { color: accent-800 }` overrode white text on `a.btn.btn-primary`, so hovered red buttons looked empty.
- Exclude `.btn` from the global link hover color and pin `--color-on-strong` on primary hover/focus/active.
- Same hardening for period selector / dataset view switch / report-problem primary.

## Test plan
- [ ] Hover `btn-primary` links (e.g. `/studi/dai-fondi-ai-posti` PDF button, `/supporter`, `/coesione`) — label stays white on darker red fill
- [ ] Hover plain text links — still darken to accent-800
- [ ] Hover `btn-ghost` — still readable accent text


Made with [Cursor](https://cursor.com)