### PR TITLE
docs(privacy): pubblicare il contatto autorizzato per privacy e supporto

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -129,10 +129,13 @@ export default function PrivacyPage() {
       <section className="panel">
         <h2 className="panel-title">I tuoi diritti</h2>
         <p>
-          Un canale privato per accesso, correzione, cancellazione, limitazione, portabilità quando
-          applicabile o opposizione non è ancora indicato sul sito. Le issue GitHub sono pubbliche:
-          non inviare dati personali. Puoi presentare reclamo al Garante per la protezione dei dati
-          personali. La pagina <a href="/supporto">Supporto</a> resta per problemi tecnici del sito.
+          Per accesso, correzione, cancellazione, limitazione, portabilità quando applicabile o
+          opposizione, usa il canale privato{" "}
+          <a href="mailto:info@mantoventure.com">info@mantoventure.com</a>.
+          Invia soltanto le informazioni necessarie a gestire la richiesta, senza password o
+          altre credenziali. Le issue GitHub sono pubbliche: non usarle per richieste privacy o
+          dati personali. Puoi presentare reclamo al Garante per la protezione dei dati personali.
+          Per assistenza tecnica consulta la pagina <a href="/supporto">Supporto</a>.
         </p>
       </section>
     </main>

--- a/src/app/supporto/page.tsx
+++ b/src/app/supporto/page.tsx
@@ -43,11 +43,14 @@ export default function SupportPage() {
       </section>
 
       <section className="panel">
-        <h2 className="panel-title">Privacy</h2>
+        <h2 className="panel-title">Contatto privato e privacy</h2>
         <p>
-          Le issue GitHub sono pubbliche. Non usarle per diritti privacy, dati personali o
-          segnalazioni riservate. Un canale privato per queste richieste non è ancora indicato su
-          questa pagina. Puoi presentare reclamo al{" "}
+          Per assistenza riservata e richieste relative ai tuoi diritti privacy scrivi a{" "}
+          <a href="mailto:info@mantoventure.com">info@mantoventure.com</a>.
+          Le issue GitHub sono pubbliche: non usarle per dati personali o segnalazioni riservate.
+          Invia soltanto le informazioni necessarie, senza password o altre credenziali.
+          Consulta l&apos;<a href="/privacy">informativa privacy</a>.
+          Puoi presentare reclamo al{" "}
           <a href="https://www.garanteprivacy.it/" target="_blank" rel="noreferrer">
             Garante per la protezione dei dati personali
           </a>.

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -64,3 +64,16 @@ test("unpatched vulnerabilities are routed to the private GitHub advisory form",
   assert.match(privacy, /Le issue GitHub sono pubbliche/);
   assert.match(privacy, /canale privato/);
 });
+
+test("privacy and support publish the authorized private contact without routing requests to public issues", async () => {
+  const pages = await Promise.all([
+    source("../src/app/privacy/page.tsx"),
+    source("../src/app/supporto/page.tsx"),
+  ]);
+  for (const page of pages) {
+    assert.match(page, /href="mailto:info@mantoventure\.com"/);
+    assert.match(page, />info@mantoventure\.com<\/a>/);
+    assert.match(page, /Le issue GitHub sono pubbliche/);
+    assert.doesNotMatch(page, /non è ancora indicato/);
+  }
+});

--- a/tests/site-navigation.test.mjs
+++ b/tests/site-navigation.test.mjs
@@ -60,14 +60,15 @@ test("every page offers the rest of its section without the header menu", async 
   assert.doesNotMatch(css, /border-radius\s*:/);
 });
 
-test("public legal pages do not expose a personal mailbox", async () => {
+test("public legal pages expose only the authorized support mailbox", async () => {
   const files = await Promise.all([
     readFile(new URL("../src/app/privacy/page.tsx", import.meta.url), "utf8"),
     readFile(new URL("../src/app/supporto/page.tsx", import.meta.url), "utf8"),
     readFile(new URL("../src/lib/site.ts", import.meta.url), "utf8"),
   ]);
   for (const source of files) {
-    assert.doesNotMatch(source, /mailto:/i);
+    const mailtoLinks = [...source.matchAll(/mailto:([^"\s]+)/gi)].map((match) => match[1]);
+    assert.ok(mailtoLinks.every((address) => address === "info@mantoventure.com"));
     assert.doesNotMatch(source, /@gmail\.com/i);
   }
   assert.doesNotMatch(files[0], /panel-title">Titolare/i);


### PR DESCRIPTION
## Modifica

Closes #415.

Pubblica il contatto autorizzato `info@mantoventure.com` nelle pagine privacy e supporto, con link mailto. Mantiene separati i canali pubblici GitHub dalle richieste privacy e dalle segnalazioni riservate e invita a non inviare credenziali o informazioni non necessarie. Aggiorna i test di regressione per ammettere soltanto la casella autorizzata.

Quattro file modificati; nessuna modifica a dati, adapter, endpoint o workflow.

## Verifica

- PASS: 13 test mirati, ESLint sui file modificati e git diff --check in locale.
- PASS: profilo completo eseguito sul commit c08d726eb36d3fcf6e7433fcc3f616774722b8a5 tramite workflow_dispatch, inclusi static, Node, ETL/snapshot, build, produzione/browser/Lighthouse, Zizmor e required: https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi/actions/runs/34504927250
- PASS: verifica Browser della preview sulle due pagine, testo e destinazione mailto, collegamento privacy/supporto e focus da tastiera; supporto desktop a 1280 px senza overflow orizzontale.
- La suite completa è stata eseguita in CI per lo spazio locale insufficiente; non viene dichiarata eseguita localmente. Nessuna email inviata e ricezione della casella non testata.

La candidatura OpenAI resta una bozza non inviata: le attestazioni del publisher non sono state selezionate.