### PR TITLE
fix(data): migrate Atlante publisher to versioned branch

### DIFF
--- a/docs/FRESHNESS_AND_REFRESH.md
+++ b/docs/FRESHNESS_AND_REFRESH.md
@@ -272,6 +272,20 @@ Stato attuale:
 
 Non riscriviamo tutti gli adapter contemporaneamente soltanto per uniformità estetica: ogni migrazione deve mantenere gli stessi risultati e passare lint, typecheck, design gate e build.
 
+## Atlante Imprese: branch di pubblicazione
+
+Il publisher usa `automation/data/company-atlas-v2` per il candidato che include
+snapshot, metadati e inventario. Il precedente branch
+`automation/data/company-atlas` resta conservato con la PR #383 chiusa: il suo
+snapshot è incluso senza modifiche nella PR #384, ma il digest di provenienza
+precedente copriva soltanto lo snapshot e non è riutilizzabile per il nuovo insieme
+di file. La separazione dei branch conserva la verifica rigorosa dei digest.
+
+Entrambi i nomi ricadono nelle protezioni `automation/data/**`: soltanto il Data
+Bot può gestirli. Il workflow e l'approvazione `source-operations` restano gli
+stessi. I refresh futuri operano esclusivamente sul branch v2; non occorre
+cancellare, aggiornare o riaprire il candidato storico.
+
 ## Pagella dei governi: ciclo di aggiornamento
 
 Il workflow settimanale `government-scorecard-refresh.yml` usa

--- a/scripts/ci/generated-artifacts.json
+++ b/scripts/ci/generated-artifacts.json
@@ -1133,7 +1133,7 @@
       },
       "refreshWorkflow": ".github/workflows/company-atlas-refresh.yml",
       "publication": {
-        "branch": "automation/data/company-atlas",
+        "branch": "automation/data/company-atlas-v2",
         "commitTitle": "chore(data): refresh Atlante Imprese snapshot",
         "prTitle": "data: refresh Atlante Imprese snapshot",
         "upstreamUrl": "https://opendata.marche.camcom.it/data/Stock-Imprese-Attive-Italia.json",

--- a/tests/etl/test_publish_data_refresh.py
+++ b/tests/etl/test_publish_data_refresh.py
@@ -94,7 +94,7 @@ class PublishDataRefreshTests(TestCase):
         self.assertEqual(
             {item["branch"] for item in publications.values()},
             {
-                "automation/data/company-atlas",
+                "automation/data/company-atlas-v2",
                 "automation/data/consulenti",
                 "automation/data/government-scorecard",
                 "automation/data/mef-participations",


### PR DESCRIPTION
Il candidato Atlante #383 usa un digest che copre soltanto lo snapshot. Dopo #384 il publisher verifica anche metadati e inventario: riutilizzare quel branch fallirebbe correttamente la verifica di provenienza. Il branch storico è protetto e resta conservato; il suo snapshot è già incluso identico in `main` (`e6800070`).

Questa modifica configura `automation/data/company-atlas-v2` per i prossimi candidati, aggiorna il test del registro e documenta la migrazione. Il nuovo nome è libero e ricade nelle stesse protezioni `automation/data/**`. Restano invariati Data Bot, approvazione `source-operations`, workflow, allowlist e verifiche dei digest.

Validazione locale: `ci:static`, `ci:action-pins`, 33 test del publisher, 9 test di governance, inventario aggiornato e `git diff --check` superati. I dati e il codice dell'app sono identici a #384.

CI completa superata sulla revisione `fd586149d04e51dc05eed423ea563c912307cb3d`, inclusi produzione e gate aggregato `required`; preview Vercel pronta. Nel primo tentativo tutte le suite browser sono passate; Lighthouse ha rilevato LCP mediano 4.015 ms su tre misure (limite 4.000 ms), contro 3.803 ms nella CI di #384 sullo stesso codice applicativo. La ripetizione dei soli job falliti, senza modificare codice o soglie, è passata con LCP mediano 3.418 ms. Entrambi gli esiti restano nei log del [run 34380325415](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34380325415). Nessuna revisione o discussione inline pendente al controllo finale.
