### PR TITLE
fix(OpenBDAP): riusa la discovery e verifica gli anni mancanti

### DIFF
--- a/src/lib/bdap-payments.ts
+++ b/src/lib/bdap-payments.ts
@@ -469,24 +469,23 @@ export async function getStatePaymentDatasetForYear(
 export const STATE_SPENDING_HISTORY_MAX_CONCURRENCY = 3;
 
 /**
- * Calendar years with a published annual mission consuntivo in the live OpenBDAP
- * catalog, ascending. The catalog is the only place that knows which years exist:
+ * Published annual mission consuntivi from one live OpenBDAP discovery. Reuse
+ * these descriptors for both year selection and totals, preserving provenance.
+ * The catalog is the only place that knows which years exist:
  * the consuntivo for a year is published during the following one, so a caller that
  * bounds an open-ended range (a legislature still in progress) must read this instead
  * of deriving the last year from the current date.
  */
-export async function getPublishedStateConsuntivoYears(
+export async function getPublishedStateConsuntivi(
   options: { signal?: AbortSignal } = {},
-): Promise<number[]> {
+): Promise<ConsuntivoBdapDataset[]> {
   const datasets = await searchProduct(
     consuntivoProductCode("mission"),
     "mission",
     "consuntivo",
     options.signal,
   );
-  const years = new Set<number>();
-  for (const dataset of datasets) years.add(dataset.referenceYear);
-  return [...years].sort((left, right) => left - right);
+  return datasets.filter((dataset): dataset is ConsuntivoBdapDataset => dataset.releaseKind === "consuntivo");
 }
 
 export type StateAnnualSpendingTotal = {
@@ -503,7 +502,7 @@ export type StateAnnualSpendingTotal = {
  */
 export async function getStateSpendingTotalsForYears(
   years: readonly number[],
-  options: { signal?: AbortSignal; concurrency?: number } = {},
+  options: { signal?: AbortSignal; concurrency?: number; datasets?: readonly ConsuntivoBdapDataset[] } = {},
 ): Promise<Map<number, StateAnnualSpendingTotal>> {
   const requestedYears = [...new Set(years)];
   for (const year of requestedYears) {
@@ -513,12 +512,7 @@ export async function getStateSpendingTotalsForYears(
   }
   if (requestedYears.length === 0) return new Map();
 
-  const datasets = await searchProduct(
-    consuntivoProductCode("mission"),
-    "mission",
-    "consuntivo",
-    options.signal,
-  );
+  const datasets = options.datasets ?? await getPublishedStateConsuntivi(options);
   const requested = new Set(requestedYears);
   const byYear = new Map<number, ConsuntivoBdapDataset>();
   for (const dataset of datasets) {

--- a/src/lib/state-spending-legislature.ts
+++ b/src/lib/state-spending-legislature.ts
@@ -1,8 +1,9 @@
 import {
-  getPublishedStateConsuntivoYears,
+  getPublishedStateConsuntivi,
   getStateSpendingTotalsForYears,
   STATE_SPENDING_HISTORY_MAX_CONCURRENCY,
   type StateAnnualSpendingTotal,
+  type ConsuntivoBdapDataset,
 } from "@/lib/bdap-payments";
 
 /**
@@ -120,10 +121,10 @@ export const LEGISLATURE_SPENDING_DEADLINE_MS = 50_000;
 
 type TotalsLoader = (
   years: readonly number[],
-  options: { signal?: AbortSignal; concurrency?: number },
+  options: { signal?: AbortSignal; concurrency?: number; datasets: readonly ConsuntivoBdapDataset[] },
 ) => Promise<Map<number, StateAnnualSpendingTotal>>;
 
-type PublishedYearsLoader = (options: { signal?: AbortSignal }) => Promise<number[]>;
+type ConsuntiviLoader = (options: { signal?: AbortSignal }) => Promise<ConsuntivoBdapDataset[]>;
 
 function abortReason(signal: AbortSignal): unknown {
   return signal.reason ?? new Error("Operazione OpenBDAP annullata");
@@ -165,7 +166,7 @@ export async function getLegislatureSpendingCycles(
     signal?: AbortSignal;
     deadlineMs?: number;
     /** Deterministic test seam; production reads the live OpenBDAP catalog. */
-    loadPublishedYears?: PublishedYearsLoader;
+    loadConsuntivi?: ConsuntiviLoader;
     /** Deterministic test seam; production uses the OpenBDAP batch reader. */
     loadTotals?: TotalsLoader;
   } = {},
@@ -184,13 +185,13 @@ export async function getLegislatureSpendingCycles(
     : deadlineController.signal;
 
   try {
-    const publishedYears = await withAbort(
+    const datasets = await withAbort(
       Promise.resolve().then(() =>
-        (options.loadPublishedYears ?? getPublishedStateConsuntivoYears)({ signal }),
+        (options.loadConsuntivi ?? getPublishedStateConsuntivi)({ signal }),
       ),
       signal,
     );
-    const latestObservedYear = publishedYears.length > 0 ? Math.max(...publishedYears) : null;
+    const latestObservedYear = datasets.length > 0 ? Math.max(...datasets.map((dataset) => dataset.referenceYear)) : null;
     const plans = LEGISLATURES.map((legislature, index) => {
       const next = LEGISLATURES[index + 1];
       const nextElectionYear = next ? Number(next.electionDate.slice(0, 4)) : null;
@@ -204,12 +205,16 @@ export async function getLegislatureSpendingCycles(
         ).filter((year) => year >= MIN_CONSUNTIVO_YEAR),
       };
     });
+    // Keep the complete interval for the current legislature too: if the catalog
+    // contains 2023 and 2025 but not 2024, the batch reader reports the missing
+    // release before any CSV download rather than silently shortening the series.
     const allYears = plans.flatMap((plan) => plan.candidateYears);
     const totals = await withAbort(
       Promise.resolve().then(() =>
         (options.loadTotals ?? getStateSpendingTotalsForYears)(allYears, {
           signal,
           concurrency: STATE_SPENDING_HISTORY_MAX_CONCURRENCY,
+          datasets,
         }),
       ),
       signal,

--- a/tests/state-spending-legislature.test.mjs
+++ b/tests/state-spending-legislature.test.mjs
@@ -90,7 +90,7 @@ test("fullYearsWithinLegislature returns exactly one year for a two-calendar-yea
 test("legislature cycles load all annual totals in one bounded batch", async () => {
   const requestedYears = [];
   const cycles = await getLegislatureSpendingCycles({
-    loadPublishedYears: async () => [2014, 2015, 2016, 2017, 2019, 2020, 2021, 2023, 2024, 2025],
+    loadConsuntivi: async () => [...totalsFor([2014, 2015, 2016, 2017, 2019, 2020, 2021, 2023, 2024, 2025]).values()].map((item) => item.source),
     loadTotals: async (years, options) => {
       requestedYears.push(years);
       assert.equal(options.concurrency, 3);
@@ -114,7 +114,7 @@ test("a legislature still in progress exposes its published years without a pre-
   const cycles = await getLegislatureSpendingCycles({
     // The annual consuntivo of the newest year is published during the following year, so the
     // last observed year is not simply the year before the current date.
-    loadPublishedYears: async () => [2014, 2015, 2016, 2017, 2019, 2020, 2021, 2023, 2024],
+    loadConsuntivi: async () => [...totalsFor([2014, 2015, 2016, 2017, 2019, 2020, 2021, 2023, 2024]).values()].map((item) => item.source),
     loadTotals: async (years) => totalsFor(years),
   });
   const nineteenth = cycles.find((cycle) => cycle.legislature.number === "XIX");
@@ -129,7 +129,7 @@ test("a legislature still in progress exposes its published years without a pre-
 test("a legislature still in progress stays empty until its first annual consuntivo is published", async () => {
   const requestedYears = [];
   const cycles = await getLegislatureSpendingCycles({
-    loadPublishedYears: async () => [],
+    loadConsuntivi: async () => [...totalsFor([]).values()].map((item) => item.source),
     loadTotals: async (years) => {
       requestedYears.push(years);
       return totalsFor(years);
@@ -146,7 +146,7 @@ test("a legislature still in progress stays empty until its first annual consunt
 test("a closed legislature still reports a missing annual total as an error", async () => {
   await assert.rejects(
     getLegislatureSpendingCycles({
-      loadPublishedYears: async () => [2014, 2015, 2016, 2017, 2019, 2020, 2021, 2025],
+      loadConsuntivi: async () => [...totalsFor([2014, 2015, 2016, 2017, 2019, 2020, 2021, 2025]).values()].map((item) => item.source),
       loadTotals: async (years) => {
         const totals = totalsFor(years);
         totals.delete(2016);
@@ -162,7 +162,7 @@ test("legislature cycles enforce one global deadline even if a loader ignores ab
   await assert.rejects(
     getLegislatureSpendingCycles({
       deadlineMs: 20,
-      loadPublishedYears: async () => [2014, 2015, 2016, 2017, 2019, 2020, 2021, 2025],
+      loadConsuntivi: async () => [...totalsFor([2014, 2015, 2016, 2017, 2019, 2020, 2021, 2025]).values()].map((item) => item.source),
       loadTotals: async (_years, options) => {
         loaderSignal = options.signal;
         return new Promise(() => {});
@@ -178,4 +178,55 @@ test("openbdap_spesa_legislature MCP dataset rejects any filter offline", async 
     queryPublicDataset({ dataset: "openbdap_spesa_legislature", year: 2024 }),
     /Filtri non supportati/,
   );
+});
+
+test('current legislature keeps a missing intermediate release as an explicit error', async (t) => {
+  let networkCalls = 0;
+  t.mock.method(globalThis, 'fetch', async () => { networkCalls++; throw Error('Unexpected download'); });
+  await assert.rejects(getLegislatureSpendingCycles({
+    loadConsuntivi: async () => [...totalsFor([2014,2015,2016,2017,2019,2020,2021,2023,2025]).values()].map(item => item.source),
+  }), /2024/);
+  assert.equal(networkCalls, 0, 'detect the catalog gap before downloading any annual data');
+});
+
+test('default legislature reader performs one catalog discovery for years and totals', async (t) => {
+  const years = [2014,2015,2016,2017,2019,2020,2021,2023,2024,2025];
+  let discoveries = 0;
+  const downloads = [];
+  t.mock.method(globalThis, 'fetch', async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith('/package_search')) {
+      discoveries++;
+      const code = url.searchParams.get('q');
+      assert.equal(code, 'PBS_SPE_RND_MISS_001');
+      return Response.json({success:true,result:{results:years.map(year => ({
+        id:`12345678-1234-4abc-8def-${String(year).padStart(12,'0')}`,
+        name:`consuntivo-${year}`,
+        title:`${year} - Pagamenti Bilancio dello Stato per Missione Consuntivo`,
+        notes:`pagamenti Bilancio dello Stato per l'esercizio finanziario di riferimento - [${code}]`,
+        metadata_modified:'2026-09-12T00:00:00.000000',
+      }))}});
+    }
+    const year = Number(url.pathname.match(/(\d{12})\.csv$/)?.[1]);
+    assert.ok(years.includes(year), url.pathname);
+    downloads.push(year);
+    return new Response([
+      'Esercizio finanziario;Codice Missione;Missione;OP Erario;OP Tesoreria;OP Esterno;OA Tesoreria;OA Spesa Funz Deleg;RSF Stipendi;RSF Altro;Note Imputazione;Totale pagato',
+      [year,'001','Missione',year*100,0,0,0,0,0,0,0,year*100].join(';'),
+    ].join('\n'), {headers:{'content-type':'text/csv'}});
+  });
+  const cycles = await getLegislatureSpendingCycles();
+  assert.equal(discoveries, 1);
+  assert.deepEqual(downloads.sort((a,b)=>a-b), years);
+  assert.deepEqual(cycles.at(-1).years.map(row=>row.year), [2023,2024,2025]);
+  assert.equal(cycles.at(-1).preElectionYear, null);
+});
+
+test('reused catalog still rejects duplicate annual releases before downloads', async (t) => {
+  const {getStateSpendingTotalsForYears} = await import('../src/lib/bdap-payments.ts');
+  const source = totalsFor([2025]).get(2025).source;
+  let calls=0;
+  t.mock.method(globalThis,'fetch',async()=>{calls++;throw Error('Unexpected download');});
+  await assert.rejects(getStateSpendingTotalsForYears([2025],{datasets:[source,{...source,packageId:'duplicate'}]}), /più consuntivi/);
+  assert.equal(calls,0);
 });


### PR DESCRIPTION
La query della spesa per legislatura scopriva due volte gli stessi consuntivi nel catalogo OpenBDAP. Ora recupera un unico catalogo e lo riusa sia per determinare gli anni pubblicati sia per caricare i totali annuali, mantenendo la deadline complessiva.

La serie corrente deve essere continua: se il catalogo contiene 2023 e 2025 ma manca 2024, la query segnala il dato mancante prima di scaricare CSV. Non inventa né salta silenziosamente esercizi. L’anno pre-elettorale e i confronti della legislatura aperta restano null.

Validazione: 63 test OpenBDAP/legislature passati e typecheck riuscito. Nuovi test verificano una sola richiesta effettiva al catalogo, il riuso dei dataset, il buco nella serie corrente e i duplicati; CI completa richiesta prima del merge.

Closes #456
Follow-up di #427.