### PR TITLE
Esplora: confronto accessibile tra serie ufficiali

### DIFF
--- a/docs/CONFRONTO_SERIE.md
+++ b/docs/CONFRONTO_SERIE.md
@@ -1,0 +1,59 @@
+# Confronto di serie ufficiali (#382)
+
+`/esplora` contiene la ricerca di relazioni tra incarichi ed enti. Non era un
+selettore di serie storiche: quel percorso resta disponibile e introduce
+`/esplora/serie`, dedicato al confronto. La navigazione e la ricerca globale
+espongono direttamente anche il nuovo strumento.
+
+## Prima versione
+
+Un form GET con quattro selettori permette di scegliere da due a quattro
+serie. Le due facoltative possono restare vuote; l’URL risultante conserva la
+selezione, anche al refresh e senza JavaScript. L’esempio iniziale confronta
+Difesa e Ordine pubblico e sicurezza italiani in milioni di euro correnti.
+
+Il catalogo comprende 26 proiezioni di snapshot già verificati:
+
+- undici funzioni COFOG Italia, totale incluso, nelle due unità native Eurostat
+  `MIO_EUR` e `PC_GDP`, annuali 2014–2024;
+- IPCA totale di IT, FR, DE ed ES, `RCH_A`, mensile 1997-01–2026-08.
+
+I perimetri sono fissati dalla famiglia. Non sono presenti upload, forecasting,
+conversioni valutarie, ribasamenti, contributi COICOP o nuove fonti. L’IPCA a/a
+resta distinto dalla variazione mensile e dal livello dell’indice.
+
+## Confini e comportamento
+
+`official-series.ts` legge esclusivamente gli adapter COFOG e pagella governi
+che convalidano gli snapshot. I centesimi COFOG tornano nell’unità originale
+milioni di euro; la quota del PIL torna in punti percentuali. L’IPCA conserva
+valori e flag originali, inclusi quelli stimati dalla fonte.
+
+Il confronto rifiuta meno di due o più di quattro serie, ID non catalogati,
+duplicati, incompatibilità di unità/frequenza/famiglia, serie vuote, periodi
+malformati, duplicati o non ordinati e assenza di un periodo comune. In questi
+casi mostra un avviso e le fonti delle selezioni riconosciute, senza grafico
+né tabella numerica sostitutiva.
+
+L’asse temporale usa l’unione dei periodi nel calendario nativo; la presenza di
+una riga non inventa un’osservazione. I valori assenti restano null e interrompono
+la linea, come il flag Eurostat `b` prima dell’osservazione interessata. Nessun
+dato viene interpolato o aggregato; zero resta zero. Le linee sono descrittive,
+non una prova di causalità. Totale e divisioni COFOG non vengono sommati.
+
+## Lettura e verifica
+
+Grafico e tabella riportano identiche osservazioni. Asse verticale comune con
+zero, legenda numerata e tratti diversi rendono il colore ridondante. La
+tabella scorre nel proprio contenitore, raggiungibile da tastiera, e riporta lo
+stato di ogni osservazione. Le etichette HTML del grafico restano leggibili su
+mobile. Una scheda visibile per serie conserva unità, frequenza, copertura,
+fonte e date distinte; query, condizioni di riuso e SHA-256 sono espandibili.
+
+`tests/official-series.test.mjs` verifica concordanza con gli snapshot,
+selezioni valide/negative, lacune e interruzioni. Lo scenario produzione
+`scripts/browser/official-series.mjs`, integrato nel core, esercita l’ingresso,
+il form reale, confronto a quattro serie, tabella e fonti, navigazione da
+tastiera e rifiuto delle selezioni incompatibili a sette larghezze da 320 a
+1600 px. Esiti effettivi dei gate vanno riportati nella PR; l’esistenza dei
+test non equivale a un loro esito positivo.

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -34,6 +34,20 @@ Per aggiungere una nuova fonte in modo ripetibile (contributor o agente), usa
 
 ## Pagella politico-economica dei governi
 
+### Confronto di serie esistenti
+
+`/esplora/serie` permette di confrontare da due a quattro serie della stessa
+famiglia: undici funzioni COFOG Italia (`gov_10a_exp`, annuale 2014–2024), in
+milioni di euro correnti oppure % del PIL, e IPCA totale IT/FR/DE/ES
+(`prc_hicp_minr`, `RCH_A`, mensile 1997-01–2026-08). Usa gli snapshot già
+validati e non acquisisce nuove fonti. Fonte, copertura, unità, date e hash
+restano associati a ogni selezione; i flag stimati/provvisori e le interruzioni
+non vengono eliminati. Unità, frequenze o definizioni incompatibili bloccano
+il confronto; lacune e zero restano distinti. Specifica e limiti in
+[CONFRONTO_SERIE.md](CONFRONTO_SERIE.md).
+
+### Serie della pagella
+
 La pagina `/governi` combina due perimetri che non vanno confusi:
 
 - **voto:** sei serie annuali AMECO della Commissione europea, per Italia,

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { inspectReceipts } from "./receipts.mjs";
 import { inspectEpea } from "./epea.mjs";
 import { inspectCulture, inspectCultureJourney, inspectInvalidCultureYears } from "./culture.mjs";
+import { inspectOfficialSeries } from "./official-series.mjs";
 import { inspectDefence } from "./defence.mjs";
 import { inspectPnrrProjects } from "./pnrr-projects.mjs";
 import { inspectTedNotices } from "./ted-notices.mjs";
@@ -906,6 +907,14 @@ try {
       });
       completed.push(label);
     }
+  }
+
+  for (const width of [320, 375, 390, 768, 1024, 1280, 1600]) {
+    const label = `Confronto serie ufficiali ${width}px`;
+    await runScenario(browser, {
+      label, pathname: "/esplora", width, validate: inspectOfficialSeries,
+    });
+    completed.push(label);
   }
 
   for (const width of [320, 375, 390, 768, 1024, 1280, 1600]) {

--- a/scripts/browser/official-series.mjs
+++ b/scripts/browser/official-series.mjs
@@ -47,21 +47,34 @@ export async function inspectOfficialSeries(page) {
   await submit(page, ids);
   await page.waitForSelector('[data-testid="series-comparison"]');
   assert.equal(await page.$$eval('[data-testid="series-source"]', (elements) => elements.length), 4);
+  const lineStyles = await page.evaluate(() => {
+    const style = (element) => ({ stroke: getComputedStyle(element).stroke, dash: getComputedStyle(element).strokeDasharray });
+    return {
+      legend: [...document.querySelectorAll('[data-testid="series-comparison"] ol svg line')].map(style),
+      chart: [...document.querySelectorAll('[data-testid="series-chart"] > g')].map(style),
+    };
+  });
+  assert.deepEqual(lineStyles.legend, lineStyles.chart, "Legend and plot must use identical line styles");
   const inflation = scorecard.series.find((series) => series.indicator_id === "inflation");
   const actual = await page.$$eval('[data-testid="series-table"] tbody tr', (elements) => elements.map((row) => ({
     period: row.cells[0].textContent,
     values: [...row.querySelectorAll("[data-value]")].map((element) => Number(element.dataset.value)),
   })));
-  assert.equal(actual.length, 356);
+  const expectedPeriods = [...new Set(inflation.geographies.flatMap((geography) => geography.points.map((point) => point.period)))].sort();
+  assert.deepEqual(actual.map((row) => row.period), expectedPeriods);
   for (const row of actual) assert.deepEqual(row.values, ["IT", "FR", "DE", "ES"].map((geo) => inflation.geographies.find((entry) => entry.geography === geo).points.find((point) => point.period === row.period)?.value));
-  assert.match(await page.$eval('[data-testid="series-table"] tbody tr:last-child', (element) => element.textContent), /Stimato dalla fonte/);
+  const lastPeriod = expectedPeriods.at(-1);
+  const expectedEstimated = inflation.geographies.filter((geography) => geography.points.find((point) => point.period === lastPeriod)?.status === "estimated").length;
+  const lastRow = await page.$eval('[data-testid="series-table"] tbody tr:last-child', (element) => element.textContent);
+  assert.equal((lastRow.match(/Stimato dalla fonte/g) ?? []).length, expectedEstimated);
   const sources = await page.$$eval('[data-testid="series-source"]', (elements) => elements.map((element) => ({
     text: element.textContent,
     url: element.querySelector('a[href*="databrowser"]').href,
   })));
-  for (const source of sources) {
+  for (const [index, source] of sources.entries()) {
+    const points = inflation.geographies.find((geography) => ids[index] === `hicp-${geography.geography}`).points;
     assert.match(source.text, /Eurostat/);
-    assert.match(source.text, /1997-01 al 2026-08/);
+    assert.ok(source.text.includes(`${points[0].period} al ${points.at(-1).period}`));
     assert.match(source.text, /% rispetto allo stesso mese/);
     assert.match(source.url, /prc_hicp_minr/);
   }

--- a/scripts/browser/official-series.mjs
+++ b/scripts/browser/official-series.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import cofog from "../../src/data/generated/eurostat-cofog-2014-2024.data.json" with { type: "json" };
+import scorecard from "../../src/data/generated/government-scorecard-page.json" with { type: "json" };
+
+async function assertShell(page) {
+  const state = await page.evaluate(() => ({
+    viewport: innerWidth,
+    root: document.documentElement.scrollWidth,
+    body: document.body.scrollWidth,
+    headings: document.querySelectorAll("main h1").length,
+  }));
+  assert.equal(state.headings, 1);
+  assert.ok(state.root <= state.viewport + 1 && state.body <= state.viewport + 1, JSON.stringify(state));
+}
+
+async function submit(page, ids) {
+  for (let index = 0; index < 4; index++) await page.select(`#serie-${index + 1}`, ids[index] ?? "");
+  await page.focus('main button[type="submit"]');
+  await Promise.all([page.waitForNavigation({ waitUntil: "networkidle2" }), page.keyboard.press("Enter")]);
+  assert.deepEqual(new URL(page.url()).searchParams.getAll("serie").filter(Boolean), ids);
+  await assertShell(page);
+}
+
+/** Exercise the actual SSR form, semantic rejection and accessible data view. */
+export async function inspectOfficialSeries(page) {
+  await page.waitForSelector('main a[href="/esplora/serie"]');
+  await page.focus('main a[href="/esplora/serie"]');
+  await page.keyboard.press("Enter");
+  await page.waitForSelector('[data-testid="series-comparison"]');
+  await assertShell(page);
+  assert.match(await page.$eval("main h1", (element) => element.textContent), /Confronta serie ufficiali/);
+  assert.equal(await page.$$eval('[data-testid="series-source"]', (elements) => elements.length), 2);
+  assert.equal(await page.$$eval('[data-testid="series-chart"] polyline', (elements) => elements.length) >= 2, true);
+  const rows = await page.$$eval('[data-testid="series-table"] tbody tr', (elements) => elements.map((row) => ({
+    period: row.cells[0].textContent,
+    values: [...row.querySelectorAll("[data-value]")].map((element) => Number(element.dataset.value)),
+  })));
+  assert.equal(rows.length, 11);
+  for (const row of rows) {
+    assert.deepEqual(row.values, ["GF02", "GF03"].map((code) => cofog.observations.find((point) => point.geo === "IT" && point.function === code && point.year === Number(row.period)).amountCents / 100_000_000));
+  }
+  const region = '[role="region"][aria-label="Valori delle serie a confronto"]';
+  await page.focus(region);
+  assert.equal(await page.evaluate(() => document.activeElement?.getAttribute("aria-label")), "Valori delle serie a confronto");
+
+  const ids = ["hicp-IT", "hicp-FR", "hicp-DE", "hicp-ES"];
+  await submit(page, ids);
+  await page.waitForSelector('[data-testid="series-comparison"]');
+  assert.equal(await page.$$eval('[data-testid="series-source"]', (elements) => elements.length), 4);
+  const inflation = scorecard.series.find((series) => series.indicator_id === "inflation");
+  const actual = await page.$$eval('[data-testid="series-table"] tbody tr', (elements) => elements.map((row) => ({
+    period: row.cells[0].textContent,
+    values: [...row.querySelectorAll("[data-value]")].map((element) => Number(element.dataset.value)),
+  })));
+  assert.equal(actual.length, 356);
+  for (const row of actual) assert.deepEqual(row.values, ["IT", "FR", "DE", "ES"].map((geo) => inflation.geographies.find((entry) => entry.geography === geo).points.find((point) => point.period === row.period)?.value));
+  assert.match(await page.$eval('[data-testid="series-table"] tbody tr:last-child', (element) => element.textContent), /Stimato dalla fonte/);
+  const sources = await page.$$eval('[data-testid="series-source"]', (elements) => elements.map((element) => ({
+    text: element.textContent,
+    url: element.querySelector('a[href*="databrowser"]').href,
+  })));
+  for (const source of sources) {
+    assert.match(source.text, /Eurostat/);
+    assert.match(source.text, /1997-01 al 2026-08/);
+    assert.match(source.text, /% rispetto allo stesso mese/);
+    assert.match(source.url, /prc_hicp_minr/);
+  }
+  const disclosure = '[data-testid="series-source"] details';
+  await page.focus(`${disclosure} summary`);
+  await page.keyboard.press("Enter");
+  assert.equal(await page.$eval(disclosure, (element) => element.open), true);
+  const hash = scorecard.sources.find((source) => source.id === "eurostat:prc_hicp_minr").raw_sha256;
+  assert.equal(await page.$eval(`${disclosure} code`, (element) => element.textContent), hash);
+
+  await submit(page, ["hicp-IT", "cofog-GF02-MIO_EUR"]);
+  await page.waitForSelector('[data-testid="series-warning"]');
+  assert.match(await page.$eval('[data-testid="series-warning"]', (element) => element.textContent), /unités?|unità|frequenza/i);
+  assert.equal(await page.$('[data-testid="series-chart"]'), null);
+  assert.equal(await page.$('[data-testid="series-table"]'), null);
+  assert.equal(await page.$$eval('[data-testid="series-source"]', (elements) => elements.length), 2);
+
+  // One viewport covers URL tampering; every viewport above drives the form.
+  if (page.viewport().width === 390) {
+    for (const query of [
+      "serie=unknown&serie=hicp-IT",
+      "serie=hicp-IT&serie=hicp-IT",
+      "serie=hicp-IT",
+      "serie=hicp-IT&serie=hicp-FR&serie=hicp-DE&serie=hicp-ES&serie=cofog-GF02-MIO_EUR",
+    ]) {
+      await page.goto(new URL(`/esplora/serie?${query}`, page.url()).href, { waitUntil: "networkidle2" });
+      await page.waitForSelector('[data-testid="series-warning"]');
+      assert.equal(await page.$('[data-testid="series-chart"]'), null);
+      await assertShell(page);
+    }
+    await submit(page, ["cofog-GF02-PC_GDP", "cofog-GF03-PC_GDP"]);
+    await page.reload({ waitUntil: "networkidle2" });
+    assert.equal(await page.$eval("#serie-1", (element) => element.value), "cofog-GF02-PC_GDP");
+    assert.match(await page.$eval('[data-testid="series-comparison"]', (element) => element.textContent), /% del PIL/);
+    await assertShell(page);
+  }
+}

--- a/src/app/esplora/page.tsx
+++ b/src/app/esplora/page.tsx
@@ -28,6 +28,12 @@ export default function EsploraPage() {
 
       </section>
 
+      <section className="panel" aria-labelledby="official-series-entry">
+        <h2 className="panel-title" id="official-series-entry">Cerchi un confronto nel tempo?</h2>
+        <p>Confronta da due a quattro serie Eurostat su spesa pubblica o prezzi, con unità compatibili, tabella e fonti per ogni serie.</p>
+        <Link href="/esplora/serie">Confronta serie ufficiali</Link>
+      </section>
+
       <EsploraSearch initialCount={searchable} />
 
       <details className="data-details">

--- a/src/app/esplora/serie/page.tsx
+++ b/src/app/esplora/serie/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { decimal, longDate, percent } from "@/lib/format";
+import {
+  compareOfficialSeries, getOfficialSeriesCatalog, officialSeriesSegments,
+  parseOfficialSeriesSelection, type OfficialSeries,
+} from "@/lib/official-series";
+import styles from "./serie.module.css";
+
+export const metadata: Metadata = {
+  title: "Confronta serie ufficiali",
+  description: "Confronta da due a quattro serie Eurostat verificate: spesa PA COFOG o prezzi IPCA, con unità compatibili, tabella e fonti.",
+};
+
+function valueLabel(value: number, unit: OfficialSeries["unit"]) {
+  // MIO_EUR is already the published unit; keep one decimal, including zero.
+  return unit === "MIO_EUR" ? decimal(value) : percent(value, unit === "PC_GDP" ? 2 : 1);
+}
+
+export default async function OfficialSeriesPage({ searchParams }: {
+  searchParams: Promise<{ serie?: string | string[] }>;
+}) {
+  const requested = parseOfficialSeriesSelection((await searchParams).serie);
+  const catalog = getOfficialSeriesCatalog();
+  const comparison = compareOfficialSeries(catalog, requested);
+  const selected = comparison.selected;
+  const families = [
+    { id: "cofog-MIO_EUR", label: "Spesa PA · annuale · milioni di euro correnti" },
+    { id: "cofog-PC_GDP", label: "Spesa PA · annuale · % del PIL" },
+    { id: "hicp-total-annual-change", label: "Prezzi IPCA · mensile · variazione annua %" },
+  ];
+  const values = comparison.ok ? comparison.rows.flatMap((row) => row.points.flatMap((point) => point ? [point.value] : [])) : [];
+  const min = Math.min(0, ...values);
+  const max = Math.max(0, ...values);
+  const range = max - min || 1;
+  const y = (value: number) => 12 + (max - value) / range * 196;
+
+  return <main className="shell page">
+    <header className={styles.intro}>
+      <p><Link href="/esplora">Esplora relazioni</Link> · <Link href="/dati">Catalogo dati</Link></p>
+      <h1>Confronta serie ufficiali</h1>
+      <p>Scegli da due a quattro serie e leggi come cambiano nel tempo. Il confronto usa i valori pubblicati da Eurostat, con la stessa unità, frequenza e definizione.</p>
+    </header>
+
+    <section className="panel" aria-labelledby="selection-title">
+      <h2 className="panel-title" id="selection-title">Scegli le serie</h2>
+      <p id="selection-help">Scegli all’interno della stessa famiglia. La spesa PA in euro, la sua quota di PIL e la variazione dei prezzi sono tre confronti distinti.</p>
+      <form action="/esplora/serie" method="get" aria-describedby="selection-help">
+        <div className={styles.selectors}>
+          {[0, 1, 2, 3].map((index) => <label key={index} htmlFor={`serie-${index + 1}`}>
+            Serie {index + 1}{index > 1 ? " (facoltativa)" : ""}
+            <select id={`serie-${index + 1}`} name="serie" defaultValue={catalog.some((series) => series.id === requested[index]) ? requested[index] : ""}>
+              <option value="">Seleziona una serie</option>
+              {families.map((family) => <optgroup label={family.label} key={family.id}>
+                {catalog.filter((series) => series.family === family.id).map((series) => <option key={series.id} value={series.id}>{series.label}</option>)}
+              </optgroup>)}
+            </select>
+          </label>)}
+        </div>
+        <div className={styles.actions}><button className="btn" type="submit">Confronta serie</button><Link href="/esplora/serie">Ripristina esempio</Link></div>
+      </form>
+    </section>
+
+    {!comparison.ok ? <section className="notice" role="alert" data-testid="series-warning">
+      <h2>Controlla la selezione</h2><p>{comparison.message}</p>
+      <p>Il grafico non viene calcolato. Correggi la selezione qui sopra.</p>
+    </section> : <>
+      <section className="panel" aria-labelledby="comparison-title" data-testid="series-comparison">
+        <h2 className="panel-title" id="comparison-title">Andamento a confronto</h2>
+        <p><strong>{selected[0].unitLabel}</strong> · Frequenza {selected[0].frequency === "annual" ? "annuale" : "mensile"} · {comparison.rows[0].period} al {comparison.rows.at(-1)!.period}</p>
+        <p>{selected[0].scope}. Nessuna normalizzazione o somma delle serie.</p>
+        <ol className={styles.legend}>
+          {selected.map((series, index) => <li key={series.id}>
+            <span className={`${styles.swatch} ${styles[`line${index}`]}`} aria-hidden="true" />
+            <span>{index + 1}. {series.label} · <a href={`#fonte-${series.id}`}>Fonte e periodo</a></span>
+          </li>)}
+        </ol>
+        <div className={styles.chart}>
+          <span className={styles.tick}>{valueLabel(max, selected[0].unit)}</span>
+          <svg viewBox="0 0 640 220" preserveAspectRatio="none" role="img" aria-labelledby="series-chart-title series-chart-desc" data-testid="series-chart">
+            <title id="series-chart-title">{`Confronto di ${selected.length} serie ufficiali, ${comparison.rows[0].period} al ${comparison.rows.at(-1)!.period}`}</title>
+            <desc id="series-chart-desc">Valori esatti e stato di ogni osservazione nella tabella seguente. Le linee si interrompono per valori mancanti o interruzioni dichiarate dalla fonte.</desc>
+            {[0, 0.5, 1].map((fraction) => <line key={fraction} x1="8" x2="632" y1={12 + fraction * 196} y2={12 + fraction * 196} className={styles.grid} vectorEffect="non-scaling-stroke" />)}
+            <line x1="8" x2="632" y1={y(0)} y2={y(0)} className={styles.zero} vectorEffect="non-scaling-stroke" />
+            {selected.map((series, seriesIndex) => <g key={series.id} className={styles[`line${seriesIndex}`]}>
+              {officialSeriesSegments(comparison.rows.map((row) => row.points[seriesIndex])).map((indices, segment) => <polyline key={segment} fill="none" strokeWidth="2.5" vectorEffect="non-scaling-stroke" points={indices.map((index) => `${8 + index / Math.max(1, comparison.rows.length - 1) * 624},${y(comparison.rows[index].points[seriesIndex]!.value)}`).join(" ")} />)}
+              {comparison.rows.map((row, index) => row.points[seriesIndex] ? <circle key={row.period} cx={8 + index / Math.max(1, comparison.rows.length - 1) * 624} cy={y(row.points[seriesIndex]!.value)} r="2.2" strokeWidth="1" vectorEffect="non-scaling-stroke" /> : null)}
+            </g>)}
+          </svg>
+          <span className={styles.tick}>{valueLabel(min, selected[0].unit)}</span>
+          <div className={styles.periods}><span>{comparison.rows[0].period}</span><span>{comparison.rows[Math.floor((comparison.rows.length - 1) / 2)].period}</span><span>{comparison.rows.at(-1)!.period}</span></div>
+        </div>
+        <p className={styles.note}>Asse verticale comune, con zero visibile. I numeri e i tratti della legenda distinguono le serie anche senza colore. Le linee descrivono l’andamento tra osservazioni: non stimano i periodi mancanti. Stato e flag sono riportati nella tabella.</p>
+      </section>
+
+      <section className="panel" aria-labelledby="series-table-title">
+        <h2 className="panel-title" id="series-table-title">Valori pubblicati e stato del dato</h2>
+        <p>Unità di tutte le colonne: {selected[0].unitLabel}. “Non disponibile” è diverso da zero. Scorri la tabella per leggere tutte le serie.</p>
+        <div className={`table-scroll ${styles.tableRegion}`} role="region" aria-label="Valori delle serie a confronto" tabIndex={0}>
+          <table className="table" data-testid="series-table">
+            <caption className="sr-only">Valori esatti delle serie selezionate, con periodo e stato della fonte</caption>
+            <thead><tr><th scope="col">Periodo</th>{selected.map((series, index) => <th key={series.id} scope="col">{index + 1}. {series.label}</th>)}</tr></thead>
+            <tbody>{comparison.rows.map((row) => <tr key={row.period}><th scope="row">{row.period}</th>{row.points.map((point, index) => <td key={selected[index].id} className="num">
+              {point ? <><span data-value={point.value}>{valueLabel(point.value, selected[index].unit)}</span><small>{point.status}{point.breakBefore ? " · Interruzione di serie" : ""}</small></> : "Non disponibile"}
+            </td>)}</tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+    </>}
+
+    {selected.length > 0 && <section className="panel" aria-labelledby="series-sources-title">
+      <h2 className="panel-title" id="series-sources-title">Fonte e periodo di ogni serie</h2>
+      <div className={styles.sources}>{selected.map((series, index) => <article id={`fonte-${series.id}`} key={`${series.id}-${index}`} data-testid="series-source">
+        <h3>{index + 1}. {series.label}</h3>
+        <p><strong>{series.source.owner}</strong> · <a href={series.source.url}>{series.source.dataset}</a></p>
+        <p>{series.points[0].period} al {series.points.at(-1)!.period} · {series.frequency === "annual" ? "Annuale" : "Mensile"} · {series.unitLabel}</p>
+        <p>{series.scope}</p>
+        <p>Ultimo aggiornamento della fonte: {longDate(series.source.updatedAt)}. Acquisizione: {longDate(series.source.acquiredAt)}. Data distinta di controllo: {longDate(series.source.checkedAt)}.</p>
+        <details className="data-details"><summary>Query, licenza e impronta del file</summary>
+          <p><a href={series.source.queryUrl}>Query ufficiale Eurostat</a> · <a href={series.source.termsUrl}>Condizioni di riuso Eurostat</a></p>
+          <p>SHA-256 della risposta sorgente: <code className={styles.hash}>{series.source.sha256}</code></p>
+        </details>
+      </article>)}</div>
+    </section>}
+
+    <section className="panel" aria-labelledby="series-method-title">
+      <h2 className="panel-title" id="series-method-title">Come leggere il confronto</h2>
+      <p>Questo primo catalogo include le undici funzioni COFOG italiane (totale compreso), in milioni di euro correnti o in percentuale del PIL, e l’IPCA totale di Italia, Francia, Germania e Spagna. Gli altri dataset restano nel <Link href="/dati">catalogo dati</Link>.</p>
+      <p>Stessa unità non basta: il confronto richiede anche la stessa frequenza e definizione. L’IPCA è un tasso annuo osservato ogni mese, non una variazione mensile né un livello dell’indice. Non è spesa pubblica e non viene sovrapposto a COFOG, pagamenti SIOPE o stanziamenti di bilancio.</p>
+      <p>I periodi mantengono il calendario originale. Non annualizziamo i mesi, non ribasiamo gli indici, non convertiamo le valute e non interpoliamo dati. Le lacune restano visibili; il flag di interruzione spezza la linea. Un valore stimato o provvisorio resta indicato come tale.</p>
+      <p>Le funzioni COFOG usano lo stesso settore S13 e la stessa contabilità SEC 2010. Il totale include le divisioni: sovrapporre le linee non autorizza a sommarle. Gli importi correnti non sono corretti per l’inflazione; la quota di PIL ha un denominatore diverso da un tasso di crescita.</p>
+      <p>Andamenti simili non dimostrano un rapporto di causa ed effetto, efficienza della spesa o responsabilità politica. Per il contesto: <Link href="/spese">spesa per funzione</Link> e <Link href="/governi">pagella dei governi</Link>.</p>
+    </section>
+  </main>;
+}

--- a/src/app/esplora/serie/page.tsx
+++ b/src/app/esplora/serie/page.tsx
@@ -71,7 +71,9 @@ export default async function OfficialSeriesPage({ searchParams }: {
         <p>{selected[0].scope}. Nessuna normalizzazione o somma delle serie.</p>
         <ol className={styles.legend}>
           {selected.map((series, index) => <li key={series.id}>
-            <span className={`${styles.swatch} ${styles[`line${index}`]}`} aria-hidden="true" />
+            <svg className={`${styles.swatch} ${styles[`line${index}`]}`} viewBox="0 0 32 10" aria-hidden="true">
+              <line x1="0" x2="32" y1="5" y2="5" strokeWidth="2.5" />
+            </svg>
             <span>{index + 1}. {series.label} · <a href={`#fonte-${series.id}`}>Fonte e periodo</a></span>
           </li>)}
         </ol>

--- a/src/app/esplora/serie/serie.module.css
+++ b/src/app/esplora/serie/serie.module.css
@@ -1,0 +1,29 @@
+.intro { margin-bottom: var(--space-6); }
+.intro p { max-width: 80ch; }
+.selectors { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); margin-block: var(--space-4); }
+.selectors label { display: grid; gap: var(--space-2); min-width: 0; }
+.selectors select { width: 100%; min-width: 0; padding: var(--space-3); border: 1px solid var(--color-neutral-400); background: var(--color-raised); color: var(--color-text); font: inherit; }
+.actions { display: flex; align-items: center; flex-wrap: wrap; gap: var(--space-4); }
+.legend { display: grid; gap: var(--space-2); list-style: none; padding: 0; }
+.legend li { display: flex; gap: var(--space-2); align-items: baseline; }
+.swatch { width: 32px; flex: 0 0 32px; border-top: 3px solid; }
+.line0 { stroke: var(--chart-primary); color: var(--chart-primary); fill: var(--chart-primary); }
+.line1 { stroke: var(--color-text); color: var(--color-text); fill: var(--color-text); stroke-dasharray: 8 4; border-top-style: dashed; }
+.line2 { stroke: var(--chart-secondary); color: var(--chart-secondary); fill: var(--chart-secondary); stroke-dasharray: 2 4; border-top-style: dotted; }
+.line3 { stroke: var(--chart-tertiary); color: var(--chart-tertiary); fill: var(--chart-tertiary); stroke-dasharray: 12 3 2 3; border-top-style: double; }
+.chart { margin-block: var(--space-4); }
+.chart svg { display: block; width: 100%; height: 220px; }
+.grid { stroke: var(--color-neutral-300); }
+.zero { stroke: var(--color-neutral-600); }
+.tick, .periods { font-size: 12px; font-variant-numeric: tabular-nums; color: var(--color-neutral-700); }
+.periods { display: flex; justify-content: space-between; gap: var(--space-2); margin-top: var(--space-2); }
+.note { font-size: 12px; color: var(--color-neutral-700); }
+.tableRegion { max-height: 480px; }
+.tableRegion th { min-width: 100px; }
+.tableRegion td small { display: block; white-space: normal; min-width: 140px; color: var(--color-neutral-700); }
+.sources { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+.sources article { min-width: 0; border-top: 1px solid var(--color-neutral-300); padding-top: var(--space-3); scroll-margin-top: var(--space-8); }
+.hash { overflow-wrap: anywhere; }
+@media (max-width: 620px) {
+  .selectors, .sources { grid-template-columns: minmax(0, 1fr); }
+}

--- a/src/app/esplora/serie/serie.module.css
+++ b/src/app/esplora/serie/serie.module.css
@@ -6,11 +6,11 @@
 .actions { display: flex; align-items: center; flex-wrap: wrap; gap: var(--space-4); }
 .legend { display: grid; gap: var(--space-2); list-style: none; padding: 0; }
 .legend li { display: flex; gap: var(--space-2); align-items: baseline; }
-.swatch { width: 32px; flex: 0 0 32px; border-top: 3px solid; }
+.swatch { width: 32px; height: 10px; flex: 0 0 32px; }
 .line0 { stroke: var(--chart-primary); color: var(--chart-primary); fill: var(--chart-primary); }
-.line1 { stroke: var(--color-text); color: var(--color-text); fill: var(--color-text); stroke-dasharray: 8 4; border-top-style: dashed; }
-.line2 { stroke: var(--chart-secondary); color: var(--chart-secondary); fill: var(--chart-secondary); stroke-dasharray: 2 4; border-top-style: dotted; }
-.line3 { stroke: var(--chart-tertiary); color: var(--chart-tertiary); fill: var(--chart-tertiary); stroke-dasharray: 12 3 2 3; border-top-style: double; }
+.line1 { stroke: var(--color-text); color: var(--color-text); fill: var(--color-text); stroke-dasharray: 8 4; }
+.line2 { stroke: var(--chart-secondary); color: var(--chart-secondary); fill: var(--chart-secondary); stroke-dasharray: 2 4; }
+.line3 { stroke: var(--chart-tertiary); color: var(--chart-tertiary); fill: var(--chart-tertiary); stroke-dasharray: 12 3 2 3; }
 .chart { margin-block: var(--space-4); }
 .chart svg { display: block; width: 100%; height: 220px; }
 .grid { stroke: var(--color-neutral-300); }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -58,6 +58,11 @@ export function integer(value: number): string {
   return integerFormatter.format(value);
 }
 
+/** A published decimal in a column whose unit is declared separately. */
+export function decimal(value: number, digits = 1): string {
+  return value.toLocaleString("it-IT", { minimumFractionDigits: digits, maximumFractionDigits: digits, useGrouping: "always" });
+}
+
 export function compactEuro(value: number): string {
   return compactEuroLike(value, value);
 }

--- a/src/lib/global-search.ts
+++ b/src/lib/global-search.ts
@@ -142,6 +142,7 @@ const ROUTE_ALIASES: Readonly<Record<string, readonly string[]>> = {
   "/pnrr": ["pnrr", "progetti pnrr", "italia domani", "regis", "missioni pnrr"],
   "/coesione/asili": ["asili", "prima infanzia", "nidi", "pnrr asili"],
   "/confronti": ["confronti", "benchmark", "comparazioni"],
+  "/esplora/serie": ["confronta serie ufficiali", "serie storiche", "Eurostat", "IPCA", "inflazione", "COFOG"],
   "/pnrr/incarichi": ["incarichi pnrr", "indire"],
   "/istituzioni": ["istituzioni", "enti istituzionali"],
   "/parlamento": ["camera", "senato", "assemblee"],

--- a/src/lib/official-series.ts
+++ b/src/lib/official-series.ts
@@ -1,0 +1,148 @@
+import "server-only";
+
+import { eurostatCofogMetadata, queryEurostatCofog } from "@/lib/eurostat-cofog-snapshot";
+import { getGovernmentScorecardV6SupplementalSnapshot } from "@/lib/data/government-scorecard-page-contract";
+
+export type OfficialPoint = Readonly<{ period: string; value: number; status: string; breakBefore: boolean }>;
+export type OfficialSeries = Readonly<{
+  id: string;
+  label: string;
+  family: string;
+  unit: "MIO_EUR" | "PC_GDP" | "RCH_A";
+  unitLabel: string;
+  frequency: "annual" | "monthly";
+  scope: string;
+  points: readonly OfficialPoint[];
+  source: Readonly<{ owner: string; dataset: string; url: string; queryUrl: string; acquiredAt: string; updatedAt: string; checkedAt: string | null; sha256: string; termsUrl: string }>;
+}>;
+
+export const DEFAULT_OFFICIAL_SERIES = ["cofog-GF02-MIO_EUR", "cofog-GF03-MIO_EUR"] as const;
+
+/** Only projections of the two existing, validated snapshot boundaries. */
+export function getOfficialSeriesCatalog(): readonly OfficialSeries[] {
+  const cofog = queryEurostatCofog({ geo: "IT" });
+  const catalog: OfficialSeries[] = [];
+  for (const unit of ["MIO_EUR", "PC_GDP"] as const) {
+    const asset = eurostatCofogMetadata.source.assets[unit === "MIO_EUR" ? "mio-eur" : "pc-gdp"];
+    for (const entry of cofog.functions) {
+      catalog.push({
+        id: `cofog-${entry.code}-${unit}`,
+        label: `${entry.label} · Italia`,
+        family: `cofog-${unit}`,
+        unit,
+        unitLabel: unit === "MIO_EUR" ? "milioni di euro correnti" : "% del PIL",
+        frequency: "annual",
+        scope: "Spesa delle PA (S13), competenza economica SEC 2010",
+        points: cofog.observations.filter((point) => point.function === entry.code).map((point) => ({
+          period: String(point.year),
+          value: unit === "MIO_EUR" ? point.amountCents / 100_000_000 : point.shareOfGdpHundredths / 100,
+          status: point.flag ? cofog.flags[point.flag] : "Nessun flag della fonte",
+          breakBefore: point.flag === "b",
+        })),
+        source: {
+          owner: eurostatCofogMetadata.source.owner,
+          dataset: eurostatCofogMetadata.source.datasetCode,
+          url: eurostatCofogMetadata.source.landingUrl,
+          queryUrl: asset.url,
+          acquiredAt: eurostatCofogMetadata.semantics.provenance.acquisitionDate,
+          updatedAt: asset.sourceUpdated,
+          checkedAt: eurostatCofogMetadata.semantics.provenance.checkedAt,
+          sha256: asset.sha256,
+          termsUrl: eurostatCofogMetadata.source.termsUrl,
+        },
+      });
+    }
+  }
+  const snapshot = getGovernmentScorecardV6SupplementalSnapshot();
+  const inflation = snapshot.series.find((series) => series.indicator_id === "inflation");
+  const source = snapshot.sources.find((entry) => entry.id === "eurostat:prc_hicp_minr");
+  if (!inflation || !source) throw new Error("Catalogo serie: IPCA o provenienza assente.");
+  const names: Record<string, string> = { IT: "Italia", FR: "Francia", DE: "Germania", ES: "Spagna" };
+  for (const geography of inflation.geographies) {
+    catalog.push({
+      id: `hicp-${geography.geography}`,
+      label: `IPCA totale · ${names[geography.geography]}`,
+      family: "hicp-total-annual-change",
+      unit: "RCH_A",
+      unitLabel: "% rispetto allo stesso mese dell’anno precedente",
+      frequency: "monthly",
+      scope: "Prezzi al consumo armonizzati, paniere totale (COICOP TOTAL)",
+      points: geography.points.map((point) => ({
+        period: point.period,
+        value: point.value,
+        status: `${point.status === "estimated" ? "Stimato dalla fonte" : point.status === "provisional" ? "Provvisorio" : "Osservato"}${point.upstream_status_or_null ? ` (flag ${point.upstream_status_or_null})` : ""}`,
+        breakBefore: point.upstream_status_or_null?.includes("b") ?? false,
+      })),
+      source: {
+        owner: source.owner,
+        dataset: source.dataset_code,
+        url: source.landing_url,
+        queryUrl: source.query_url,
+        acquiredAt: source.retrieved_at,
+        updatedAt: source.upstream_updated_at,
+        checkedAt: null,
+        sha256: source.raw_sha256,
+        termsUrl: source.terms_url,
+      },
+    });
+  }
+  return catalog;
+}
+
+export type OfficialComparison =
+  | { ok: false; message: string; selected: readonly OfficialSeries[] }
+  | { ok: true; selected: readonly OfficialSeries[]; rows: readonly { period: string; points: readonly (OfficialPoint | null)[] }[] };
+
+/** Refuse incompatible semantics as well as units/frequency. Calendar slots are
+ * labels only: absent observations stay null; values are never interpolated. */
+export function compareOfficialSeries(catalog: readonly OfficialSeries[], requested: readonly string[]): OfficialComparison {
+  const selected = [...new Set(requested)].flatMap((id) => catalog.find((series) => series.id === id) ?? []);
+  const reject = (message: string): OfficialComparison => ({ ok: false, message, selected });
+  if (requested.length < 2 || requested.length > 4) return reject("Scegli da due a quattro serie.");
+  if (new Set(requested).size !== requested.length) return reject("Scegli serie diverse: la selezione contiene duplicati.");
+  if (selected.length !== requested.length) return reject("Una serie richiesta non appartiene al catalogo verificato.");
+  const first = selected[0];
+  if (selected.some((series) => series.unit !== first.unit || series.frequency !== first.frequency || series.family !== first.family || series.scope !== first.scope)) {
+    return reject("Confronto non disponibile: unità, frequenza o significato delle serie non sono compatibili. Scegli serie della stessa famiglia.");
+  }
+  const ordinal = (period: string) => first.frequency === "annual" ? Number(period) : Number(period.slice(0, 4)) * 12 + Number(period.slice(5)) - 1;
+  for (const series of selected) {
+    if (!series.points.length || series.points.some((point, index) =>
+      !Number.isFinite(point.value) ||
+      !(first.frequency === "annual" ? /^\d{4}$/ : /^\d{4}-(0[1-9]|1[0-2])$/).test(point.period) ||
+      (index > 0 && ordinal(point.period) <= ordinal(series.points[index - 1].period)))) {
+      return reject("Serie non valida: periodi duplicati, ordine inatteso o osservazioni mancanti/non valide.");
+    }
+  }
+  const start = Math.min(...selected.map((series) => ordinal(series.points[0].period)));
+  const end = Math.max(...selected.map((series) => ordinal(series.points.at(-1)!.period)));
+  if (end - start > 1200) return reject("Intervallo non supportato dal confronto.");
+  const maps = selected.map((series) => new Map(series.points.map((point) => [point.period, point])));
+  const rows = Array.from({ length: end - start + 1 }, (_, index) => {
+    const n = start + index;
+    const period = first.frequency === "annual" ? String(n) : `${Math.floor(n / 12)}-${String(n % 12 + 1).padStart(2, "0")}`;
+    return { period, points: maps.map((points) => points.get(period) ?? null) };
+  });
+  if (!rows.some((row) => row.points.every((point) => point !== null))) return reject("Le serie non hanno un periodo osservato comune.");
+  return { ok: true, selected, rows };
+}
+
+export function parseOfficialSeriesSelection(value: string | string[] | undefined): string[] {
+  return value === undefined ? [...DEFAULT_OFFICIAL_SERIES] : (typeof value === "string" ? [value] : value).filter((id) => id !== "");
+}
+
+/** Segments stop before a source break and on every absent calendar point. */
+export function officialSeriesSegments(points: readonly (OfficialPoint | null)[]): number[][] {
+  const segments: number[][] = [];
+  let current: number[] = [];
+  for (let index = 0; index < points.length; index++) {
+    const point = points[index];
+    if (!point || point.breakBefore) {
+      if (current.length) segments.push(current);
+      current = [];
+    }
+    if (point) current.push(index);
+  }
+  if (current.length) segments.push(current);
+  return segments;
+}

--- a/src/lib/public-discovery.ts
+++ b/src/lib/public-discovery.ts
@@ -34,6 +34,7 @@ export const PUBLIC_INDEXABLE_PATHS = [
   "/enti",
   "/entrate",
   "/esplora",
+  "/esplora/serie",
   "/fonti",
   "/fonti/calendario",
   "/fonti/catalogo",

--- a/src/lib/site-navigation.ts
+++ b/src/lib/site-navigation.ts
@@ -166,6 +166,7 @@ export const PRIMARY_NAV: readonly NavSection[] = [
       { href: "/controlli", label: "Segnali" },
       { href: "/controlli/sintesi", label: "Sintesi" },
       { href: "/esplora", label: "Esplora relazioni" },
+      { href: "/esplora/serie", label: "Confronta serie ufficiali" },
     ],
   },
   { href: "/assistente", label: "Assistente", icon: "assistant" },

--- a/tests/official-series.test.mjs
+++ b/tests/official-series.test.mjs
@@ -40,10 +40,13 @@ test("HICP keeps the original annual rates at monthly frequency and estimated ob
     assert.equal(series.source.updatedAt, source.upstream_updated_at);
     assert.equal(series.source.acquiredAt, source.retrieved_at);
     assert.equal(series.source.checkedAt, null);
-    assert.match(series.points.at(-1).status, /Stimato dalla fonte.*e/);
+    for (const [index, point] of points.entries()) {
+      if (point.status === "estimated") assert.match(series.points[index].status, /Stimato dalla fonte/);
+      if (point.upstream_status_or_null) assert.ok(series.points[index].status.includes(`flag ${point.upstream_status_or_null}`));
+    }
     assert.equal(series.points.filter((point) => point.status.startsWith("Stimato")).length, points.filter((point) => point.status === "estimated").length);
   }
-  assert.equal(catalog.find((series) => series.id === "hicp-IT").points.at(-1).value, 3.2);
+  assert.equal(catalog.find((series) => series.id === "hicp-IT").points.at(-1).value, inflation.geographies.find((geography) => geography.geography === "IT").points.at(-1).value);
 });
 
 test("two and four compatible selections preserve order and all original values", () => {

--- a/tests/official-series.test.mjs
+++ b/tests/official-series.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import "./helpers/register-ts-alias.mjs";
+
+const { getOfficialSeriesCatalog, compareOfficialSeries, parseOfficialSeriesSelection, officialSeriesSegments } = await import("../src/lib/official-series.ts");
+const { queryEurostatCofog, eurostatCofogMetadata } = await import("../src/lib/eurostat-cofog-snapshot.ts");
+const { getGovernmentScorecardV6SupplementalSnapshot } = await import("../src/lib/data/government-scorecard-page-contract.ts");
+const { PRIMARY_NAV, flattenNavLinks } = await import("../src/lib/site-navigation.ts");
+const { PUBLIC_INDEXABLE_PATHS } = await import("../src/lib/public-discovery.ts");
+const catalog = getOfficialSeriesCatalog();
+
+test("COFOG catalog preserves published units, coverage, source asset and flags for every function", () => {
+  assert.equal(catalog.length, 26);
+  assert.equal(new Set(catalog.map((series) => series.id)).size, catalog.length);
+  const source = queryEurostatCofog({ geo: "IT" });
+  for (const series of catalog.filter((series) => series.frequency === "annual")) {
+    const code = series.id.split("-")[1];
+    const rows = source.observations.filter((point) => point.function === code);
+    assert.ok(rows.every((point) => point.amountCents % 10_000_000 === 0), "MIO_EUR keeps the source's one decimal without rounding away precision");
+    assert.equal(series.points.length, 11);
+    assert.deepEqual(series.points.map((point) => point.period), rows.map((point) => String(point.year)));
+    assert.deepEqual(series.points.map((point) => point.value), rows.map((point) => series.unit === "MIO_EUR" ? point.amountCents / 100_000_000 : point.shareOfGdpHundredths / 100));
+    assert.deepEqual(series.points.map((point) => point.breakBefore), rows.map((point) => point.flag === "b"));
+    const asset = eurostatCofogMetadata.source.assets[series.unit === "MIO_EUR" ? "mio-eur" : "pc-gdp"];
+    assert.equal(series.source.sha256, asset.sha256);
+    assert.equal(series.source.queryUrl, asset.url);
+    assert.equal(series.source.checkedAt, eurostatCofogMetadata.semantics.provenance.checkedAt);
+  }
+});
+
+test("HICP keeps the original annual rates at monthly frequency and estimated observations", () => {
+  const snapshot = getGovernmentScorecardV6SupplementalSnapshot();
+  const inflation = snapshot.series.find((series) => series.indicator_id === "inflation");
+  const source = snapshot.sources.find((entry) => entry.id === "eurostat:prc_hicp_minr");
+  for (const series of catalog.filter((series) => series.unit === "RCH_A")) {
+    const points = inflation.geographies.find((geo) => series.id === `hicp-${geo.geography}`).points;
+    assert.equal(series.frequency, "monthly");
+    assert.deepEqual(series.points.map(({ period, value }) => ({ period, value })), points.map(({ period, value }) => ({ period, value })));
+    assert.equal(series.source.sha256, source.raw_sha256);
+    assert.equal(series.source.updatedAt, source.upstream_updated_at);
+    assert.equal(series.source.acquiredAt, source.retrieved_at);
+    assert.equal(series.source.checkedAt, null);
+    assert.match(series.points.at(-1).status, /Stimato dalla fonte.*e/);
+    assert.equal(series.points.filter((point) => point.status.startsWith("Stimato")).length, points.filter((point) => point.status === "estimated").length);
+  }
+  assert.equal(catalog.find((series) => series.id === "hicp-IT").points.at(-1).value, 3.2);
+});
+
+test("two and four compatible selections preserve order and all original values", () => {
+  for (const ids of [parseOfficialSeriesSelection(undefined), ["hicp-IT", "hicp-FR", "hicp-DE", "hicp-ES"], ["cofog-GF02-PC_GDP", "cofog-GF03-PC_GDP"]]) {
+    const view = compareOfficialSeries(catalog, ids);
+    assert.equal(view.ok, true);
+    assert.deepEqual(view.selected.map((series) => series.id), ids);
+    for (const [index, series] of view.selected.entries()) assert.deepEqual(view.rows.map((row) => row.points[index]), series.points);
+  }
+});
+
+test("invalid counts, duplicate and unknown selections never return numerical comparisons", () => {
+  for (const ids of [[], ["hicp-IT"], ["hicp-IT", "hicp-FR", "hicp-DE", "hicp-ES", "cofog-GF01-MIO_EUR"], ["hicp-IT", "hicp-IT"], ["hicp-IT", "unknown"]]) {
+    const view = compareOfficialSeries(catalog, ids);
+    assert.equal(view.ok, false);
+    assert.equal("rows" in view, false);
+    assert.ok(view.message.length);
+  }
+  assert.deepEqual(parseOfficialSeriesSelection(["hicp-IT", "hicp-FR", "", ""]), ["hicp-IT", "hicp-FR"]);
+  assert.deepEqual(parseOfficialSeriesSelection(""), []);
+});
+
+test("unit, frequency, family and scope incompatibilities fail independently", () => {
+  const pair = structuredClone(catalog.filter((series) => ["hicp-IT", "hicp-FR"].includes(series.id)));
+  for (const [field, value] of [["unit", "PC_GDP"], ["frequency", "annual"], ["family", "different-growth-rate"], ["scope", "Different population or accounting boundary"]]) {
+    const changed = structuredClone(pair);
+    changed[1][field] = value;
+    assert.equal(compareOfficialSeries(changed, changed.map((series) => series.id)).ok, false, field);
+  }
+  assert.equal(compareOfficialSeries(catalog, ["cofog-GF02-MIO_EUR", "cofog-GF03-PC_GDP"]).ok, false);
+  assert.equal(compareOfficialSeries(catalog, ["cofog-GF02-PC_GDP", "hicp-IT"]).ok, false);
+});
+
+test("calendar gaps remain null, published zero stays zero and breaks stop chart segments", () => {
+  const pair = structuredClone(catalog.filter((series) => ["hicp-IT", "hicp-FR"].includes(series.id)));
+  for (const series of pair) series.points = series.points.slice(0, 5);
+  pair[0].points[0].value = 0;
+  pair[0].points.splice(1, 1);
+  pair[0].points[2].breakBefore = true;
+  pair[1].points.pop();
+  const view = compareOfficialSeries(pair, pair.map((series) => series.id));
+  assert.equal(view.ok, true);
+  assert.deepEqual(view.rows.map((row) => row.period), ["1997-01", "1997-02", "1997-03", "1997-04", "1997-05"]);
+  assert.equal(view.rows[0].points[0].value, 0);
+  assert.equal(view.rows[1].points[0], null);
+  assert.equal(view.rows[4].points[1], null);
+  assert.deepEqual(officialSeriesSegments(view.rows.map((row) => row.points[0])), [[0], [2], [3, 4]]);
+});
+
+test("empty, duplicate, reversed, malformed, nonfinite and nonoverlapping observations fail closed", () => {
+  for (const mutate of [
+    (series) => { series.points = []; },
+    (series) => { series.points[1] = series.points[0]; },
+    (series) => { series.points.reverse(); },
+    (series) => { series.points[0].period = "1997-13"; },
+    (series) => { series.points[0].value = NaN; },
+    (series) => { series.points = [{ ...series.points[0], period: "1990-01" }]; },
+  ]) {
+    const pair = structuredClone(catalog.filter((series) => ["hicp-IT", "hicp-FR"].includes(series.id)));
+    mutate(pair[0]);
+    assert.equal(compareOfficialSeries(pair, pair.map((series) => series.id)).ok, false);
+  }
+});
+
+test("comparison is reachable through navigation and public discovery", () => {
+  assert.ok(flattenNavLinks(PRIMARY_NAV).some((entry) => entry.href === "/esplora/serie"));
+  assert.ok(PUBLIC_INDEXABLE_PATHS.includes("/esplora/serie"));
+});

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -167,7 +167,7 @@ test("activeNavSection resolves nested routes to the parent menu", () => {
   assert.equal(isNavChildActive("/appalti", "/appalti", appalti.children), true);
   assert.deepEqual(
     appalti?.children?.map((child) => child.label),
-    ["Appalti", "Incarichi", "Catalogo dati", "Segnali", "Sintesi", "Esplora relazioni"],
+    ["Appalti", "Incarichi", "Catalogo dati", "Segnali", "Sintesi", "Esplora relazioni", "Confronta serie ufficiali"],
   );
   assert.ok(
     appalti?.children
@@ -186,6 +186,11 @@ test("activeNavSection resolves nested routes to the parent menu", () => {
   const sintesi = activeNavSection("/controlli/sintesi");
   assert.equal(sintesi?.href, "/controlli");
   assert.equal(isNavChildActive("/controlli/sintesi", "/controlli/sintesi", sintesi.children), true);
+
+  const series = activeNavSection("/esplora/serie");
+  assert.equal(series?.href, "/controlli");
+  assert.equal(isNavChildActive("/esplora/serie", "/esplora/serie", series.children), true);
+  assert.equal(isNavChildActive("/esplora/serie", "/esplora", series.children), false);
 
   const catalog = activeNavSection("/dati/vincitori");
   assert.equal(catalog?.href, "/controlli");


### PR DESCRIPTION
Da /esplora mancava un modo per confrontare direttamente serie ufficiali già presenti nel progetto. Questa PR aggiunge /esplora/serie, raggiungibile da Esplora, navigazione e ricerca.

Il catalogo iniziale contiene 26 serie validate: funzioni COFOG italiane in milioni di euro correnti o quota di PIL e IPCA totale di Italia, Francia, Germania e Spagna. Il modulo GET consente confronti condivisibili di 2–4 serie e rifiuta selezioni con unità, frequenze, definizioni o perimetri incompatibili.

Grafico e tabella mantengono valori, lacune, interruzioni di serie e flag della fonte. Ogni serie dichiara periodo, query, provenienza e impronta del file. Non vengono importati nuovi dataset, interpolati valori o ribasati indici. La legenda usa gli stessi tratti del grafico; note metodologiche spiegano i limiti del confronto.

Verifica: CI completa sull'ultima revisione prima dell'apertura della PR, con controlli statici, sicurezza, Node, ETL, snapshot, build, E2E di produzione e Lighthouse. I nuovi E2E usano il modulo reale, quattro serie, tabella, fonti, tastiera e selezioni incompatibili a 320, 375, 390, 768, 1024, 1280 e 1600 px, nei temi chiaro e scuro.

Esecuzione: https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34465947129

L'ambiente locale non consente il controllo della memoria richiesto dalla build e da un test; per questi gate fa fede l'esecuzione completa sui runner GitHub.

Closes #382