### PR TITLE
Design: palette istituzionale accessibile e coerente

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,7 +4,7 @@
 
 **Direzione: “Il registro pubblico.”**
 
-DoveVannoINostriSoldi è un prodotto operativo di consultazione e verifica. Deve sembrare un documento pubblico contemporaneo: carta chiara, inchiostro nero, un accento rosso per azioni ed evidenze e toni petrolio per i dati. Niente pannelli traslucidi, niente bagliori, niente angoli arrotondati.
+DoveVannoINostriSoldi è un prodotto operativo di consultazione e verifica. Deve sembrare un documento pubblico contemporaneo: carta fredda, inchiostro blu scuro, un accento rosso per azioni ed evidenze e toni petrolio per i dati. Niente pannelli traslucidi, niente bagliori, niente angoli arrotondati.
 
 La direzione è **dati subito, fonte vicina, superfici piatte**.
 
@@ -27,21 +27,21 @@ I token vivono in `src/app/design-system.css`; la base e la chrome dell'applicaz
 
 ## 02 Colors
 
-La palette è grigio-carta caldo con rosso di segnalazione e petrolio per mappe e serie quantitative. Evitare neon, glow e colori decorativi in competizione con i dati.
+La palette è carta fredda istituzionale con rosso di segnalazione e petrolio per mappe e serie quantitative. Evitare neon, glow e colori decorativi in competizione con i dati.
 
 ### Core tokens
 
-- `--color-bg: #f3f2f2` — fondo applicazione;
-- `--color-surface: #eae9e9` — fondo secondario;
+- `--color-bg: #f3f5f7` — fondo applicazione;
+- `--color-surface: #e8edf2` — fondo secondario;
 - `--color-raised: #ffffff` — superficie dei pannelli;
-- `--color-text: #201e1d` — testo principale e fondo dei tooltip;
-- `--color-accent: #ec3013` — azione ed evidenza;
-- `--color-accent-2: #e15b47` — accento secondario, usato di rado;
+- `--color-text: #182b3a` — testo principale e fondo dei tooltip;
+- `--color-accent: #b42332` — azione ed evidenza;
+- `--color-accent-2: #a82b3b` — accento secondario, usato di rado;
 - `--color-divider` — separatore calcolato dal testo.
 
 ### Rampe tonali
 
-Nel tema chiaro, `--color-neutral-100…900` e `--color-accent-100…900` sono generate in OKLCH su un'unica scala di luminosità: lo stesso passo di due rampe diverse ha lo stesso valore visivo. Le regole d'uso:
+Nel tema chiaro, `--color-neutral-100…900` usa grigi freddi ordinati per luminosità; `--color-accent-100…900` riserva il rosso ad azioni e stati. I passi non implicano un identico contrasto fra famiglie: si verificano le coppie effettive. Palette, motivazioni e soglie sono in [Palette istituzionale](docs/INSTITUTIONAL_PALETTE.md). Le regole d'uso:
 
 - `neutral-200` separatori interni di tabelle ed elenchi;
 - `neutral-300` bordo dei pannelli e delle bande;
@@ -76,7 +76,7 @@ Il blocco `[data-theme="dark"]` ridefinisce superfici, rampe, stati e serie. Le 
 
 Per le sole composizioni additive istituzionali (treemap Ministeri / Palazzo Chigi / Regioni) esistono `--chart-category-blue|teal|purple|amber|green|slate`: famiglie miscelate al 40% con il bianco, con testo inchiostro leggibile, senza usare il rosso come colore di categoria. Il rosso resta per CTA, evidenza e warning.
 
-Le coroplete regionali usano cinque passi sequenziali `--chart-map-1…5`, dal petrolio chiaro allo scuro, con contorno `--color-neutral-500` da 1px. Il passo più chiaro deve distinguersi dal pannello bianco; i confini restano leggibili anche fra due regioni chiare. `--chart-data-primary` e `--chart-data-track` sono i ruoli per serie quantitative senza significato di allarme.
+Le coroplete regionali usano cinque passi sequenziali `--chart-map-1…5`, dal petrolio chiaro allo scuro, con contorno `--color-neutral-500` da 1px e valori testuali associati. Il passo più chiaro deve distinguersi dal pannello bianco; i confini restano leggibili anche fra due regioni chiare. Nel tema scuro la quantità crescente usa passi progressivamente più chiari, con la stessa legenda. `--chart-data-primary` e `--chart-data-track` sono i ruoli per serie quantitative senza significato di allarme.
 
 Regione selezionata: contorno `--color-text` da 2px. Regione senza dato: `--color-neutral-200`.
 
@@ -157,13 +157,13 @@ Use: fotografia additiva dello stesso totale, categorie mutuamente esclusive, co
 
 ### Bar rows
 
-Il pattern ricorrente `etichetta | traccia | valore`: traccia `neutral-200`, riempimento accento, valore tabulare a destra.
+Il pattern ricorrente `etichetta | traccia | valore`: traccia `--chart-data-track`, riempimento `--chart-data-primary`, valore tabulare a destra.
 
-**Il mese ancora in corso usa `neutral-500` invece dell'accento** e porta un asterisco: è un numero destinato a salire e non va confrontato con i mesi chiusi. Un anno già concluso non ha nessun mese in corso — tutte le barre sono accento e la nota dice “Anno chiuso: tutti i mesi sono definitivi”. La regola sta in `src/lib/siope-calendar.ts` e decide in base all'anno in cui abbiamo scaricato il file, non al numero del mese.
+**Il mese ancora in corso usa `neutral-500` invece del petrolio quantitativo** e porta un asterisco: è un numero destinato a salire e non va confrontato con i mesi chiusi. Un anno già concluso non ha nessun mese in corso — tutte le barre usano il ruolo quantitativo e la nota dice “Anno chiuso: tutti i mesi sono definitivi”. La regola sta in `src/lib/siope-calendar.ts` e decide in base all'anno in cui abbiamo scaricato il file, non al numero del mese.
 
 ### Charts
 
-Recharts legge i token: assi e griglia in `--color-neutral-300/600`, serie dai `--chart-*`. I tooltip sono l'unica superficie scura del sistema: fondo `--color-text`, testo `--color-neutral-100`, valore in bianco.
+Recharts legge i token: assi e griglia in `--color-neutral-300/600`, serie dai `--chart-*`. I tooltip usano una superficie inversa: fondo `--color-text`, testo `--color-on-strong-muted`, valore `--color-on-strong`.
 
 Dove basta, il grafico è HTML e CSS (barre, donut in `conic-gradient`) invece di una libreria: meno JavaScript e stessa leggibilità.
 

--- a/docs/INSTITUTIONAL_PALETTE.md
+++ b/docs/INSTITUTIONAL_PALETTE.md
@@ -1,0 +1,58 @@
+# Palette istituzionale
+
+La palette della issue #374 mantiene il «registro pubblico»: superfici piatte,
+font Geist, struttura e marchio invariati. Carta fredda e inchiostro blu danno
+continuità a header, navigazione, pannelli e footer senza fondi crema, accenti
+terracotta o effetti luminosi. Il rosso segnala un'azione; il petrolio descrive
+una quantità senza suggerire un giudizio sulla spesa.
+
+| Ruolo | Token light | Valore | Uso |
+| --- | --- | --- | --- |
+| Carta | `--color-bg` | `#f3f5f7` | Chrome e fondo pagina |
+| Superficie | `--color-surface` | `#e8edf2` | Sezioni secondarie |
+| Pannello | `--color-raised` | `#ffffff` | Dati e controlli |
+| Inchiostro | `--color-text` | `#182b3a` | Testo principale |
+| Testo secondario | `--color-neutral-600` | `#536474` | Note e metadati |
+| Azione/focus | `--color-accent` | `#b42332` | Interazioni, mai normali barre di valore |
+| Link/CTA | `--color-accent-700` | `#a51d2d` | Link e pulsanti; varianti 800/900 per hover/active |
+| Dati | `--chart-data-primary` | `#176575` | Serie principale e barre |
+| Traccia | `--chart-data-track` | `#dce7ec` | Base delle barre |
+| Confine controllo | `--color-neutral-400` | `#71808e` | Input e pulsanti secondari |
+
+Tutti i valori rimangono in `src/app/design-system.css`. I nomi pubblici dei
+token sono conservati. Le categorie additive usano blu, petrolio, malva spento,
+ocra, verde e ardesia: solo quando le categorie sono mutuamente esclusive, con
+etichette e tabella dei valori. Nessuna nuova serie viola dominante.
+
+La mappa usa cinque passi sequenziali dal chiaro `#dbe8ed` al petrolio
+`#176575`. In dark mode la scala va da `#324e59` a `#a1cbd4`: più quantità,
+più luminosità. La legenda, i valori, il selettore regionale e il bordo di
+selezione mantengono l'informazione accessibile senza riconoscere il colore.
+La composizione e le barre mensili della home già leggono i ruoli dedicati:
+la migrazione avviene aggiornando i token, senza duplicare stili di pagina.
+Il mese incompleto resta grigio con asterisco e spiegazione; l'indicatore di
+freschezza ordinaria diventa neutro. Il quinto ruolo di serie non eredita più
+l'accento rosso. Gli stati fonte mantengono testo e significato espliciti:
+positivo verde, attenzione ocra, critico rosso.
+
+## Contrasto e verifica
+
+Le coppie testuali previste devono raggiungere 4,5:1; focus, confini dei
+controlli e barra/traccia almeno 3:1. Soglie tratte dalle spiegazioni W3C di
+[WCAG 2.2 1.4.3](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+e [1.4.11](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html).
+Non si arrotonda un rapporto insufficiente per farlo passare.
+
+`tests/institutional-ui-palette.test.mjs` calcola luminanza sRGB e contrasto
+per testo, metadati, link, CTA, stati, foreground inversi, focus, input e barre
+in entrambi i temi; verifica anche ordine delle rampe e ruoli delle superfici
+principali. `institutional-chart-palette` conserva il controllo sulle sei
+famiglie e sui valori testuali delle composizioni; `ui-craft-regressions` e
+`coesione-ui` proteggono gli altri contratti visivi.
+
+La suite produzione `core` legge gli stili realmente applicati a home,
+chrome, testi e barre a 320, 375, 390, 768, 1024, 1280 e 1600px, nei due temi.
+Verifica overflow, valori regionali accessibili e contrasto; salva screenshot
+home a 390 e 1280px in `artifacts/browser/institutional-palette/`.
+Il test dei token non equivale a una certificazione WCAG dell'intero sito:
+restano necessari i controlli browser della revisione esatta distribuita.

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -3,6 +3,7 @@ import { inspectReceipts } from "./receipts.mjs";
 import { inspectEpea } from "./epea.mjs";
 import { inspectCulture, inspectCultureJourney, inspectInvalidCultureYears } from "./culture.mjs";
 import { inspectDefence } from "./defence.mjs";
+import { inspectInstitutionalPalette } from "./institutional-palette.mjs";
 import { inspectPnrrProjects } from "./pnrr-projects.mjs";
 import { inspectTedNotices } from "./ted-notices.mjs";
 import { inspectAnacCpv } from "./anac-cpv.mjs";
@@ -691,6 +692,17 @@ const completed = [];
 
 try {
   browser = await launchBrowser();
+
+  for (const width of [320, 375, 390, 768, 1024, 1280, 1600]) {
+    const label = `Palette istituzionale ${width}px`;
+    await runScenario(browser, {
+      label,
+      pathname: "/",
+      width,
+      validate: (page) => inspectInstitutionalPalette(page, { label, width }),
+    });
+    completed.push(label);
+  }
 
   for (const width of [390, 768, 1280]) {
     const label = `Pagella governi ${width}px`;

--- a/scripts/browser/institutional-palette.mjs
+++ b/scripts/browser/institutional-palette.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { defaultArtifactsDir } from "./harness.mjs";
+
+// Read the production DOM and computed styles: token-only tests cannot detect
+// component overrides or production CSS ordering regressions.
+export async function inspectInstitutionalPalette(page, { label, width }) {
+  const state = await page.evaluate(() => {
+    const root = getComputedStyle(document.documentElement);
+    const context = document.createElement("canvas").getContext("2d");
+    function rgb(css) {
+      context.fillStyle = css;
+      context.fillRect(0, 0, 1, 1);
+      return [...context.getImageData(0, 0, 1, 1).data].slice(0, 3);
+    }
+    function luminance(css) {
+      const channels = rgb(css).map((value) => value / 255).map((value) => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+      return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+    }
+    function contrast(first, second) {
+      const a = luminance(first), b = luminance(second);
+      return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+    }
+    function background(element) {
+      for (let current = element; current; current = current.parentElement) {
+        const value = getComputedStyle(current).backgroundColor;
+        if (value !== "rgba(0, 0, 0, 0)" && value !== "transparent") return value;
+      }
+      return root.getPropertyValue("--color-bg");
+    }
+    const texts = [...document.querySelectorAll('main h1, .panel-title, footer a, header .brand, main .notice a')]
+      .filter((element) => element.getClientRects().length && getComputedStyle(element).visibility !== "hidden")
+      .map((element) => ({ text: element.textContent.trim().slice(0, 60), ratio: contrast(getComputedStyle(element).color, background(element)) }));
+    const bars = [...document.querySelectorAll('main li > i > b')]
+      .filter((element) => element.getBoundingClientRect().width > 0)
+      .map((element) => ({
+        color: rgb(getComputedStyle(element).backgroundColor).join(","),
+        ratio: contrast(getComputedStyle(element).backgroundColor, getComputedStyle(element.parentElement).backgroundColor),
+        label: element.closest("li").textContent.trim(),
+      }));
+    return {
+      theme: document.documentElement.dataset.theme,
+      texts, bars,
+      data: rgb(root.getPropertyValue("--chart-data-primary")).join(","),
+      running: rgb(root.getPropertyValue("--color-neutral-500")).join(","),
+      regions: document.querySelectorAll('[data-region-map="true"] path[role="button"]').length,
+      mapLabels: [...document.querySelectorAll('[data-region-map="true"] path[role="button"]')].every((element) => Boolean(element.getAttribute("aria-label"))),
+    };
+  });
+  assert.ok(state.texts.length > 5, `${label}: no visible civic text samples`);
+  for (const sample of state.texts) assert.ok(sample.ratio >= 4.5, `${label}: ${sample.text} contrast ${sample.ratio}`);
+  assert.ok(state.bars.length >= 12, `${label}: monthly and category bars missing`);
+  for (const bar of state.bars) {
+    assert.ok([state.data, state.running].includes(bar.color), `${label}: ordinary bar uses a non-quantitative role`);
+    assert.ok(bar.ratio >= 3, `${label}: bar/track contrast ${bar.ratio}`);
+    assert.ok(bar.label.length > 0, `${label}: bar lacks a text equivalent`);
+  }
+  assert.equal(state.regions, 20, `${label}: regional map missing`);
+  assert.equal(state.mapLabels, true, `${label}: region values must remain accessible without colour`);
+  if ([390, 1280].includes(width)) {
+    const directory = path.join(defaultArtifactsDir(), "institutional-palette", `${state.theme}-${width}`);
+    await mkdir(directory, { recursive: true });
+    await page.screenshot({ path: path.join(directory, "home.png"), fullPage: true });
+  }
+}

--- a/src/app/design-system.css
+++ b/src/app/design-system.css
@@ -1,5 +1,5 @@
 /*
- * Modernist — token layer and component primitives.
+ * Registro pubblico — institutional token layer and component primitives.
  *
  * Retuning the look starts here: every surface in the app reads these
  * variables instead of hard-coding a colour. See DESIGN.md for the rules that
@@ -8,49 +8,49 @@
 
 :root {
   color-scheme: light;
-  --color-announcement-bg: #201e1d;
+  --color-announcement-bg: #182b3a;
   --color-announcement-text: #ffffff;
-  --color-bg: #f3f2f2;
-  --color-surface: #eae9e9;
+  --color-bg: #f3f5f7;
+  --color-surface: #e8edf2;
   --color-raised: #ffffff;
-  --color-text: #201e1d;
+  --color-text: #182b3a;
   --color-on-strong: #ffffff;
-  --color-on-strong-muted: #d7d3d3;
-  --color-accent: #ec3013;
-  --color-accent-2: #e15b47;
-  --color-divider: color-mix(in srgb, #201e1d 40%, transparent);
+  --color-on-strong-muted: #c5cfd8;
+  --color-accent: #b42332;
+  --color-accent-2: #a82b3b;
+  --color-divider: color-mix(in srgb, #182b3a 40%, transparent);
 
-  /* Tonal ramps — generated in OKLCH on one shared lightness scale, so the
-     same step of any role matches the others in visual value. */
-  --color-neutral-100: #f8f4f4;
-  --color-neutral-200: #eae7e7;
-  --color-neutral-300: #d7d3d3;
-  --color-neutral-400: #bab6b6;
-  --color-neutral-500: #9b9797;
-  --color-neutral-600: #6a6666;
-  --color-neutral-700: #605d5d;
-  --color-neutral-800: #444141;
-  --color-neutral-900: #2d2b2b;
+  /* Cool paper and blue ink: restrained surfaces, AA text and 3:1 controls.
+     See docs/INSTITUTIONAL_PALETTE.md for measured role pairs. */
+  --color-neutral-100: #f6f8fa;
+  --color-neutral-200: #e5eaf0;
+  --color-neutral-300: #c5cfd8;
+  --color-neutral-400: #71808e;
+  --color-neutral-500: #657786;
+  --color-neutral-600: #536474;
+  --color-neutral-700: #435565;
+  --color-neutral-800: #2d4050;
+  --color-neutral-900: #1d3040;
 
-  --color-accent-100: #fff2ef;
-  --color-accent-200: #ffe0d9;
-  --color-accent-300: #ffc4b8;
-  --color-accent-400: #ff9783;
-  --color-accent-500: #ff563c;
-  --color-accent-600: #dd2b0f;
-  --color-accent-700: #ae1800;
-  --color-accent-800: #7c1405;
-  --color-accent-900: #4d170e;
+  --color-accent-100: #fff1f2;
+  --color-accent-200: #fbdde1;
+  --color-accent-300: #f1b9c1;
+  --color-accent-400: #df8795;
+  --color-accent-500: #c94c60;
+  --color-accent-600: #b42332;
+  --color-accent-700: #a51d2d;
+  --color-accent-800: #811827;
+  --color-accent-900: #5d1723;
 
-  --color-accent-2-100: #fff2ef;
-  --color-accent-2-200: #ffe0da;
-  --color-accent-2-300: #ffc4b9;
-  --color-accent-2-400: #ff9784;
-  --color-accent-2-500: #ef6853;
-  --color-accent-2-600: #c94b39;
-  --color-accent-2-700: #9e3526;
-  --color-accent-2-800: #71261b;
-  --color-accent-2-900: #471d16;
+  --color-accent-2-100: #fff1f2;
+  --color-accent-2-200: #f7dfe3;
+  --color-accent-2-300: #eabfc7;
+  --color-accent-2-400: #d7929e;
+  --color-accent-2-500: #bd6072;
+  --color-accent-2-600: #a82b3b;
+  --color-accent-2-700: #872438;
+  --color-accent-2-800: #651f30;
+  --color-accent-2-900: #451c27;
 
   /* Status — reused by freshness badges and source health. Kept inside the
      neutral/accent value range so a status chip never outshouts a number. */
@@ -84,9 +84,9 @@
 
   /* Elevation — derived from the ground: soft ink-tinted shadows on a
      light theme. */
-  --shadow-sm: 0 1px 2px color-mix(in srgb, #2d2b2b 14%, transparent);
-  --shadow-md: 0 3px 10px color-mix(in srgb, #2d2b2b 16%, transparent);
-  --shadow-lg: 0 12px 32px color-mix(in srgb, #2d2b2b 22%, transparent);
+  --shadow-sm: 0 1px 2px color-mix(in srgb, #1d3040 14%, transparent);
+  --shadow-md: 0 3px 10px color-mix(in srgb, #1d3040 16%, transparent);
+  --shadow-lg: 0 12px 32px color-mix(in srgb, #1d3040 22%, transparent);
 
   /* Layout — the shell is fluid; these only bound it on very wide screens. */
   --max: 1560px;
@@ -98,7 +98,7 @@
   --chart-secondary: var(--color-neutral-800);
   --chart-tertiary: var(--color-neutral-500);
   --chart-quaternary: var(--color-neutral-400);
-  --chart-quinary: var(--color-accent-300);
+  --chart-quinary: var(--chart-category-slate);
   --chart-negative: var(--color-accent-700);
   /* Country comparison palette. Shape and dash patterns remain redundant so
      the lines stay distinguishable without relying on colour alone. */
@@ -114,22 +114,22 @@
 
   /* Neutral quantities and completion use their own roles. Red is reserved
      for actions, warnings and genuinely critical states. */
-  --chart-data-primary: #176b73;
-  --chart-data-track: #dce9e9;
-  --chart-map-1: #deebeb;
-  --chart-map-2: #b9d4d6;
-  --chart-map-3: #86b3b7;
-  --chart-map-4: #4b9097;
-  --chart-map-5: #176b73;
-  --chart-progress: #73833a;
-  --chart-progress-track: #e5e8d9;
+  --chart-data-primary: #176575;
+  --chart-data-track: #dce7ec;
+  --chart-map-1: #dbe8ed;
+  --chart-map-2: #b4ced8;
+  --chart-map-3: #7eabbc;
+  --chart-map-4: #477f94;
+  --chart-map-5: #176575;
+  --chart-progress: #526b36;
+  --chart-progress-track: #e1e8d9;
 
   /* Additive part-to-whole charts only. Red stays for CTA and warnings. */
-  --chart-category-blue: #2855a5;
-  --chart-category-teal: #087c74;
-  --chart-category-purple: #6b46a3;
-  --chart-category-amber: #9a5b00;
-  --chart-category-green: #2f6f44;
+  --chart-category-blue: #285a80;
+  --chart-category-teal: #176b65;
+  --chart-category-purple: #625675;
+  --chart-category-amber: #805b22;
+  --chart-category-green: #386848;
   --chart-category-slate: #405b70;
 
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
@@ -138,6 +138,8 @@
 
 [data-theme="dark"] {
   color-scheme: dark;
+  --color-accent: #ff8897;
+  --color-accent-2: #efa0ad;
 
   --color-bg: #141313;
   --color-surface: #1c1a1a;
@@ -152,8 +154,8 @@
   --color-neutral-100: #1d1b1b;
   --color-neutral-200: #272424;
   --color-neutral-300: #373333;
-  --color-neutral-400: #504b4b;
-  --color-neutral-500: #746e6e;
+  --color-neutral-400: #7e858d;
+  --color-neutral-500: #939ba3;
   --color-neutral-600: #9f9898;
   --color-neutral-700: #bdb6b6;
   --color-neutral-800: #d8d2d2;
@@ -188,6 +190,11 @@
 
   --chart-data-primary: #65b7bf;
   --chart-data-track: #283a3b;
+  --chart-map-1: #324e59;
+  --chart-map-2: #416775;
+  --chart-map-3: #558797;
+  --chart-map-4: #70a7b6;
+  --chart-map-5: #a1cbd4;
   --chart-progress: #b3c576;
   --chart-progress-track: #333924;
   --chart-country-italy: #75b4ff;

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -205,7 +205,7 @@
   width: 7px;
   height: 7px;
   flex: none;
-  background: var(--color-accent);
+  background: var(--color-neutral-600);
 }
 
 .headline {

--- a/tests/institutional-ui-palette.test.mjs
+++ b/tests/institutional-ui-palette.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const css = fs.readFileSync(new URL("../src/app/design-system.css", import.meta.url), "utf8");
+const declarations = (block) => Object.fromEntries([...block.matchAll(/(--[\w-]+):\s*([^;]+);/g)].map((match) => [match[1], match[2].trim()]));
+const light = declarations(css.match(/:root\s*\{([\s\S]*?)\n\}/)[1]);
+const dark = { ...light, ...declarations(css.match(/\[data-theme="dark"\]\s*\{([\s\S]*?)\n\}/)[1]) };
+function value(tokens, name) {
+  const raw = tokens[name];
+  assert.ok(raw, `${name}: missing token`);
+  const alias = raw.match(/^var\((--[\w-]+)\)$/);
+  return alias ? value(tokens, alias[1]) : raw;
+}
+function luminance(hex) {
+  assert.match(hex, /^#[\da-f]{6}$/i);
+  const channels = [1, 3, 5].map((offset) => parseInt(hex.slice(offset, offset + 2), 16) / 255)
+    .map((n) => n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4);
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+function contrast(a, b) {
+  const first = luminance(a), second = luminance(b);
+  return (Math.max(first, second) + 0.05) / (Math.min(first, second) + 0.05);
+}
+for (const [theme, tokens] of Object.entries({ light, dark })) {
+  test(`${theme}: civic text, links, controls and status role pairs meet AA`, () => {
+    const pairs = [];
+    for (const surface of ["bg", "surface", "raised", "neutral-100", "neutral-200"]) {
+      for (const foreground of ["text", "neutral-600", "neutral-700", "neutral-800", "accent-700", "accent-800"]) {
+        pairs.push([`--color-${foreground}`, `--color-${surface}`, 4.5]);
+      }
+    }
+    for (const status of ["positive", "warning", "critical"]) pairs.push([`--color-${status}`, `--color-${status}-bg`, 4.5]);
+    for (const foreground of ["on-strong", "on-strong-muted"]) pairs.push([`--color-${foreground}`, "--color-text", 4.5]);
+    for (const action of ["accent-700", "accent-800", "accent-900"]) pairs.push(["--color-raised", `--color-${action}`, 4.5]);
+    for (const surface of ["bg", "surface", "raised"]) {
+      pairs.push(["--focus-ring", `--color-${surface}`, 3], ["--color-neutral-400", `--color-${surface}`, 3]);
+    }
+    pairs.push(["--color-announcement-text", "--color-announcement-bg", 4.5], ["--chart-data-primary", "--chart-data-track", 3], ["--chart-progress", "--chart-progress-track", 3]);
+    for (const [foreground, background, minimum] of pairs) {
+      const ratio = contrast(value(tokens, foreground), value(tokens, background));
+      assert.ok(ratio >= minimum, `${foreground} on ${background}: ${ratio.toFixed(3)} < ${minimum}`);
+    }
+  });
+  test(`${theme}: additive category tints retain AA text`, () => {
+    for (const category of ["blue", "teal", "purple", "amber", "green", "slate"]) {
+      const fill = value(tokens, `--chart-category-${category}`);
+      const raised = value(tokens, "--color-raised");
+      const mixed = "#" + [1, 3, 5].map((offset) => Math.round(
+        parseInt(fill.slice(offset, offset + 2), 16) * 0.4 + parseInt(raised.slice(offset, offset + 2), 16) * 0.6,
+      ).toString(16).padStart(2, "0")).join("");
+      assert.ok(contrast(value(tokens, "--color-text"), mixed) >= 4.5, `${category}: text on 40% category tint`);
+    }
+  });
+  test(`${theme}: map bins are strictly sequential and normal quantities are not red`, () => {
+    const ramp = [1, 2, 3, 4, 5].map((step) => luminance(value(tokens, `--chart-map-${step}`)));
+    assert.equal(new Set(ramp).size, 5);
+    for (let index = 1; index < ramp.length; index++) assert.ok(theme === "light" ? ramp[index] < ramp[index - 1] : ramp[index] > ramp[index - 1]);
+    for (const role of ["primary", "data-primary", "quinary", "map-5"]) {
+      assert.notEqual(value(tokens, `--chart-${role}`), value(tokens, "--color-accent"));
+      assert.notEqual(value(tokens, `--chart-${role}`), value(tokens, "--color-accent-700"));
+    }
+  });
+}
+
+test("home bars, map and additive composition retain dedicated data roles and text equivalents", () => {
+  for (const file of ["../src/app/home.module.css", "../src/components/home-italy-charts.module.css"]) {
+    const source = fs.readFileSync(new URL(file, import.meta.url), "utf8");
+    assert.match(source, /background: var\(--chart-data-primary\)/);
+    assert.match(source, /background: var\(--chart-data-track\)/);
+  }
+  const composition = fs.readFileSync(new URL("../src/components/spending-composition.module.css", import.meta.url), "utf8");
+  assert.doesNotMatch(composition, /var\(--color-accent/);
+  const map = fs.readFileSync(new URL("../src/components/italy-regions-map.tsx", import.meta.url), "utf8");
+  assert.match(map, /aria-label/);
+  assert.match(map, /data-region-selector/);
+});


### PR DESCRIPTION
La palette precedente mescolava superfici calde, accenti molto saturi e ruoli quantitativi poco uniformi. Questa PR adotta carta fredda, inchiostro blu scuro e petrolio per i dati, mantenendo il rosso per azioni e stati.

I colori restano centralizzati nei token esistenti. Sono documentate le coppie di contrasto, le categorie additive e le rampe delle mappe nei temi chiaro e scuro; la home mantiene etichette e valori leggibili senza dipendere dal colore.

Verifica: CI completa sullo stesso contenuto prima dell'apertura della PR, con controlli statici, sicurezza, Node, ETL, snapshot, build, E2E di produzione e Lighthouse. I nuovi controlli browser verificano contrasto effettivo, barre, mappe e layout a 320, 375, 390, 768, 1024, 1280 e 1600 px, in entrambi i temi.

Esecuzione: https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34465134163

L'ambiente locale non consente il controllo della memoria richiesto dalla build e da un test; per questi gate fa fede l'esecuzione completa sui runner GitHub.

Closes #374