### PR TITLE
fix(home): elimina gli spazi extra nel grafico COFOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Upload home composition layout evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: home-composition-layout
+          path: artifacts/browser/home-composition/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Upload Lighthouse reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -700,6 +700,7 @@ try {
       label,
       pathname: "/",
       width,
+      touch: width === 390,
       validate: async (page) => {
         await inspectInstitutionalPalette(page, { label, width });
         await inspectHomeCompositionSpacing(page, { width });

--- a/scripts/browser/core.mjs
+++ b/scripts/browser/core.mjs
@@ -4,6 +4,7 @@ import { inspectEpea } from "./epea.mjs";
 import { inspectCulture, inspectCultureJourney, inspectInvalidCultureYears } from "./culture.mjs";
 import { inspectDefence } from "./defence.mjs";
 import { inspectInstitutionalPalette } from "./institutional-palette.mjs";
+import { inspectHomeCompositionSpacing } from "./home-composition.mjs";
 import { inspectPnrrProjects } from "./pnrr-projects.mjs";
 import { inspectTedNotices } from "./ted-notices.mjs";
 import { inspectAnacCpv } from "./anac-cpv.mjs";
@@ -699,7 +700,10 @@ try {
       label,
       pathname: "/",
       width,
-      validate: (page) => inspectInstitutionalPalette(page, { label, width }),
+      validate: async (page) => {
+        await inspectInstitutionalPalette(page, { label, width });
+        await inspectHomeCompositionSpacing(page, { width });
+      },
     });
     completed.push(label);
   }

--- a/scripts/browser/home-composition.mjs
+++ b/scripts/browser/home-composition.mjs
@@ -65,6 +65,12 @@ export async function inspectHomeCompositionSpacing(page, { width }) {
     assert.equal(await page.$eval(selector, (button) => button.getAttribute("aria-expanded")), "false");
   }
   const theme = await page.$eval("html", (element) => element.dataset.theme);
+  console.log(JSON.stringify({
+    check: "home-composition-spacing", theme, width,
+    maxTitleAmountGap: Math.max(...rows.map((row) => row.amountBox.top - row.title.bottom)),
+    rowHeights: rows.map((row) => row.row.height),
+    tooltipTargets: rows.filter((row) => row.button).map((row) => row.button.width),
+  }));
   const directory = path.join(defaultArtifactsDir(), "home-composition", `${theme}-${width}`);
   await mkdir(directory, { recursive: true });
   await writeFile(path.join(directory, "geometry.json"), JSON.stringify(rows, null, 2));

--- a/scripts/browser/home-composition.mjs
+++ b/scripts/browser/home-composition.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { defaultArtifactsDir } from "./harness.mjs";
+
+const chart = 'ol[aria-label^="Composizione spesa pubblica Italia"]';
+
+async function geometry(page) {
+  return page.$$eval(`${chart} > li`, (rows) => rows.map((row) => {
+    const copy = row.querySelector(":scope > div");
+    const name = copy.querySelector("a");
+    const amount = copy.querySelector('[class*="barAmount"]');
+    const button = copy.querySelector("button");
+    const bounds = (element) => {
+      const { top, bottom, left, right, height, width } = element.getBoundingClientRect();
+      return { top, bottom, left, right, height, width };
+    };
+    return {
+      name: name.textContent, amount: amount.textContent,
+      row: bounds(row), copy: bounds(copy), title: bounds(name), amountBox: bounds(amount),
+      button: button ? bounds(button) : null,
+    };
+  }));
+}
+
+export async function inspectHomeCompositionSpacing(page, { width }) {
+  const rows = await geometry(page);
+  assert.equal(rows.length, 10, "Home: ten COFOG divisions remain visible");
+  assert.ok(rows.filter((row) => row.button).length >= 3, "Home: tooltip rows missing");
+  for (const [index, row] of rows.entries()) {
+    assert.match(row.amount, /mld €/);
+    const textGap = row.amountBox.top - row.title.bottom;
+    assert.ok(textGap >= -1 && textGap <= 6, `${row.name}: title/amount gap ${textGap}px`);
+    if (row.button) {
+      assert.ok(row.button.width >= 44 && row.button.height >= 44, `${row.name}: touch target shrunk`);
+      assert.ok(row.button.left >= row.title.right, `${row.name}: tooltip overlaps title`);
+      assert.ok(row.button.top >= row.row.top - 1 && row.button.bottom <= row.row.bottom + 1, `${row.name}: touch target overlaps another row`);
+    }
+    if (index) assert.ok(row.row.top - rows[index - 1].row.bottom <= 9, `${row.name}: extra inter-row space`);
+  }
+
+  const triggers = await page.$$eval(`${chart} button[aria-controls]`, (buttons) => buttons.map((button) => button.getAttribute("aria-controls")));
+  for (const id of triggers) {
+    const selector = `${chart} button[aria-controls="${id}"]`;
+    await page.focus(selector);
+    await page.waitForFunction((id) => document.getElementById(id)?.dataset.positioned === "true", {}, id);
+    const box = await page.$eval(`#${id}`, (element) => {
+      const rect = element.getBoundingClientRect();
+      return { left: rect.left, right: rect.right };
+    });
+    assert.ok(box.left >= 0 && box.right <= width + 1, `${id}: tooltip outside viewport`);
+    const openedRows = await geometry(page);
+    for (const [index, row] of rows.entries()) {
+      assert.ok(Math.abs(openedRows[index].row.height - row.row.height) <= 1, `${id}: opening changes row height`);
+    }
+    await page.keyboard.press("Escape");
+    assert.equal(await page.$eval(selector, (button) => button.getAttribute("aria-expanded")), "false");
+  }
+
+  if (width === 390) {
+    const selector = `${chart} button[aria-controls="${triggers[0]}"]`;
+    await page.tap(selector);
+    assert.equal(await page.$eval(selector, (button) => button.getAttribute("aria-expanded")), "true");
+    await page.tap(selector);
+    assert.equal(await page.$eval(selector, (button) => button.getAttribute("aria-expanded")), "false");
+  }
+  const theme = await page.$eval("html", (element) => element.dataset.theme);
+  const directory = path.join(defaultArtifactsDir(), "home-composition", `${theme}-${width}`);
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "geometry.json"), JSON.stringify(rows, null, 2));
+  const panel = await page.$('section[aria-labelledby="pa-split-title"]');
+  await panel.screenshot({ path: path.join(directory, "composition.png") });
+}

--- a/src/components/home-italy-charts.module.css
+++ b/src/components/home-italy-charts.module.css
@@ -15,15 +15,22 @@
 }
 
 .barCopy {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  /* Keep the 44px touch target beside both lines, not in the title row. */
+  min-height: 44px;
+}
+
+.barText {
   display: grid;
   gap: 1px;
   min-width: 0;
 }
 
 .barName {
-  display: flex;
-  align-items: start;
-  gap: 4px;
+  display: block;
   min-width: 0;
   color: var(--color-neutral-800);
   font-size: 13px;

--- a/src/components/home-italy-charts.tsx
+++ b/src/components/home-italy-charts.tsx
@@ -17,25 +17,23 @@ export function HomeItalyCompositionChart({
     <ol className={styles.bars} aria-label={ariaLabel}>
       {slices.map((slice) => {
         const width = maxShare > 0 ? (slice.sharePercent / maxShare) * 100 : 0;
-        const label = (
-          <span className={styles.barName}>
-            {slice.href ? <Link href={slice.href}>{slice.label}</Link> : slice.label}
-            {slice.note ? (
-              <InfoTooltip
-                id={`home-slice-${slice.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`}
-                label={`Perimetro: ${slice.label}`}
-              >
-                {slice.note}
-              </InfoTooltip>
-            ) : null}
-          </span>
-        );
-
         return (
           <li key={slice.id}>
             <div className={styles.barCopy}>
-              {label}
-              <span className={styles.barAmount}>{billions(slice.amountEuro)} mld €</span>
+              <div className={styles.barText}>
+                <span className={styles.barName}>
+                  {slice.href ? <Link href={slice.href}>{slice.label}</Link> : slice.label}
+                </span>
+                <span className={styles.barAmount}>{billions(slice.amountEuro)} mld €</span>
+              </div>
+              {slice.note ? (
+                <InfoTooltip
+                  id={`home-slice-${slice.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`}
+                  label={`Perimetro: ${slice.label}`}
+                >
+                  {slice.note}
+                </InfoTooltip>
+              ) : null}
             </div>
             <i aria-hidden="true">
               <b style={{ width: `${width}%` }} />

--- a/src/components/info-tooltip.tsx
+++ b/src/components/info-tooltip.tsx
@@ -21,6 +21,7 @@ export function InfoTooltip({
   const pointerInteraction = useRef(false);
 
   const closeTooltip = useCallback(() => {
+    pointerInteraction.current = false;
     setTooltipLeft(null);
     setOpen(false);
   }, []);
@@ -109,10 +110,9 @@ export function InfoTooltip({
         aria-describedby={open ? id : undefined}
         aria-expanded={open}
         onPointerDown={() => {
+          // Touch can focus after pointerup, before click. Keep the pointer
+          // intent until click so focus and click do not toggle it twice.
           pointerInteraction.current = true;
-        }}
-        onPointerUp={() => {
-          pointerInteraction.current = false;
         }}
         onPointerCancel={() => {
           pointerInteraction.current = false;

--- a/tests/ui-craft-regressions.test.mjs
+++ b/tests/ui-craft-regressions.test.mjs
@@ -90,7 +90,8 @@ test("CI verifies every main commit and uses the current artifact runtime", asyn
   assert.doesNotMatch(ci, /github\.event\.pull_request\.number \|\| github\.ref/);
   // upload-artifact must be SHA-pinned (supply-chain security).
   assert.doesNotMatch(`${ci}\n${mefRefresh}`, /actions\/upload-artifact@v\d/);
-  assert.equal((`${ci}\n${mefRefresh}`.match(/actions\/upload-artifact@[0-9a-f]{40}/g) ?? []).length, 5);
+  assert.equal((`${ci}\n${mefRefresh}`.match(/actions\/upload-artifact@[0-9a-f]{40}/g) ?? []).length, 6);
+  assert.match(ci, /name: home-composition-layout\n\s+path: artifacts\/browser\/home-composition\//);
   assert.match(ci, /name: Upload procurement award-year screenshots\n\s+if: always\(\)\n\s+uses: actions\/upload-artifact@[0-9a-f]{40}[^\n]*\n\s+with:\n\s+name: procurement-award-year-screenshots\n\s+path: artifacts\/browser\/procurement-award-year\//);
   assert.match(harness, /const BROWSER_LAUNCH_TIMEOUT_MS = 60_000;/);
   assert.match(harness, /timeoutMs = BROWSER_LAUNCH_TIMEOUT_MS/);


### PR DESCRIPTION
## Cosa cambia

Le icone informative da 44 px aumentavano l’altezza della riga del titolo e separavano gli importi dalle prime tre voci del grafico COFOG. Titolo e importo ora condividono un blocco compatto, affiancato dal tooltip, conservando il target touch e lo stile del sito. Importi e proporzioni delle barre invariati.

Gli E2E hanno inoltre riprodotto un problema al primo tap: il focus apriva il tooltip e il click lo richiudeva. Il componente conserva ora l’intento del puntatore fino al click.

## Evidenza

Verificato il commit `e0a1e080a4343736d37d4b196be54a2d9846c50f`.

- [x] Diff limitato alla correzione e ai relativi controlli.
- [x] E2E di regressione: spaziatura, target da 44 px, tooltip entro viewport, stabilità delle righe, focus/Escape e apertura/chiusura al tap.
- [x] Home verificata a 320, 375, 390, 768, 1024, 1280 e 1600 px, in tema chiaro e scuro. Distanza massima misurata titolo/importo: 1,890625 px in tutti i 14 scenari.
- [x] CI completa: controlli statici/design/brand, action pins, sicurezza workflow, test Node, ETL e artifact offline, build, suite browser completa, CSP e Lighthouse.
- [x] `git diff --check` e 19 test UI mirati locali superati.
- [x] CodeQL, Dependency Review e deployment Vercel riusciti.

[CI completa](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34474964382). Screenshot e misure dei 14 scenari nell’artifact `home-composition-layout` dello stesso run. Il budget Lighthouse su IRPEF passa: performance 91%, accessibilità 100%.

## Limiti

Touch verificato mediante emulazione Chromium, non su dispositivo fisico. La preview Vercel richiede login e non è stata ispezionata manualmente; gli E2E sono eseguiti sulla build di produzione del runner GitHub. Gli screenshot sono stati generati dalla CI, ma il download nell’ambiente locale non è riuscito. La build locale è bloccata da `uv_resident_set_memory` dell’ambiente; la build CI è riuscita. Nessun dato pubblico modificato.