### PR TITLE
fix: sottoscrizioni MCP e distinzione fra app e fonti indisponibili

### DIFF
--- a/.github/workflows/runtime-health.yml
+++ b/.github/workflows/runtime-health.yml
@@ -57,10 +57,18 @@ jobs:
               const revision = checks.find((check) => check?.name === "health")?.revision;
               console.log("| Field | Value |");
               console.log("| --- | --- |");
-              console.log(`| Result | ${payload?.ok === true ? "pass" : "fail"} |`);
+              console.log(`| Application | ${payload?.ok === true ? "pass" : "fail"} |`);
               console.log(`| Checks | ${passed} pass, ${failed} fail, ${checks.length} total |`);
               console.log(`| Warnings | ${warnings} |`);
               console.log(`| Revision | ${/^[0-9a-f]{40}$/u.test(revision ?? "") ? revision : "unknown"} |`);
+              if (warnings > 0) {
+                console.log("");
+                console.log("Upstream degradation remains visible in Source health; it does not imply an application outage.");
+                for (const warning of payload.warnings) {
+                  const sources = Array.isArray(warning.down) ? warning.down.filter((id) => /^[a-z0-9-]+$/.test(id)) : [];
+                  console.log(`- Unreachable official sources: ${sources.join(", ")}`);
+                }
+              }
             } catch {
               console.log("_The health probe payload was not valid JSON._");
             }
@@ -68,8 +76,8 @@ jobs:
           NODE
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload runtime health evidence on failure
-        if: failure()
+      - name: Preserve runtime health evidence including upstream warnings
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: runtime-health

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,19 @@ osservare le fonti ufficiali esterne e aggiornare gli snapshot. Il validatore
 offline viene usato sia localmente sia nei workflow di refresh, garantendo una
 sola implementazione del contratto.
 
+### Disponibilità dell'app e delle fonti
+
+`Runtime health` controlla ogni 15 minuti homepage, health, contratto del registro
+fonti e chiamate MCP. Una risposta valida che segnala una fonte esterna `down`
+produce un avviso con gli ID delle fonti: non equivale a un down dell'app.
+Errori HTTP dell'endpoint DVNS, contratti malformati e guasti MCP restano bloccanti.
+Il report JSON viene conservato anche in presenza di soli avvisi.
+
+`Source health` resta il monitor dedicato, ogni sei ore, per indisponibilità
+upstream e validità dello snapshot SSN. Il monitor parlamentare conserva i propri
+retry e controlli. Gli avvisi runtime non rendono raggiungibile una fonte né
+aggiornano o convalidano nuovamente gli snapshot.
+
 ### Network guard
 
 La CI attiva un **application-level network guard** durante la verifica ETL e

--- a/scripts/browser/assistant-attachments.mjs
+++ b/scripts/browser/assistant-attachments.mjs
@@ -11,8 +11,9 @@ const fixture=name=>resolve('tests/fixtures/assistant',name);
 let activePage,activeWidth;
 try {
   for(const width of process.env.DVNS_ATTACHMENT_WIDTH ? [Number(process.env.DVNS_ATTACHMENT_WIDTH)] : [320,390,743,768,983,1280]) {
-    const page=await browser.newPage(),errors=[],requests=[]; activePage=page;activeWidth=width;
+    const page=await browser.newPage(),errors=[],requests=[],workerEvents=[]; activePage=page;activeWidth=width;
     page.on('pageerror',error=>errors.push(error.message));
+    for(const event of ['workercreated','workerdestroyed'])page.on(event,()=>{workerEvents.push({event,at:Date.now()});if(workerEvents.length>64)workerEvents.shift();});
     await page.setViewport({width,height:[743,768,983].includes(width)?695:844});
     await page.setRequestInterception(true);
     page.on('request',request=>{
@@ -23,9 +24,21 @@ try {
       void request.respond({status:200,contentType:'text/event-stream',body:[...activities.map(activity=>({type:'activity',activity})),{type:'delta',text:answer.text},{type:'done',response:answer}].map(e=>`data: ${JSON.stringify(e)}\n\n`).join('')});
     });
     await page.goto(new URL('/assistente',defaultBaseUrl()).href,{waitUntil:'networkidle0'});
-    await page.evaluate(()=>{window.__progress=[];new MutationObserver(()=>{for(const el of document.querySelectorAll('[role="progressbar"]'))window.__progress.push(Number(el.getAttribute('aria-valuenow')));}).observe(document.body,{subtree:true,childList:true,attributes:true,attributeFilter:['aria-valuenow']});});
+    await page.evaluate(()=>{
+      window.__progress=[];window.__preparationTimeline=[];
+      new MutationObserver(()=>{
+        for(const el of document.querySelectorAll('[role="progressbar"]')){
+          const progress=Number(el.getAttribute('aria-valuenow'));window.__progress.push(progress);
+          const item=el.closest('li');
+          const record={slot:item?Array.from(item.parentElement.children).indexOf(item):-1,progress,at:performance.now()};
+          const previous=window.__preparationTimeline.at(-1);
+          if(!previous||previous.slot!==record.slot||previous.progress!==record.progress)window.__preparationTimeline.push(record);
+          if(window.__preparationTimeline.length>128)window.__preparationTimeline.shift();
+        }
+      }).observe(document.body,{subtree:true,childList:true,attributes:true,attributeFilter:['aria-valuenow']});
+    });
     const upload=async paths=>{const input=await page.$('input[type="file"]');await input.uploadFile(...paths);};
-    const ready=async count=>page.waitForFunction(count=>document.querySelectorAll('[aria-label="Allegati da inviare"] li[data-ready="true"][data-error="false"]').length===count,{},count).catch(async error=>{await page.screenshot({path:`artifacts/browser/assistant-attachments-${width}-failure.png`,fullPage:true});console.error(JSON.stringify({width,errors,files:await page.$$eval('[aria-label="Allegati da inviare"] li',els=>els.map(el=>({title:el.title,ready:el.dataset.ready,error:el.dataset.error}))),alerts:await page.$$eval('[role="alert"]',els=>els.map(el=>el.textContent))}));throw error;});
+    const ready=async count=>page.waitForFunction(count=>document.querySelectorAll('[aria-label="Allegati da inviare"] li[data-ready="true"][data-error="false"]').length===count,{},count).catch(async error=>{await page.screenshot({path:`artifacts/browser/assistant-attachments-${width}-failure.png`,fullPage:true});console.error(JSON.stringify({width,errors,workerEvents,preparationTimeline:await page.evaluate(()=>window.__preparationTimeline),files:await page.$$eval('[aria-label="Allegati da inviare"] li',els=>els.map(el=>({title:el.title,ready:el.dataset.ready,error:el.dataset.error}))),alerts:await page.$$eval('[role="alert"]',els=>els.map(el=>el.textContent))}));throw error;});
     const click=label=>page.click(`button[aria-label="${label}"]`);
     const complete=number=>page.waitForFunction(number=>!!document.querySelector('[data-assistant-reply] table')&&document.querySelector('[data-assistant-reply]')?.textContent.includes(`Risposta di prova ${number}.`)&&!document.querySelector('button[aria-label="Interrompi ricerca"]'),{},number);
     await upload(['riepilogo.pdf','relazione.docx','pagamenti.xlsx','nota.txt','criteri.md','nota.txt','criteri.md','nota.txt'].map(fixture));await ready(8);

--- a/scripts/mcp_http_smoke.mjs
+++ b/scripts/mcp_http_smoke.mjs
@@ -63,6 +63,52 @@ async function mcpRequest(
 
 await waitForServer();
 
+// Exercise the real HTTP path: an internal rewrite may compress and buffer SSE
+// even when the route-level ReadableStream tests deliver frames immediately.
+for (const pathname of ["/api/mcp", "/mcp"]) {
+  const caller = new AbortController();
+  const timer = setTimeout(() => caller.abort(), 5_000);
+  let reader;
+  try {
+    const response = await fetch(new URL(pathname, baseUrl), {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Accept-Encoding": "gzip",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "MCP-Method": "subscriptions/listen",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "subscription-smoke", method: "subscriptions/listen", params: {
+        notifications: { toolsListChanged: true },
+        _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} },
+      } }),
+      signal: caller.signal,
+    });
+    assert.equal(response.status, 200, `${pathname}: subscription must succeed`);
+    assert.equal(response.headers.get("cache-control"), "private, no-store, no-transform");
+    assert.equal(response.headers.get("content-encoding"), null, `${pathname}: SSE must not be compressed`);
+    reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let frame = "";
+    while (!frame.includes("\n\n")) {
+      const chunk = await reader.read();
+      assert.equal(chunk.done, false, `${pathname}: stream closed before acknowledgement`);
+      frame += decoder.decode(chunk.value, { stream: true });
+      assert.ok(byteLength(frame) <= 8_192, `${pathname}: oversized acknowledgement`);
+    }
+    const data = frame.split("\n").find((line) => line.startsWith("data: "));
+    assert.ok(data, `${pathname}: missing acknowledgement`);
+    const ack = JSON.parse(data.slice(6));
+    assert.equal(ack.method, "notifications/subscriptions/acknowledged");
+    assert.equal(ack.params.notifications.toolsListChanged, true);
+  } finally {
+    clearTimeout(timer);
+    await reader?.cancel().catch(() => undefined);
+    caller.abort();
+  }
+}
+
 const pageResponse = await fetch(new URL("/territori/irpef", baseUrl), {
   signal: AbortSignal.timeout(10_000),
 });

--- a/scripts/mcp_http_smoke.mjs
+++ b/scripts/mcp_http_smoke.mjs
@@ -63,52 +63,6 @@ async function mcpRequest(
 
 await waitForServer();
 
-// Exercise the real HTTP path: an internal rewrite may compress and buffer SSE
-// even when the route-level ReadableStream tests deliver frames immediately.
-for (const pathname of ["/api/mcp", "/mcp"]) {
-  const caller = new AbortController();
-  const timer = setTimeout(() => caller.abort(), 5_000);
-  let reader;
-  try {
-    const response = await fetch(new URL(pathname, baseUrl), {
-      method: "POST",
-      headers: {
-        Accept: "application/json, text/event-stream",
-        "Accept-Encoding": "gzip",
-        "Content-Type": "application/json",
-        "MCP-Protocol-Version": "2026-07-28",
-        "MCP-Method": "subscriptions/listen",
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", id: "subscription-smoke", method: "subscriptions/listen", params: {
-        notifications: { toolsListChanged: true },
-        _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} },
-      } }),
-      signal: caller.signal,
-    });
-    assert.equal(response.status, 200, `${pathname}: subscription must succeed`);
-    assert.equal(response.headers.get("cache-control"), "private, no-store, no-transform");
-    assert.equal(response.headers.get("content-encoding"), null, `${pathname}: SSE must not be compressed`);
-    reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let frame = "";
-    while (!frame.includes("\n\n")) {
-      const chunk = await reader.read();
-      assert.equal(chunk.done, false, `${pathname}: stream closed before acknowledgement`);
-      frame += decoder.decode(chunk.value, { stream: true });
-      assert.ok(byteLength(frame) <= 8_192, `${pathname}: oversized acknowledgement`);
-    }
-    const data = frame.split("\n").find((line) => line.startsWith("data: "));
-    assert.ok(data, `${pathname}: missing acknowledgement`);
-    const ack = JSON.parse(data.slice(6));
-    assert.equal(ack.method, "notifications/subscriptions/acknowledged");
-    assert.equal(ack.params.notifications.toolsListChanged, true);
-  } finally {
-    clearTimeout(timer);
-    await reader?.cancel().catch(() => undefined);
-    caller.abort();
-  }
-}
-
 const pageResponse = await fetch(new URL("/territori/irpef", baseUrl), {
   signal: AbortSignal.timeout(10_000),
 });
@@ -581,6 +535,55 @@ for (const year of [2020, 2021, 2022]) {
   assert.equal(invalidApi.headers.get("cache-control"), "no-store");
 }
 
+// Let the existing public-client rate-limit window expire before the extra probes.
+await new Promise((resolve) => setTimeout(resolve, 60_100));
+
+// Exercise the real HTTP path: an internal rewrite may compress and buffer SSE
+// even when the route-level ReadableStream tests deliver frames immediately.
+for (const pathname of ["/api/mcp", "/mcp"]) {
+  const caller = new AbortController();
+  const timer = setTimeout(() => caller.abort(), 5_000);
+  let reader;
+  try {
+    const response = await fetch(new URL(pathname, baseUrl), {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Accept-Encoding": "gzip",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "MCP-Method": "subscriptions/listen",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "subscription-smoke", method: "subscriptions/listen", params: {
+        notifications: { toolsListChanged: true },
+        _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} },
+      } }),
+      signal: caller.signal,
+    });
+    assert.equal(response.status, 200, `${pathname}: subscription must succeed`);
+    assert.equal(response.headers.get("cache-control"), "private, no-store, no-transform");
+    assert.equal(response.headers.get("content-encoding"), null, `${pathname}: SSE must not be compressed`);
+    reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let frame = "";
+    while (!frame.includes("\n\n")) {
+      const chunk = await reader.read();
+      assert.equal(chunk.done, false, `${pathname}: stream closed before acknowledgement`);
+      frame += decoder.decode(chunk.value, { stream: true });
+      assert.ok(byteLength(frame) <= 8_192, `${pathname}: oversized acknowledgement`);
+    }
+    const data = frame.split("\n").find((line) => line.startsWith("data: "));
+    assert.ok(data, `${pathname}: missing acknowledgement`);
+    const ack = JSON.parse(data.slice(6));
+    assert.equal(ack.method, "notifications/subscriptions/acknowledged");
+    assert.equal(ack.params.notifications.toolsListChanged, true);
+  } finally {
+    clearTimeout(timer);
+    await reader?.cancel().catch(() => undefined);
+    caller.abort();
+  }
+}
+
 console.log(JSON.stringify({
   ok: true,
   baseUrl: baseUrl.origin,
@@ -598,6 +601,8 @@ console.log(JSON.stringify({
     "unsupported-detail-filter",
     "integrated-query",
     "education-query-pagination-provenance",
+    "modern-subscriptions",
+    "compatibility-modern-subscriptions",
     "modern-discovery",
     "compatibility-modern-discovery",
     "modern-query",

--- a/scripts/runtime-health.mjs
+++ b/scripts/runtime-health.mjs
@@ -450,16 +450,15 @@ export function validateSourceHealthPayload(response, body) {
       code: "invalid_source_health_contract",
     });
   }
-  if (down.length > 0) {
-    throw new RuntimeHealthError(`${down.length} fonte/i ufficiale/i non raggiungibile/i`, {
-      code: "source_unreachable",
-    });
-  }
   return {
     status: response.status,
     active: active.length,
     reachable: reachable.length,
     notProbed: notProbed.length,
+    ...(down.length > 0 ? {
+      warning: `${down.length} fonte/i ufficiale/i non raggiungibile/i; dettagli nel monitor Source health`,
+      down: down.map((source) => source.sourceId),
+    } : {}),
   };
 }
 
@@ -630,7 +629,7 @@ function safeError(error) {
 function checkRecord(name, result, startedAt) {
   return {
     name,
-    status: "pass",
+    status: result.warning ? "warning" : "pass",
     durationMs: Math.max(0, Date.now() - startedAt),
     attempts: result.attempts ?? 1,
     ...Object.fromEntries(
@@ -860,9 +859,6 @@ function printSummary(report) {
   for (const check of report.checks) {
     const detail = check.error ?? (check.warning ?? "ok");
     lines.push(`| ${check.name} | ${check.status} | ${check.attempts} | ${check.durationMs} ms | ${detail} |`);
-  }
-  for (const warning of report.warnings) {
-    lines.push(`| ${warning.check} | warning | — | — | ${warning.warning} |`);
   }
   const summary = lines.join("\n");
   console.log(summary);

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -204,6 +204,7 @@ async function requestWithBoundedBody(request: Request): Promise<Request | Respo
 
 export async function POST(request: Request) {
   const startedAt = performance.now();
+  let isSubscription = false;
   let operationalContext = extractMcpOperationalContext(request);
   const reportOperationalLimit = (
     outcome: "rate_limited" | "concurrency_limited" | "deadline_exceeded",
@@ -262,9 +263,11 @@ export async function POST(request: Request) {
         }
         if (boundedRequest instanceof Response) return boundedRequest;
         try {
+          const body = await boundedRequest.clone().json();
+          isSubscription = !Array.isArray(body) && body?.method === "subscriptions/listen";
           operationalContext = extractMcpOperationalContext(
             boundedRequest,
-            await boundedRequest.clone().json(),
+            body,
           );
         } catch {
           operationalContext = extractMcpOperationalContext(boundedRequest);
@@ -275,11 +278,14 @@ export async function POST(request: Request) {
       {
         requestId: () => operationalContext.requestId,
         onTimeout: () => reportOperationalLimit("deadline_exceeded", 504),
+        isSubscription: () => isSubscription,
+        onComplete: release,
       },
     );
     return secureResponse(response, request);
-  } finally {
+  } catch (error) {
     release();
+    throw error;
   }
 }
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -28,8 +28,12 @@ const handler = createMcpHandler(createDvnsMcpServer, {
   onerror: reportMcpHandlerError,
 });
 
-function secureResponse(response: Response, request?: Request): Response {
-  response.headers.set("Cache-Control", "private, no-store");
+function secureResponse(response: Response, request?: Request, subscription = false): Response {
+  // The compatibility rewrite runs through Next's compression middleware.
+  // Compressing a small SSE acknowledgement buffers it until the stream ends.
+  response.headers.set("Cache-Control", subscription && response.headers.get("content-type")?.startsWith("text/event-stream")
+    ? "private, no-store, no-transform"
+    : "private, no-store");
   response.headers.set("X-Content-Type-Options", "nosniff");
   if (request && requestHostAllowed(request)) {
     const origin = request.headers.get("origin");
@@ -282,7 +286,7 @@ export async function POST(request: Request) {
         onComplete: release,
       },
     );
-    return secureResponse(response, request);
+    return secureResponse(response, request, isSubscription);
   } catch (error) {
     release();
     throw error;

--- a/src/lib/mcp/request-deadline.ts
+++ b/src/lib/mcp/request-deadline.ts
@@ -3,7 +3,59 @@ type JsonRpcId = string | number | null;
 type DeadlineOptions = Readonly<{
   requestId?: () => JsonRpcId;
   onTimeout?: () => void;
+  isSubscription?: () => boolean;
+  onComplete?: () => void;
 }>;
+
+/** A subscription has a bounded lifetime, but its EOF is not an RPC timeout. */
+function subscriptionResponse(
+  response: Response,
+  signal: AbortSignal,
+  abort: () => void,
+  remainingMs: number,
+  onComplete?: () => void,
+): Response {
+  const reader = response.body!.getReader();
+  let closed = false;
+  let timer: ReturnType<typeof setTimeout>;
+  let output: ReadableStreamDefaultController<Uint8Array>;
+  const finish = (reason?: unknown, error = false, cancelled = false) => {
+    if (closed) return;
+    closed = true;
+    clearTimeout(timer);
+    signal.removeEventListener("abort", onAbort);
+    if (!cancelled) {
+      if (error) output.error(reason);
+      else output.close();
+    }
+    void reader.cancel(reason).catch(() => undefined).finally(() => reader.releaseLock());
+    abort();
+    onComplete?.();
+  };
+  const onAbort = () => finish(signal.reason);
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      output = controller;
+      timer = setTimeout(() => finish("MCP subscription lifetime ended"), remainingMs);
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) onAbort();
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (closed) return;
+        if (done) finish();
+        else controller.enqueue(value);
+      } catch (error) {
+        finish(error, true);
+      }
+    },
+    cancel(reason) { finish(reason, false, true); },
+  });
+  const headers = new Headers(response.headers);
+  headers.delete("Content-Length");
+  return new Response(body, { status: response.status, statusText: response.statusText, headers });
+}
 
 function timeoutResponse(id: JsonRpcId): Response {
   return Response.json(
@@ -60,7 +112,8 @@ async function bufferedResponse(
  * Draining is intentional: legacy Streamable HTTP replies expose their SSE
  * headers before a tool finishes. Waiting for the terminal frame keeps the
  * application deadline in charge of the whole exchange instead of only the
- * time-to-first-byte.
+ * time-to-first-byte. Subscription SSE is the exception: forward it immediately
+ * and end its lifetime with a clean EOF, retaining the slot until it closes.
  */
 export async function runMcpExchangeWithDeadline(
   request: Request,
@@ -68,6 +121,8 @@ export async function runMcpExchangeWithDeadline(
   timeoutMs: number,
   options: DeadlineOptions = {},
 ): Promise<Response> {
+  const startedAt = performance.now();
+  let streaming = false;
   const controller = new AbortController();
   const signal = request.signal.aborted
     ? request.signal
@@ -102,10 +157,27 @@ export async function runMcpExchangeWithDeadline(
     }, timeoutMs);
   });
 
-  const exchange = (async () => bufferedResponse(await fetcher(timedRequest), state))();
+  const exchange = (async () => {
+    const response = await fetcher(timedRequest);
+    if (state.timedOut) {
+      void response.body?.cancel("MCP deadline exceeded").catch(() => undefined);
+      return response;
+    }
+    if (!state.timedOut && response.ok && response.body
+      && response.headers.get("content-type")?.split(";", 1)[0].trim() === "text/event-stream"
+      && options.isSubscription?.()) {
+      streaming = true;
+      return subscriptionResponse(
+        response, signal, () => controller.abort(),
+        Math.max(0, timeoutMs - (performance.now() - startedAt)), options.onComplete,
+      );
+    }
+    return bufferedResponse(response, state);
+  })();
   try {
     return await Promise.race([exchange, deadline]);
   } finally {
     if (!state.timedOut && timer) clearTimeout(timer);
+    if (!streaming) options.onComplete?.();
   }
 }

--- a/tests/etl/test_workflow_governance.py
+++ b/tests/etl/test_workflow_governance.py
@@ -106,7 +106,12 @@ class WorkflowGovernanceTests(unittest.TestCase):
         self.assertNotIn("Object.entries(payload)", text)
         self.assertIn("| Warnings |", text)
         self.assertIn("| Revision |", text)
-        self.assertRegex(text, r"(?m)^\s*if:\s*failure\(\)\s*$")
+        # Upstream warnings are non-fatal for app availability, but their
+        # evidence must be retained just like application failures.
+        self.assertRegex(
+            text,
+            r"(?m)^\s*if:\s*always\(\)\s*\n\s*uses:\s*actions/upload-artifact@",
+        )
         self.assertIn("name: runtime-health", text)
         self.assertIn("path: ${{ runner.temp }}/runtime-health.json", text)
         self.assertIn("if-no-files-found: ignore", text)

--- a/tests/mcp-deadline.test.mjs
+++ b/tests/mcp-deadline.test.mjs
@@ -61,3 +61,91 @@ test("MCP deadline buffers a completed SSE response before returning it", async 
   assert.equal(response.headers.get("x-test"), "preserved");
   assert.equal(await response.text(), "event: message\ndata: complete\n\n");
 });
+
+test("MCP subscriptions deliver the acknowledgement immediately and close cleanly at the deadline", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  let cancelled = false, completed = 0, timeouts = 0, signal;
+  const pending = runMcpExchangeWithDeadline(
+    new Request("https://example.test/api/mcp", { method: "POST" }),
+    async (request) => {
+      signal = request.signal;
+      return new Response(new ReadableStream({
+        start(controller) { controller.enqueue(new TextEncoder().encode("data: acknowledged\n\n")); },
+        cancel() { cancelled = true; },
+      }), { headers: { "Content-Type": "text/event-stream" } });
+    },
+    25,
+    { isSubscription: () => true, onComplete: () => completed++, onTimeout: () => timeouts++ },
+  );
+  let response;
+  pending.then((value) => { response = value; });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(response, "subscription headers must be delivered before the deadline");
+  assert.equal(response.status, 200);
+  const reader = response.body.getReader();
+  assert.match(new TextDecoder().decode((await reader.read()).value), /acknowledged/);
+  assert.equal(completed, 0, "keep the concurrency slot until the stream ends");
+  context.mock.timers.tick(25);
+  assert.equal((await reader.read()).done, true);
+  assert.equal(cancelled, true);
+  assert.equal(signal.aborted, true);
+  assert.equal(completed, 1);
+  assert.equal(timeouts, 0, "a normal subscription lifetime is not a request timeout");
+});
+
+for (const mode of ["cancel", "abort", "eof", "error"]) {
+  test(`MCP subscription releases resources once on ${mode}`, async (context) => {
+    context.mock.timers.enable({ apis: ["setTimeout"] });
+    const caller = new AbortController();
+    let source, cancelled = 0, completed = 0;
+    const response = await runMcpExchangeWithDeadline(
+      new Request("https://example.test/api/mcp", { method: "POST", signal: caller.signal }),
+      async () => new Response(new ReadableStream({
+        start(controller) { source = controller; },
+        cancel() { cancelled++; },
+      }), { headers: { "Content-Type": "text/event-stream" } }),
+      25,
+      { isSubscription: () => true, onComplete: () => completed++ },
+    );
+    const reader = response.body.getReader();
+    if (mode === "cancel") await reader.cancel();
+    else if (mode === "abort") { caller.abort(); assert.equal((await reader.read()).done, true); }
+    else if (mode === "eof") { source.close(); assert.equal((await reader.read()).done, true); }
+    else { source.error(new Error("broken stream")); await assert.rejects(reader.read(), /broken stream/); }
+    assert.equal(completed, 1);
+    if (["cancel", "abort"].includes(mode)) assert.equal(cancelled, 1);
+    context.mock.timers.tick(100);
+    assert.equal(completed, 1);
+  });
+}
+
+test("MCP subscription setup errors remain finite JSON responses", async () => {
+  let completed = 0;
+  const response = await runMcpExchangeWithDeadline(
+    new Request("https://example.test/api/mcp", { method: "POST" }),
+    async () => Response.json({ error: "invalid subscription" }, { status: 400 }),
+    25,
+    { isSubscription: () => true, onComplete: () => completed++ },
+  );
+  assert.equal(response.status, 400);
+  assert.equal(completed, 1);
+});
+
+test("MCP still times out subscription setup and cancels a late response", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  let deliver, completed = 0, timeouts = 0, cancelled = false;
+  const pending = runMcpExchangeWithDeadline(
+    new Request("https://example.test/api/mcp", { method: "POST" }),
+    () => new Promise((resolve) => { deliver = resolve; }), 25,
+    { isSubscription: () => true, onComplete: () => completed++, onTimeout: () => timeouts++ },
+  );
+  context.mock.timers.tick(25);
+  assert.equal((await pending).status, 504);
+  deliver(new Response(new ReadableStream({ cancel() { cancelled = true; } }), {
+    headers: { "Content-Type": "text/event-stream" },
+  }));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(cancelled, true);
+  assert.equal(completed, 1);
+  assert.equal(timeouts, 1);
+});

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -951,6 +951,7 @@ test("MCP modern subscriptions acknowledge immediately, retain capacity and rele
       const response = await POST(request(headers, body));
       assert.equal(response.status, 200);
       assert.match(response.headers.get("content-type"), /text\/event-stream/);
+      assert.equal(response.headers.get("cache-control"), "private, no-store, no-transform");
       const reader = response.body.getReader(); streams.push(reader);
       const frame = new TextDecoder().decode((await reader.read()).value);
       assert.match(frame, /notifications\/subscriptions\/acknowledged/);

--- a/tests/mcp-route.test.mjs
+++ b/tests/mcp-route.test.mjs
@@ -938,3 +938,29 @@ test("MCP tool responses stay below the wire-size budget", async () => {
   assert.notEqual(irpefEvent.result.isError, true);
   assert.equal(irpefEvent.result.structuredContent.data.pagination.returned, 100);
 });
+
+test("MCP modern subscriptions acknowledge immediately, retain capacity and release on cancellation", { timeout: 5_000 }, async () => {
+  const headers = { "MCP-Protocol-Version": "2026-07-28", "MCP-Method": "subscriptions/listen" };
+  const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "subscriptions/listen", params: {
+    notifications: { toolsListChanged: true },
+    _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} },
+  } });
+  const streams = [];
+  try {
+    for (let i = 0; i < 8; i++) {
+      const response = await POST(request(headers, body));
+      assert.equal(response.status, 200);
+      assert.match(response.headers.get("content-type"), /text\/event-stream/);
+      const reader = response.body.getReader(); streams.push(reader);
+      const frame = new TextDecoder().decode((await reader.read()).value);
+      assert.match(frame, /notifications\/subscriptions\/acknowledged/);
+      assert.match(frame, /"toolsListChanged":true/);
+    }
+    assert.equal((await POST(request())).status, 503);
+    await streams.pop().cancel();
+    assert.equal((await POST(request())).status, 200);
+  } finally {
+    await Promise.all(streams.map((reader) => reader.cancel()));
+  }
+  assert.equal((await POST(request())).status, 200);
+});

--- a/tests/runtime-health.test.mjs
+++ b/tests/runtime-health.test.mjs
@@ -393,7 +393,7 @@ test("requestWithRetry aborts on timeout and never follows redirects", async () 
   assert.equal(redirect.response.status, 302);
 });
 
-test("runHealthMonitor fails on unreachable sources and performs checks sequentially", async () => {
+test("runHealthMonitor reports upstream degradation without declaring the application down", async () => {
   const calls = [];
   const report = await runHealthMonitor({
     baseUrl: "https://example.test/ignored?q=redact#fragment",
@@ -403,13 +403,13 @@ test("runHealthMonitor fails on unreachable sources and performs checks sequenti
     additionalAllowedOrigins: ["https://example.test"],
   });
 
-  assert.equal(report.ok, false);
+  assert.equal(report.ok, true);
   assert.equal(report.baseUrl, "https://example.test");
   assert.equal(report.checks.length, 7);
   assert.equal(report.checks.filter((check) => check.status === "pass").length, 6);
   const sourceHealth = report.checks.find((check) => check.name === "source-health");
-  assert.equal(sourceHealth.status, "fail");
-  assert.equal(sourceHealth.code, "source_unreachable");
+  assert.equal(sourceHealth.status, "warning");
+  assert.ok(sourceHealth.down.length > 0);
   assert.equal(sourceHealth.attempts, 1);
   assert.equal(report.checks.find((check) => check.name === "health").revision, REVISION);
   assert.deepEqual(calls.map((call) => call.path), [
@@ -421,7 +421,8 @@ test("runHealthMonitor fails on unreachable sources and performs checks sequenti
     "/mcp",
     "/api/mcp",
   ]);
-  assert.equal(report.warnings.length, 0);
+  assert.equal(report.warnings.length, 1);
+  assert.equal(report.warnings[0].check, "source-health");
   const queryCall = calls.at(-1);
   const queryRequest = JSON.parse(queryCall.body);
   assert.deepEqual(queryRequest.params.arguments, {


### PR DESCRIPTION
Le richieste MCP `subscriptions/listen` venivano bufferizzate fino alla deadline e restituivano HTTP 504 dopo 12 secondi. Ora ricevono subito lo stream e terminano con una chiusura ordinata entro il budget del server. Lo slot di concorrenza viene liberato alla chiusura, alla cancellazione o all'errore; le chiamate finite conservano la deadline e il relativo 504. `no-transform` sulle sole sottoscrizioni impedisce inoltre che la compressione del rewrite `/mcp` trattenga il primo evento fino alla chiusura.

Runtime health registra le fonti ufficiali indisponibili come warning con gli ID coinvolti e conserva sempre il report. Errori HTTP, contratti DVNS non validi e chiamate MCP fallite restano bloccanti. Source health e il monitor parlamentare continuano a segnalare i guasti delle fonti esterne.

Il timeout di preparazione degli allegati non è stato riprodotto: 40 lotti da 8 file, anche con CPU rallentata e intercettazione delle richieste come in CI, sono passati. Non viene modificata la preparazione dei file; il test browser registra ora eventi dei worker e avanzamento per slot, con limiti di memoria, per localizzare un'eventuale ricorrenza. Riferimento: #344, che resta aperta per questo punto.

Verifica su `cf9cf4a4c1e10f417f10d85b17431584dcd10612`:

- Regressione riprodotta prima della correzione; test su stream, cancellazione, deadline, concorrenza e contratti passati. Smoke HTTP verifica il primo evento senza compressione sia su `/api/mcp` sia su `/mcp`.
- Build, snapshot offline, controlli statici/action pins e suite locale completa di produzione passati: allegati alle sei larghezze previste, browser, MCP, carico e Lighthouse.
- [CI GitHub sull'ultimo commit](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34228986295) interamente passata: Node, static, ETL e snapshot offline, produzione, Zizmor e gate required. Anche CodeQL e Dependency Review sono passati.

La verifica locale completa ETL aveva incontrato limiti di spazio/socket e un'aspettativa del test di governance da aggiornare per la conservazione dei warning. Il test è stato aggiornato e i casi interessati sono passati nelle riesecuzioni mirate con spazio e socket disponibili; la CI ha poi confermato la suite completa.
