### PR TITLE
refactor(etl): parsing monetario condiviso con policy esplicite

### DIFF
--- a/docs/DATA_IMPORT_STANDARD.md
+++ b/docs/DATA_IMPORT_STANDARD.md
@@ -29,6 +29,7 @@ assi. Se un asse manca nella fonte, si dichiara assente: non si ricostruisce.
 - Unità unica e dichiarata: preferire **centesimi di euro** negli snapshot
   tipizzati; nel corpus le celle restano stringhe e il parser condiviso deve
   documentare come si convertono.
+- Per gli ETL Python vedi le [primitive monetarie e le policy degli adapter](ETL_MONETARY_PARSING.md).
 - Natura contabile **distinta**, mai sommata in silenzio:
   - stanziamento / previsione
   - impegno

--- a/docs/ETL_MONETARY_PARSING.md
+++ b/docs/ETL_MONETARY_PARSING.md
@@ -1,0 +1,83 @@
+# Parsing monetario degli ETL
+
+Le policy descrivono il contratto della singola fonte. Non si riconosce il formato
+automaticamente e non si interpretano vuoti o marcatori di privacy come zero.
+
+## Contratti prima dell'estrazione (#315)
+
+I casi in `tests/etl/test_monetary_adapters.py` passano anche sui due adapter
+precedenti all'estrazione delle primitive comuni.
+
+| Adapter | Formato | Segno e assenza | Conversione |
+| --- | --- | --- | --- |
+| OpenCivitas 2022 | Intero o decimale con virgola, senza raggruppamenti; spazi esterni rimossi | Il parser ammette il meno; la normalizzazione richiede spesa storica non negativa e spesa standard positiva. Vuoti opzionali e celle con flag restano `None`; i quattro importi principali sono obbligatori | Euro in centesimi, `ROUND_HALF_UP`, anche oltre due cifre decimali |
+| SSN/CCE 2024 | Punto e due cifre decimali esatte, senza raggruppamenti; spazi esterni rimossi | Il meno è ammesso; importo obbligatorio, nessun marcatore testuale di assenza ammesso | Euro in centesimi esatti; precisione diversa rifiutata |
+| SIOPE, solo riferimento | Interi con meno opzionale, nessuno spazio | Secondo il contratto dell'adapter | La fonte è già in centesimi: nessuna moltiplicazione per 100 |
+
+Il segno `+`, la notazione esponenziale, i valori non finiti e i separatori delle
+migliaia sono rifiutati dai due parser migrati. Il limite di pubblicazione è
+`abs(centesimi) <= 9_007_199_254_740_991`.
+
+OpenCivitas confronta totali e importi per abitante usando i `Decimal` originali
+prima dell'arrotondamento. La trasformazione non deve anticipare tale passaggio
+né cambiare il parsing delle percentuali, dei livelli o dell'annualità 2021.
+
+## API condivisa
+
+`scripts/etl/monetary.py` espone una `MoneyPolicy` immutabile e due funzioni:
+
+- `parse_cents(raw, policy)` valida tutta la stringa con il `pattern` dichiarato,
+  normalizza soltanto i separatori ammessi e converte con `Decimal`.
+- `decimal_to_cents(value, policy)` converte un `Decimal` già validato. È il
+  punto usato da `cents()` di OpenCivitas, dopo le riconciliazioni originali.
+
+La policy rende espliciti regex (inclusa la precisione ammessa), separatori,
+unità (`euros` oppure `cents`), ammissione dei negativi, spazi esterni e
+arrotondamento (`reject` oppure `half_up`). Se una fonte ammette raggruppamenti,
+la sua regex deve validarne la posizione prima della rimozione del separatore.
+Le policy dei due adapter attuali non li ammettono.
+
+```python
+import re
+from monetary import MoneyPolicy, parse_cents
+
+policy = MoneyPolicy(
+    pattern=re.compile(r"-?\d+\.\d{2}"),
+    decimal_separator=".",
+    unit="euros",
+    allow_negative=True,
+    rounding="reject",
+    strip_whitespace=True,
+)
+assert parse_cents("12.34", policy) == 1234
+```
+
+I valori non finiti, i formati errati, i segni vietati e i centesimi frazionari
+senza arrotondamento ammesso producono `AmountError`. `AmountRangeError`, sua
+sottoclasse, distingue gli importi fuori intervallo. I wrapper preservano
+`StructuralError` / `SnapshotError` e aggiungono campo o riga della fonte.
+
+Il cambio di unità è esatto e non dipende dalla precisione del contesto Decimal
+del chiamante. L'arrotondamento avviene una sola volta, al centesimo; poi si
+controlla il limite sicuro. Nessun passaggio attraverso `float`.
+
+Restano negli adapter: vuoti obbligatori/opzionali, privacy e anomalie, vincoli
+contabili sul segno, riconciliazioni, periodo, fonte e provenienza. In particolare
+`decimal_value()`, `clean_metric()` e `basis_points()` conservano la logica
+OpenCivitas preesistente; la primitiva comune sostituisce la sola conversione
+monetaria in `cents()`. SIOPE e OpenCivitas 2021 non sono migrati.
+
+## Verifica offline
+
+```bash
+DVNS_OFFLINE_GUARD=1 PYTHONPATH=scripts/etl:scripts/ci \
+  .venv/bin/python -m unittest discover -s tests/etl -p 'test_monetary*.py'
+DVNS_OFFLINE_GUARD=1 PYTHONPATH=scripts/etl:scripts/ci \
+  .venv/bin/python -m unittest discover -s tests/etl -p 'test_ssn_cce_snapshot.py'
+```
+
+I test coprono i contratti prima della migrazione, arrotondamento e limiti,
+formati dichiarati/rifiutati, assenza e privacy, riconciliazioni e conversione
+di ogni cella monetaria degli snapshot esistenti. Non rigenerano gli artifact:
+hash, metadati e contenuti versionati restano invariati. I gate completi ETL e
+snapshot seguono `CONTRIBUTING.md`.

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -408,7 +408,9 @@
         "command": "python scripts/etl/opencivitas_snapshot.py --check",
         "coveredBy": "standalone"
       },
-      "reconciliationTests": [],
+      "reconciliationTests": [
+        "tests/etl/test_monetary_adapters.py"
+      ],
       "nodeTests": [
         "tests/opencivitas-contract.test.mjs"
       ],
@@ -804,7 +806,8 @@
         "coveredBy": "standalone"
       },
       "reconciliationTests": [
-        "tests/etl/test_ssn_cce_snapshot.py"
+        "tests/etl/test_ssn_cce_snapshot.py",
+        "tests/etl/test_monetary_adapters.py"
       ],
       "nodeTests": [],
       "generator": {

--- a/scripts/etl/monetary.py
+++ b/scripts/etl/monetary.py
@@ -1,0 +1,81 @@
+"""Explicit source formats and exact Decimal-to-cents conversion for ETL adapters."""
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+import re
+from typing import Literal
+
+
+MAX_SAFE_CENTS = 9_007_199_254_740_991
+
+
+class AmountError(ValueError):
+    """A present monetary value does not match its declared policy."""
+
+
+class AmountRangeError(AmountError):
+    """The converted amount exceeds the safe publication interval."""
+
+
+@dataclass(frozen=True)
+class MoneyPolicy:
+    pattern: re.Pattern[str]
+    decimal_separator: Literal[".", ","]
+    unit: Literal["euros", "cents"]
+    allow_negative: bool
+    rounding: Literal["reject", "half_up"]
+    strip_whitespace: bool
+    thousands_separator: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.decimal_separator not in (".", ",") or self.unit not in ("euros", "cents"):
+            raise ValueError("Unsupported monetary format or unit")
+        if self.rounding not in ("reject", "half_up"):
+            raise ValueError("Unsupported monetary rounding policy")
+        if self.thousands_separator is not None and (
+            self.thousands_separator not in (".", ",", " ", "\u00a0")
+            or self.thousands_separator == self.decimal_separator
+        ):
+            raise ValueError("Invalid thousands separator")
+
+
+def decimal_to_cents(value: Decimal, policy: MoneyPolicy) -> int:
+    """Convert a present Decimal; missing/privacy markers belong to the adapter."""
+    if not isinstance(value, Decimal) or not value.is_finite():
+        raise AmountError("A finite Decimal is required")
+    if not policy.allow_negative and value < 0:
+        raise AmountError("Negative amounts are not allowed")
+    # Reject huge exponents before arithmetic or construction of a Python integer.
+    # This loose bound admits rounding at the exact safe boundary below.
+    if value.copy_abs() > Decimal(MAX_SAFE_CENTS + 1):
+        raise AmountRangeError("Amount exceeds the safe integer interval")
+    # Shift the exponent exactly, without ambient Decimal precision or underflow.
+    scaled = value
+    if policy.unit == "euros" and value:
+        sign, digits, exponent = value.as_tuple()
+        scaled = Decimal((sign, digits, exponent + 2))
+    if scaled.copy_abs() > Decimal(MAX_SAFE_CENTS + 1):
+        raise AmountRangeError("Amount exceeds the safe integer interval")
+    rounded = scaled.to_integral_value(rounding=ROUND_HALF_UP)
+    if policy.rounding == "reject" and rounded != scaled:
+        raise AmountError("Fractional cents are not allowed")
+    if rounded.copy_abs() > MAX_SAFE_CENTS:
+        raise AmountRangeError("Amount exceeds the safe integer interval")
+    return int(rounded)
+
+
+def parse_cents(raw: str, policy: MoneyPolicy) -> int:
+    """Validate the entire source string before normalizing declared separators."""
+    if not isinstance(raw, str):
+        raise AmountError("A monetary string is required")
+    value = raw.strip() if policy.strip_whitespace else raw
+    if not policy.pattern.fullmatch(value):
+        raise AmountError("Amount does not match the source format")
+    if policy.thousands_separator is not None:
+        value = value.replace(policy.thousands_separator, "")
+    value = value.replace(policy.decimal_separator, ".")
+    try:
+        decimal = Decimal(value)
+    except InvalidOperation as error:
+        raise AmountError("Invalid decimal amount") from error
+    return decimal_to_cents(decimal, policy)

--- a/scripts/etl/opencivitas_snapshot.py
+++ b/scripts/etl/opencivitas_snapshot.py
@@ -21,6 +21,9 @@ from pathlib import Path, PurePosixPath
 from urllib.parse import urlparse
 from zipfile import BadZipFile, ZipFile
 
+from monetary import AmountError, AmountRangeError, MoneyPolicy, decimal_to_cents
+from monetary import MAX_SAFE_CENTS as MAX_SAFE_INTEGER
+
 REFERENCE_YEAR = 2022
 PUBLISHED_AT = "2025-08-07"
 LANDING_URL = "https://www.opencivitas.it/it/open-data"
@@ -35,8 +38,16 @@ OFFICIAL_HOSTS = {"docs.opencivitas.it", "www.opencivitas.it", "opencivitas.it"}
 USER_AGENT = "DoveVannoINostriSoldi-ETL/1.0 (+https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi)"
 TRANSIENT_HTTP = {408, 425, 429, 500, 502, 503, 504}
 MAX_RETRIES = 2
-MAX_SAFE_INTEGER = 9_007_199_254_740_991
 EXPECTED_MUNICIPALITIES = 6_557
+DECIMAL_RE = re.compile(r"-?\d+(?:,\d+)?")
+MONEY_POLICY = MoneyPolicy(
+    pattern=DECIMAL_RE,
+    decimal_separator=",",
+    unit="euros",
+    allow_negative=True,
+    rounding="half_up",
+    strip_whitespace=True,
+)
 
 SELECTED_INDICATORS = {
     "FST_RIPROPORZIONATO_BI": "Spesa standard - Euro",
@@ -275,7 +286,7 @@ def decimal_value(value: str, field: str, *, required: bool = True) -> Decimal |
         if required:
             raise StructuralError(f"{field}: valore numerico mancante")
         return None
-    if not re.fullmatch(r"-?\d+(?:,\d+)?", cleaned):
+    if not DECIMAL_RE.fullmatch(cleaned):
         raise StructuralError(f"{field}: formato numerico italiano inatteso")
     try:
         parsed = Decimal(cleaned.replace(",", "."))
@@ -287,10 +298,12 @@ def decimal_value(value: str, field: str, *, required: bool = True) -> Decimal |
 
 
 def cents(value: Decimal, field: str) -> int:
-    result = int((value * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
-    if abs(result) > MAX_SAFE_INTEGER:
-        raise StructuralError(f"{field}: importo oltre il limite sicuro JavaScript")
-    return result
+    try:
+        return decimal_to_cents(value, MONEY_POLICY)
+    except AmountRangeError as error:
+        raise StructuralError(f"{field}: importo oltre il limite sicuro JavaScript") from error
+    except AmountError as error:
+        raise StructuralError(f"{field}: importo non valido") from error
 
 
 def basis_points(value: Decimal, field: str) -> int:

--- a/scripts/etl/ssn_cce_snapshot.py
+++ b/scripts/etl/ssn_cce_snapshot.py
@@ -23,19 +23,28 @@ import tempfile
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
-from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Iterable
+
+from monetary import AmountError, AmountRangeError, MoneyPolicy, parse_cents
+from monetary import MAX_SAFE_CENTS as MAX_SAFE_INTEGER
 
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LOCK = ROOT / "scripts/etl/specs/ssn-cce-2024.source.json"
 DEFAULT_OUTPUT = ROOT / "src/data/generated/ssn-cce-2024.json"
-MAX_SAFE_INTEGER = 9_007_199_254_740_991
 DATE_RE = re.compile(r"^\d{2}/\d{2}/\d{4}$")
 ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 AMOUNT_RE = re.compile(r"^-?\d+\.\d{2}$")
+MONEY_POLICY = MoneyPolicy(
+    pattern=AMOUNT_RE,
+    decimal_separator=".",
+    unit="euros",
+    allow_negative=True,
+    rounding="reject",
+    strip_whitespace=True,
+)
 
 EXPECTED_METRICS = {
     "productionCosts": ("BZ9999", "Totale costi della produzione (B)"),
@@ -211,16 +220,12 @@ def load_lock(path: Path = DEFAULT_LOCK) -> dict[str, object]:
 
 
 def parse_amount_cents(raw: str, label: str) -> int:
-    value = raw.strip()
-    if not AMOUNT_RE.fullmatch(value):
-        raise SnapshotError(f"Importo non valido in {label}: {raw!r}")
     try:
-        cents = int((Decimal(value) * 100).to_integral_exact())
-    except (InvalidOperation, ValueError) as error:
+        return parse_cents(raw, MONEY_POLICY)
+    except AmountRangeError as error:
+        raise SnapshotError(f"Importo fuori intervallo sicuro in {label}") from error
+    except AmountError as error:
         raise SnapshotError(f"Importo non valido in {label}: {raw!r}") from error
-    if abs(cents) > MAX_SAFE_INTEGER:
-        raise SnapshotError(f"Importo fuori intervallo sicuro in {label}")
-    return cents
 
 
 def parse_date(raw: str, label: str) -> str:

--- a/tests/etl/test_monetary.py
+++ b/tests/etl/test_monetary.py
@@ -1,0 +1,105 @@
+import re
+import unittest
+from dataclasses import replace
+from decimal import Decimal, Inexact, ROUND_DOWN, localcontext
+
+from monetary import AmountError, AmountRangeError, MAX_SAFE_CENTS, MoneyPolicy, decimal_to_cents, parse_cents
+
+
+EUROS = MoneyPolicy(
+    pattern=re.compile(r"-?\d+(?:,\d+)?"), decimal_separator=",", unit="euros",
+    allow_negative=True, rounding="half_up", strip_whitespace=True,
+)
+CENTS = MoneyPolicy(
+    pattern=re.compile(r"-?[0-9]+"), decimal_separator=".", unit="cents",
+    allow_negative=True, rounding="reject", strip_whitespace=False,
+)
+
+
+class MonetaryTests(unittest.TestCase):
+    def test_units_sign_zero_and_declared_precision(self):
+        for raw, policy, expected in (
+            ("123", EUROS, 12300), ("123", CENTS, 123),
+            ("0", EUROS, 0), ("-0", CENTS, 0), ("-123", CENTS, -123),
+            ("1,004", EUROS, 100), ("1,005", EUROS, 101), ("-1,005", EUROS, -101),
+            (" 1,005\n", EUROS, 101), ("0001,50", EUROS, 150),
+            ("1,00", replace(EUROS, rounding="reject"), 100),
+        ):
+            with self.subTest(raw=raw, policy=policy):
+                actual = parse_cents(raw, policy)
+                self.assertIs(type(actual), int)
+                self.assertEqual(actual, expected)
+        for raw, policy in (
+            ("-1", replace(EUROS, allow_negative=False)),
+            ("1,001", replace(EUROS, rounding="reject")),
+            (" 1", CENTS), ("1.00", CENTS), ("1,00", CENTS),
+        ):
+            with self.subTest(raw=raw, policy=policy), self.assertRaises(AmountError):
+                parse_cents(raw, policy)
+
+    def test_grouping_must_be_declared_and_match_the_entire_format(self):
+        italian = replace(EUROS, pattern=re.compile(r"-?(?:\d+|\d{1,3}(?:\.\d{3})+),\d{2}"), thousands_separator=".")
+        english = replace(italian, pattern=re.compile(r"-?(?:\d+|\d{1,3}(?:,\d{3})+)\.\d{2}"), decimal_separator=".", thousands_separator=",")
+        for raw, policy in (("1.234.567,89", italian), ("1,234,567.89", english)):
+            with self.subTest(raw=raw):
+                self.assertEqual(parse_cents(raw, policy), 123456789)
+                with self.assertRaises(AmountError):
+                    parse_cents(raw, EUROS)
+        for raw, policy in (("1.23,45", italian), ("1234.567,89", italian),
+                            ("1..234,56", italian), ("1,23.45", english), ("1,234.5", english)):
+            with self.subTest(raw=raw), self.assertRaises(AmountError):
+                parse_cents(raw, policy)
+
+    def test_missing_nonfinite_and_malformed_values_are_never_zero(self):
+        for raw in ("", " ", "n.d.", "*", "NaN", "Infinity", "-Infinity",
+                    "+1", "1e2", "1.00", "1 000", "--1", "1,", ",1", None, 1, 1.5, True):
+            with self.subTest(raw=raw), self.assertRaises(AmountError):
+                parse_cents(raw, EUROS)
+        for value in (Decimal("NaN"), Decimal("sNaN"), Decimal("Infinity"),
+                      Decimal("-Infinity"), None, 1, 1.5, True):
+            with self.subTest(value=value), self.assertRaises(AmountError):
+                decimal_to_cents(value, EUROS)
+        permissive = replace(EUROS, pattern=re.compile(r".+"))
+        for raw in ("NaN", "Infinity", "bad"):
+            with self.subTest(raw=raw), self.assertRaises(AmountError):
+                parse_cents(raw, permissive)
+
+    def test_safe_bounds_include_half_up_rounding(self):
+        for sign in ("", "-"):
+            expected = MAX_SAFE_CENTS * (-1 if sign else 1)
+            for raw in (f"{sign}90071992547409,91", f"{sign}90071992547409,914"):
+                with self.subTest(raw=raw):
+                    self.assertEqual(parse_cents(raw, EUROS), expected)
+            self.assertEqual(parse_cents(f"{sign}{MAX_SAFE_CENTS}", CENTS), expected)
+            for raw in (f"{sign}90071992547409,915", f"{sign}90071992547409,92", f"{sign}999999999999999999999999"):
+                with self.subTest(raw=raw), self.assertRaises(AmountRangeError):
+                    parse_cents(raw, EUROS)
+            with self.assertRaises(AmountRangeError):
+                parse_cents(f"{sign}{MAX_SAFE_CENTS + 1}", CENTS)
+
+    def test_conversion_does_not_round_intermediate_values_or_depend_on_context(self):
+        # Rounding before the cent boundary would turn this into 1.005 and 101 cents.
+        long_fraction = "1,004" + "9" * 60
+        with localcontext() as context:
+            context.prec = 3
+            context.rounding = ROUND_DOWN
+            context.traps[Inexact] = True
+            self.assertEqual(parse_cents(long_fraction, EUROS), 100)
+            self.assertEqual(parse_cents("90071992547409,91", EUROS), MAX_SAFE_CENTS)
+            self.assertEqual(parse_cents("-1,005", EUROS), -101)
+            with self.assertRaises(AmountError):
+                decimal_to_cents(Decimal("1e-10000000"), replace(EUROS, rounding="reject"))
+            self.assertEqual(decimal_to_cents(Decimal("1e-10000000"), EUROS), 0)
+            with self.assertRaises(AmountRangeError):
+                decimal_to_cents(Decimal("1e10000000"), EUROS)
+
+    def test_unknown_policy_values_fail_closed(self):
+        for change in ({"unit": "thousands"}, {"rounding": "truncate"},
+                       {"decimal_separator": ";"}, {"thousands_separator": ","},
+                       {"thousands_separator": "_"}):
+            with self.subTest(change=change), self.assertRaises(ValueError):
+                replace(EUROS, **change)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/etl/test_monetary_adapters.py
+++ b/tests/etl/test_monetary_adapters.py
@@ -1,0 +1,107 @@
+"""Characterize the source-specific monetary contracts before sharing primitives."""
+
+import json
+import unittest
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+import opencivitas_snapshot as opencivitas
+import ssn_cce_snapshot as ssn
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class MonetaryAdapterTests(unittest.TestCase):
+    def test_opencivitas_comma_decimals_and_half_up_rounding(self):
+        for raw, expected in (
+            ("0", 0), ("-0,000", 0), ("123", 12300),
+            (" 123,45\n", 12345), ("-123,45", -12345),
+            ("1,004", 100), ("1,005", 101), ("-1,005", -101),
+            ("90071992547409,91", opencivitas.MAX_SAFE_INTEGER),
+            ("-90071992547409,91", -opencivitas.MAX_SAFE_INTEGER),
+        ):
+            with self.subTest(raw=raw):
+                value = opencivitas.decimal_value(raw, "SPESA_STORICA")
+                self.assertIsInstance(value, Decimal)
+                self.assertEqual(opencivitas.cents(value, "SPESA_STORICA"), expected)
+
+    def test_opencivitas_rejects_other_formats_and_missing_required_values(self):
+        for raw in ("", " ", "1.00", "1.000,00", "1,000,00", "1 000,00",
+                    "+1", "1e2", "NaN", "Infinity", "--1", ",5", "1,", "n.d."):
+            with self.subTest(raw=raw):
+                with self.assertRaisesRegex(opencivitas.StructuralError, "SPESA_STORICA"):
+                    opencivitas.decimal_value(raw, "SPESA_STORICA")
+        for raw in ("90071992547409,92", "-90071992547409,92"):
+            with self.subTest(raw=raw):
+                with self.assertRaisesRegex(opencivitas.StructuralError, "SPESA_STORICA.*limite sicuro"):
+                    opencivitas.cents(opencivitas.decimal_value(raw, "SPESA_STORICA"), "SPESA_STORICA")
+
+    def test_opencivitas_missing_and_flagged_cells_remain_distinct_from_zero(self):
+        code = "SPESA_STORICA"
+        self.assertIsNone(opencivitas.decimal_value(" ", code, required=False))
+        self.assertIsNone(opencivitas.clean_metric({}, code, [], required=False))
+        with self.assertRaisesRegex(opencivitas.StructuralError, "Indicatore SPESA_STORICA mancante"):
+            opencivitas.clean_metric({}, code, [])
+        for flag in ("privacy", "anomaly"):
+            with self.subTest(flag=flag):
+                row = {"value": "non numerico", "privacy": "", "anomaly": ""}
+                row[flag] = "oscurato"
+                warnings = []
+                self.assertIsNone(opencivitas.clean_metric({code: row}, code, warnings))
+                self.assertEqual(warnings, ["SPESA_STORICA: oscurato"])
+        self.assertEqual(opencivitas.clean_metric(
+            {code: {"value": "0", "privacy": "", "anomaly": ""}}, code, []), Decimal(0))
+
+    def test_opencivitas_normalization_preserves_rounding_and_reconciliation(self):
+        values = {
+            "SPESA_STORICA": "100,005", "FST_RIPROPORZIONATO_BI": "200,005",
+            "SPESA_STORICA_PROAB": "100,005", "FST_RIPROPORZIONATO_BI_PROAB": "200,005",
+        }
+        rows = {key: {"value": value, "privacy": "", "anomaly": ""} for key, value in values.items()}
+        entity = {"istatCode": "001001", "name": "Comune test", "province": "Torino", "region": "Piemonte"}
+        with patch.object(opencivitas, "load_entities", return_value={"test": entity}), \
+                patch.object(opencivitas, "verify_indicators"), \
+                patch.object(opencivitas, "load_raw_data", return_value={"test": rows}), \
+                patch.object(opencivitas, "EXPECTED_MUNICIPALITIES", 1):
+            snapshot = opencivitas.normalize(b"", b"", b"", "2026-09-06T00:00:00Z")
+            record = dict(zip(snapshot["municipalityColumns"], snapshot["municipalityRows"][0], strict=True))
+            self.assertEqual([record[key] for key in (
+                "historicalSpendingCents", "standardSpendingCents", "differenceCents",
+                "historicalPerCapitaCents", "standardPerCapitaCents", "differencePerCapitaCents",
+                "differenceBasisPoints", "serviceDifferenceBasisPoints",
+            )], [10001, 20001, -10000, 10001, 20001, -10000, -5000, None])
+            for raw, privacy in (("", ""), ("0", "oscurato"), ("-1", "")):
+                with self.subTest(raw=raw, privacy=privacy):
+                    rows["SPESA_STORICA"] = {"value": raw, "privacy": privacy, "anomaly": ""}
+                    with self.assertRaises(opencivitas.StructuralError):
+                        opencivitas.normalize(b"", b"", b"", "2026-09-06T00:00:00Z")
+
+    def test_ssn_requires_two_decimal_places_in_euros(self):
+        for raw, expected in (("0.00", 0), ("-0.00", 0), ("123.45", 12345),
+                              (" -123.45\n", -12345), ("90071992547409.91", ssn.MAX_SAFE_INTEGER)):
+            with self.subTest(raw=raw):
+                self.assertEqual(ssn.parse_amount_cents(raw, "Importo riga 7"), expected)
+        for raw in ("", " ", "n.d.", "123", "1.2", "1.234", "1,00", "1,000.00",
+                    "1.000,00", "1 000.00", "+1.00", "1e2", "NaN", "Infinity", ".50", "1."):
+            with self.subTest(raw=raw):
+                with self.assertRaisesRegex(ssn.SnapshotError, "Importo non valido in Importo riga 7"):
+                    ssn.parse_amount_cents(raw, "Importo riga 7")
+        for raw in ("90071992547409.92", "-90071992547409.92"):
+            with self.subTest(raw=raw):
+                with self.assertRaisesRegex(ssn.SnapshotError, "fuori intervallo sicuro in Importo riga 7"):
+                    ssn.parse_amount_cents(raw, "Importo riga 7")
+
+    def test_existing_opencivitas_monetary_cells_retain_exact_cents(self):
+        snapshot = json.loads((ROOT / "src/data/generated/opencivitas-2022.json").read_text())
+        columns = [index for index, name in enumerate(snapshot["municipalityColumns"]) if name.endswith("Cents")]
+        for row in snapshot["municipalityRows"]:
+            for index in columns:
+                expected = row[index]
+                decimal = Decimal(expected).scaleb(-2)
+                self.assertEqual(opencivitas.cents(decimal, snapshot["municipalityColumns"][index]), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/etl/test_ssn_cce_snapshot.py
+++ b/tests/etl/test_ssn_cce_snapshot.py
@@ -111,6 +111,22 @@ class SsnCceSnapshotTests(unittest.TestCase):
         with self.assertRaisesRegex(ETL.SnapshotError, "Importo non valido"):
             ETL.parse_csv(payload, synthetic_lock(payload))
 
+    def test_required_amount_is_not_replaced_with_zero(self):
+        for raw in ("", " ", "n.d.", "*", "NaN"):
+            with self.subTest(raw=raw):
+                payload = csv_payload(valid_row(amount=raw))
+                with self.assertRaisesRegex(ETL.SnapshotError, "Importo Totale riga 2"):
+                    ETL.parse_csv(payload, synthetic_lock(payload))
+
+    def test_existing_snapshot_values_round_trip_through_the_source_parser(self):
+        snapshot = json.loads((ROOT / "src/data/generated/ssn-cce-2024.json").read_text())
+        for group in [snapshot["national"], *snapshot["regions"], *snapshot["entities"]]:
+            for metric, cents in group["values"].items():
+                sign = "-" if cents < 0 else ""
+                euros, remainder = divmod(abs(cents), 100)
+                raw = f"{sign}{euros}.{remainder:02d}"
+                self.assertEqual(ETL.parse_amount_cents(raw, metric), cents)
+
     def test_build_snapshot_uses_official_national_and_regional_inputs(self):
         lock = copy.deepcopy(ETL.load_lock(SPEC_PATH))
         metric_rows = [


### PR DESCRIPTION
OpenCivitas 2022 e SSN/CCE condividono la conversione monetaria in centesimi, mantenendo i rispettivi formati: virgola e ROUND_HALF_UP per OpenCivitas; punto e due decimali esatti per SSN. `MoneyPolicy` rende espliciti formato, unità, segno, spazi e arrotondamento; i wrapper conservano gli errori con campo/riga.

Closes #315

La conversione usa Decimal senza float e senza arrotondamenti intermedi dovuti al contesto del chiamante. Vuoti, privacy, riconciliazioni e vincoli contabili restano negli adapter; nessuna modifica a snapshot, fonti, periodi, UI, API o MCP. OpenCivitas 2021 e SIOPE restano fuori dalla migrazione.

## Evidenza

- [x] Revisione completa del diff: nove file, limitati a helper, due adapter, test, documentazione e relativo registro dei controlli.
- [x] Sei test di caratterizzazione superati prima della migrazione; 12 test helper/adapter e 7 test SSN superati dopo.
- [x] Casi parametrizzati: unità euro/centesimi, segni, precisione, arrotondamento, formati/raggruppamenti, limiti sicuri, non finiti, valori mancanti e oscurati; test di riconciliazione e conversione di tutte le celle monetarie degli snapshot esistenti.
- [x] 20.000 confronti deterministici con le implementazioni di main: risultati identici.
- [x] Node completo: 1.129 PASS, un test live OpenBDAP saltato per fonte non raggiungibile. La prima esecuzione nel sandbox incontrava listen EPERM; la suite completa è passata con loopback consentito.
- [x] Static, action pins, 35 controlli offline degli snapshot, build e git diff --check PASS.
- [x] Suite ETL completa offline: 564 test, 7 skip previsti; tutti i gate di produzione PASS (Browser, MCP HTTP/load, CSP, Lighthouse). Navigazione con sidebar verificata su 55 destinazioni e 9 larghezze.
- [x] CI remota interamente verde sulla SHA `ca0a8862a61b7ec7176bdc4c4bc86a6b38a92595`: required, static, Node, ETL, produzione, CodeQL, dependency review, Zizmor e Vercel. Nessuna review o discussione inline pendente.
- [x] Preview Vercel controllata personalmente nel Browser a 1280 px: tabella SSN, importi attesi, sidebar attuale, nessun overflow globale o errore console.

API e policy documentate in `docs/ETL_MONETARY_PARSING.md`. Nessun artifact o metadato di fonte rigenerato. Non sono necessari nuovi download delle fonti per il refactoring.

