### PR TITLE
fix(charts): aggiorna valori e variazioni con il cursore

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bench:runtime": "node --experimental-strip-types scripts/bench/runtime.mjs",
     "test:browser:navigation": "node --experimental-strip-types scripts/browser/navigation.mjs",
     "test:browser:core": "node scripts/browser/core.mjs",
+    "test:browser:charts": "node scripts/browser/chart-interactions.mjs",
     "test:browser:papers": "node scripts/browser/papers.mjs",
     "test:browser:editorial": "node --experimental-strip-types scripts/browser/editorial.mjs",
     "test:browser:report": "node scripts/browser/report.mjs",

--- a/scripts/browser/chart-interactions.mjs
+++ b/scripts/browser/chart-interactions.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { closeBrowser, defaultBaseUrl, launchBrowser, runScenario } from "./harness.mjs";
+import { inspectRecharts, RECHARTS_ROUTES } from "./recharts-interactions.mjs";
+
+const baseUrl = defaultBaseUrl();
+const chronology = JSON.parse(readFileSync(new URL("../etl/specs/government-scorecard-chronology.json", import.meta.url), "utf8"));
+
+export async function inspectGovernmentChart(page, card) {
+  const svg = await card.$('svg[tabindex="0"]');
+  if (!svg) return;
+  const id = await card.evaluate((element) => element.dataset.slideId);
+  const read = () => card.evaluate((element) => ({
+    id: element.dataset.slideId,
+    period: element.querySelector('[role="status"] strong').textContent,
+    summaries: [...element.querySelectorAll('[data-series-summary]')].map((summary) => ({
+      period: summary.querySelector('[data-selected-period]')?.textContent,
+      value: summary.querySelector('[data-selected-value]')?.textContent,
+      change: summary.querySelector('[data-selected-change]')?.textContent,
+    })),
+    periods: [...element.querySelectorAll('thead th')].slice(1, -1).map((cell) => cell.textContent),
+    rows: [...element.querySelectorAll('tbody tr')].map((row) => [...row.querySelectorAll('td')].map((cell) => cell.textContent)),
+  }));
+  await svg.evaluate((element) => {
+    element.scrollIntoView({ block: "center", behavior: "instant" });
+    element.focus({ preventScroll: true });
+  });
+  for (const key of ["Home", "ArrowRight", "End", "ArrowLeft"]) {
+    await page.keyboard.press(key);
+    const state = await read();
+    assert.equal(state.id, id, `${id}: i tasti del grafico cambiano indicatore`);
+    assert.equal(state.summaries.length, 4, `${id}: riepiloghi della selezione assenti`);
+    const index = state.periods.indexOf(state.period);
+    assert.ok(index >= 0);
+    if (key === "Home") assert.equal(index, 0);
+    if (key === "End") assert.equal(index, state.periods.length - 1);
+    for (const [countryIndex, summary] of state.summaries.entries()) {
+      const observations = state.rows[countryIndex].slice(0, -1).filter((value) => value !== "n.d.");
+      if (observations.length === 0) {
+        assert.equal(summary.value, undefined);
+        continue;
+      }
+      assert.ok(summary.period.includes(state.period), `${id}: riepilogo fermo su un altro periodo`);
+      assert.equal(summary.value, state.rows[countryIndex][index], `${id}: valore diverso dalla tabella`);
+      const number = (value) => Number(value.split(" · ")[0].replaceAll(".", "").replace(",", "."));
+      const first = observations[0];
+      if (summary.value !== "n.d." && observations.length >= 2) {
+        const tolerance = (await card.evaluate((element) => element.textContent.includes("Valori: Euro"))) ? 1 : 0.02;
+        assert.ok(Math.abs(number(summary.change) - (number(summary.value) - number(first))) <= tolerance,
+          `${id}: variazione incoerente con il valore selezionato`);
+      } else assert.equal(summary.change, "n.d.");
+    }
+  }
+  // Real pointer coordinates in the SVG viewBox, including its responsive transform.
+  const target = await svg.evaluate((element) => {
+    const point = element.createSVGPoint();
+    point.x = 62;
+    point.y = 120;
+    const screen = point.matrixTransform(element.getScreenCTM());
+    return { x: screen.x, y: screen.y };
+  });
+  if ((await page.viewport()).hasTouch) await page.touchscreen.tap(target.x, target.y);
+  else await page.mouse.move(target.x, target.y);
+  await page.waitForFunction((slideId) => {
+    const element = document.querySelector(`[data-slide-id="${slideId}"]`);
+    return element.querySelector('[role="status"] strong').textContent === element.querySelector('thead th:nth-child(2)').textContent;
+  }, {}, id);
+  const pointerState = await read();
+  assert.ok(pointerState.summaries.every((summary) => summary.period === undefined || summary.period.includes(pointerState.period)), `${id}: puntatore e riepilogo non sincronizzati`);
+}
+
+const browser = await launchBrowser();
+try {
+  const scenarios = [390, 768, 1280].map((width) => ({ width, id: "berlusconi-iv" }));
+  for (const government of chronology.governments) {
+    if (government.id !== "berlusconi-iv") scenarios.push({ width: 1280, id: government.id });
+  }
+  for (const { width, id } of scenarios) {
+    await runScenario(browser, {
+      suite: "chart-interactions", label: `government-chart-${id}-${width}`, pathname: `/governi/${id}`, width, baseUrl,
+      validate: async (page) => {
+        await page.waitForSelector('[data-slide-id]');
+        await inspectGovernmentChart(page, await page.$('[data-slide-id]'));
+        await page.evaluate(() => [...document.querySelectorAll('button')].find((button) => button.textContent === "Vista elenco").click());
+        await page.waitForSelector('[data-view="list"]');
+        for (const scope of ["Mandato", "Serie completa"]) {
+          await page.evaluate((text) => [...document.querySelectorAll('button')].find((button) => button.textContent === text).click(), scope);
+          for (const card of await page.$$('[data-slide-id]')) await inspectGovernmentChart(page, card);
+        }
+        assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), true, "overflow della pagina");
+      },
+    });
+    console.log(`PASS government chart interactions ${id} ${width}px`);
+  }
+  for (const width of [390, 768, 1280]) {
+    for (const [pathname, minimumCharts] of RECHARTS_ROUTES) {
+      await runScenario(browser, {
+        suite: "chart-interactions", label: `chart-${pathname}-${width}`, pathname, width, baseUrl,
+        validate: (page) => inspectRecharts(page, minimumCharts),
+      });
+      console.log(`PASS chart interactions ${pathname} ${width}px`);
+    }
+  }
+} finally { await closeBrowser(browser); }

--- a/scripts/browser/recharts-interactions.mjs
+++ b/scripts/browser/recharts-interactions.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+
+// Covers snapshot-backed Recharts through public callers. State spending,
+// administrations and datasets reuse SpendingBarChart, exercised with the
+// committed vincitori dataset so a live OpenBDAP outage cannot fail this gate.
+export const RECHARTS_ROUTES = [
+  ["/debito", 1], ["/spese/sanita/storico", 2], ["/coesione", 1],
+  ["/istruzione", 1], ["/report/2026-08", 2], ["/dati/vincitori", 1], ["/enti", 1],
+  ["/spese/sanita", 1], ["/palazzo-chigi", 1], ["/ministeri", 1],
+  ["/regioni", 1], ["/spese/legge-di-bilancio", 2],
+];
+
+export async function inspectRecharts(page, minimumCharts) {
+  await page.waitForFunction((minimum) => document.querySelectorAll('.recharts-wrapper svg').length >= minimum, {}, minimumCharts);
+  const charts = await page.$$(".recharts-wrapper");
+  for (const [index, chart] of charts.entries()) {
+    await chart.evaluate((element) => element.scrollIntoView({ block: "center", behavior: "instant" }));
+    const targets = await chart.evaluate((element) => {
+      const bars = [...element.querySelectorAll(".recharts-bar-rectangle path")];
+      const tiles = [...element.querySelectorAll(".recharts-treemap-depth-1 rect")];
+      const marks = bars.length ? bars : tiles;
+      if (marks.length) return marks.map((mark) => {
+        const box = mark.getBoundingClientRect();
+        return { x: box.x + box.width / 2, y: box.y + box.height / 2 + scrollY, width: box.width, height: box.height };
+      }).filter((box) => box.width > 2 && box.height > 2).slice(0, 3);
+      const grid = element.querySelector(".recharts-cartesian-grid");
+      if (!grid) return [];
+      const box = grid.getBoundingClientRect();
+      return [0.15, 0.5, 0.85].map((ratio) => ({ x: box.x + box.width * ratio, y: box.y + box.height / 2 + scrollY }));
+    });
+    assert.ok(targets.length >= 2, `grafico ${index}: almeno due punti da controllare`);
+    const texts = [];
+    for (const target of targets) {
+      // Tall rankings exceed the viewport. Bring each mark below the sticky
+      // header before sending actual input, instead of hovering the header.
+      const position = await page.evaluate((point) => {
+        window.scrollTo({ top: point.y - innerHeight / 2, behavior: "instant" });
+        return { x: point.x, y: point.y - scrollY };
+      }, target);
+      if ((await page.viewport()).hasTouch) await page.touchscreen.tap(position.x, position.y);
+      else await page.mouse.move(position.x, position.y);
+      await page.waitForFunction((element) => {
+        const tooltip = element.querySelector(".recharts-tooltip-wrapper");
+        return tooltip && getComputedStyle(tooltip).visibility === "visible" && tooltip.textContent.length > 0;
+      }, {}, chart);
+      texts.push(await chart.evaluate((element) => element.querySelector(".recharts-tooltip-wrapper").textContent));
+    }
+    assert.ok(new Set(texts).size >= 2, `grafico ${index}: il contenuto non segue il punto selezionato`);
+  }
+}

--- a/scripts/ci/run-production-gates.sh
+++ b/scripts/ci/run-production-gates.sh
@@ -111,6 +111,10 @@ echo "::group::Browser core suite"
 npm run test:browser:core
 echo "::endgroup::"
 
+echo "::group::Browser chart interactions"
+npm run test:browser:charts
+echo "::endgroup::"
+
 echo "::group::Browser editorial suite"
 npm run test:browser:editorial
 echo "::endgroup::"

--- a/src/app/governi/_components/chart-utils.ts
+++ b/src/app/governi/_components/chart-utils.ts
@@ -57,6 +57,21 @@ export function hasGovernmentChartTrend(periods: readonly string[]): boolean {
   return new Set(periods).size >= 2;
 }
 
+export function getGovernmentChartSelection(
+  points: readonly GovernmentChartPoint[],
+  period: string | null,
+) {
+  const first = points[0];
+  const selected = points.find((point) => point.period === period);
+  return {
+    first,
+    selected,
+    change: first && selected && hasGovernmentChartTrend(points.map((point) => point.period))
+      ? selected.value - first.value
+      : null,
+  };
+}
+
 function governmentChartPeriodEndExclusive(
   periodStart: string,
   frequency: GovernmentScorecardV6ChartSlide["frequency"],

--- a/src/app/governi/_components/indicator-carousel.tsx
+++ b/src/app/governi/_components/indicator-carousel.tsx
@@ -22,6 +22,7 @@ import {
   formatGovernmentChartPeriod,
   formatGovernmentChartPointStatus,
   formatGovernmentChartValue,
+  getGovernmentChartSelection,
   GOVERNMENT_CHART_COLORS,
   GOVERNMENT_CHART_MARKERS,
   GOVERNMENT_CHART_PATTERNS,
@@ -137,6 +138,10 @@ function IndicatorChart({
       change: first && last && last.period_start > first.period_start ? last.value - first.value : null,
     };
   });
+  const selections = visibleSeries.map((series) => ({
+    ...series,
+    ...getGovernmentChartSelection(series.points, activePeriod),
+  }));
 
   return (
     <article
@@ -253,17 +258,17 @@ function IndicatorChart({
         </div>
       )}
 
-      <div className={styles.seriesSummary} aria-label="Valori iniziali, finali e variazioni">
-        {summaries.map((series) => (
-          <article key={series.id}>
+      <div className={styles.seriesSummary} aria-label="Valori iniziali, selezionati e variazioni">
+        {selections.map((series) => (
+          <article key={series.id} data-series-summary={series.id}>
             <h4><span style={{ backgroundColor: GOVERNMENT_CHART_COLORS[series.id] }} aria-hidden="true" /><b aria-hidden="true">{GOVERNMENT_CHART_MARKERS[series.id]}</b>{series.label}</h4>
-            {series.first && series.last && series.change !== null ? (
+            {series.first ? (
               <dl>
                 <div><dt>Inizio del periodo · {formatGovernmentChartPeriod(series.first.period)}</dt><dd>{formatGovernmentChartValue(series.first.value, chart.unit)}{formatGovernmentChartPointStatus(series.first)}</dd></div>
-                <div><dt>Fine del periodo · {formatGovernmentChartPeriod(series.last.period)}</dt><dd>{formatGovernmentChartValue(series.last.value, chart.unit)}{formatGovernmentChartPointStatus(series.last)}</dd></div>
-                <div><dt>Variazione</dt><dd>{formatChange(series.change, chart.unit)}</dd></div>
+                <div><dt data-selected-period>Periodo selezionato · {activePeriod === null ? "n.d." : formatGovernmentChartPeriod(activePeriod)}</dt><dd data-selected-value>{series.selected ? `${formatGovernmentChartValue(series.selected.value, chart.unit)}${formatGovernmentChartPointStatus(series.selected)}` : "n.d."}</dd></div>
+                <div><dt>Variazione dall’inizio</dt><dd data-selected-change>{series.change === null ? "n.d." : formatChange(series.change, chart.unit)}</dd></div>
               </dl>
-            ) : <p>Servono almeno due periodi pubblicati per calcolare una variazione.</p>}
+            ) : <p>Nessun dato pubblicato nel periodo.</p>}
           </article>
         ))}
       </div>
@@ -277,7 +282,7 @@ function IndicatorChart({
               <tr>
                 <th scope="col">Paese</th>
                 {periods.map((period) => <th scope="col" key={period}>{formatGovernmentChartPeriod(period)}</th>)}
-                <th scope="col">Variazione</th>
+                <th scope="col">Variazione intero periodo</th>
               </tr>
             </thead>
             <tbody>
@@ -318,6 +323,7 @@ export function IndicatorCarousel({ charts }: { charts: GovernmentScorecardV6Cha
 
   const move = (delta: number) => setActiveIndex((current) => (current + delta + total) % total);
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if ((event.target as Element).closest('[data-chart-plot="true"]')) return;
     if (event.key === "ArrowLeft") {
       event.preventDefault();
       move(-1);
@@ -363,7 +369,7 @@ export function IndicatorCarousel({ charts }: { charts: GovernmentScorecardV6Cha
         <ol className={styles.indicatorList} aria-label="Tutti i grafici degli indicatori">
           {charts.slides.map((chart, index) => (
             <li key={chart.indicator_id}>
-              <IndicatorChart chart={chart} scope={scope} position={index + 1} total={total} listView />
+              <IndicatorChart key={scope} chart={chart} scope={scope} position={index + 1} total={total} listView />
             </li>
           ))}
         </ol>
@@ -379,7 +385,7 @@ export function IndicatorCarousel({ charts }: { charts: GovernmentScorecardV6Cha
           onPointerUp={onPointerUp}
           onPointerCancel={() => { pointerStart.current = null; }}
         >
-          <IndicatorChart chart={activeSlide} scope={scope} position={activeIndex + 1} total={total} />
+          <IndicatorChart key={`${activeSlide.indicator_id}-${scope}`} chart={activeSlide} scope={scope} position={activeIndex + 1} total={total} />
         </div>
       )}
 

--- a/tests/government-scorecard-chart.test.mjs
+++ b/tests/government-scorecard-chart.test.mjs
@@ -12,12 +12,32 @@ const {
   formatGovernmentChartPeriod,
   formatGovernmentChartPublicationStatus,
   formatGovernmentChartPointStatus,
+  getGovernmentChartSelection,
   GOVERNMENT_CHART_COLORS,
   hasGovernmentChartTrend,
   isGovernmentChartPointInWindow,
   isGovernmentChartStartBoundaryPeriod,
   splitGovernmentChartAtMissingPeriods,
 } = await import("../src/app/governi/_components/chart-utils.ts");
+
+test("selection compares the exact selected observation with the start, without filling gaps", () => {
+  const points = [
+    { period: "2008-05", value: 3.7, status: "observed" },
+    { period: "2009-02", value: 1.4, status: "estimated" },
+    { period: "2011-11", value: 3.7, status: "observed" },
+  ];
+  const selected = getGovernmentChartSelection(points, "2009-02");
+  assert.equal(selected.selected, points[1]);
+  assert.equal(selected.first, points[0]);
+  assert.ok(Math.abs(selected.change - (-2.3)) < 1e-10);
+  assert.equal(getGovernmentChartSelection(points, "2008-05").change, 0);
+  assert.equal(getGovernmentChartSelection(points, "2011-11").change, 0);
+  assert.equal(getGovernmentChartSelection(points, "2010-01").change, null);
+  assert.equal(getGovernmentChartSelection(points, null).selected, undefined);
+  assert.equal(getGovernmentChartSelection([], "2009-02").change, null);
+  assert.equal(getGovernmentChartSelection([points[0]], "2008-05").change, null);
+  assert.equal(getGovernmentChartSelection([{ period: "2020", value: 0 }, { period: "2021", value: -2 }], "2021").change, -2);
+});
 
 test("pointer positions map to the closest bounded chart period", () => {
   assert.equal(getClosestGovernmentChartPointIndex(0, 100), null);


### PR DESCRIPTION
## Cosa cambia

Nelle pagelle dei governi il cursore aggiornava il tooltip, ma le schede continuavano a confrontare inizio e fine dell'intero mandato. Ora mostrano il valore del periodo selezionato e la variazione rispetto all'inizio: per l'inflazione italiana di febbraio 2009, 1,4 rispetto a 3,7 iniziale produce −2,3, anziché lo zero dell'intero mandato.

I tasti freccia e Home/End nel grafico non comandano più anche il carosello. Cambiare indicatore o intervallo ripristina la selezione; dati mancanti e serie con un solo periodo mantengono la variazione non disponibile. La tabella conserva il confronto esplicitamente etichettato «Variazione intero periodo».

La PR comprende soltanto sette file: componente e funzione di selezione, test Node, due script browser, comando npm e collegamento al runner di produzione. Snapshot, metodologia e API non cambiano.

## Evidenza

- [x] Il diff è limitato al problema dichiarato.
- [x] Riprodotto prima della correzione il cursore che cambia periodo con riepiloghi invariati; aggiunti test di regressione del calcolo e delle interazioni.
- [x] Eseguiti controlli statici (lint, typecheck, report, design e brand), action pins e build.
- [x] Eseguite suite Node ed ETL con network guard: gli unici errori erano socket locali vietati dal sandbox; i rispettivi test del guard sono passati nella riesecuzione con loopback consentito. Restano gli skip previsti dalle suite (3 Node, 7 ETL).
- [x] Passati tutti i 37 controlli offline degli snapshot.
- [x] Verificato `git diff --check`.

### UI e accessibilità

- [x] Tastiera, focus, stati senza dati, console e tabelle equivalenti verificati.
- [x] Caso segnalato: nove indicatori, Mandato/Serie completa, carosello/elenco e input mouse/tocco/tastiera a 390, 768 e 1280 px.
- [x] Tutti i 17 governi verificati a 1280 px; dodici ulteriori pagine con grafici Recharts a 390, 768 e 1280 px.
- [x] Passate le suite di produzione per navigazione, browser core, paper, editoriale, segnalazioni simulate, report mensili, studi e CSP; passati smoke/load MCP e soglie Lighthouse (mediana di tre run).

## Limiti e prove non eseguite

Il runner completo di produzione si è inizialmente fermato perché il nuovo test assumeva tre grafici in `/stato`, mentre OpenBDAP ne rendeva disponibili solo due. Il test permanente usa ora `/dati/vincitori`, snapshot versionato che esercita lo stesso componente a barre. Dopo questa correzione sono stati rieseguiti con successo i controlli Recharts e tutti i gate restanti sulla medesima build; non è stato ripetuto il runner completo dall'inizio.

Lo storico mensile live dello Stato non era disponibile per la verifica browser; il relativo componente è stato controllato nel codice. I controlli touch sono emulati in Chromium, non eseguiti su dispositivi fisici. CI remota e preview sono da verificare sulla PR.
