### PR TITLE
fix: completa lo stato fonti prima del timeout HTTP

### DIFF
--- a/src/lib/data/cached-live-views.ts
+++ b/src/lib/data/cached-live-views.ts
@@ -21,7 +21,9 @@ export type CachedSourceHealthStatus = Readonly<{
 }>;
 
 async function loadSourceHealthStatus(): Promise<CachedSourceHealthStatus> {
-  const sources = await getSourceHealthOverview({ deadlineMs: 6_000 });
+  // Finish probes before the API's 6-second request deadline so aborted
+  // upstreams can become source-level results instead of an HTTP timeout.
+  const sources = await getSourceHealthOverview({ deadlineMs: 4_000 });
   return { checkedAt: new Date().toISOString(), sources };
 }
 

--- a/tests/source-health-cold-deadline.test.mjs
+++ b/tests/source-health-cold-deadline.test.mjs
@@ -8,6 +8,8 @@ const { validateSourceHealthPayload } = await import('../scripts/runtime-health.
 
 test('cold source-health reports timed-out upstreams before the HTTP request expires', async () => {
   const originalFetch = globalThis.fetch;
+  const originalFetchMode = process.env.DVNS_SOURCE_FETCH_USE_GLOBAL;
+  process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = '1';
   const signals = [];
   globalThis.fetch = async (input, init = {}) => {
     const signal = init.signal ?? (input instanceof Request ? input.signal : undefined);
@@ -48,5 +50,7 @@ test('cold source-health reports timed-out upstreams before the HTTP request exp
   } finally {
     await getCachedSourceHealthOverview().catch(() => {});
     globalThis.fetch = originalFetch;
+    if (originalFetchMode === undefined) delete process.env.DVNS_SOURCE_FETCH_USE_GLOBAL;
+    else process.env.DVNS_SOURCE_FETCH_USE_GLOBAL = originalFetchMode;
   }
 });

--- a/tests/source-health-cold-deadline.test.mjs
+++ b/tests/source-health-cold-deadline.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import './helpers/register-ts-alias.mjs';
+
+const { GET } = await import('../src/app/api/fonti/stato/route.ts');
+const { getCachedSourceHealthOverview } = await import('../src/lib/data/cached-live-views.ts');
+const { validateSourceHealthPayload } = await import('../scripts/runtime-health.mjs');
+
+test('cold source-health reports timed-out upstreams before the HTTP request expires', async () => {
+  const originalFetch = globalThis.fetch;
+  const signals = [];
+  globalThis.fetch = async (input, init = {}) => {
+    const signal = init.signal ?? (input instanceof Request ? input.signal : undefined);
+    assert.ok(signal, 'every live probe must carry cancellation');
+    signals.push(signal);
+    return new Promise((_resolve, reject) => {
+      const fallback = setTimeout(() => reject(new Error('probe ignored cancellation')), 12_000);
+      const abort = () => {
+        clearTimeout(fallback);
+        reject(signal.reason);
+      };
+      if (signal.aborted) abort();
+      else signal.addEventListener('abort', abort, { once: true });
+    });
+  };
+
+  try {
+    const response = await GET(new Request('http://localhost/api/fonti/stato'));
+    const payload = await response.json();
+    // A timed-out caller must not leave its shared population using real fetch.
+    await getCachedSourceHealthOverview();
+    assert.equal(response.status, 200, JSON.stringify(payload));
+    assert.ok(signals.length > 0);
+    assert.ok(signals.every(signal => signal.aborted));
+    assert.equal(payload.summary.reachable, 0);
+    assert.ok(payload.summary.unreachable > 0);
+    const result = validateSourceHealthPayload(response, JSON.stringify(payload));
+    assert.ok(result.warning, 'upstream timeouts remain visible to the runtime monitor');
+    assert.equal(result.down.length, payload.summary.unreachable);
+
+    const requests = signals.length;
+    const warm = await GET(new Request('http://localhost/api/fonti/stato'));
+    const cached = await warm.json();
+    assert.equal(warm.status, 200);
+    assert.equal(cached.observedAt, payload.observedAt);
+    assert.deepEqual(cached.sources, payload.sources);
+    assert.equal(signals.length, requests, 'the next caller reuses the completed health check');
+  } finally {
+    await getCachedSourceHealthOverview().catch(() => {});
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/source-health.test.mjs
+++ b/tests/source-health.test.mjs
@@ -24,7 +24,7 @@ test("source status page uses the persistent five-minute health cache", () => {
   assert.match(route, /observedAt:\s*checkedAt/);
   assert.doesNotMatch(route, /const observedAt = new Date\(\)\.toISOString\(\)/);
   assert.match(cache, /SOURCE_HEALTH_CACHE_SECONDS = 300/);
-  assert.match(cache, /getSourceHealthOverview\(\{ deadlineMs: 6_000 \}\)/);
+  assert.match(cache, /getSourceHealthOverview\(\{ deadlineMs: 4_000 \}\)/);
   assert.match(cache, /return \{ checkedAt: new Date\(\)\.toISOString\(\), sources \}/);
 });
 


### PR DESCRIPTION
Quando la cache di `/api/fonti/stato` è vuota e una fonte non risponde, il budget della richiesta e il deadline dei probe scadono entrambi dopo 6 secondi. Il timer HTTP parte per primo: il chiamante riceve 504 appena prima che gli adapter abbiano prodotto il risultato valido con la fonte marcata `down`.

Anticipa a 4 secondi il deadline della popolazione condivisa, lasciando margine per comporre e restituire lo stato delle fonti. Il budget HTTP di 6 secondi, il limite funzione di 10 secondi, la cache di cinque minuti e la segnalazione dei veri errori applicativi restano invariati.

Il nuovo test offline esercita il vero percorso handler → cache → adapter → validatore Runtime health con upstream pendenti fino all'abort. Prima della modifica fallisce con `504 !== 200`; dopo passa, verifica l'abort dei probe, il warning delle fonti indisponibili e il riuso del risultato da parte del chiamante successivo. Riproduzione diagnostica: primo GET da 504 in 6.005 ms a 200 in 4.021 ms, sempre con quattro fonti `down`, mai falsamente dichiarate raggiungibili.

Validazione locale completa PASS: 19 test mirati, ci:static, action pins, suite Node (1.335 passati, 2 skip), ETL (686 casi, 7 skip), 45 controlli snapshot, build, tutti i gate di produzione (browser, MCP e Lighthouse), git diff --check. La regressione è confermata con tutti gli 11 trasporti simulati, incluso IPA, senza richieste alle fonti.

Preview Vercel dell'head `484a447d` READY: pagina Stato fonti verificata con 34 fonti, IPA/SIOPE raggiungibili e OpenBDAP segnalato in timeout dopo circa 4 secondi. CI completa PASS sullo stesso head: static, Node, ETL, snapshot, produzione, Zizmor, CodeQL e dependency review. Il primo job di produzione ha superato tutti i controlli funzionali e si è fermato su LCP della pagina IRPEF a 4.153 ms rispetto alla soglia 4.000 ms. La ripetizione dei soli job falliti, senza modifiche al codice o alle soglie, ha superato tutti i gate: LCP IRPEF 3.408 ms. [Run CI, tentativo 2](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34263473442/attempts/2).

Il difetto è emerso verificando una run Runtime health del fork che controllava il sito canonico. È distinto dall'errore OpenCoesione `DATA_BOT_APP_CLIENT_ID is required`: questa PR non configura publisher, segreti o workflow dei fork. I log Vercel mostrano timeout vicino al limite funzione; la riproduzione dimostra questo caso applicativo, senza attribuire automaticamente ogni 504 ospitato alla stessa causa.

Fixes #360. Separata dalla riorganizzazione del registro di #349.
