### PR TITLE
perf(build): limita i bundle runtime ANAC (#350)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,11 @@ latenza delle fonti live, rete, rendering o cold start.
 
 ### Build Vercel senza lavoro duplicato
 
+`npm run build` verifica anche i manifest dei pacchetti runtime: blocca il
+tracing accidentale di test, documentazione e ricerca, controlla gli artifact
+ANAC necessari e impedisce l'inclusione dell'indice operatori nelle route enti.
+Vedi [misure e verifica dei bundle](docs/VERCEL_RUNTIME_BUNDLES.md).
+
 `vercel.json` evita il download Chromium solo durante l'installazione Vercel:
 quel deployment esegue `next build`, mentre i test browser girano nel job
 `production` di GitHub Actions. `npm ci` locale e in CI conserva il download

--- a/docs/VERCEL_RUNTIME_BUNDLES.md
+++ b/docs/VERCEL_RUNTIME_BUNDLES.md
@@ -1,0 +1,71 @@
+# Runtime bundles and deployment time
+
+The ANAC readers used `readFileSync(fd)` after checking an open file descriptor.
+Turbopack interpreted the numeric descriptor as a dynamic filesystem path and
+included the whole project in six route traces. The operator reader also resolved
+the repository root before joining its fixed artifact directory, producing a
+second broad tracing warning.
+
+The readers now fill a buffer bounded by the checked file size using `readSync`
+on the same descriptor. Partial reads continue until complete; early EOF fails
+closed. The before/after file fingerprints, size limits, hashes, source locks,
+path validation and descriptor cleanup remain in place. The operator artifact
+path is joined directly from `process.cwd()` and its fixed directory.
+
+## Local comparison
+
+Measured on 8 September 2026, main `bbe8dcb5`, Node 22.23.2 and Next 16.3.3.
+The same checkout and committed corpus were used before and after the reader
+changes. Values count unique normalized paths in each emitted `.nft.json`,
+including runtime code and data, in decimal MB.
+
+| Route | Before | After | Reduction |
+| --- | ---: | ---: | ---: |
+| `/enti/[codice]` | 689.0 MB | 318.8 MB | 54% |
+| `/api/enti/[codice]` | 680.1 MB | 309.9 MB | 54% |
+| `/enti/[codice]/appalti` | 658.3 MB | 60.6 MB | 91% |
+| `/enti/[codice]/appalti/confronti` | 651.6 MB | 57.9 MB | 91% |
+| `/appalti/operatori` | 651.1 MB | 219.1 MB | 66% |
+| `/appalti/operatori/[ref]` | 651.2 MB | 219.1 MB | 66% |
+
+The complete build contains 150 App Router traces. No trace includes tests,
+documentation or research files after the change. The operator index remains
+in its own routes; it is no longer bundled into entity routes. All required
+ANAC shards and provenance files are present.
+
+These are local trace sizes, not uploaded Vercel package sizes. Routes can share
+files and Vercel can group functions, so do not sum these rows as storage or
+transfer savings. The warm local rebuild is not a controlled compilation-time
+benchmark. The separate operator browsing index work addresses request latency.
+
+## Build gate
+
+`npm run build` runs `scripts/ci/check-runtime-traces.mjs` after Next succeeds,
+both locally and on Vercel. The gate rejects accidental tracing of tests, docs
+or research, missing referenced files and cross-domain ANAC inclusion. It also
+requires every entity/CPV/operator shard and the source-lock inputs consumed by
+the affected routes, deriving the inventory from the committed manifests.
+
+To inspect an existing build:
+
+```bash
+node scripts/ci/check-runtime-traces.mjs
+node --test tests/runtime-traces.test.mjs
+```
+
+If a route intentionally starts reading a new runtime asset, update its precise
+inventory and verify the deployed route. Do not suppress the gate or remove
+integrity checks to silence a bundler warning.
+
+## Hosted measurement
+
+The production deployment of `bbe8dcb5` took 9m34s, including 7m53s in
+`Deploying outputs`. This identifies the phase to compare after the package
+change. That phase includes Vercel's internal work; its logs do not separate
+upload time from platform processing. A smaller trace alone does not prove a
+specific time or billing saving.
+
+Compare deployments on the same build-machine configuration and record cache
+restoration, compilation, output publication, total duration and Vercel resource
+sizes. Build resources and runtime CPU/memory are separate settings. No larger
+machine or reduction of correctness checks is required by this change.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "brand:check": "node scripts/brand/generate-icons.mjs --check",
     "readme:screenshots": "node scripts/brand/capture-readme.mjs",
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/ci/check-runtime-traces.mjs",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "next typegen && tsc --noEmit",

--- a/scripts/ci/check-runtime-traces.mjs
+++ b/scripts/ci/check-runtime-traces.mjs
@@ -1,0 +1,88 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ENTITY = "src/data/generated/anac-entity-procurement-page";
+const CPV = "src/data/generated/anac-procurement-cpv";
+const OPERATOR = "src/data/generated/anac-operator-awards-index";
+const SPEC = "scripts/etl/specs";
+
+function walk(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+}
+
+/** Check the emitted package, including data opened dynamically at runtime. */
+export function checkTrace(root, manifest, required = [], forbidden = []) {
+  const trace = JSON.parse(readFileSync(manifest, "utf8"));
+  if (trace.version !== 1 || !Array.isArray(trace.files)) {
+    throw new Error(`Invalid runtime trace: ${manifest}`);
+  }
+  const paths = new Set(trace.files.map((file) => resolve(dirname(manifest), file)));
+  const files = [...paths].map((file) => relative(root, file).replaceAll("\\", "/"));
+  const unexpected = files.filter((file) => /^(tests|docs|research)\//.test(file)
+    || forbidden.some((prefix) => file.startsWith(`${prefix}/`)));
+  if (unexpected.length) throw new Error(`${relative(root, manifest)} traces unrelated files: ${unexpected.slice(0, 5).join(", ")}`);
+  const missing = required.filter((file) => !paths.has(resolve(root, file)));
+  if (missing.length) throw new Error(`${relative(root, manifest)} omits runtime files: ${missing.slice(0, 5).join(", ")}`);
+  // stat also fails if a trace points at an absent file; normalize before counting.
+  return { files: paths.size, bytes: [...paths].reduce((sum, file) => sum + statSync(file).size, 0) };
+}
+
+export function checkRuntimeTraces(root = process.cwd()) {
+  root = resolve(root);
+  const json = (path) => JSON.parse(readFileSync(resolve(root, path), "utf8"));
+  const entityFiles = [
+    `${ENTITY}/meta.json`,
+    ...json(`${ENTITY}/meta.json`).shards.map((shard) => shard.path),
+    `${SPEC}/anac-entity-procurement-page.source.json`,
+    `${SPEC}/anac-entity-procurement.source.json`,
+    `${SPEC}/anac-awardees.source.json`,
+  ];
+  const cpvSpec = json(`${SPEC}/anac-procurement-cpv.source.json`);
+  const cpvFiles = [
+    `${CPV}/meta.json`, `${SPEC}/anac-procurement-cpv.source.json`,
+    cpvSpec.profiles.path, cpvSpec.sourceLock.path,
+    ...json(`${CPV}/meta.json`).shards.map((shard) => `${CPV}/${shard.id}.jsonl.gz`),
+  ];
+  const operatorMeta = json(`${OPERATOR}/meta.json`);
+  const operatorFiles = [
+    `${OPERATOR}/meta.json`, `${OPERATOR}/search.jsonl.gz`,
+    `${SPEC}/anac-operator-awards-index.source.json`,
+    ...operatorMeta.shards.map((shard) => shard.path),
+    ...(operatorMeta.summaries ? [operatorMeta.summaries.path] : []),
+  ];
+  const peers = "src/data/generated/anac-procurement-peers";
+  const peerFiles = [
+    `${peers}/meta.json`, `${peers}/snapshot.json.gz`, `${SPEC}/anac-procurement-peers.source.json`,
+    ...Object.values(json(`${SPEC}/anac-procurement-peers.source.json`).inputs).map((entry) => entry.path),
+  ];
+  const requirements = new Map([
+    ["enti/[codice]/page.js.nft.json", [...entityFiles, ...cpvFiles]],
+    ["enti/[codice]/appalti/page.js.nft.json", [...entityFiles, ...cpvFiles]],
+    ["enti/[codice]/appalti/confronti/page.js.nft.json", peerFiles],
+    ["appalti/operatori/page.js.nft.json", operatorFiles],
+    ["appalti/operatori/[ref]/page.js.nft.json", operatorFiles],
+  ]);
+  const appRoot = resolve(root, ".next/server/app");
+  const results = [];
+  for (const manifest of walk(appRoot).filter((path) => path.endsWith(".nft.json"))) {
+    const route = relative(appRoot, manifest).replaceAll("\\", "/");
+    const forbidden = route.startsWith("appalti/operatori/") ? [ENTITY, CPV]
+      : route.startsWith("enti/") || route.startsWith("api/enti/") ? [OPERATOR] : [];
+    results.push({ route, ...checkTrace(root, manifest, requirements.get(route), forbidden) });
+    requirements.delete(route);
+  }
+  if (requirements.size) throw new Error(`Missing runtime traces: ${[...requirements.keys()].join(", ")}`);
+  return results;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const results = checkRuntimeTraces();
+  console.log(`Runtime traces: ${results.length} checked; required ANAC artifacts present; no tests, docs or research bundled.`);
+  for (const result of results.filter(({ route }) => /^(enti\/\[codice\]|appalti\/operatori)/.test(route))) {
+    console.log(`${result.route}: ${result.files} files, ${(result.bytes / 1024 / 1024).toFixed(1)} MiB`);
+  }
+}

--- a/src/lib/data/anac-entity-procurement-page.ts
+++ b/src/lib/data/anac-entity-procurement-page.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, fstatSync, openSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { gunzipSync } from "node:zlib";
 import type { IpaEntity } from "@/lib/ipa";
@@ -1429,7 +1429,15 @@ function readStableFile(
     fd = openSync(path, "r");
     const before = fstatSync(fd);
     if (!before.isFile() || before.size > maxBytes) throw new Error(`ANAC entity page: ${label} oltre il limite.`);
-    const bytes = readFileSync(fd);
+    // Read only the checked size from the same descriptor. readFileSync(fd)
+    // is interpreted as a dynamic path by Turbopack and traces the whole repo.
+    const bytes = Buffer.alloc(before.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = readSync(fd, bytes, offset, bytes.length - offset, offset);
+      if (!count) throw new Error(`ANAC entity page: ${label} cambiato durante la lettura.`);
+      offset += count;
+    }
     const after = fstatSync(fd);
     const beforeFingerprint = fingerprintFromStat(before);
     const afterFingerprint = fingerprintFromStat(after);

--- a/src/lib/data/anac-operator-awards-index.ts
+++ b/src/lib/data/anac-operator-awards-index.ts
@@ -1,8 +1,8 @@
 import "server-only";
 
 import { createHash } from "node:crypto";
-import { closeSync, existsSync, fstatSync, openSync, readFileSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 const DATASET = "anac-operator-awards-index" as const;
@@ -210,12 +210,8 @@ const operatorCache = new Map<string, AnacOperatorRecord | null>();
 const MAX_SUMMARIES_BYTES = 2_000_000;
 const MAX_SUMMARY_ROWS = 50;
 
-function repoRoot(): string {
-  return resolve(process.cwd());
-}
-
 function artifactPath(...parts: string[]): string {
-  return join(repoRoot(), ARTIFACT_DIR, ...parts);
+  return join(process.cwd(), ARTIFACT_DIR, ...parts);
 }
 
 function sha256Bytes(value: Buffer): string {
@@ -592,7 +588,7 @@ function assertNationalSummaries(value: unknown): AnacOperatorNationalSummaries 
 }
 
 function loadSourceSpecSha(): string {
-  const raw = readFileSync(join(repoRoot(), SOURCE_SPEC_PATH));
+  const raw = readFileSync(join(process.cwd(), SOURCE_SPEC_PATH));
   return sha256Bytes(raw);
 }
 
@@ -604,7 +600,15 @@ function readStableUtf8(path: string, maxBytes: number, label: string): string {
     const before = fstatSync(fd);
     if (!before.isFile()) throw new Error(`${label} non e un file`);
     if (before.size > maxBytes) throw new Error(`${label} troppo grande`);
-    const bytes = readFileSync(fd);
+    // Read only the checked size from the same descriptor. readFileSync(fd)
+    // is interpreted as a dynamic path by Turbopack and traces the whole repo.
+    const bytes = Buffer.alloc(before.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = readSync(fd, bytes, offset, bytes.length - offset, offset);
+      if (!count) throw new Error(`${label} cambiato durante la lettura`);
+      offset += count;
+    }
     const after = fstatSync(fd);
     if (
       before.size !== after.size ||

--- a/tests/anac-entity-procurement-page.test.mjs
+++ b/tests/anac-entity-procurement-page.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import "./helpers/register-ts-alias.mjs";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
@@ -323,6 +325,62 @@ test("loaded profile exposes withheld concentration without changing the shard s
       assert.equal("concentration" in fixture.record, false);
     }
   } finally {
+    cleanup(fixture);
+  }
+});
+
+test("descriptor reader handles partial reads without changing the published profile", async (t) => {
+  const fixture = makeFixture();
+  const originalRead = fs.readSync;
+  let reads = 0;
+  t.mock.method(fs, "readSync", (fd, buffer, offset, length, position) => {
+    reads++;
+    return originalRead(fd, buffer, offset, Math.min(length, 17), position);
+  });
+  syncBuiltinESMExports();
+  try {
+    const result = await loader.loadAnacEntityProcurementPage({ codiceIpa: fixture.record.codiceIpa, currentEntityCf: fixture.record.codiceFiscaleEnte, rootDirectory: fixture.projectRoot });
+    assert.equal(result.status, "available");
+    assert.deepEqual(result.profile.summary, fixture.record.summary);
+    assert.ok(reads > 10);
+  } finally {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+    cleanup(fixture);
+  }
+});
+
+test("descriptor reader fails closed on an early EOF", async (t) => {
+  const fixture = makeFixture();
+  t.mock.method(fs, "readSync", () => 0);
+  syncBuiltinESMExports();
+  try {
+    const result = await loader.loadAnacEntityProcurementPage({ codiceIpa: fixture.record.codiceIpa, currentEntityCf: fixture.record.codiceFiscaleEnte, rootDirectory: fixture.projectRoot });
+    assert.equal(result.status, "unavailable");
+    assert.equal(result.reason, "artifact-invalid");
+  } finally {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+    cleanup(fixture);
+  }
+});
+
+test("descriptor reader rejects a file growing after the checked read", async (t) => {
+  const fixture = makeFixture();
+  const originalRead = fs.readSync;
+  t.mock.method(fs, "readSync", (fd, buffer, offset, length, position) => {
+    const count = originalRead(fd, buffer, offset, length, position);
+    fs.appendFileSync(join(fixture.projectRoot, ARTIFACT_RELATIVE, "meta.json"), " ");
+    return count;
+  });
+  syncBuiltinESMExports();
+  try {
+    const result = await loader.loadAnacEntityProcurementPage({ codiceIpa: fixture.record.codiceIpa, currentEntityCf: fixture.record.codiceFiscaleEnte, rootDirectory: fixture.projectRoot });
+    assert.equal(result.status, "unavailable");
+    assert.equal(result.reason, "artifact-invalid");
+  } finally {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
     cleanup(fixture);
   }
 });

--- a/tests/runtime-traces.test.mjs
+++ b/tests/runtime-traces.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import test from "node:test";
+import { checkTrace } from "../scripts/ci/check-runtime-traces.mjs";
+
+function fixture(t, files) {
+  const root = mkdtempSync(join(tmpdir(), "dvns-runtime-trace-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const manifest = join(root, ".next/server/app/enti/page.js.nft.json");
+  mkdirSync(dirname(manifest), { recursive: true });
+  for (const file of files) {
+    mkdirSync(dirname(join(root, file)), { recursive: true });
+    writeFileSync(join(root, file), "bytes");
+  }
+  writeFileSync(manifest, JSON.stringify({ version: 1, files: files.map((file) => relative(dirname(manifest), join(root, file))) }));
+  return { root, manifest };
+}
+
+test("runtime package guard requires dynamically opened artifacts", (t) => {
+  const artifact = "src/data/generated/anac-entity-procurement-page/entities/ab.jsonl.gz";
+  const { root, manifest } = fixture(t, [artifact]);
+  assert.deepEqual(checkTrace(root, manifest, [artifact]), { files: 1, bytes: 5 });
+  assert.throws(() => checkTrace(root, manifest, [artifact.replace("ab", "cd")]), /omits runtime files/);
+});
+
+test("runtime package guard rejects accidental repository-wide and cross-domain tracing", (t) => {
+  const { root, manifest } = fixture(t, ["tests/fixtures/private.json"]);
+  assert.throws(() => checkTrace(root, manifest), /traces unrelated files/);
+  const other = fixture(t, ["src/data/generated/unrelated/large.json"]);
+  assert.throws(() => checkTrace(other.root, other.manifest, [], ["src/data/generated/unrelated"]), /traces unrelated files/);
+});
+
+test("runtime package guard fails on traced files missing from the deployment", (t) => {
+  const { root, manifest } = fixture(t, ["required.json"]);
+  rmSync(join(root, "required.json"));
+  assert.throws(() => checkTrace(root, manifest), /ENOENT/);
+});


### PR DESCRIPTION
I reader ANAC facevano includere l’intero repository in sei funzioni Vercel. Le letture ora riempiono un buffer limitato alla dimensione verificata usando lo stesso file descriptor; restano controllati EOF anticipato, cambiamenti del file, confinamento dei percorsi, hash, source lock e cleanup. Il percorso degli artifact operatori viene costruito direttamente dalla directory fissa.

Il build verifica tutti i 150 manifest: gli shard e i file di provenienza necessari devono essere presenti, mentre test, documentazione, ricerca e indici ANAC estranei alla route fanno fallire il gate. Il controllo è passato anche sul builder Vercel; i warning che estendevano il tracing all’intero progetto sono spariti.

| Misura Vercel | Produzione bbe8dcb5 | Preview 7fabf49 |
| --- | ---: | ---: |
| Deploy completo | 9:34 | 6:23 |
| Fase Deploying outputs | 7:53 | 4:26 |
| Scheda ente | 522 MB | 263 MB |
| API ente | 520 MB | 261 MB |
| Appalti ente | 516 MB | 55,6 MB |
| Confronto appalti | 514 MB | 55,6 MB |
| Elenco e scheda operatori | 514 MB | 222 MB |

Il confronto hosted usa lo stesso corpus, Node 24.x, regione iad1 e macchina 4 core/8 GB; entrambi i deployment ripristinano una cache. Il tempo complessivo osservato scende del 33%, ma due deployment non provano un risparmio di fatturazione né garantiscono ogni build futura. Le funzioni possono condividere file: non sommare le dimensioni come risparmio totale. Misure locali e limiti in `docs/VERCEL_RUNTIME_BUNDLES.md`.

Verifiche locali: ci:static, action pins, build, 32 test ANAC, 3 regressioni del gate, 686 test ETL (7 skip), 45 verifiche snapshot e suite completa di produzione PASS. Lighthouse locale: Performance 97; Accessibility, Best Practices e SEO 100; LCP mediano 2.582 ms, CLS 0. La suite Node completa in CI è PASS; localmente il primo run aveva un fallimento temporale nello storico SSN, poi passato nella ripetizione isolata del file (21 pass, 1 skip).

In CI sono PASS static, sicurezza, Node, ETL/snapshot, CodeQL e dipendenze. Il primo job production ha superato tutte le verifiche funzionali e fallito solo Lighthouse con LCP mediano 4.013 ms contro la soglia di 4.000 ms. La ripetizione del solo job fallito è PASS sullo stesso codice e senza modificare le soglie: LCP mediano 3.951 ms, Performance 88, Accessibility/Best Practices/SEO 100, CLS 0. Anche il gate aggregato required è PASS. Il margine LCP rimane ridotto; entrambi gli esiti sono conservati nel workflow 34273031808.

Preview Vercel Ready e verificata via browser: scheda di Veroli, appalti e filtro CPV elettricità, confronto con 221 Comuni simili, elenco di 478.418 operatori e scheda MEDTRONIC con dati dello shard. L’accesso diretto a `/api/health` nella preview è stato bloccato dal browser e non è contato come verifica HTTP.

La riduzione del costo delle richieste dell’elenco operatori resta nel lavoro distinto della PR #357.

Closes #350
